### PR TITLE
support/crate-report-form: Split `security` checkbox into `malicious-code` and `vulnerability`

### DIFF
--- a/app/components/support/crate-report-form.css
+++ b/app/components/support/crate-report-form.css
@@ -62,6 +62,22 @@
   }
 }
 
+.vulnerability-report {
+    padding: var(--space-s) var(--space-s);
+    background-color: light-dark(white, #141413);
+    border: 1px solid var(--gray-border);
+    border-radius: var(--space-3xs);
+    width: 100%;
+
+    :first-child {
+        margin-top: 0;
+    }
+
+    :last-child {
+        margin-bottom: 0;
+    }
+}
+
 .buttons {
   position: relative;
   margin: var(--space-m) 0;

--- a/app/components/support/crate-report-form.gjs
+++ b/app/components/support/crate-report-form.gjs
@@ -2,6 +2,7 @@ import { Input, Textarea } from '@ember/component';
 import { fn, uniqueId } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -29,7 +30,7 @@ const REASONS = [
   },
   {
     reason: 'vulnerability',
-    description: 'it contains a vulnerability (please try to contact the crate author first)',
+    description: 'it contains a vulnerability',
   },
   {
     reason: 'other',
@@ -82,6 +83,10 @@ export default class CrateReportForm extends Component {
 
   get isMaliciousCodeReport() {
     return this.selectedReasons.includes('malicious-code');
+  }
+
+  get isVulnerabilityReport() {
+    return this.selectedReasons.includes('vulnerability');
   }
 
   @action
@@ -181,6 +186,20 @@ ${this.detail}
           </div>
         {{/if}}
       </fieldset>
+
+      {{#if this.isVulnerabilityReport}}
+        <div class='vulnerability-report form-group' data-test-id='vulnerability-report'>
+          <h3>🔍 Vulnerability Report</h3>
+          <p>For crate vulnerabilities, please consider:</p>
+          <ul>
+            <li>Contacting the crate author first when possible</li>
+            <li>Reporting to the
+              <a href='https://rustsec.org/contributing.html' target='_blank' rel='noopener noreferrer'>RustSec Advisory
+                Database</a></li>
+            <li>Reviewing our <LinkTo @route='policies.security' target='_blank'>security policy</LinkTo></li>
+          </ul>
+        </div>
+      {{/if}}
 
       <fieldset class='form-group' data-test-id='fieldset-detail'>
         {{#let (uniqueId) as |id|}}

--- a/app/components/support/crate-report-form.gjs
+++ b/app/components/support/crate-report-form.gjs
@@ -80,6 +80,10 @@ export default class CrateReportForm extends Component {
     this.reasonsInvalid = false;
   }
 
+  get isMaliciousCodeReport() {
+    return this.selectedReasons.includes('malicious-code');
+  }
+
   @action
   submit() {
     if (!this.validate()) {
@@ -91,7 +95,7 @@ export default class CrateReportForm extends Component {
   }
 
   composeMail() {
-    let crate = this.crate;
+    let { crate, isMaliciousCodeReport } = this;
     let reasons = this.reasons
       .map(({ reason, description }) => {
         let selected = this.isReasonSelected(reason);
@@ -107,9 +111,16 @@ Additional details:
 ${this.detail}
 `;
     let subject = `The "${crate}" crate`;
-    let address = 'help@crates.io';
-    let mailto = `mailto:${address}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-    return mailto;
+    if (isMaliciousCodeReport) {
+      subject = `[SECURITY] ${subject}`;
+    }
+
+    let addresses = 'help@crates.io';
+    if (isMaliciousCodeReport) {
+      addresses += ',security@rust-lang.org';
+    }
+
+    return `mailto:${addresses}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
   }
 
   <template>
@@ -195,7 +206,11 @@ ${this.detail}
       <div class='buttons'>
         <button type='submit' class='report-button button button--small' data-test-id='report-button'>
           Report to
-          <strong>help@crates.io</strong>
+          {{#if this.isMaliciousCodeReport}}
+            <strong>help@crates.io & security@rust-lang.org</strong>
+          {{else}}
+            <strong>help@crates.io</strong>
+          {{/if}}
         </button>
       </div>
     </form>

--- a/app/components/support/crate-report-form.gjs
+++ b/app/components/support/crate-report-form.gjs
@@ -24,7 +24,11 @@ const REASONS = [
     description: 'it is abusive or otherwise harmful',
   },
   {
-    reason: 'security',
+    reason: 'malicious-code',
+    description: 'it contains malicious code',
+  },
+  {
+    reason: 'vulnerability',
     description: 'it contains a vulnerability (please try to contact the crate author first)',
   },
   {

--- a/e2e/acceptance/support.spec.ts
+++ b/e2e/acceptance/support.spec.ts
@@ -133,7 +133,7 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
 - [ ] it contains malicious code
-- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it contains a vulnerability
 - [ ] it is violating the usage policy in some other way (please specify below)
 
 Additional details:
@@ -178,7 +178,7 @@ Additional details:
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
 - [ ] it contains malicious code
-- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it contains a vulnerability
 - [x] it is violating the usage policy in some other way (please specify below)
 
 Additional details:
@@ -257,7 +257,7 @@ test detail
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
 - [ ] it contains malicious code
-- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it contains a vulnerability
 - [ ] it is violating the usage policy in some other way (please specify below)
 
 Additional details:
@@ -298,7 +298,7 @@ Additional details:
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
 - [ ] it contains malicious code
-- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it contains a vulnerability
 - [x] it is violating the usage policy in some other way (please specify below)
 
 Additional details:
@@ -344,7 +344,7 @@ test detail
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
 - [x] it contains malicious code
-- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it contains a vulnerability
 - [ ] it is violating the usage policy in some other way (please specify below)
 
 Additional details:
@@ -358,5 +358,21 @@ test detail
     await page.waitForFunction(() => !!globalThis.openKwargs);
     await page.waitForFunction(expect => globalThis.openKwargs.url === expect, mailto);
     await page.waitForFunction(expect => globalThis.openKwargs.target === expect, '_self');
+  });
+
+  test('shows help text for vulnerability reports', async ({ page }) => {
+    await page.goto('/support');
+    await page.getByTestId('link-crate-violation').click();
+    await expect(page).toHaveURL('/support?inquire=crate-violation');
+
+    const crateInput = page.getByTestId('crate-input');
+    await crateInput.fill('nanomsg');
+    await expect(crateInput).toHaveValue('nanomsg');
+    await expect(page.getByTestId('vulnerability-report')).not.toBeVisible();
+
+    const checkbox = page.getByTestId('vulnerability-checkbox');
+    await checkbox.check();
+    await expect(checkbox).toBeChecked();
+    await expect(page.getByTestId('vulnerability-report')).toBeVisible();
   });
 });

--- a/e2e/acceptance/support.spec.ts
+++ b/e2e/acceptance/support.spec.ts
@@ -130,6 +130,7 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
 - [x] it contains spam
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
+- [ ] it contains malicious code
 - [ ] it contains a vulnerability (please try to contact the crate author first)
 - [ ] it is violating the usage policy in some other way (please specify below)
 
@@ -174,6 +175,7 @@ Additional details:
 - [x] it contains spam
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
+- [ ] it contains malicious code
 - [ ] it contains a vulnerability (please try to contact the crate author first)
 - [x] it is violating the usage policy in some other way (please specify below)
 
@@ -263,6 +265,7 @@ test detail
 - [x] it contains spam
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
+- [ ] it contains malicious code
 - [ ] it contains a vulnerability (please try to contact the crate author first)
 - [ ] it is violating the usage policy in some other way (please specify below)
 
@@ -303,6 +306,7 @@ Additional details:
 - [x] it contains spam
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
+- [ ] it contains malicious code
 - [ ] it contains a vulnerability (please try to contact the crate author first)
 - [x] it is violating the usage policy in some other way (please specify below)
 

--- a/e2e/acceptance/support.spec.ts
+++ b/e2e/acceptance/support.spec.ts
@@ -1,6 +1,19 @@
 import { test, expect } from '@/e2e/helper';
 
 test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
+  test.beforeEach(async ({ page, msw }) => {
+    let crate = msw.db.crate.create({ name: 'nanomsg' });
+    msw.db.version.create({ crate, num: '0.6.0' });
+
+    // mock `window.open()`
+    await page.addInitScript(() => {
+      globalThis.open = (url, target, features) => {
+        globalThis.openKwargs = { url, target, features };
+        return { document: { write() {}, close() {} }, close() {} } as ReturnType<(typeof globalThis)['open']>;
+      };
+    });
+  });
+
   test('shows an inquire list', async ({ page, percy, a11y }) => {
     await page.goto('/support');
     await expect(page).toHaveURL('/support');
@@ -32,17 +45,6 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
 
   test.describe('reporting a crate from support page', () => {
     test.beforeEach(async ({ page, msw }) => {
-      let crate = msw.db.crate.create({ name: 'nanomsg' });
-      msw.db.version.create({ crate, num: '0.6.0' });
-
-      // mock `window.open()`
-      await page.addInitScript(() => {
-        globalThis.open = (url, target, features) => {
-          globalThis.openKwargs = { url, target, features };
-          return { document: { write() {}, close() {} }, close() {} } as ReturnType<(typeof globalThis)['open']>;
-        };
-      });
-
       await page.goto('/support');
       await page.getByTestId('link-crate-violation').click();
       await expect(page).toHaveURL('/support?inquire=crate-violation');
@@ -195,17 +197,6 @@ test detail
 
   test.describe('reporting a crate from crate page', () => {
     test.beforeEach(async ({ page, msw }) => {
-      let crate = msw.db.crate.create({ name: 'nanomsg' });
-      msw.db.version.create({ crate, num: '0.6.0' });
-
-      // mock `window.open()`
-      await page.addInitScript(() => {
-        globalThis.open = (url, target, features) => {
-          globalThis.openKwargs = { url, target, features };
-          return { document: { write() {}, close() {} }, close() {} } as ReturnType<(typeof globalThis)['open']>;
-        };
-      });
-
       await page.goto('/crates/nanomsg');
       await page.getByTestId('link-crate-report').click();
       await expect(page).toHaveURL('/support?crate=nanomsg&inquire=crate-violation');
@@ -322,5 +313,50 @@ test detail
       await page.waitForFunction(expect => globalThis.openKwargs.url === expect, mailto);
       await page.waitForFunction(expect => globalThis.openKwargs.target === expect, '_self');
     });
+  });
+
+  test('valid form with required detail', async ({ page }) => {
+    await page.goto('/support');
+    await page.getByTestId('link-crate-violation').click();
+    await expect(page).toHaveURL('/support?inquire=crate-violation');
+
+    const crateInput = page.getByTestId('crate-input');
+    await crateInput.fill('nanomsg');
+    await expect(crateInput).toHaveValue('nanomsg');
+    const checkbox = page.getByTestId('malicious-code-checkbox');
+    await checkbox.check();
+    await expect(checkbox).toBeChecked();
+    const detailInput = page.getByTestId('detail-input');
+    await detailInput.fill('test detail');
+    await expect(detailInput).toHaveValue('test detail');
+
+    await page.waitForFunction(() => globalThis.openKwargs === undefined);
+    const reportButton = page.getByTestId('report-button');
+    await reportButton.click();
+
+    await expect(page.getByTestId('crate-invalid')).not.toBeVisible();
+    await expect(page.getByTestId('reasons-invalid')).not.toBeVisible();
+    await expect(page.getByTestId('detail-invalid')).not.toBeVisible();
+
+    let body = `I'm reporting the https://crates.io/crates/nanomsg crate because:
+
+- [ ] it contains spam
+- [ ] it is name-squatting (reserving a crate name without content)
+- [ ] it is abusive or otherwise harmful
+- [x] it contains malicious code
+- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it is violating the usage policy in some other way (please specify below)
+
+Additional details:
+
+test detail
+`;
+    let subject = `[SECURITY] The "nanomsg" crate`;
+    let addresses = 'help@crates.io,security@rust-lang.org';
+    let mailto = `mailto:${addresses}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+    // wait for `window.open()` to be called
+    await page.waitForFunction(() => !!globalThis.openKwargs);
+    await page.waitForFunction(expect => globalThis.openKwargs.url === expect, mailto);
+    await page.waitForFunction(expect => globalThis.openKwargs.target === expect, '_self');
   });
 });

--- a/tests/acceptance/support-test.js
+++ b/tests/acceptance/support-test.js
@@ -145,7 +145,7 @@ module('Acceptance | support', function (hooks) {
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
 - [ ] it contains malicious code
-- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it contains a vulnerability
 - [ ] it is violating the usage policy in some other way (please specify below)
 
 Additional details:
@@ -183,7 +183,7 @@ Additional details:
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
 - [ ] it contains malicious code
-- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it contains a vulnerability
 - [x] it is violating the usage policy in some other way (please specify below)
 
 Additional details:
@@ -284,7 +284,7 @@ test detail
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
 - [ ] it contains malicious code
-- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it contains a vulnerability
 - [ ] it is violating the usage policy in some other way (please specify below)
 
 Additional details:
@@ -320,7 +320,7 @@ Additional details:
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
 - [ ] it contains malicious code
-- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it contains a vulnerability
 - [x] it is violating the usage policy in some other way (please specify below)
 
 Additional details:
@@ -359,7 +359,7 @@ test detail
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
 - [x] it contains malicious code
-- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it contains a vulnerability
 - [ ] it is violating the usage policy in some other way (please specify below)
 
 Additional details:
@@ -372,5 +372,19 @@ test detail
     assert.true(!!window.openKwargs);
     assert.strictEqual(window.openKwargs.url, mailto);
     assert.strictEqual(window.openKwargs.target, '_self');
+  });
+
+  test('shows help text for vulnerability reports', async function (assert) {
+    await visit('/support');
+    await click('[data-test-id="link-crate-violation"]');
+    assert.strictEqual(currentURL(), '/support?inquire=crate-violation');
+
+    await fillIn('[data-test-id="crate-input"]', 'nanomsg');
+    assert.dom('[data-test-id="crate-input"]').hasValue('nanomsg');
+    assert.dom('[data-test-id="vulnerability-report"]').doesNotExist();
+
+    await click('[data-test-id="vulnerability-checkbox"]');
+    assert.dom('[data-test-id="vulnerability-checkbox"]').isChecked();
+    assert.dom('[data-test-id="vulnerability-report"]').exists();
   });
 });

--- a/tests/acceptance/support-test.js
+++ b/tests/acceptance/support-test.js
@@ -13,6 +13,17 @@ import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | support', function (hooks) {
   setupApplicationTest(hooks);
+  setupWindowMock(hooks);
+
+  hooks.beforeEach(function () {
+    let crate = this.db.crate.create({ name: 'nanomsg' });
+    this.db.version.create({ crate, num: '0.6.0' });
+
+    window.open = (url, target, features) => {
+      window.openKwargs = { url, target, features };
+      return { document: { write() {}, close() {} }, close() {} };
+    };
+  });
 
   test('shows an inquire list', async function (assert) {
     await visit('/support');
@@ -51,19 +62,8 @@ module('Acceptance | support', function (hooks) {
     );
   });
 
-  module('reporting a crate from support page', function (hooks) {
-    setupWindowMock(hooks);
-
+  module('reporting a crate from support page', function () {
     async function prepare(context, assert) {
-      let { db } = context;
-      let crate = db.crate.create({ name: 'nanomsg' });
-      db.version.create({ crate, num: '0.6.0' });
-
-      window.open = (url, target, features) => {
-        window.openKwargs = { url, target, features };
-        return { document: { write() {}, close() {} }, close() {} };
-      };
-
       await visit('/support');
       await click('[data-test-id="link-crate-violation"]');
       assert.strictEqual(currentURL(), '/support?inquire=crate-violation');
@@ -199,19 +199,8 @@ test detail
     });
   });
 
-  module('reporting a crate from crate page', function (hooks) {
-    setupWindowMock(hooks);
-
+  module('reporting a crate from crate page', function () {
     async function prepare(context, assert) {
-      let { db } = context;
-      let crate = db.crate.create({ name: 'nanomsg' });
-      db.version.create({ crate, num: '0.6.0' });
-
-      window.open = (url, target, features) => {
-        window.openKwargs = { url, target, features };
-        return { document: { write() {}, close() {} }, close() {} };
-      };
-
       await visit('/crates/nanomsg');
       assert.strictEqual(currentURL(), '/crates/nanomsg');
 
@@ -345,5 +334,43 @@ test detail
       assert.strictEqual(window.openKwargs.url, mailto);
       assert.strictEqual(window.openKwargs.target, '_self');
     });
+  });
+
+  test('malicious code reports are sent to security@rust-lang.org too', async function (assert) {
+    await visit('/support');
+    await click('[data-test-id="link-crate-violation"]');
+    assert.strictEqual(currentURL(), '/support?inquire=crate-violation');
+
+    await fillIn('[data-test-id="crate-input"]', 'nanomsg');
+    assert.dom('[data-test-id="crate-input"]').hasValue('nanomsg');
+    await click('[data-test-id="malicious-code-checkbox"]');
+    assert.dom('[data-test-id="malicious-code-checkbox"]').isChecked();
+    await fillIn('[data-test-id="detail-input"]', 'test detail');
+    assert.dom('[data-test-id="detail-input"]').hasValue('test detail');
+    await click('[data-test-id="report-button"]');
+
+    assert.dom('[data-test-id="crate-invalid"]').doesNotExist();
+    assert.dom('[data-test-id="reasons-invalid"]').doesNotExist();
+    assert.dom('[data-test-id="detail-invalid"]').doesNotExist();
+
+    let body = `I'm reporting the https://crates.io/crates/nanomsg crate because:
+
+- [ ] it contains spam
+- [ ] it is name-squatting (reserving a crate name without content)
+- [ ] it is abusive or otherwise harmful
+- [x] it contains malicious code
+- [ ] it contains a vulnerability (please try to contact the crate author first)
+- [ ] it is violating the usage policy in some other way (please specify below)
+
+Additional details:
+
+test detail
+`;
+    let subject = `[SECURITY] The "nanomsg" crate`;
+    let addresses = 'help@crates.io,security@rust-lang.org';
+    let mailto = `mailto:${addresses}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+    assert.true(!!window.openKwargs);
+    assert.strictEqual(window.openKwargs.url, mailto);
+    assert.strictEqual(window.openKwargs.target, '_self');
   });
 });

--- a/tests/acceptance/support-test.js
+++ b/tests/acceptance/support-test.js
@@ -144,6 +144,7 @@ module('Acceptance | support', function (hooks) {
 - [x] it contains spam
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
+- [ ] it contains malicious code
 - [ ] it contains a vulnerability (please try to contact the crate author first)
 - [ ] it is violating the usage policy in some other way (please specify below)
 
@@ -181,6 +182,7 @@ Additional details:
 - [x] it contains spam
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
+- [ ] it contains malicious code
 - [ ] it contains a vulnerability (please try to contact the crate author first)
 - [x] it is violating the usage policy in some other way (please specify below)
 
@@ -292,6 +294,7 @@ test detail
 - [x] it contains spam
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
+- [ ] it contains malicious code
 - [ ] it contains a vulnerability (please try to contact the crate author first)
 - [ ] it is violating the usage policy in some other way (please specify below)
 
@@ -327,6 +330,7 @@ Additional details:
 - [x] it contains spam
 - [ ] it is name-squatting (reserving a crate name without content)
 - [ ] it is abusive or otherwise harmful
+- [ ] it contains malicious code
 - [ ] it contains a vulnerability (please try to contact the crate author first)
 - [x] it is violating the usage policy in some other way (please specify below)
 


### PR DESCRIPTION
This better reflects our [security policy](https://crates.io/policies/security), which treats these cases slightly different. With this PR, malicious code reports are also sent to security@rust-lang.org to improve response times. Clicking the vulnerability checkbox now shows an additional help text suggesting to the user to first contact the crate author, file a RustSec report and read our security policy.

/cc @rust-lang/security @rust-lang/wg-secure-code 

### Malicious Code
<img width="838" height="396" alt="Bildschirmfoto 2025-10-06 um 14 20 47" src="https://github.com/user-attachments/assets/a71ea30d-9d69-41b7-b350-5c8394e9e7cc" />

### Vulnerability
<img width="844" height="528" alt="Bildschirmfoto 2025-10-06 um 14 20 33" src="https://github.com/user-attachments/assets/292f794a-a1ac-4b5b-965d-63e1d4c11000" />


