### PR TITLE
fix: correct the schema of the versions table

### DIFF
--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -1109,10 +1109,10 @@ diesel::table! {
         keywords -> Array<Nullable<Text>>,
         /// JSONB representation of the version number for sorting purposes.
         semver_ord -> Nullable<Jsonb>,
-        /// JSONB data containing JWT claims from the trusted publisher (e.g., GitHub Actions context like repository, run_id, sha)
-        trustpub_data -> Nullable<Jsonb>,
         /// Source Lines of Code statistics for this version, stored as JSON with language breakdown and totals.
         linecounts -> Nullable<Jsonb>,
+        /// JSONB data containing JWT claims from the trusted publisher (e.g., GitHub Actions context like repository, run_id, sha)
+        trustpub_data -> Nullable<Jsonb>,
     }
 }
 


### PR DESCRIPTION
I think the order of the files in the versions table was broken, because Diesel runs migrations based on their creation time. Although we merged [a325520a](https://github.com/rust-lang/crates.io/commit/a325520a52f6baa2ef118ceda2f65a410c9b6518) a long time ago, its migration file is newer than [c977a31](https://github.com/rust-lang/crates.io/commit/c977a317234c896c6f14965bb7f7b9b80d32f6d7).
As a result, if you run the migrations locally, you’ll end up with a reordered schema file.