### PR TITLE
trustpub/emails: Add support for GitLab configs

### DIFF
--- a/src/controllers/trustpub/github_configs/create/mod.rs
+++ b/src/controllers/trustpub/github_configs/create/mod.rs
@@ -1,7 +1,7 @@
 use crate::app::AppState;
 use crate::auth::AuthCheck;
 use crate::controllers::krate::load_crate;
-use crate::controllers::trustpub::emails::ConfigCreatedEmail;
+use crate::controllers::trustpub::emails::{ConfigCreatedEmail, ConfigType};
 use crate::controllers::trustpub::github_configs::json;
 use crate::util::errors::{AppResult, bad_request, forbidden, server_error};
 use anyhow::Context;
@@ -117,11 +117,13 @@ pub async fn create_trustpub_github_config(
         .collect::<Vec<_>>();
 
     for (recipient, email_address) in &recipients {
+        let saved_config = ConfigType::GitHub(&saved_config);
+
         let context = ConfigCreatedEmail {
             recipient,
             auth_user,
             krate: &krate,
-            saved_config: &saved_config,
+            saved_config,
         };
 
         if let Err(err) = send_notification_email(&state, email_address, context).await {

--- a/src/controllers/trustpub/github_configs/delete/mod.rs
+++ b/src/controllers/trustpub/github_configs/delete/mod.rs
@@ -1,6 +1,6 @@
 use crate::app::AppState;
 use crate::auth::AuthCheck;
-use crate::controllers::trustpub::emails::ConfigDeletedEmail;
+use crate::controllers::trustpub::emails::{ConfigDeletedEmail, ConfigType};
 use crate::util::errors::{AppResult, bad_request, not_found};
 use anyhow::Context;
 use axum::extract::Path;
@@ -82,11 +82,13 @@ pub async fn delete_trustpub_github_config(
         .collect::<Vec<_>>();
 
     for (recipient, email_address) in &recipients {
+        let config = ConfigType::GitHub(&config);
+
         let context = ConfigDeletedEmail {
             recipient,
             auth_user,
             krate: &krate,
-            config: &config,
+            config,
         };
 
         if let Err(err) = send_notification_email(&state, email_address, context).await {

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_gitlab-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_gitlab-2.snap
@@ -1,0 +1,16 @@
+---
+source: src/controllers/trustpub/emails.rs
+expression: rendered.body_text
+---
+Hello octocat!
+
+You added a new "Trusted Publishing" configuration for GitLab CI to your crate "my-crate". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
+
+This configuration allows the workflow file at https://gitlab.com/rust-lang/my-crate/-/blob/HEAD/.gitlab-ci.yml to publish new versions of this crate.
+
+If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
+
+If you are unable to revert the change and need to do so, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_gitlab_with_environment-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_gitlab_with_environment-2.snap
@@ -1,0 +1,16 @@
+---
+source: src/controllers/trustpub/emails.rs
+expression: rendered.body_text
+---
+Hello octocat!
+
+You added a new "Trusted Publishing" configuration for GitLab CI to your crate "my-crate". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
+
+This configuration allows the workflow file at https://gitlab.com/rust-lang/my-crate/-/blob/HEAD/.gitlab-ci.yml to publish new versions of this crate. The workflow must use the `production` environment.
+
+If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
+
+If you are unable to revert the change and need to do so, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_gitlab-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_gitlab-2.snap
@@ -1,0 +1,14 @@
+---
+source: src/controllers/trustpub/emails.rs
+expression: rendered.body_text
+---
+Hello octocat!
+
+You removed a "Trusted Publishing" configuration for GitLab CI from your crate "my-crate".
+
+The removed configuration was for the workflow file at https://gitlab.com/rust-lang/my-crate/-/blob/HEAD/.gitlab-ci.yml.
+
+If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_gitlab_with_environment-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_gitlab_with_environment-2.snap
@@ -1,0 +1,14 @@
+---
+source: src/controllers/trustpub/emails.rs
+expression: rendered.body_text
+---
+Hello octocat!
+
+You removed a "Trusted Publishing" configuration for GitLab CI from your crate "my-crate".
+
+The removed configuration was for the workflow file at https://gitlab.com/rust-lang/my-crate/-/blob/HEAD/.gitlab-ci.yml using the `production` environment.
+
+If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/email/templates/trustpub_config_created/body.txt.j2
+++ b/src/email/templates/trustpub_config_created/body.txt.j2
@@ -1,18 +1,29 @@
 {% extends "base.txt.j2" %}
 
+{% if saved_config.type == "GitHub" %}
+    {% set ci_provider = "GitHub Actions" %}
+{% elif saved_config.type == "GitLab" %}
+    {% set ci_provider = "GitLab CI" %}
+{% endif %}
+
 {% block content %}
 Hello {{ recipient }}!
 
 {% if recipient == auth_user.gh_login -%}
-You added a new "Trusted Publishing" configuration for GitHub Actions to your crate "{{ krate.name }}". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
+You added a new "Trusted Publishing" configuration for {{ ci_provider }} to your crate "{{ krate.name }}". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 {%- else -%}
-crates.io user {{ auth_user.gh_login }} added a new "Trusted Publishing" configuration for GitHub Actions to a crate that you manage ("{{ krate.name }}"). Trusted publishers act as trusted users and can publish new versions of the crate automatically.
+crates.io user {{ auth_user.gh_login }} added a new "Trusted Publishing" configuration for {{ ci_provider }} to a crate that you manage ("{{ krate.name }}"). Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 {%- endif %}
 
+{% if saved_config.type == "GitHub" -%}
 This configuration allows the workflow file at https://github.com/{{ saved_config.repository_owner }}/{{ saved_config.repository_name }}/blob/HEAD/.github/workflows/{{ saved_config.workflow_filename }} to publish new versions of this crate.
 {%- if saved_config.environment %} The workflow must use the `{{ saved_config.environment }}` environment (https://github.com/{{ saved_config.repository_owner }}/{{ saved_config.repository_name }}/deployments/{{ saved_config.environment }}).
 {%- endif %}
-
+{% elif saved_config.type == "GitLab" -%}
+This configuration allows the workflow file at https://gitlab.com/{{ saved_config.namespace }}/{{ saved_config.project }}/-/blob/HEAD/{{ saved_config.workflow_filepath }} to publish new versions of this crate.
+{%- if saved_config.environment %} The workflow must use the `{{ saved_config.environment }}` environment.
+{%- endif %}
+{% endif %}
 If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
 
 If you are unable to revert the change and need to do so, you can email help@crates.io for assistance.

--- a/src/email/templates/trustpub_config_deleted/body.txt.j2
+++ b/src/email/templates/trustpub_config_deleted/body.txt.j2
@@ -1,18 +1,30 @@
 {% extends "base.txt.j2" %}
 
+{% if config.type == "GitHub" %}
+    {% set ci_provider = "GitHub Actions" %}
+{% elif config.type == "GitLab" %}
+    {% set ci_provider = "GitLab CI" %}
+{% endif %}
+
 {% block content %}
 Hello {{ recipient }}!
 
 {% if recipient == auth_user.gh_login -%}
-You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "{{ krate.name }}".
+You removed a "Trusted Publishing" configuration for {{ ci_provider }} from your crate "{{ krate.name }}".
 {%- else -%}
-crates.io user {{ auth_user.gh_login }} removed a "Trusted Publishing" configuration for GitHub Actions from a crate that you manage ("{{ krate.name }}").
+crates.io user {{ auth_user.gh_login }} removed a "Trusted Publishing" configuration for {{ ci_provider }} from a crate that you manage ("{{ krate.name }}").
 {%- endif %}
 
+{% if config.type == "GitHub" -%}
 The removed configuration was for the workflow file at https://github.com/{{ config.repository_owner }}/{{ config.repository_name }}/blob/HEAD/.github/workflows/{{ config.workflow_filename }}
 {%- if config.environment %} using the `{{ config.environment }}` environment
 {%- endif -%}
 .
-
+{% elif config.type == "GitLab" -%}
+The removed configuration was for the workflow file at https://gitlab.com/{{ config.namespace }}/{{ config.project }}/-/blob/HEAD/{{ config.workflow_filepath }}
+{%- if config.environment %} using the `{{ config.environment }}` environment
+{%- endif -%}
+.
+{% endif %}
 If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
 {% endblock %}


### PR DESCRIPTION
This PR adjusts the `trustpub_config_created/deleted` emails to support GitLab CI configurations.

### Related

- https://github.com/rust-lang/crates.io/issues/11987