### PR TITLE
Replace config field list with GitHub URLs in trustpub emails

### DIFF
--- a/src/controllers/trustpub/github_configs/create/snapshots/crates_io__controllers__trustpub__github_configs__create__tests__happy_path-3.snap
+++ b/src/controllers/trustpub/github_configs/create/snapshots/crates_io__controllers__trustpub__github_configs__create__tests__happy_path-3.snap
@@ -13,12 +13,7 @@ Hello foo!
 
 You added a new "Trusted Publishing" configuration for GitHub Actions to your crate "foo". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: foo-rs
-- Workflow filename: publish.yml
-- Environment: (not set)
+This configuration allows the workflow file at https://github.com/rust-lang/foo-rs/blob/HEAD/.github/workflows/publish.yml to publish new versions of this crate.
 
 If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
 

--- a/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__happy_path-2.snap
+++ b/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__happy_path-2.snap
@@ -13,12 +13,7 @@ Hello foo!
 
 You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "foo".
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: foo-rs
-- Workflow filename: publish.yml
-- Environment: (not set)
+The removed configuration was for the workflow file at https://github.com/rust-lang/foo-rs/blob/HEAD/.github/workflows/publish.yml.
 
 If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
 

--- a/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__legacy_token_auth-2.snap
+++ b/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__legacy_token_auth-2.snap
@@ -13,12 +13,7 @@ Hello foo!
 
 You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "foo".
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: foo-rs
-- Workflow filename: publish.yml
-- Environment: (not set)
+The removed configuration was for the workflow file at https://github.com/rust-lang/foo-rs/blob/HEAD/.github/workflows/publish.yml.
 
 If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
 

--- a/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__token_auth_with_trusted_publishing_scope-2.snap
+++ b/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__token_auth_with_trusted_publishing_scope-2.snap
@@ -13,12 +13,7 @@ Hello foo!
 
 You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "foo".
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: foo-rs
-- Workflow filename: publish.yml
-- Environment: (not set)
+The removed configuration was for the workflow file at https://github.com/rust-lang/foo-rs/blob/HEAD/.github/workflows/publish.yml.
 
 If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
 

--- a/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__token_auth_with_wildcard_crate_scope-2.snap
+++ b/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__token_auth_with_wildcard_crate_scope-2.snap
@@ -13,12 +13,7 @@ Hello foo!
 
 You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "foo".
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: foo-rs
-- Workflow filename: publish.yml
-- Environment: (not set)
+The removed configuration was for the workflow file at https://github.com/rust-lang/foo-rs/blob/HEAD/.github/workflows/publish.yml.
 
 If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
 

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email-2.snap
@@ -6,12 +6,7 @@ Hello octocat!
 
 You added a new "Trusted Publishing" configuration for GitHub Actions to your crate "my-crate". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: rust
-- Workflow filename: publish.yml
-- Environment: (not set)
+This configuration allows the workflow file at https://github.com/rust-lang/rust/blob/HEAD/.github/workflows/publish.yml to publish new versions of this crate.
 
 If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
 

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_different_recipient-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_different_recipient-2.snap
@@ -6,12 +6,7 @@ Hello team-member!
 
 crates.io user octocat added a new "Trusted Publishing" configuration for GitHub Actions to a crate that you manage ("my-crate"). Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: rust
-- Workflow filename: publish.yml
-- Environment: (not set)
+This configuration allows the workflow file at https://github.com/rust-lang/rust/blob/HEAD/.github/workflows/publish.yml to publish new versions of this crate.
 
 If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
 

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_with_environment-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_with_environment-2.snap
@@ -6,12 +6,7 @@ Hello octocat!
 
 You added a new "Trusted Publishing" configuration for GitHub Actions to your crate "my-crate". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: rust
-- Workflow filename: publish.yml
-- Environment: production
+This configuration allows the workflow file at https://github.com/rust-lang/rust/blob/HEAD/.github/workflows/publish.yml to publish new versions of this crate. The workflow must use the `production` environment (https://github.com/rust-lang/rust/deployments/production).
 
 If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
 

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email-2.snap
@@ -6,12 +6,7 @@ Hello octocat!
 
 You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "my-crate".
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: rust
-- Workflow filename: publish.yml
-- Environment: (not set)
+The removed configuration was for the workflow file at https://github.com/rust-lang/rust/blob/HEAD/.github/workflows/publish.yml.
 
 If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
 

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_different_recipient-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_different_recipient-2.snap
@@ -6,12 +6,7 @@ Hello team-member!
 
 crates.io user octocat removed a "Trusted Publishing" configuration for GitHub Actions from a crate that you manage ("my-crate").
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: rust
-- Workflow filename: publish.yml
-- Environment: (not set)
+The removed configuration was for the workflow file at https://github.com/rust-lang/rust/blob/HEAD/.github/workflows/publish.yml.
 
 If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
 

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_with_environment-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_with_environment-2.snap
@@ -6,12 +6,7 @@ Hello octocat!
 
 You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "my-crate".
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: rust
-- Workflow filename: publish.yml
-- Environment: production
+The removed configuration was for the workflow file at https://github.com/rust-lang/rust/blob/HEAD/.github/workflows/publish.yml using the `production` environment.
 
 If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
 

--- a/src/email/templates/trustpub_config_created/body.txt.j2
+++ b/src/email/templates/trustpub_config_created/body.txt.j2
@@ -9,12 +9,9 @@ You added a new "Trusted Publishing" configuration for GitHub Actions to your cr
 crates.io user {{ auth_user.gh_login }} added a new "Trusted Publishing" configuration for GitHub Actions to a crate that you manage ("{{ krate.name }}"). Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 {%- endif %}
 
-Trusted Publishing configuration:
-
-- Repository owner: {{ saved_config.repository_owner }}
-- Repository name: {{ saved_config.repository_name }}
-- Workflow filename: {{ saved_config.workflow_filename }}
-- Environment: {{ saved_config.environment or "(not set)" }}
+This configuration allows the workflow file at https://github.com/{{ saved_config.repository_owner }}/{{ saved_config.repository_name }}/blob/HEAD/.github/workflows/{{ saved_config.workflow_filename }} to publish new versions of this crate.
+{%- if saved_config.environment %} The workflow must use the `{{ saved_config.environment }}` environment (https://github.com/{{ saved_config.repository_owner }}/{{ saved_config.repository_name }}/deployments/{{ saved_config.environment }}).
+{%- endif %}
 
 If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
 

--- a/src/email/templates/trustpub_config_deleted/body.txt.j2
+++ b/src/email/templates/trustpub_config_deleted/body.txt.j2
@@ -9,12 +9,10 @@ You removed a "Trusted Publishing" configuration for GitHub Actions from your cr
 crates.io user {{ auth_user.gh_login }} removed a "Trusted Publishing" configuration for GitHub Actions from a crate that you manage ("{{ krate.name }}").
 {%- endif %}
 
-Trusted Publishing configuration:
-
-- Repository owner: {{ config.repository_owner }}
-- Repository name: {{ config.repository_name }}
-- Workflow filename: {{ config.workflow_filename }}
-- Environment: {{ config.environment or "(not set)" }}
+The removed configuration was for the workflow file at https://github.com/{{ config.repository_owner }}/{{ config.repository_name }}/blob/HEAD/.github/workflows/{{ config.workflow_filename }}
+{%- if config.environment %} using the `{{ config.environment }}` environment
+{%- endif -%}
+.
 
 If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
 {% endblock %}

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__trustpub__full_flow-11.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__trustpub__full_flow-11.snap
@@ -30,12 +30,7 @@ Hello foo!
 
 You added a new "Trusted Publishing" configuration for GitHub Actions to your crate "foo". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 
-Trusted Publishing configuration:
-
-- Repository owner: rust-lang
-- Repository name: foo-rs
-- Workflow filename: publish.yml
-- Environment: (not set)
+This configuration allows the workflow file at https://github.com/rust-lang/foo-rs/blob/HEAD/.github/workflows/publish.yml to publish new versions of this crate.
 
 If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
 


### PR DESCRIPTION
Replaces the bulleted list of configuration fields (repository owner, repository name, workflow filename, environment) with prose containing direct GitHub URLs to the workflow file and environment page.

For config created emails:
- Link to workflow file at `github.com/{owner}/{repo}/blob/HEAD/.github/workflows/{filename}`
- When environment is set, also link to `github.com/{owner}/{repo}/deployments/{environment}`

For config deleted emails:
- Link to workflow file
- When environment is set, mention environment name inline without URL

This makes it immediately clear what workflow is authorized and provides one-click access to view the workflow file and environment configuration.