### PR TITLE
Add missing `.select()` and `.returning()` calls

### DIFF
--- a/crates/crates_io_database/src/models/action.rs
+++ b/crates/crates_io_database/src/models/action.rs
@@ -54,7 +54,10 @@ pub struct VersionOwnerAction {
 
 impl VersionOwnerAction {
     pub async fn all(conn: &mut AsyncPgConnection) -> QueryResult<Vec<Self>> {
-        version_owner_actions::table.load(conn).await
+        version_owner_actions::table
+            .select(Self::as_select())
+            .load(conn)
+            .await
     }
 
     pub fn by_version<'a>(
@@ -100,6 +103,7 @@ impl NewVersionOwnerAction {
     pub async fn insert(&self, conn: &mut AsyncPgConnection) -> QueryResult<VersionOwnerAction> {
         diesel::insert_into(version_owner_actions::table)
             .values(self)
+            .returning(VersionOwnerAction::as_select())
             .get_result(conn)
             .await
     }

--- a/crates/crates_io_database/src/models/category.rs
+++ b/crates/crates_io_database/src/models/category.rs
@@ -55,6 +55,7 @@ impl Category {
             async move {
                 let categories: Vec<Category> = categories::table
                     .filter(categories::slug.eq_any(slugs))
+                    .select(Category::as_select())
                     .load(conn)
                     .await?;
 
@@ -400,6 +401,7 @@ mod tests {
             .unwrap();
 
         let cat: Category = Category::by_slug("cat1::sub1")
+            .select(Category::as_select())
             .first(&mut conn)
             .await
             .unwrap();

--- a/crates/crates_io_database/src/models/cloudfront_invalidation_queue.rs
+++ b/crates/crates_io_database/src/models/cloudfront_invalidation_queue.rs
@@ -39,6 +39,7 @@ impl CloudFrontInvalidationQueueItem {
         cloudfront_invalidation_queue::table
             .order(cloudfront_invalidation_queue::created_at.asc())
             .limit(limit)
+            .select(Self::as_select())
             .load(conn)
             .await
     }

--- a/crates/crates_io_database/src/models/keyword.rs
+++ b/crates/crates_io_database/src/models/keyword.rs
@@ -32,6 +32,7 @@ impl Keyword {
     pub async fn find_by_keyword(conn: &mut AsyncPgConnection, name: &str) -> QueryResult<Keyword> {
         keywords::table
             .filter(keywords::keyword.eq(lower(name)))
+            .select(Keyword::as_select())
             .first(conn)
             .await
     }
@@ -55,6 +56,7 @@ impl Keyword {
 
         keywords::table
             .filter(keywords::keyword.eq_any(&lowercase_names))
+            .select(Keyword::as_select())
             .load(conn)
             .await
     }

--- a/crates/crates_io_database/src/models/team.rs
+++ b/crates/crates_io_database/src/models/team.rs
@@ -45,6 +45,7 @@ impl NewTeam<'_> {
             .on_conflict(teams::github_id)
             .do_update()
             .set(self)
+            .returning(Team::as_returning())
             .get_result(conn)
             .await
     }

--- a/crates/crates_io_database/src/models/trustpub/gitlab_config.rs
+++ b/crates/crates_io_database/src/models/trustpub/gitlab_config.rs
@@ -73,6 +73,7 @@ mod tests {
         // Retrieve the config
         let retrieved_config = trustpub_configs_gitlab::table
             .filter(trustpub_configs_gitlab::id.eq(inserted_config.id))
+            .select(GitLabConfig::as_select())
             .first::<GitLabConfig>(&mut conn)
             .await
             .unwrap();

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -97,7 +97,10 @@ pub async fn find_category(
 ) -> AppResult<Json<GetResponse>> {
     let mut conn = state.db_read().await?;
 
-    let cat: Category = Category::by_slug(&slug).first(&mut conn).await?;
+    let cat: Category = Category::by_slug(&slug)
+        .select(Category::as_select())
+        .first(&mut conn)
+        .await?;
     let (subcats, parents) = tokio::try_join!(
         cat.subcategories(&mut conn),
         cat.parent_categories(&mut conn).boxed(),

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -196,7 +196,8 @@ async fn prepare_list(
             crate_owner_invitations::invited_user_id,
         ))
         // We fetch one element over the page limit to then detect whether there is a next page.
-        .limit(pagination.per_page + 1);
+        .limit(pagination.per_page + 1)
+        .select(CrateOwnerInvitation::as_select());
 
     // Load and paginate the results.
     let mut raw_invitations: Vec<CrateOwnerInvitation> = match pagination.page {

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -53,7 +53,7 @@ pub async fn list_keywords(
 ) -> AppResult<Json<ListResponse>> {
     use crate::schema::keywords;
 
-    let mut query = keywords::table.into_boxed();
+    let mut query = keywords::table.select(Keyword::as_select()).into_boxed();
 
     query = match &params.sort {
         Some(sort) if sort == "crates" => query.order(keywords::crates_cnt.desc()),

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -118,6 +118,7 @@ pub async fn get_summary(state: AppState) -> AppResult<Json<SummaryResponse>> {
         keywords::table
             .order(keywords::crates_cnt.desc())
             .limit(10)
+            .select(Keyword::as_select())
             .load(&mut conn)
             .boxed(),
     )?;

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -27,7 +27,11 @@ pub async fn find_team(state: AppState, Path(name): Path<String>) -> AppResult<J
     use crate::schema::teams::dsl::{login, teams};
 
     let mut conn = state.db_read().await?;
-    let team: Team = teams.filter(login.eq(&name)).first(&mut conn).await?;
+    let team: Team = teams
+        .filter(login.eq(&name))
+        .select(Team::as_select())
+        .first(&mut conn)
+        .await?;
     let team = EncodableTeam::from(team);
     Ok(Json(GetResponse { team }))
 }

--- a/src/controllers/trustpub/tokens/exchange/gitlab_tests.rs
+++ b/src/controllers/trustpub/tokens/exchange/gitlab_tests.rs
@@ -410,6 +410,7 @@ async fn test_lazy_namespace_id_population() -> anyhow::Result<()> {
     let config: GitLabConfig = trustpub_configs_gitlab::table
         .filter(trustpub_configs_gitlab::namespace.eq(NAMESPACE))
         .filter(trustpub_configs_gitlab::project.eq(PROJECT))
+        .select(GitLabConfig::as_select())
         .first(&mut conn)
         .await?;
 

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -154,6 +154,7 @@ impl RateLimiter {
                 publish_limit_buckets::last_refill.eq(publish_limit_buckets::last_refill
                     + refill_rate.into_sql::<Interval>() * tokens_to_add),
             ))
+            .returning(Bucket::as_select())
             .get_result(conn)
             .await
     }
@@ -170,7 +171,7 @@ impl RateLimiter {
     }
 }
 
-#[derive(Queryable, Insertable, Debug, PartialEq, Clone, Copy)]
+#[derive(Queryable, Insertable, Selectable, Debug, PartialEq, Clone, Copy)]
 #[diesel(table_name = publish_limit_buckets, check_for_backend(diesel::pg::Pg))]
 #[allow(dead_code)] // Most fields only read in tests
 struct Bucket {
@@ -725,6 +726,7 @@ mod tests {
                 last_refill: now,
                 action: LimitedAction::PublishNew,
             })
+            .returning(Bucket::as_returning())
             .get_result(conn)
             .await
     }


### PR DESCRIPTION
We were relying on the implicit column order in many places, which can lead to subtle bugs. The `Selectable` trait ensures that fields are filled according to their corresponding column name.

This should unblock us from being able to use `column_sorting = name` with `diesel` (see https://github.com/rust-lang/crates.io/pull/12044#issuecomment-3375453049)