### PR TITLE
Add workflow file verification to trusted publisher form

### DIFF
--- a/app/templates/crate/settings/new-trusted-publisher.css
+++ b/app/templates/crate/settings/new-trusted-publisher.css
@@ -45,3 +45,20 @@
 .cancel-button {
     border-radius: 4px;
 }
+
+.workflow-verification {
+    margin-top: var(--space-2xs);
+    font-size: 0.85em;
+
+    :global(a), :global(a):hover {
+        color: inherit;
+    }
+}
+
+.workflow-verification--success {
+    color: var(--green800);
+}
+
+.workflow-verification--warning {
+    color: var(--yellow700);
+}

--- a/app/templates/crate/settings/new-trusted-publisher.gjs
+++ b/app/templates/crate/settings/new-trusted-publisher.gjs
@@ -7,6 +7,7 @@ import autoFocus from '@zestia/ember-auto-focus/modifiers/auto-focus';
 import perform from 'ember-concurrency/helpers/perform';
 import preventDefault from 'ember-event-helpers/helpers/prevent-default';
 import eq from 'ember-truth-helpers/helpers/eq';
+import not from 'ember-truth-helpers/helpers/not';
 
 import LoadingSpinner from 'crates-io/components/loading-spinner';
 
@@ -51,6 +52,7 @@ import LoadingSpinner from 'crates-io/components/loading-spinner';
             data-test-repository-owner
             {{autoFocus}}
             {{on 'input' @controller.resetRepositoryOwnerValidation}}
+            {{on 'input' (perform @controller.verifyWorkflowTask)}}
           />
 
           {{#if @controller.repositoryOwnerInvalid}}
@@ -79,6 +81,7 @@ import LoadingSpinner from 'crates-io/components/loading-spinner';
             class='input base-input'
             data-test-repository-name
             {{on 'input' @controller.resetRepositoryNameValidation}}
+            {{on 'input' (perform @controller.verifyWorkflowTask)}}
           />
 
           {{#if @controller.repositoryNameInvalid}}
@@ -107,6 +110,7 @@ import LoadingSpinner from 'crates-io/components/loading-spinner';
             class='input base-input'
             data-test-workflow-filename
             {{on 'input' @controller.resetWorkflowFilenameValidation}}
+            {{on 'input' (perform @controller.verifyWorkflowTask)}}
           />
 
           {{#if @controller.workflowFilenameInvalid}}
@@ -138,6 +142,41 @@ import LoadingSpinner from 'crates-io/components/loading-spinner';
               <code>release.yml</code>
               or
               <code>publish.yml</code>.
+            </div>
+          {{/if}}
+
+          {{#if (not @controller.verificationUrl)}}
+            <div class='workflow-verification' data-test-workflow-verification='initial'>
+              The workflow filename will be verified once all necessary fields are filled.
+            </div>
+          {{else if (eq @controller.verifyWorkflowTask.last.value 'success')}}
+            <div class='workflow-verification workflow-verification--success' data-test-workflow-verification='success'>
+              ✓ Workflow file found at
+              <a href='{{@controller.verificationUrl}}' target='_blank' rel='noopener noreferrer'>
+                {{@controller.verificationUrl}}
+              </a>
+            </div>
+          {{else if (eq @controller.verifyWorkflowTask.last.value 'not-found')}}
+            <div
+              class='workflow-verification workflow-verification--warning'
+              data-test-workflow-verification='not-found'
+            >
+              ⚠ Workflow file not found at
+              <a href='{{@controller.verificationUrl}}' target='_blank' rel='noopener noreferrer'>
+                {{@controller.verificationUrl}}
+              </a>
+            </div>
+          {{else if (eq @controller.verifyWorkflowTask.last.value 'error')}}
+            <div class='workflow-verification workflow-verification--warning' data-test-workflow-verification='error'>
+              ⚠ Could not verify workflow file at
+              <a href='{{@controller.verificationUrl}}' target='_blank' rel='noopener noreferrer'>
+                {{@controller.verificationUrl}}
+              </a>
+              (network error)
+            </div>
+          {{else}}
+            <div class='workflow-verification' data-test-workflow-verification='verifying'>
+              Verifying...
             </div>
           {{/if}}
         {{/let}}

--- a/packages/crates-io-msw/handlers/github.js
+++ b/packages/crates-io-msw/handlers/github.js
@@ -1,0 +1,7 @@
+import { http, HttpResponse } from 'msw';
+
+export default [
+  http.head('https://raw.githubusercontent.com/:owner/:projec/HEAD/.github/workflows/:workflow_filename', () => {
+    return new HttpResponse(null, { status: 404 });
+  }),
+];

--- a/packages/crates-io-msw/index.js
+++ b/packages/crates-io-msw/index.js
@@ -2,6 +2,7 @@ import apiTokenHandlers from './handlers/api-tokens.js';
 import categoryHandlers from './handlers/categories.js';
 import cratesHandlers from './handlers/crates.js';
 import docsRsHandlers from './handlers/docs-rs.js';
+import githubHandlers from './handlers/github.js';
 import inviteHandlers from './handlers/invites.js';
 import keywordHandlers from './handlers/keywords.js';
 import metadataHandlers from './handlers/metadata.js';
@@ -32,6 +33,7 @@ export const handlers = [
   ...categoryHandlers,
   ...cratesHandlers,
   ...docsRsHandlers,
+  ...githubHandlers,
   ...inviteHandlers,
   ...keywordHandlers,
   ...metadataHandlers,


### PR DESCRIPTION
This PR automatically verifies that the specified GitHub Actions workflow file exists when creating a new Trusted Publisher configuration. The verification:

- Triggers automatically after all required fields are filled (500ms debounce in production, no delay in tests)
- Uses HEAD request to check workflow file existence at raw.githubusercontent.com
- Shows one of five states:
  - Initial: "The workflow filename will be verified..."
  - Verifying: "Verifying..."
  - Success (200): Green checkmark with clickable URL
  - Not found (404): Yellow warning with clickable URL
  - Error (5xx/network): Yellow warning with clickable URL
- Non-blocking: Users can still submit the form even if verification fails
- URLs are clickable links that open in a new tab

All verification messages are displayed in the same area to prevent layout shifts.

### Screenshots

<img width="673" height="213" alt="Bildschirmfoto 2025-10-07 um 18 44 49" src="https://github.com/user-attachments/assets/fdc08430-202a-40a2-bc05-d0a888500170" />
<img width="653" height="204" alt="Bildschirmfoto 2025-10-07 um 18 45 01" src="https://github.com/user-attachments/assets/fbdffec3-c3e5-4d8c-8de0-f9b6dd5f5d27" />
