### PR TITLE
renovate: Include `diesel-` prefixed package in "diesel packages" group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,7 +49,7 @@
             commitMessageTopic: "Rust",
         },
         {
-            matchDepNames: ["/^diesel$/", "/^diesel_/"],
+            matchDepNames: ["/^diesel$/", "/^diesel_/", "/^diesel-/"],
             groupName: "diesel packages",
         },
         {


### PR DESCRIPTION
`diesel_full_text_search` and `diesel_migrations` use underscores, but for some reason `diesel-async` uses hyphens. This adds the pattern to the renovate group, so that renovate updates these packages together :)

In other words: it should automatically merge https://github.com/rust-lang/crates.io/pull/12033 into https://github.com/rust-lang/crates.io/pull/11890