### PR TITLE
CSP: Add `https://raw.githubusercontent.com` to `connect-src`

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -189,7 +189,7 @@ impl Server {
         // the `script` in `public/github-redirect.html`
         let content_security_policy = format!(
             "default-src 'self'; \
-            connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org {cdn_domain}; \
+            connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org https://raw.githubusercontent.com {cdn_domain}; \
             script-src 'self' 'unsafe-eval' 'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE=' 'sha256-dbf9FMl76C7BnK1CC3eWb3pvsQAUaTYSHAlBy9tNTG0='; \
             style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; \
             font-src https://code.cdn.mozilla.net; \


### PR DESCRIPTION
This is apparently needed for the workflow file verification to work on staging and production.

### Related

- https://github.com/rust-lang/crates.io/pull/12057