### PR TITLE
Remain on current page if navigating to reverse dependencies page fails

### DIFF
--- a/app/routes/crate/reverse-dependencies.js
+++ b/app/routes/crate/reverse-dependencies.js
@@ -10,7 +10,7 @@ export default class ReverseDependenciesRoute extends Route {
     page: { refreshModel: true },
   };
 
-  async model(params) {
+  async model(params, transition) {
     params.reverse = true;
     params.crate = this.modelFor('crate');
     let crateName = params.crate.name;
@@ -18,15 +18,8 @@ export default class ReverseDependenciesRoute extends Route {
     try {
       return await this.store.query('dependency', params);
     } catch (error) {
-      let message = `Could not load reverse dependencies for the "${crateName}" crate`;
-
-      let details = error.errors?.[0]?.detail;
-      if (details && !details.startsWith('{')) {
-        message += `: ${details}`;
-      }
-
-      this.notifications.error(message);
-      this.router.replaceWith('catch-all');
+      let title = `${crateName}: Failed to load dependents`;
+      this.router.replaceWith('catch-all', { transition, error, title });
     }
   }
 

--- a/tests/acceptance/reverse-dependencies-test.js
+++ b/tests/acceptance/reverse-dependencies-test.js
@@ -66,29 +66,17 @@ module('Acceptance | /crates/:crate_id/reverse_dependencies', function (hooks) {
     assert.dom('[data-test-total-rows]').hasText('22');
   });
 
-  test('shows a generic error if the server is broken', async function (assert) {
+  test('shows error message if loading of reverse dependencies fails', async function (assert) {
     let { foo } = prepare(this);
 
     let error = HttpResponse.json({}, { status: 500 });
     this.worker.use(http.get('/api/v1/crates/:crate_id/reverse_dependencies', () => error));
 
     await visit(`/crates/${foo.name}/reverse_dependencies`);
-    assert.strictEqual(currentURL(), `/crates/${foo.name}`);
-    assert
-      .dom('[data-test-notification-message="error"]')
-      .hasText('Could not load reverse dependencies for the "foo" crate');
-  });
-
-  test('shows a detailed error if available', async function (assert) {
-    let { foo } = prepare(this);
-
-    let error = HttpResponse.json({ errors: [{ detail: 'cannot request more than 100 items' }] }, { status: 400 });
-    this.worker.use(http.get('/api/v1/crates/:crate_id/reverse_dependencies', () => error));
-
-    await visit(`/crates/${foo.name}/reverse_dependencies`);
-    assert.strictEqual(currentURL(), `/crates/${foo.name}`);
-    assert
-      .dom('[data-test-notification-message="error"]')
-      .hasText('Could not load reverse dependencies for the "foo" crate: cannot request more than 100 items');
+    assert.strictEqual(currentURL(), `/crates/${foo.name}/reverse_dependencies`);
+    assert.dom('[data-test-404-page]').isVisible();
+    assert.dom('[data-test-title]').hasText(`${foo.name}: Failed to load dependents`);
+    assert.dom('[data-test-go-back]').isVisible();
+    assert.dom('[data-test-try-again]').isNotVisible();
   });
 });


### PR DESCRIPTION
This resolves one of the reports in #11834.

Widely depended-on crates can cause timeouts when loading the reverse dependencies page.

The reverse dependencies route is the only one (bar email verification, which makes sense) that sends you to the index page upon error.

This pull request updates the error handling logic to use the `catch-all` redirect, matching the behaviour of the standard (forward?) dependencies page.