### PR TITLE
trustpub: Derive `Clone` for claims structs

### DIFF
--- a/crates/crates_io_trustpub/src/github/claims.rs
+++ b/crates/crates_io_trustpub/src/github/claims.rs
@@ -12,7 +12,7 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation};
 /// Publishing" implementation.
 ///
 /// See <https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token>.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GitHubClaims {
     pub aud: String,
     #[serde(with = "ts_seconds")]

--- a/crates/crates_io_trustpub/src/gitlab/claims.rs
+++ b/crates/crates_io_trustpub/src/gitlab/claims.rs
@@ -12,7 +12,7 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation};
 /// Publishing" implementation.
 ///
 /// See <https://docs.gitlab.com/ci/secrets/id_token_authentication/#token-payload>.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GitLabClaims {
     pub aud: String,
     #[serde(with = "ts_seconds")]

--- a/crates/crates_io_trustpub/src/unverified.rs
+++ b/crates/crates_io_trustpub/src/unverified.rs
@@ -29,7 +29,7 @@ static EMPTY_KEY: LazyLock<DecodingKey> = LazyLock::new(|| DecodingKey::from_sec
 /// validation. Specifically, this only extracts the `iss` claim, which is
 /// used to look up the corresponding OIDC key set to then verify the
 /// JWT signature.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct UnverifiedClaims {
     pub iss: String,
 }


### PR DESCRIPTION
This is required for `jsonwebtoken@10` compatibility, but we may as well do it now, since the update itself is still blocked on external factors :)