### PR TITLE
views: Apply `remove_blocked_urls()` to version fields

### DIFF
--- a/src/views.rs
+++ b/src/views.rs
@@ -968,6 +968,10 @@ impl EncodableVersion {
             ..
         } = version;
 
+        let homepage = remove_blocked_urls(homepage);
+        let documentation = remove_blocked_urls(documentation);
+        let repository = remove_blocked_urls(repository);
+
         let links = EncodableVersionLinks {
             dependencies: format!("/api/v1/crates/{crate_name}/{num}/dependencies"),
             version_downloads: format!("/api/v1/crates/{crate_name}/{num}/downloads"),


### PR DESCRIPTION
Ensures that homepage, documentation, and repository URLs are filtered for versions using the same blocked domain list as crate-level fields.

Looks like we missed this when we added these fields to the versions 😅 