### PR TITLE
Block high page numbers unconditionally

### DIFF
--- a/src/tests/pagination.rs
+++ b/src/tests/pagination.rs
@@ -1,14 +1,12 @@
 use crate::builders::CrateBuilder;
 use crate::util::{RequestHelper, TestApp};
 use insta::assert_snapshot;
-use ipnetwork::IpNetwork;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn pagination_blocks_ip_from_cidr_block_list() {
+async fn pagination_blocks_high_page_numbers() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
             config.max_allowed_page_offset = 1;
-            config.page_offset_cidr_blocklist = vec!["127.0.0.1/24".parse::<IpNetwork>().unwrap()];
         })
         .with_user()
         .await;

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -497,8 +497,6 @@ fn simple_config() -> config::Server {
         blocked_traffic: Default::default(),
         blocked_ips: Default::default(),
         max_allowed_page_offset: 200,
-        page_offset_ua_blocklist: vec![],
-        page_offset_cidr_blocklist: vec![],
         excluded_crate_names: vec![],
         domain_name: "crates.io".into(),
         allowed_origins: Default::default(),


### PR DESCRIPTION
Remove conditional blocking based on user-agent and IP address blocklists. Now all requests exceeding `max_allowed_page_offset` are blocked when the endpoint uses `.limit_page_numbers()`, regardless of the requesting client's identity.

This simplifies the pagination logic and removes the need for maintaining blocklists while still protecting against performance issues from deep pagination.