### PR TITLE
components/pagination: Disable prev/next buttons on boundary pages

### DIFF
--- a/app/components/pagination.css
+++ b/app/components/pagination.css
@@ -32,7 +32,7 @@
             fill: currentColor;
         }
 
-        &:hover {
+        &:hover:not(:global(.disabled)) {
             :global(circle) {
                 fill: var(--main-bg-dark);
             }
@@ -44,5 +44,11 @@
     .next:hover,
     .prev:hover {
         background: none;
+    }
+
+    .next:global(.disabled),
+    .prev:global(.disabled) {
+        opacity: 0.5;
+        cursor: not-allowed;
     }
 }

--- a/app/components/pagination.gjs
+++ b/app/components/pagination.gjs
@@ -2,11 +2,13 @@ import { concat, hash } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
 
 import svgJar from 'ember-svg-jar/helpers/svg-jar';
+import { eq } from 'ember-truth-helpers';
 
 <template>
   <nav class='pagination' aria-label='Pagination navigation'>
     <LinkTo
       @query={{hash page=@pagination.prevPage}}
+      @disabled={{eq @pagination.currentPage 1}}
       class='prev'
       rel='prev'
       title='previous page'
@@ -25,6 +27,7 @@ import svgJar from 'ember-svg-jar/helpers/svg-jar';
     </ol>
     <LinkTo
       @query={{hash page=@pagination.nextPage}}
+      @disabled={{eq @pagination.currentPage @pagination.availablePages}}
       class='next'
       rel='next'
       title='next page'


### PR DESCRIPTION
<img width="404" height="77" alt="Bildschirmfoto 2025-10-27 um 16 01 54" src="https://github.com/user-attachments/assets/4fdcfdb8-4b7a-407d-9112-61016a037569" />

Turns out `LinkTo` supports a `@disabled` argument these days, which sets the `disabled` CSS class and disables click-to-transition behavior (see https://api.emberjs.com/ember/release/classes/Ember.Templates.components?anchor=LinkTo#LinkTo). It is still possible to right-click and open in new tab, since the content stays a regular `<a>` element, but this still seems like am improvement over the status quo.