### PR TITLE
trustpub: Block `pull_request_target` and `workflow_run` triggers

### DIFF
--- a/crates/crates_io_trustpub/src/github/claims.rs
+++ b/crates/crates_io_trustpub/src/github/claims.rs
@@ -25,6 +25,7 @@ pub struct GitHubClaims {
     pub repository: String,
     pub workflow_ref: String,
     pub environment: Option<String>,
+    pub event_name: String,
     pub run_id: String,
     pub sha: String,
 }
@@ -119,6 +120,7 @@ mod tests {
           "repository": "octo-org/octo-repo",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
           "environment": "prod",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha"
         }
@@ -136,6 +138,7 @@ mod tests {
           "aud": AUDIENCE,
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -155,6 +158,7 @@ mod tests {
           "repository": "octo-org/octo-repo",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
           "environment": null,
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha"
         }
@@ -171,6 +175,7 @@ mod tests {
           "aud": AUDIENCE,
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -180,7 +185,7 @@ mod tests {
         }))?;
 
         let error = GitHubClaims::decode(&jwt, AUDIENCE, &DECODING_KEY).unwrap_err();
-        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `jti`", line: 1, column: 297)))"#);
+        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `jti`", line: 1, column: 330)))"#);
 
         Ok(())
     }
@@ -194,6 +199,7 @@ mod tests {
           "aud": "somebody-else",
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -217,6 +223,7 @@ mod tests {
           "aud": [AUDIENCE, "somebody-else"],
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -238,6 +245,7 @@ mod tests {
           "jti": "example-id",
           "aud": AUDIENCE,
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -247,7 +255,7 @@ mod tests {
         }))?;
 
         let error = GitHubClaims::decode(&jwt, AUDIENCE, &DECODING_KEY).unwrap_err();
-        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `repository`", line: 1, column: 282)))"#);
+        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `repository`", line: 1, column: 315)))"#);
 
         Ok(())
     }
@@ -259,6 +267,7 @@ mod tests {
           "jti": "example-id",
           "aud": AUDIENCE,
           "repository": "octo-org/octo-repo",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -268,7 +277,7 @@ mod tests {
         }))?;
 
         let error = GitHubClaims::decode(&jwt, AUDIENCE, &DECODING_KEY).unwrap_err();
-        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `repository_owner_id`", line: 1, column: 289)))"#);
+        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `repository_owner_id`", line: 1, column: 322)))"#);
 
         Ok(())
     }
@@ -281,6 +290,7 @@ mod tests {
           "aud": AUDIENCE,
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "iss": "https://token.actions.githubusercontent.com",
@@ -289,7 +299,7 @@ mod tests {
         }))?;
 
         let error = GitHubClaims::decode(&jwt, AUDIENCE, &DECODING_KEY).unwrap_err();
-        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `workflow_ref`", line: 1, column: 231)))"#);
+        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `workflow_ref`", line: 1, column: 264)))"#);
 
         Ok(())
     }
@@ -303,6 +313,7 @@ mod tests {
           "aud": AUDIENCE,
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -325,6 +336,7 @@ mod tests {
           "aud": AUDIENCE,
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -348,6 +360,7 @@ mod tests {
           "aud": AUDIENCE,
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -356,7 +369,7 @@ mod tests {
         }))?;
 
         let error = GitHubClaims::decode(&jwt, AUDIENCE, &DECODING_KEY).unwrap_err();
-        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `exp`", line: 1, column: 299)))"#);
+        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `exp`", line: 1, column: 332)))"#);
 
         Ok(())
     }
@@ -370,6 +383,7 @@ mod tests {
           "aud": AUDIENCE,
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -393,6 +407,7 @@ mod tests {
           "aud": AUDIENCE,
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
@@ -401,7 +416,7 @@ mod tests {
         }))?;
 
         let error = GitHubClaims::decode(&jwt, AUDIENCE, &DECODING_KEY).unwrap_err();
-        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `iat`", line: 1, column: 299)))"#);
+        assert_compact_debug_snapshot!(error, @r#"Error(Json(Error("missing field `iat`", line: 1, column: 332)))"#);
 
         Ok(())
     }
@@ -415,6 +430,7 @@ mod tests {
           "aud": AUDIENCE,
           "repository": "octo-org/octo-repo",
           "repository_owner_id": "65",
+          "event_name": "workflow_dispatch",
           "run_id": "example-run-id",
           "sha": "example-sha",
           "workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",

--- a/src/tests/routes/trustpub/tokens/exchange/github.rs
+++ b/src/tests/routes/trustpub/tokens/exchange/github.rs
@@ -417,6 +417,40 @@ async fn test_workflow_filename_mismatch() -> anyhow::Result<()> {
 }
 
 // ============================================================================
+// Dangerous event trigger tests
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pull_request_target_event_rejected() -> anyhow::Result<()> {
+    let client = prepare().await?;
+
+    let mut claims = default_claims();
+    claims.event_name = "pull_request_target".into();
+
+    let body = claims.as_exchange_body()?;
+    let response = client.post::<()>(URL, body).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Trusted Publishing does not support the `pull_request_target` event trigger due to security concerns. Please use a different trigger such as `push`, `release`, or `workflow_dispatch`."}]}"#);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_workflow_run_event_rejected() -> anyhow::Result<()> {
+    let client = prepare().await?;
+
+    let mut claims = default_claims();
+    claims.event_name = "workflow_run".into();
+
+    let body = claims.as_exchange_body()?;
+    let response = client.post::<()>(URL, body).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Trusted Publishing does not support the `workflow_run` event trigger due to security concerns. Please use a different trigger such as `push`, `release`, or `workflow_dispatch`."}]}"#);
+
+    Ok(())
+}
+
+// ============================================================================
 // Environment matching tests
 // ============================================================================
 


### PR DESCRIPTION
Add validation to reject GitHub Actions workflows using `pull_request_target` or `workflow_run` event triggers during trusted publishing token exchange.

These triggers are dangerous because they run in the target repository's security context while being triggerable by forked repositories, creating a privilege escalation vector.

The validation occurs after JWT decoding and JTI replay prevention but before any config matching, ensuring early rejection of potentially dangerous requests.

Changes:
- Add `event_name` field to `GitHubClaims` struct
- Implement validation check in `handle_github_token_inner()`
- Add tests for `pull_request_target` and `workflow_run` rejection
- Update all existing tests to include `event_name` field