### PR TITLE
diesel.toml: Add `https://` prefix to URL

### DIFF
--- a/diesel.toml
+++ b/diesel.toml
@@ -1,5 +1,5 @@
 # For documentation on how to configure this file,
-# see diesel.rs/guides/configuring-diesel-cli
+# see https://diesel.rs/guides/configuring-diesel-cli
 [print_schema]
 file = "crates/crates_io_database/src/schema.rs"
 with_docs = true


### PR DESCRIPTION
... to make it clickable in most editors