### PR TITLE
crates-io-msw: Remove `happy-dom` dependency

### DIFF
--- a/packages/crates-io-msw/package.json
+++ b/packages/crates-io-msw/package.json
@@ -23,7 +23,6 @@
     "semver": "7.7.3"
   },
   "devDependencies": {
-    "happy-dom": "20.0.10",
     "vitest": "4.0.4"
   }
 }

--- a/packages/crates-io-msw/vitest.config.js
+++ b/packages/crates-io-msw/vitest.config.js
@@ -3,9 +3,5 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     setupFiles: 'vitest.setup.js',
-
-    // The default Node.js environment does not support using relative paths
-    // with `msw`, so we use `happy-dom` instead.
-    environment: 'happy-dom',
   },
 });

--- a/packages/crates-io-msw/vitest.setup.js
+++ b/packages/crates-io-msw/vitest.setup.js
@@ -3,6 +3,9 @@ import { afterAll, afterEach, beforeAll } from 'vitest';
 
 import { db, handlers } from './index.js';
 
+// Polyfill `location.href` for MSW to resolve relative URLs
+globalThis.location = { href: 'https://crates.io/' };
+
 const server = setupServer(...handlers);
 
 beforeAll(() => server.listen());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,12 +334,9 @@ importers:
         specifier: 7.7.3
         version: 7.7.3
     devDependencies:
-      happy-dom:
-        specifier: 20.0.10
-        version: 20.0.10
       vitest:
         specifier: 4.0.4
-        version: 4.0.4(@types/node@24.9.2)(happy-dom@20.0.10)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.11.6(@types/node@24.9.2)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1)
+        version: 4.0.4(@types/node@24.9.2)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.11.6(@types/node@24.9.2)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1)
 
 packages:
 
@@ -2170,9 +2167,6 @@ packages:
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
-  '@types/node@20.19.23':
-    resolution: {integrity: sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==}
-
   '@types/node@24.9.2':
     resolution: {integrity: sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==}
 
@@ -2217,9 +2211,6 @@ packages:
 
   '@types/uuid@8.3.4':
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
-
-  '@types/whatwg-mimetype@3.0.2':
-    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -5010,10 +5001,6 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
-  happy-dom@20.0.10:
-    resolution: {integrity: sha512-6umCCHcjQrhP5oXhrHQQvLB0bwb1UzHAHdsXy+FjtKoYjUhmNZsQL8NivwM1vDvNEChJabVrUYxUnp/ZdYmy2g==}
-    engines: {node: '>=20.0.0'}
-
   has-ansi@3.0.0:
     resolution: {integrity: sha512-5JRDTvNq6mVkaMHQVXrGnaCXHD6JfqxwCy8LA/DQSqLLqePR9uaJVm2u3Ek/UziJFQz+d1ul99RtfIhE2aorkQ==}
     engines: {node: '>=4'}
@@ -6738,7 +6725,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.13.0:
@@ -7705,9 +7691,6 @@ packages:
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -8009,10 +7992,6 @@ packages:
 
   whatwg-mimetype@2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
-
-  whatwg-mimetype@3.0.0:
-    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
-    engines: {node: '>=12'}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -10467,7 +10446,7 @@ snapshots:
 
   '@types/chai-as-promised@7.1.8':
     dependencies:
-      '@types/chai': 4.3.20
+      '@types/chai': 5.2.3
 
   '@types/chai@4.3.20': {}
 
@@ -10664,10 +10643,6 @@ snapshots:
 
   '@types/minimatch@3.0.5': {}
 
-  '@types/node@20.19.23':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@24.9.2':
     dependencies:
       undici-types: 7.16.0
@@ -10712,8 +10687,6 @@ snapshots:
     optional: true
 
   '@types/uuid@8.3.4': {}
-
-  '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -14528,12 +14501,6 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
-  happy-dom@20.0.10:
-    dependencies:
-      '@types/node': 20.19.23
-      '@types/whatwg-mimetype': 3.0.2
-      whatwg-mimetype: 3.0.0
-
   has-ansi@3.0.0:
     dependencies:
       ansi-regex: 3.0.1
@@ -17588,8 +17555,6 @@ snapshots:
 
   underscore@1.13.7: {}
 
-  undici-types@6.21.0: {}
-
   undici-types@7.16.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -17702,7 +17667,7 @@ snapshots:
       terser: 5.44.0
       yaml: 2.8.1
 
-  vitest@4.0.4(@types/node@24.9.2)(happy-dom@20.0.10)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.11.6(@types/node@24.9.2)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1):
+  vitest@4.0.4(@types/node@24.9.2)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.11.6(@types/node@24.9.2)(typescript@5.9.3))(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.4
       '@vitest/mocker': 4.0.4(msw@2.11.6(@types/node@24.9.2)(typescript@5.9.3))(vite@7.1.12(@types/node@24.9.2)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))
@@ -17726,7 +17691,6 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.9.2
-      happy-dom: 20.0.10
       jsdom: 25.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - jiti
@@ -17880,8 +17844,6 @@ snapshots:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@2.3.0: {}
-
-  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
 


### PR DESCRIPTION
This replaces the `happy-dom` environment with a minimal polyfill that provides only what MSW needs to resolve relative URLs: `location.href`.

This eliminates an unnecessary ~1MB dependency while maintaining full test compatibility. All 236 tests continue to pass.