### PR TITLE
Add version link to publish notification emails

### DIFF
--- a/src/email/templates/publish_notification/body.txt.j2
+++ b/src/email/templates/publish_notification/body.txt.j2
@@ -3,7 +3,9 @@
 {% block content %}
 Hello {{ recipient }}!
 
-A new version of the package {{ krate }} ({{ version }}) was published{{ publisher_info }} at {{ publish_time }}.
+A new version of {{ krate }} crate was published{{ publisher_info }} at {{ publish_time }}.
+
+View v{{ version }} here: https://{{ domain }}/crates/{{ krate }}/{{ version }}
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 {% endblock %}

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate-5.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate-5.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo_new (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo_new crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo_new/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub__full_flow-11.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub__full_flow-11.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 
@@ -49,7 +51,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.1.0) was published by GitHub Actions (https://github.com/rust-lang/foo-rs/actions/runs/example-run-id) at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by GitHub Actions (https://github.com/rust-lang/foo-rs/actions/runs/example-run-id) at [0000-00-00T00:00:00Z].
+
+View v1.1.0 here: https://crates.io/crates/foo/1.1.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_new_crate-3.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_new_crate-3.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_old_crate-3.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_old_crate-3.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_really_old_crate-3.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_really_old_crate-3.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-11.snap
+++ b/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-11.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 
@@ -45,7 +47,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.2.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.2.0 here: https://crates.io/crates/foo/1.2.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-2.snap
+++ b/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-2.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-5.snap
+++ b/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-5.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-7.snap
+++ b/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-7.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/snapshots/integration__owners__new_crate_owner-2.snap
+++ b/src/tests/snapshots/integration__owners__new_crate_owner-2.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo_owner (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo_owner crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo_owner/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 
@@ -45,7 +47,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo_owner (2.0.0) was published by Bar (https://crates.io/users/Bar) at [0000-00-00T00:00:00Z].
+A new version of foo_owner crate was published by Bar (https://crates.io/users/Bar) at [0000-00-00T00:00:00Z].
+
+View v2.0.0 here: https://crates.io/crates/foo_owner/2.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 
@@ -62,7 +66,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello Bar!
 
-A new version of the package foo_owner (2.0.0) was published by your account (https://crates.io/users/Bar) at [0000-00-00T00:00:00Z].
+A new version of foo_owner crate was published by your account (https://crates.io/users/Bar) at [0000-00-00T00:00:00Z].
+
+View v2.0.0 here: https://crates.io/crates/foo_owner/2.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/snapshots/integration__owners__new_crate_owner.snap
+++ b/src/tests/snapshots/integration__owners__new_crate_owner.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo_owner (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of foo_owner crate was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+View v1.0.0 here: https://crates.io/crates/foo_owner/1.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/tests/snapshots/integration__team__publish_owned.snap
+++ b/src/tests/snapshots/integration__team__publish_owned.snap
@@ -11,7 +11,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello user-all-teams!
 
-A new version of the package foo_team_owned (2.0.0) was published by user-one-team (https://crates.io/users/user-one-team) at [0000-00-00T00:00:00Z].
+A new version of foo_team_owned crate was published by user-one-team (https://crates.io/users/user-one-team) at [0000-00-00T00:00:00Z].
+
+View v2.0.0 here: https://crates.io/crates/foo_team_owned/2.0.0
 
 If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 

--- a/src/worker/jobs/send_publish_notifications.rs
+++ b/src/worker/jobs/send_publish_notifications.rs
@@ -107,7 +107,8 @@ impl BackgroundJob for SendPublishNotificationsJob {
                     krate => krate,
                     version => version,
                     publish_time => publish_time,
-                    publisher_info => publisher_info
+                    publisher_info => publisher_info,
+                    domain => ctx.config.domain_name
                 },
             );
 


### PR DESCRIPTION
Include a direct link to the newly published version in publish notification emails sent to crate owners.

The email body now displays the version link on a separate line for better visibility:

> View v1.0.0 here: https://crates.io/crates/foo/1.0.0