### PR TITLE
Add authorization logging across requests 

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -288,13 +288,19 @@ async fn authenticate(parts: &Parts, conn: &mut AsyncPgConnection) -> AppResult<
 
     match authenticate_via_cookie(parts, conn).await {
         Ok(None) => {}
-        Ok(Some(auth)) => return Ok(Authentication::Cookie(auth)),
+        Ok(Some(auth)) => {
+            parts.request_log().add("auth_type", "cookie");
+            return Ok(Authentication::Cookie(auth));
+        }
         Err(err) => return Err(err),
     }
 
     match authenticate_via_token(parts, conn).await {
         Ok(None) => {}
-        Ok(Some(auth)) => return Ok(Authentication::Token(auth)),
+        Ok(Some(auth)) => {
+            parts.request_log().add("auth_type", "token");
+            return Ok(Authentication::Token(auth));
+        }
         Err(err) => return Err(err),
     }
 

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -172,6 +172,8 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
         .transpose()?;
 
     let auth = if let Some(trustpub_token) = trustpub_token {
+        request_log.add("auth_type", "trustpub");
+
         let Some(existing_crate) = &existing_crate else {
             let error = forbidden(
                 "Trusted Publishing tokens do not support creating new crates. Publish the crate manually, first",


### PR DESCRIPTION
This adds: 
- Masked (SHA256 hashed) logging of Authorization header
- Masked (SHA256 hashed) logging of Cookie header
- new custom_metadata.auth_type log entry for the authorization type, being: trustpub, cookie, token

Using a masked version of the authorization or cookie headers across the logs, we can specifically look for cases of tokens used across requests. This can let us detect cases such as: someone attempting tokens/cookies across multiple users, a token used across various crates, or cookie theft across users. 

This came up when responding to the recent phishing incidents, where I wanted to quickly investigate, via logs, actions conducted across users and crates with specific tokens, or correlate past vs. future actions of a given user matching on token/cookie and not specifically just IP/user.