### PR TITLE
CI: Run Android SDK removal in the background to speed up the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,8 @@ jobs:
         with:
           persist-credentials: false
 
-      # Remove the Android SDK to free up space
-      - run: sudo rm -rf /usr/local/lib/android
+      # Remove the Android SDK in the background to free up space
+      - run: sudo rm -rf /usr/local/lib/android &
 
       - name: Install Typst
         run: |


### PR DESCRIPTION
We were spending up to 30% of our CI time just on clearing up disk space for the compilation of our own code. It would be best if GitHub offered a bit more free disk space on their runners, but unfortunately they only guarantee 14 GB.

This PR changes the step that deletes the Android SDK (~10GB) to run in the background. AFAICT this does not seem to significantly affect the performance of the other steps in the workflow, but it does mean that we no longer spend 3-4 minutes just deleting files before we actually start to work on something useful (download crates, compiling crates, testing our code).