### PR TITLE
Fix Sentry child span capture by binding Hub correctly

### DIFF
--- a/crates/crates_io_worker/src/util.rs
+++ b/crates/crates_io_worker/src/util.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use sentry_core::Hub;
+use sentry_core::{Hub, SentryFutureExt};
 use std::any::Any;
 use std::future::Future;
 use std::panic::PanicHookInfo;
@@ -20,7 +20,7 @@ where
 
     hub.configure_scope(|scope| scope.set_span(Some(tx.clone().into())));
 
-    let result = callback().await;
+    let result = callback().bind_hub(hub).await;
 
     tx.set_status(match result.is_ok() {
         true => sentry_core::protocol::SpanStatus::Ok,

--- a/crates/crates_io_worker/src/worker.rs
+++ b/crates/crates_io_worker/src/worker.rs
@@ -7,7 +7,6 @@ use diesel_async::pooled_connection::deadpool::Pool;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::{AsyncConnection, AsyncPgConnection};
 use futures_util::FutureExt;
-use sentry_core::{Hub, SentryFutureExt};
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Duration;
@@ -87,10 +86,7 @@ impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
                         .and_then(std::convert::identity)
                 });
 
-                let result = future
-                    .instrument(span.clone())
-                    .bind_hub(Hub::current())
-                    .await;
+                let result = future.instrument(span.clone()).await;
 
                 let _enter = span.enter();
                 match result {


### PR DESCRIPTION
The root cause was that `with_sentry_transaction()` created a new Hub with the transaction context, but then in `worker.rs` the code called `.bind_hub(Hub::current())` which bound the future to the original Hub instead of the new one. This meant all child tracing spans were attached to the wrong Hub that lacked the transaction context, so Sentry never saw them as children of the transaction.

The fix moves the `.bind_hub(hub)` call inside `with_sentry_transaction()` so the callback future executes with the correct Hub that has the transaction, ensuring all child spans are properly associated with the parent transaction.

---

Disclaimer: Claude Code figured this out. At first it looked in entirely the wrong places, but once I nudged it into looking at the right areas it found the issue. I didn't trust it, so I tested it out on staging and it indeed seems to solve the problem

### Before

<img width="885" height="146" alt="Bildschirmfoto 2025-11-06 um 12 50 50" src="https://github.com/user-attachments/assets/66c2b6e9-56a2-451c-9fe7-cd5a457a3f85" />

### After

<img width="887" height="372" alt="Bildschirmfoto 2025-11-06 um 12 50 40" src="https://github.com/user-attachments/assets/000ce4d3-d315-4001-a9b9-838247775dff" />
