### PR TITLE
Add GitLab CI/CD support to publish notifications

### DIFF
--- a/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_gitlab__full_flow-11.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_gitlab__full_flow-11.snap
@@ -51,7 +51,7 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of foo crate was published at [0000-00-00T00:00:00Z].
+A new version of foo crate was published by GitLab CI/CD (https://gitlab.com/rust-lang/foo-rs/-/jobs/11530106120) at [0000-00-00T00:00:00Z].
 
 View v1.1.0 here: https://crates.io/crates/foo/1.1.0
 

--- a/src/worker/jobs/send_publish_notifications.rs
+++ b/src/worker/jobs/send_publish_notifications.rs
@@ -97,6 +97,16 @@ impl BackgroundJob for SendPublishNotificationsJob {
                 ) => &format!(
                     " by GitHub Actions (https://github.com/{repository}/actions/runs/{run_id})",
                 ),
+                (
+                    _,
+                    Some(TrustpubData::GitLab {
+                        project_path,
+                        job_id,
+                        ..
+                    }),
+                ) => {
+                    &format!(" by GitLab CI/CD (https://gitlab.com/{project_path}/-/jobs/{job_id})")
+                }
                 _ => "",
             };
 


### PR DESCRIPTION
Show "by GitLab CI/CD" with job URL when package is published via GitLab trusted publishing

### Related

- https://github.com/rust-lang/crates.io/issues/11987