### PR TITLE
trustpub/msw: Implement GitLab trusted publishing endpoints

### DIFF
--- a/packages/crates-io-msw/handlers/trustpub.js
+++ b/packages/crates-io-msw/handlers/trustpub.js
@@ -1,3 +1,4 @@
 import gitHubConfigs from './trustpub/github-configs.js';
+import gitLabConfigs from './trustpub/gitlab-configs.js';
 
-export default [...gitHubConfigs];
+export default [...gitHubConfigs, ...gitLabConfigs];

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs.js
@@ -1,0 +1,5 @@
+import createGitLabConfig from './gitlab-configs/create.js';
+import deleteGitLabConfig from './gitlab-configs/delete.js';
+import listGitLabConfigs from './gitlab-configs/list.js';
+
+export default [listGitLabConfigs, createGitLabConfig, deleteGitLabConfig];

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/create.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/create.js
@@ -1,0 +1,61 @@
+import { http, HttpResponse } from 'msw';
+
+import { db } from '../../../index.js';
+import { serializeGitLabConfig } from '../../../serializers/trustpub/gitlab-config.js';
+import { notFound } from '../../../utils/handlers.js';
+import { getSession } from '../../../utils/session.js';
+
+export default http.post('/api/v1/trusted_publishing/gitlab_configs', async ({ request }) => {
+  let { user } = getSession();
+  if (!user) {
+    return HttpResponse.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
+  }
+
+  let body = await request.json();
+
+  let { gitlab_config } = body;
+  if (!gitlab_config) {
+    return HttpResponse.json({ errors: [{ detail: 'invalid request body' }] }, { status: 400 });
+  }
+
+  let { crate: crateName, namespace, project, workflow_filepath, environment } = gitlab_config;
+  if (!crateName || !namespace || !project || !workflow_filepath) {
+    return HttpResponse.json({ errors: [{ detail: 'missing required fields' }] }, { status: 400 });
+  }
+
+  let crate = db.crate.findFirst({ where: { name: { equals: crateName } } });
+  if (!crate) return notFound();
+
+  // Check if the user is an owner of the crate
+  let isOwner = db.crateOwnership.findFirst({
+    where: {
+      crate: { id: { equals: crate.id } },
+      user: { id: { equals: user.id } },
+    },
+  });
+  if (!isOwner) {
+    return HttpResponse.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
+  }
+
+  // Check if the user has a verified email
+  let hasVerifiedEmail = user.emailVerified;
+  if (!hasVerifiedEmail) {
+    let detail = 'You must verify your email address to create a Trusted Publishing config';
+    return HttpResponse.json({ errors: [{ detail }] }, { status: 403 });
+  }
+
+  // Create a new GitLab config
+  let config = db.trustpubGitlabConfig.create({
+    crate,
+    namespace,
+    namespace_id: null,
+    project,
+    workflow_filepath,
+    environment: environment ?? null,
+    created_at: new Date().toISOString(),
+  });
+
+  return HttpResponse.json({
+    gitlab_config: serializeGitLabConfig(config),
+  });
+});

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/delete.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/delete.js
@@ -1,0 +1,32 @@
+import { http, HttpResponse } from 'msw';
+
+import { db } from '../../../index.js';
+import { notFound } from '../../../utils/handlers.js';
+import { getSession } from '../../../utils/session.js';
+
+export default http.delete('/api/v1/trusted_publishing/gitlab_configs/:id', ({ params }) => {
+  let { user } = getSession();
+  if (!user) {
+    return HttpResponse.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
+  }
+
+  let id = parseInt(params.id);
+  let config = db.trustpubGitlabConfig.findFirst({ where: { id: { equals: id } } });
+  if (!config) return notFound();
+
+  // Check if the user is an owner of the crate
+  let isOwner = db.crateOwnership.findFirst({
+    where: {
+      crate: { id: { equals: config.crate.id } },
+      user: { id: { equals: user.id } },
+    },
+  });
+  if (!isOwner) {
+    return HttpResponse.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
+  }
+
+  // Delete the config
+  db.trustpubGitlabConfig.delete({ where: { id: { equals: id } } });
+
+  return new HttpResponse(null, { status: 204 });
+});

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/delete.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/delete.test.js
@@ -1,0 +1,109 @@
+import { assert, test } from 'vitest';
+
+import { db } from '../../../index.js';
+
+test('happy path', async function () {
+  let crate = db.crate.create({ name: 'test-crate' });
+  db.version.create({ crate });
+
+  let user = db.user.create({ email_verified: true });
+  db.mswSession.create({ user });
+
+  // Create crate ownership
+  db.crateOwnership.create({
+    crate,
+    user,
+  });
+
+  // Create GitLab config
+  let config = db.trustpubGitlabConfig.create({
+    crate,
+    namespace: 'rust-lang',
+    project: 'crates.io',
+    workflow_filepath: '.gitlab-ci.yml',
+    created_at: '2023-01-01T00:00:00Z',
+  });
+
+  let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs/${config.id}`, {
+    method: 'DELETE',
+  });
+
+  assert.strictEqual(response.status, 204);
+  assert.strictEqual(await response.text(), '');
+
+  // Verify the config was deleted
+  let deletedConfig = db.trustpubGitlabConfig.findFirst({ where: { id: { equals: config.id } } });
+  assert.strictEqual(deletedConfig, null);
+});
+
+test('returns 403 if unauthenticated', async function () {
+  let response = await fetch('/api/v1/trusted_publishing/gitlab_configs/1', {
+    method: 'DELETE',
+  });
+
+  assert.strictEqual(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'must be logged in to perform that action' }],
+  });
+});
+
+test('returns 404 if config ID is invalid', async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/trusted_publishing/gitlab_configs/invalid', {
+    method: 'DELETE',
+  });
+
+  assert.strictEqual(response.status, 404);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'Not Found' }],
+  });
+});
+
+test("returns 404 if config can't be found", async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/trusted_publishing/gitlab_configs/999999', {
+    method: 'DELETE',
+  });
+
+  assert.strictEqual(response.status, 404);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'Not Found' }],
+  });
+});
+
+test('returns 400 if user is not an owner of the crate', async function () {
+  let crate = db.crate.create({ name: 'test-crate-not-owner' });
+  db.version.create({ crate });
+
+  let owner = db.user.create();
+  db.crateOwnership.create({
+    crate,
+    user: owner,
+  });
+
+  // Create GitLab config
+  let config = db.trustpubGitlabConfig.create({
+    crate,
+    namespace: 'rust-lang',
+    project: 'crates.io',
+    workflow_filepath: '.gitlab-ci.yml',
+    created_at: '2023-01-01T00:00:00Z',
+  });
+
+  // Login as a different user
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs/${config.id}`, {
+    method: 'DELETE',
+  });
+
+  assert.strictEqual(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'You are not an owner of this crate' }],
+  });
+});

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.js
@@ -1,0 +1,42 @@
+import { http, HttpResponse } from 'msw';
+
+import { db } from '../../../index.js';
+import { serializeGitLabConfig } from '../../../serializers/trustpub/gitlab-config.js';
+import { notFound } from '../../../utils/handlers.js';
+import { getSession } from '../../../utils/session.js';
+
+export default http.get('/api/v1/trusted_publishing/gitlab_configs', ({ request }) => {
+  let url = new URL(request.url);
+
+  let { user } = getSession();
+  if (!user) {
+    return HttpResponse.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
+  }
+
+  let crateName = url.searchParams.get('crate');
+  if (!crateName) {
+    return HttpResponse.json({ errors: [{ detail: 'missing or invalid filter' }] }, { status: 400 });
+  }
+
+  let crate = db.crate.findFirst({ where: { name: { equals: crateName } } });
+  if (!crate) return notFound();
+
+  // Check if the user is an owner of the crate
+  let isOwner = db.crateOwnership.findFirst({
+    where: {
+      crate: { id: { equals: crate.id } },
+      user: { id: { equals: user.id } },
+    },
+  });
+  if (!isOwner) {
+    return HttpResponse.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
+  }
+
+  let configs = db.trustpubGitlabConfig.findMany({
+    where: { crate: { id: { equals: crate.id } } },
+  });
+
+  return HttpResponse.json({
+    gitlab_configs: configs.map(config => serializeGitLabConfig(config)),
+  });
+});

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.test.js
@@ -1,0 +1,128 @@
+import { assert, test } from 'vitest';
+
+import { db } from '../../../index.js';
+
+test('happy path', async function () {
+  let crate = db.crate.create({ name: 'test-crate' });
+  db.version.create({ crate });
+
+  let user = db.user.create({ email_verified: true });
+  db.mswSession.create({ user });
+
+  // Create crate ownership
+  db.crateOwnership.create({
+    crate,
+    user,
+  });
+
+  // Create GitLab configs
+  let config1 = db.trustpubGitlabConfig.create({
+    crate,
+    namespace: 'rust-lang',
+    namespace_id: null,
+    project: 'crates.io',
+    workflow_filepath: '.gitlab-ci.yml',
+    created_at: '2023-01-01T00:00:00Z',
+  });
+
+  let config2 = db.trustpubGitlabConfig.create({
+    crate,
+    namespace: 'rust-lang',
+    namespace_id: '12345',
+    project: 'cargo',
+    workflow_filepath: '.gitlab/ci.yml',
+    environment: 'production',
+    created_at: '2023-02-01T00:00:00Z',
+  });
+
+  let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=${crate.name}`);
+  assert.strictEqual(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    gitlab_configs: [
+      {
+        id: Number(config1.id),
+        crate: crate.name,
+        namespace: 'rust-lang',
+        namespace_id: null,
+        project: 'crates.io',
+        workflow_filepath: '.gitlab-ci.yml',
+        environment: null,
+        created_at: '2023-01-01T00:00:00Z',
+      },
+      {
+        id: Number(config2.id),
+        crate: crate.name,
+        namespace: 'rust-lang',
+        namespace_id: '12345',
+        project: 'cargo',
+        workflow_filepath: '.gitlab/ci.yml',
+        environment: 'production',
+        created_at: '2023-02-01T00:00:00Z',
+      },
+    ],
+  });
+});
+
+test('happy path with no configs', async function () {
+  let crate = db.crate.create({ name: 'test-crate-empty' });
+  db.version.create({ crate });
+
+  let user = db.user.create({ email_verified: true });
+  db.mswSession.create({ user });
+
+  // Create crate ownership
+  db.crateOwnership.create({
+    crate,
+    user,
+  });
+
+  let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=${crate.name}`);
+  assert.strictEqual(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    gitlab_configs: [],
+  });
+});
+
+test('returns 403 if unauthenticated', async function () {
+  let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=test-crate`);
+  assert.strictEqual(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'must be logged in to perform that action' }],
+  });
+});
+
+test('returns 400 if query params are missing', async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs`);
+  assert.strictEqual(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'missing or invalid filter' }],
+  });
+});
+
+test("returns 404 if crate can't be found", async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=nonexistent`);
+  assert.strictEqual(response.status, 404);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'Not Found' }],
+  });
+});
+
+test('returns 400 if user is not an owner of the crate', async function () {
+  let crate = db.crate.create({ name: 'test-crate-not-owner' });
+  db.version.create({ crate });
+
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=${crate.name}`);
+  assert.strictEqual(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'You are not an owner of this crate' }],
+  });
+});

--- a/packages/crates-io-msw/index.js
+++ b/packages/crates-io-msw/index.js
@@ -23,6 +23,7 @@ import keyword from './models/keyword.js';
 import mswSession from './models/msw-session.js';
 import team from './models/team.js';
 import trustpubGithubConfig from './models/trustpub/github-config.js';
+import trustpubGitlabConfig from './models/trustpub/gitlab-config.js';
 import user from './models/user.js';
 import versionDownload from './models/version-download.js';
 import version from './models/version.js';
@@ -57,6 +58,7 @@ export const db = factory({
   mswSession,
   team,
   trustpubGithubConfig,
+  trustpubGitlabConfig,
   user,
   versionDownload,
   version,

--- a/packages/crates-io-msw/models/trustpub/gitlab-config.js
+++ b/packages/crates-io-msw/models/trustpub/gitlab-config.js
@@ -1,0 +1,25 @@
+import { nullable, oneOf, primaryKey } from '@mswjs/data';
+
+import { applyDefault } from '../../utils/defaults.js';
+
+export default {
+  id: primaryKey(Number),
+
+  crate: oneOf('crate'),
+  namespace: String,
+  namespace_id: nullable(String),
+  project: String,
+  workflow_filepath: String,
+  environment: nullable(String),
+  created_at: String,
+
+  preCreate(attrs, counter) {
+    applyDefault(attrs, 'id', () => counter);
+    applyDefault(attrs, 'namespace', () => 'rust-lang');
+    applyDefault(attrs, 'namespace_id', () => null);
+    applyDefault(attrs, 'project', () => `repo-${attrs.id}`);
+    applyDefault(attrs, 'workflow_filepath', () => '.gitlab-ci.yml');
+    applyDefault(attrs, 'environment', () => null);
+    applyDefault(attrs, 'created_at', () => '2023-01-01T00:00:00Z');
+  },
+};

--- a/packages/crates-io-msw/models/trustpub/gitlab-config.test.js
+++ b/packages/crates-io-msw/models/trustpub/gitlab-config.test.js
@@ -1,0 +1,82 @@
+import { test } from 'vitest';
+
+import { db } from '../../index.js';
+
+test('defaults are applied', ({ expect }) => {
+  let crate = db.crate.create();
+  let config = db.trustpubGitlabConfig.create({ crate });
+  expect(config).toMatchInlineSnapshot(`
+    {
+      "crate": {
+        "_extra_downloads": [],
+        "badges": [],
+        "categories": [],
+        "created_at": "2010-06-16T21:30:45Z",
+        "description": "This is the description for the crate called "crate-1"",
+        "documentation": null,
+        "downloads": 37035,
+        "homepage": null,
+        "id": 1,
+        "keywords": [],
+        "name": "crate-1",
+        "recent_downloads": 321,
+        "repository": null,
+        "updated_at": "2017-02-24T12:34:56Z",
+        Symbol(type): "crate",
+        Symbol(primaryKey): "id",
+      },
+      "created_at": "2023-01-01T00:00:00Z",
+      "environment": null,
+      "id": 1,
+      "namespace": "rust-lang",
+      "namespace_id": null,
+      "project": "repo-1",
+      "workflow_filepath": ".gitlab-ci.yml",
+      Symbol(type): "trustpubGitlabConfig",
+      Symbol(primaryKey): "id",
+    }
+  `);
+});
+
+test('fields can be set', ({ expect }) => {
+  let crate = db.crate.create({ name: 'serde' });
+  let config = db.trustpubGitlabConfig.create({
+    crate,
+    namespace: 'serde-rs',
+    namespace_id: '12345',
+    project: 'serde',
+    workflow_filepath: '.gitlab/ci.yml',
+    environment: 'production',
+  });
+  expect(config).toMatchInlineSnapshot(`
+    {
+      "crate": {
+        "_extra_downloads": [],
+        "badges": [],
+        "categories": [],
+        "created_at": "2010-06-16T21:30:45Z",
+        "description": "This is the description for the crate called "serde"",
+        "documentation": null,
+        "downloads": 37035,
+        "homepage": null,
+        "id": 1,
+        "keywords": [],
+        "name": "serde",
+        "recent_downloads": 321,
+        "repository": null,
+        "updated_at": "2017-02-24T12:34:56Z",
+        Symbol(type): "crate",
+        Symbol(primaryKey): "id",
+      },
+      "created_at": "2023-01-01T00:00:00Z",
+      "environment": "production",
+      "id": 1,
+      "namespace": "serde-rs",
+      "namespace_id": "12345",
+      "project": "serde",
+      "workflow_filepath": ".gitlab/ci.yml",
+      Symbol(type): "trustpubGitlabConfig",
+      Symbol(primaryKey): "id",
+    }
+  `);
+});

--- a/packages/crates-io-msw/serializers/trustpub/gitlab-config.js
+++ b/packages/crates-io-msw/serializers/trustpub/gitlab-config.js
@@ -1,0 +1,10 @@
+import { serializeModel } from '../../utils/serializers.js';
+
+export function serializeGitLabConfig(config) {
+  let serialized = serializeModel(config);
+
+  // Extract crate name from the crate relationship
+  serialized.crate = serialized.crate.name;
+
+  return serialized;
+}


### PR DESCRIPTION
This adds MSW handlers, models, and tests for GitLab trusted publishing configuration endpoints, mirroring the existing GitHub implementation.

### Related

- https://github.com/rust-lang/crates.io/issues/11987