### PR TITLE
Add `pubtime` field to index entries with environment variable toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,6 +1651,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "chrono",
  "claims",
  "crates_io_env_vars",
  "git2",

--- a/crates/crates_io_index/Cargo.toml
+++ b/crates/crates_io_index/Cargo.toml
@@ -18,6 +18,7 @@ testing = []
 [dependencies]
 anyhow = "=1.0.100"
 base64 = "=0.22.1"
+chrono = "=0.4.42"
 crates_io_env_vars = { path = "../crates_io_env_vars" }
 git2 = "=0.20.2"
 secrecy = "=0.10.3"

--- a/crates/crates_io_index/data.rs
+++ b/crates/crates_io_index/data.rs
@@ -1,4 +1,5 @@
 use crate::features::FeaturesMap;
+use chrono::{DateTime, Utc};
 use std::cmp::Ordering;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -24,6 +25,9 @@ pub struct Crate {
     pub links: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rust_version: Option<String>,
+    /// Publication timestamp in ISO8601 format
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pubtime: Option<DateTime<Utc>>,
     /// The schema version for this entry.
     ///
     /// If this is None, it defaults to version 1. Entries with unknown

--- a/crates/crates_io_index/ser.rs
+++ b/crates/crates_io_index/ser.rs
@@ -31,6 +31,7 @@ mod tests {
             yanked: None,
             links: None,
             rust_version: None,
+            pubtime: None,
             v: None,
         };
         let mut buffer = Vec::new();
@@ -58,6 +59,7 @@ mod tests {
                 yanked: None,
                 links: None,
                 rust_version: None,
+                pubtime: None,
                 v: None,
             })
             .collect::<Vec<_>>();

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -96,6 +96,9 @@ pub struct Server {
 
     /// Banner message to display on all pages (e.g., for security incidents).
     pub banner_message: Option<String>,
+
+    /// Include publication timestamp in index entries (ISO8601 format).
+    pub index_include_pubtime: bool,
 }
 
 impl Server {
@@ -193,6 +196,7 @@ impl Server {
         let trustpub_audience = var("TRUSTPUB_AUDIENCE")?.unwrap_or_else(|| domain_name.clone());
         let disable_token_creation = var("DISABLE_TOKEN_CREATION")?.filter(|s| !s.is_empty());
         let banner_message = var("BANNER_MESSAGE")?.filter(|s| !s.is_empty());
+        let index_include_pubtime = var_parsed("INDEX_INCLUDE_PUBTIME")?.unwrap_or(false);
 
         Ok(Server {
             db: DatabasePools::full_from_environment(&base)?,
@@ -243,6 +247,7 @@ impl Server {
             trustpub_audience,
             disable_token_creation,
             banner_message,
+            index_include_pubtime,
         })
     }
 }

--- a/src/snapshots/crates_io__index__tests__index_metadata_with_pubtime.snap
+++ b/src/snapshots/crates_io__index__tests__index_metadata_with_pubtime.snap
@@ -1,0 +1,24 @@
+---
+source: src/index.rs
+expression: metadata
+---
+[
+  {
+    "name": "bar",
+    "vers": "1.0.0",
+    "deps": [],
+    "cksum": "                                                                ",
+    "features": {},
+    "yanked": false,
+    "pubtime": "2020-01-01T00:00:00Z"
+  },
+  {
+    "name": "bar",
+    "vers": "2.0.0",
+    "deps": [],
+    "cksum": "                                                                ",
+    "features": {},
+    "yanked": false,
+    "pubtime": "2020-02-01T00:00:00Z"
+  }
+]

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -523,6 +523,7 @@ fn simple_config() -> config::Server {
         trustpub_audience: AUDIENCE.to_string(),
         disable_token_creation: None,
         banner_message: None,
+        index_include_pubtime: false,
     }
 }
 

--- a/src/worker/jobs/index/sync.rs
+++ b/src/worker/jobs/index/sync.rs
@@ -42,7 +42,7 @@ impl BackgroundJob for SyncToGitIndex {
         let crate_name = self.krate.clone();
         let mut conn = env.deadpool.get().await?;
 
-        let new = get_index_data(&crate_name, &mut conn)
+        let new = get_index_data(&crate_name, &mut conn, env.config.index_include_pubtime)
             .await
             .context("Failed to get index data")?;
 
@@ -114,7 +114,7 @@ impl BackgroundJob for SyncToSparseIndex {
         let crate_name = self.krate.clone();
         let mut conn = env.deadpool.get().await?;
 
-        let content = get_index_data(&crate_name, &mut conn)
+        let content = get_index_data(&crate_name, &mut conn, env.config.index_include_pubtime)
             .await
             .context("Failed to get index data")?;
 


### PR DESCRIPTION
This adds support for including publication timestamps in index entries, controlled by the `INDEX_INCLUDE_PUBTIME` environment variable.

The field uses `skip_serializing_if` for backward compatibility - when disabled or `None`, the field is omitted from JSON output.

Usage:

```bash
INDEX_INCLUDE_PUBTIME=true  # Enable timestamps
INDEX_INCLUDE_PUBTIME=false # Disable (default)
```

### Related

- https://github.com/rust-lang/cargo/issues/15491