### PR TITLE
trustpub: Fix `verificationUrl` to only return GitHub URLs when GitHub publisher is used

### DIFF
--- a/app/controllers/crate/settings/new-trusted-publisher.js
+++ b/app/controllers/crate/settings/new-trusted-publisher.js
@@ -35,7 +35,7 @@ export default class NewTrustedPublisherController extends Controller {
   }
 
   get verificationUrl() {
-    if (this.namespace && this.project && this.workflow) {
+    if (this.publisher === 'GitHub' && this.namespace && this.project && this.workflow) {
       return `https://raw.githubusercontent.com/${this.namespace}/${this.project}/HEAD/.github/workflows/${this.workflow}`;
     }
   }


### PR DESCRIPTION
The previous code worked fine because we were only supporting GitHub for now, but this will soon change, so we should fix this condition.

### Related

- https://github.com/rust-lang/crates.io/issues/11987