### PR TITLE
trustpub: Reset `publisher` field to `GitHub` on setting page visit

### DIFF
--- a/app/routes/crate/settings/new-trusted-publisher.js
+++ b/app/routes/crate/settings/new-trusted-publisher.js
@@ -9,6 +9,7 @@ export default class NewTrustedPublisherRoute extends Route {
   setupController(controller, model) {
     super.setupController(controller, model);
 
+    controller.publisher = 'GitHub';
     controller.namespace = '';
     controller.project = '';
     controller.workflow = '';


### PR DESCRIPTION
Just like we reset the field values, we should also reset the publisher that is shown by default when the user visits the page.