### PR TITLE
trustpub: Extract URL parsing logic into fns

### DIFF
--- a/app/routes/crate/settings/new-trusted-publisher.js
+++ b/app/routes/crate/settings/new-trusted-publisher.js
@@ -16,38 +16,65 @@ export default class NewTrustedPublisherRoute extends Route {
     controller.environment = '';
 
     let repository = model.crate.repository;
-    if (repository && repository.startsWith('https://github.com/')) {
-      try {
-        let url = new URL(repository);
-        let pathParts = url.pathname.slice(1).split('/');
-        if (pathParts.length >= 2) {
-          controller.namespace = pathParts[0];
-          controller.project = pathParts[1].replace(/.git$/, '');
-        }
-      } catch {
-        // ignore malformed URLs
-      }
-    } else if (repository && repository.startsWith('https://gitlab.com/')) {
-      controller.publisher = 'GitLab';
-      try {
-        let url = new URL(repository);
-        let pathParts = url.pathname.slice(1).split('/');
+    if (!repository) return;
 
-        // Find the repository path end (indicated by /-/ for trees/blobs/etc)
-        let repoEndIndex = pathParts.indexOf('-');
-        if (repoEndIndex !== -1) {
-          pathParts = pathParts.slice(0, repoEndIndex);
-        }
-
-        if (pathParts.length >= 2) {
-          // For GitLab, support nested groups: https://gitlab.com/a/b/c
-          // namespace = "a/b", project = "c"
-          controller.namespace = pathParts.slice(0, -1).join('/');
-          controller.project = pathParts.at(-1).replace(/.git$/, '');
-        }
-      } catch {
-        // ignore malformed URLs
-      }
+    let prefillData = parseRepositoryUrl(repository);
+    if (prefillData) {
+      controller.publisher = prefillData.publisher;
+      controller.namespace = prefillData.namespace;
+      controller.project = prefillData.project;
     }
   }
+}
+
+function parseRepositoryUrl(repository) {
+  if (repository.startsWith('https://github.com/')) {
+    return parseGitHubUrl(repository);
+  } else if (repository.startsWith('https://gitlab.com/')) {
+    return parseGitLabUrl(repository);
+  }
+  return null;
+}
+
+function parseGitHubUrl(repository) {
+  try {
+    let url = new URL(repository);
+    let pathParts = url.pathname.slice(1).split('/');
+    if (pathParts.length >= 2) {
+      return {
+        publisher: 'GitHub',
+        namespace: pathParts[0],
+        project: pathParts[1].replace(/.git$/, ''),
+      };
+    }
+  } catch {
+    // ignore malformed URLs
+  }
+  return null;
+}
+
+function parseGitLabUrl(repository) {
+  try {
+    let url = new URL(repository);
+    let pathParts = url.pathname.slice(1).split('/');
+
+    // Find the repository path end (indicated by /-/ for trees/blobs/etc)
+    let repoEndIndex = pathParts.indexOf('-');
+    if (repoEndIndex !== -1) {
+      pathParts = pathParts.slice(0, repoEndIndex);
+    }
+
+    if (pathParts.length >= 2) {
+      // For GitLab, support nested groups: https://gitlab.com/a/b/c
+      // namespace = "a/b", project = "c"
+      return {
+        publisher: 'GitLab',
+        namespace: pathParts.slice(0, -1).join('/'),
+        project: pathParts.at(-1).replace(/.git$/, ''),
+      };
+    }
+  } catch {
+    // ignore malformed URLs
+  }
+  return null;
 }


### PR DESCRIPTION
Refactor repository URL parsing in the route to use dedicated functions for GitHub and GitLab parsing. This improves code organization and makes it easier to add support for additional platforms.