### PR TITLE
trustpub: Simplify `verificationUrl` getter with early return

### DIFF
--- a/app/controllers/crate/settings/new-trusted-publisher.js
+++ b/app/controllers/crate/settings/new-trusted-publisher.js
@@ -35,9 +35,13 @@ export default class NewTrustedPublisherController extends Controller {
   }
 
   get verificationUrl() {
-    if (this.publisher === 'GitHub' && this.namespace && this.project && this.workflow) {
+    if (!this.namespace || !this.project || !this.workflow) return;
+
+    if (this.publisher === 'GitHub') {
       return `https://raw.githubusercontent.com/${this.namespace}/${this.project}/HEAD/.github/workflows/${this.workflow}`;
-    } else if (this.publisher === 'GitLab' && this.namespace && this.project && this.workflow) {
+    }
+
+    if (this.publisher === 'GitLab') {
       return `https://gitlab.com/${this.namespace}/${this.project}/-/raw/HEAD/${this.workflow}`;
     }
   }


### PR DESCRIPTION
Use early return pattern to reduce nesting and improve readability of the verification URL generation logic.