### PR TITLE
Tweak an old migration to work on PG 17

### DIFF
--- a/migrations/20170308140537_create_to_semver_no_prerelease/up.sql
+++ b/migrations/20170308140537_create_to_semver_no_prerelease/up.sql
@@ -9,7 +9,7 @@ CREATE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE AS
     split_part($1, '.', 1)::int4,
     split_part($1, '.', 2)::int4,
     split_part(split_part($1, '+', 1), '.', 3)::int4
-  )::semver_triple
+  )::public.semver_triple
   WHERE strpos($1, '-') = 0
   $$ LANGUAGE SQL
 ;


### PR DESCRIPTION
While setting up a clean development environment this migration was
failing on postgres 17. This seems to be a change in behavior relative
to postgres 16.

Confusingly, the error occurs while creating the index:

```
ERROR:  type "semver_triple" does not exist
LINE 6:   )::semver_triple
             ^
QUERY:
  SELECT (
    split_part($1, '.', 1)::int4,
    split_part($1, '.', 2)::int4,
    split_part(split_part($1, '+', 1), '.', 3)::int4
  )::semver_triple
  WHERE strpos($1, '-') = 0

CONTEXT:  SQL function "to_semver_no_prerelease" during inlining
```

Fortunately, we're no longer using this function or the index and we can
allow the migration history to play out by including the schema in the
cast expression.