### PR TITLE
CSP: Add `gitlab.com` for Trusted Publishing workflow path verification

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -179,7 +179,7 @@ impl Server {
         // the `script` in `public/github-redirect.html`
         let content_security_policy = format!(
             "default-src 'self'; \
-            connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org https://raw.githubusercontent.com {cdn_domain}; \
+            connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org https://raw.githubusercontent.com https://gitlab.com {cdn_domain}; \
             script-src 'self' 'unsafe-eval' 'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE=' 'sha256-dbf9FMl76C7BnK1CC3eWb3pvsQAUaTYSHAlBy9tNTG0='; \
             style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; \
             font-src https://code.cdn.mozilla.net; \


### PR DESCRIPTION
see https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/Trusted.20Publishing.20GitLab.20support/near/558841660

/cc @walterhpearce 