### PR TITLE
CI: Fix `actions/create-github-app-token` version comment

### DIFF
--- a/.github/workflows/update-aws-ip-ranges.yml
+++ b/.github/workflows/update-aws-ip-ranges.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'rust-lang' }}
     steps:
-      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2
+      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         id: app-token
         with:
           app-id: ${{ vars.WORKFLOWS_CRATES_IO_APP_ID }}


### PR DESCRIPTION
This fixes a zizmor warning on the `main` branch.