### PR TITLE
Add serial comma for bin names formatting in install instructions

### DIFF
--- a/app/components/crate-sidebar/install-instructions.gjs
+++ b/app/components/crate-sidebar/install-instructions.gjs
@@ -59,7 +59,7 @@ export default class InstallInstructions extends Component {
             {{~#if (eq index 0)~}}
               <span class='bin-name'>{{binName}}</span>
             {{~else if (eq index (sum @binNames.length -1))~}}
-              and
+              , and
               <span class='bin-name'>{{binName}}</span>
             {{~else~}}
               ,


### PR DESCRIPTION
Adds an [Oxford comma] to the list of installed binaries.

[Oxford comma]: https://en.wikipedia.org/wiki/Serial_comma

This should fix the issue where the `and` comes right after the second-to-last item, without any space in between.

[An example available here](https://crates.io/crates/cargo-difftests/0.6.1):

<img width="355" height="153" alt="image" src="https://github.com/user-attachments/assets/ce3b402f-839d-4459-bcfb-d65f92fdc7e5" />