### PR TITLE
Add monthly and weekly downloads to recent downloads calculation

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -314,6 +314,14 @@ pub struct EncodableCrate {
     #[schema(example = 456_789)]
     pub recent_downloads: Option<i64>,
 
+    /// The total number of downloads for this crate in the last month.
+    #[schema(example = 123_456)]
+    pub monthly_downloads: Option<i64>,
+
+    /// The total number of downloads for this crate in the last week.
+    #[schema(example = 56_789)]
+    pub weekly_downloads: Option<i64>,
+
     /// The "default" version of this crate.
     ///
     /// This version will be displayed by default on the crate's page.
@@ -380,6 +388,8 @@ impl EncodableCrate {
         exact_match: bool,
         downloads: i64,
         recent_downloads: Option<i64>,
+        monthly_downloads: Option<i64>,
+        weekly_downloads: Option<i64>,
     ) -> Self {
         let Crate {
             name,
@@ -440,6 +450,8 @@ impl EncodableCrate {
             created_at,
             downloads,
             recent_downloads,
+            monthly_downloads,
+            weekly_downloads,
             versions,
             keywords: keyword_ids,
             categories: category_ids,
@@ -477,6 +489,8 @@ impl EncodableCrate {
         exact_match: bool,
         downloads: i64,
         recent_downloads: Option<i64>,
+        monthly_downloads: Option<i64>,
+        weekly_downloads: Option<i64>,
     ) -> Self {
         Self::from(
             krate,
@@ -490,6 +504,8 @@ impl EncodableCrate {
             exact_match,
             downloads,
             recent_downloads,
+            monthly_downloads,
+            weekly_downloads,
         )
     }
 }
@@ -1187,6 +1203,8 @@ mod tests {
                 .and_utc(),
             downloads: 0,
             recent_downloads: None,
+            monthly_downloads: None,
+            weekly_downloads: None,
             default_version: None,
             num_versions: 0,
             yanked: false,

--- a/crates/crates_io_database/src/schema.patch
+++ b/crates/crates_io_database/src/schema.patch
@@ -40,7 +40,7 @@
          /// The `id` column of the `dependencies` table.
          ///
          /// Its SQL type is `Int4`.
-@@ -773,6 +767,24 @@
+@@ -773,6 +767,32 @@
  }
  
  diesel::table! {
@@ -58,6 +58,14 @@
 +        ///
 +        /// Its SQL type is `BigInt`.
 +        downloads -> BigInt,
++        /// The `monthly` column of the `recent_crate_downloads` table.
++        ///
++        /// Its SQL type is `BigInt`.
++        monthly -> BigInt,
++        /// The `weekly` column of the `recent_crate_downloads` table.
++        ///
++        /// Its SQL type is `BigInt`.
++        weekly -> BigInt,
 +    }
 +}
 +
@@ -65,7 +73,7 @@
      use diesel::sql_types::*;
      use diesel_full_text_search::Tsvector;
  
-@@ -1214,7 +1226,8 @@
+@@ -1214,7 +1234,8 @@
  diesel::joinable!(crate_downloads -> crates (crate_id));
  diesel::joinable!(crate_owner_invitations -> crates (crate_id));
  diesel::joinable!(crate_owners -> crates (crate_id));
@@ -75,7 +83,7 @@
  diesel::joinable!(crates_categories -> categories (category_id));
  diesel::joinable!(crates_categories -> crates (crate_id));
  diesel::joinable!(crates_keywords -> crates (crate_id));
-@@ -1230,6 +1243,7 @@
+@@ -1230,6 +1251,7 @@
  diesel::joinable!(publish_limit_buckets -> users (user_id));
  diesel::joinable!(publish_rate_overrides -> users (user_id));
  diesel::joinable!(readme_renderings -> versions (version_id));
@@ -83,7 +91,7 @@
  diesel::joinable!(trustpub_configs_github -> crates (crate_id));
  diesel::joinable!(trustpub_configs_gitlab -> crates (crate_id));
  diesel::joinable!(version_downloads -> versions (version_id));
-@@ -1262,6 +1276,7 @@
+@@ -1262,6 +1284,7 @@
      publish_limit_buckets,
      publish_rate_overrides,
      readme_renderings,

--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -783,6 +783,14 @@ diesel::table! {
         ///
         /// Its SQL type is `BigInt`.
         downloads -> BigInt,
+        /// The `monthly` column of the `recent_crate_downloads` table.
+        ///
+        /// Its SQL type is `BigInt`.
+        monthly -> BigInt,
+        /// The `weekly` column of the `recent_crate_downloads` table.
+        ///
+        /// Its SQL type is `BigInt`.
+        weekly -> BigInt,
     }
 }
 

--- a/migrations/2025-11-30-121230-add_monthly_downloads/down.sql
+++ b/migrations/2025-11-30-121230-add_monthly_downloads/down.sql
@@ -1,0 +1,8 @@
+DROP MATERIALIZED VIEW recent_crate_downloads;
+CREATE MATERIALIZED VIEW recent_crate_downloads (crate_id, downloads) AS
+  SELECT crate_id, SUM(version_downloads.downloads) FROM version_downloads
+    INNER JOIN versions
+      ON version_downloads.version_id = versions.id
+    WHERE version_downloads.date > date(CURRENT_TIMESTAMP - INTERVAL '90 days')
+    GROUP BY crate_id;
+CREATE UNIQUE INDEX recent_crate_downloads_crate_id ON recent_crate_downloads (crate_id);

--- a/migrations/2025-11-30-121230-add_monthly_downloads/up.sql
+++ b/migrations/2025-11-30-121230-add_monthly_downloads/up.sql
@@ -1,0 +1,13 @@
+DROP MATERIALIZED VIEW recent_crate_downloads;
+CREATE MATERIALIZED VIEW recent_crate_downloads (crate_id, downloads, monthly, weekly) AS
+  SELECT
+    crate_id,
+    SUM(version_downloads.downloads),
+    SUM(version_downloads.downloads) FILTER (WHERE version_downloads.date > CURRENT_DATE - 30),
+    SUM(version_downloads.downloads) FILTER (WHERE version_downloads.date > CURRENT_DATE - 7)
+  FROM version_downloads
+    INNER JOIN versions
+      ON version_downloads.version_id = versions.id
+    WHERE version_downloads.date > CURRENT_DATE - 90
+    GROUP BY crate_id;
+CREATE UNIQUE INDEX recent_crate_downloads_crate_id ON recent_crate_downloads (crate_id);

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -701,6 +701,8 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
                 false,
                 downloads,
                 None,
+                None,
+                None,
             ),
             warnings,
         }))

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -258,6 +258,8 @@ pub async fn list_crates(
                 record.exact_match,
                 record.downloads,
                 Some(record.recent_downloads.unwrap_or(0)),
+                None,
+                None,
             )
         })
         .collect::<Vec<_>>();

--- a/src/controllers/krate/update.rs
+++ b/src/controllers/krate/update.rs
@@ -189,6 +189,8 @@ async fn update_inner(
         false,
         downloads,
         recent_downloads,
+        None,
+        None,
     );
 
     Ok(Json(PatchResponse {

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -181,6 +181,8 @@ fn encode_crates(
                     false,
                     record.total_downloads,
                     record.recent_downloads,
+                    None,
+                    None,
                 ))
             })
             .collect()

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__auth__new_krate_with_bearer_token-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__auth__new_krate_with_bearer_token-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo_new",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo_new",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate_twice-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate_twice-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "2.0.0",
     "max_version": "2.0.0",
+    "monthly_downloads": null,
     "name": "foo_twice",
     "newest_version": "2.0.0",
     "num_versions": 2,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate_twice_alt-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate_twice_alt-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "2.0.0",
     "max_version": "2.0.0",
+    "monthly_downloads": null,
     "name": "foo_twice",
     "newest_version": "0.99.0",
     "num_versions": 2,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate_weird_version-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate_weird_version-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": null,
     "max_version": "0.0.0-pre",
+    "monthly_downloads": null,
     "name": "foo_weird",
     "newest_version": "0.0.0-pre",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate_with_token-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate_with_token-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo_new",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0+foo",
     "max_version": "1.0.0+foo",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.0.0+foo",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": null,
     "max_version": "1.0.0-beta.1",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.0.0-beta.1",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0+foo",
     "max_version": "1.0.0+foo",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.0.0+foo",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__categories__good_categories-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__categories__good_categories-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo_good_cat",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__dependencies__dep_limit-4.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__dependencies__dep_limit-4.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__edition__edition_is_saved-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__edition__edition_is_saved-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__keywords__good_keywords-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__keywords__good_keywords-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo_good_key",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__links__crate_with_links_field.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__links__crate_with_links_field.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__boolean_readme-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__boolean_readme-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__lib_and_bin_crate-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__lib_and_bin_crate-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.1.0",
     "max_version": "1.1.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.1.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__readme__new_krate_with_empty_readme-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__readme__new_krate_with_empty_readme-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo_readme",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__readme__new_krate_with_readme-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__readme__new_krate_with_readme-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": null,
     "name": "foo_readme",
     "newest_version": "1.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__readme__new_krate_with_readme_and_plus_version-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__readme__new_krate_with_readme_and_plus_version-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0+foo",
     "max_version": "1.0.0+foo",
+    "monthly_downloads": null,
     "name": "foo_readme",
     "newest_version": "1.0.0+foo",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_github__full_flow-7.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_github__full_flow-7.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.1.0",
     "max_version": "1.1.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.1.0",
     "num_versions": 2,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_github__happy_path-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_github__happy_path-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.1.0",
     "max_version": "1.1.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.1.0",
     "num_versions": 2,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_github__happy_path_with_fancy_auth_header-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_github__happy_path_with_fancy_auth_header-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.1.0",
     "max_version": "1.1.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.1.0",
     "num_versions": 2,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_gitlab__full_flow-7.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_gitlab__full_flow-7.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.1.0",
     "max_version": "1.1.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.1.0",
     "num_versions": 2,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_gitlab__happy_path-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_gitlab__happy_path-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.1.0",
     "max_version": "1.1.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.1.0",
     "num_versions": 2,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_gitlab__happy_path_with_fancy_auth_header-2.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_gitlab__happy_path_with_fancy_auth_header-2.snap
@@ -25,6 +25,7 @@ expression: response.json()
     },
     "max_stable_version": "1.1.0",
     "max_version": "1.1.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "1.1.0",
     "num_versions": 2,
@@ -33,6 +34,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "warnings": {

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__include_default_version-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__include_default_version-2.snap
@@ -26,6 +26,7 @@ expression: response.json()
     },
     "max_stable_version": null,
     "max_version": "0.0.0",
+    "monthly_downloads": null,
     "name": "foo_default_version",
     "newest_version": "0.0.0",
     "num_versions": 3,
@@ -34,6 +35,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "keywords": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__new_name-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__new_name-2.snap
@@ -26,6 +26,7 @@ expression: response.json()
     },
     "max_stable_version": null,
     "max_version": "0.0.0",
+    "monthly_downloads": null,
     "name": "new",
     "newest_version": "0.0.0",
     "num_versions": 1,
@@ -34,6 +35,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "keywords": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__show-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__show-2.snap
@@ -28,6 +28,7 @@ expression: response.json()
     },
     "max_stable_version": "1.0.0",
     "max_version": "1.0.0",
+    "monthly_downloads": 10,
     "name": "foo_show",
     "newest_version": "0.5.1",
     "num_versions": 3,
@@ -40,6 +41,7 @@ expression: response.json()
       2,
       1
     ],
+    "weekly_downloads": 10,
     "yanked": false
   },
   "keywords": [

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__show_all_yanked-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__show_all_yanked-2.snap
@@ -28,6 +28,7 @@ expression: response.json()
     },
     "max_stable_version": null,
     "max_version": "0.0.0",
+    "monthly_downloads": 10,
     "name": "foo_show",
     "newest_version": "0.0.0",
     "num_versions": 2,
@@ -39,6 +40,7 @@ expression: response.json()
       2,
       1
     ],
+    "weekly_downloads": 10,
     "yanked": true
   },
   "keywords": [

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__show_minimal-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__show_minimal-2.snap
@@ -26,6 +26,7 @@ expression: response.json()
     },
     "max_stable_version": null,
     "max_version": "0.0.0",
+    "monthly_downloads": null,
     "name": "foo_show_minimal",
     "newest_version": "0.0.0",
     "num_versions": 3,
@@ -34,6 +35,7 @@ expression: response.json()
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   },
   "keywords": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-3.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-3.snap
@@ -25,6 +25,7 @@ expression: json
     },
     "max_stable_version": null,
     "max_version": "0.0.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "0.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: json
     "trustpub_only": true,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   }
 }

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-6.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-6.snap
@@ -25,6 +25,7 @@ expression: json
     },
     "max_stable_version": null,
     "max_version": "0.0.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "0.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: json
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   }
 }

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-9.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-9.snap
@@ -26,6 +26,7 @@ expression: json
     },
     "max_stable_version": "0.99.0",
     "max_version": "0.99.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "0.99.0",
     "num_versions": 1,
@@ -36,6 +37,7 @@ expression: json
     "versions": [
       1
     ],
+    "weekly_downloads": null,
     "yanked": false
   },
   "keywords": [],

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-3.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-3.snap
@@ -25,6 +25,7 @@ expression: json
     },
     "max_stable_version": null,
     "max_version": "0.0.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "0.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: json
     "trustpub_only": false,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   }
 }

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-6.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-6.snap
@@ -25,6 +25,7 @@ expression: json
     },
     "max_stable_version": null,
     "max_version": "0.0.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "0.0.0",
     "num_versions": 1,
@@ -33,6 +34,7 @@ expression: json
     "trustpub_only": true,
     "updated_at": "[datetime]",
     "versions": null,
+    "weekly_downloads": null,
     "yanked": false
   }
 }

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-9.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-9.snap
@@ -26,6 +26,7 @@ expression: json
     },
     "max_stable_version": "0.99.0",
     "max_version": "0.99.0",
+    "monthly_downloads": null,
     "name": "foo",
     "newest_version": "0.99.0",
     "num_versions": 1,
@@ -36,6 +37,7 @@ expression: json
     "versions": [
       1
     ],
+    "weekly_downloads": null,
     "yanked": false
   },
   "keywords": [],

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -325,6 +325,15 @@ expression: response.json()
             "example": "2.0.0-beta.1",
             "type": "string"
           },
+          "monthly_downloads": {
+            "description": "The total number of downloads for this crate in the last month.",
+            "example": 123456,
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "name": {
             "description": "The name of the crate.",
             "example": "serde",
@@ -378,6 +387,15 @@ expression: response.json()
             },
             "type": [
               "array",
+              "null"
+            ]
+          },
+          "weekly_downloads": {
+            "description": "The total number of downloads for this crate in the last week.",
+            "example": 56789,
+            "format": "int64",
+            "type": [
+              "integer",
               "null"
             ]
           },


### PR DESCRIPTION
We calculate the recent downloads using a materialized view that we refresh every day. But it's only for last 90 days.

Most of the other ecosystems like [NPM](https://shields.io/badges/npm-downloads), [PyPi](https://shields.io/badges/py-pi-downloads), [Packagist](https://shields.io/badges/packagist-downloads), [Hex](https://shields.io/badges/hex-pm-downloads) provide daily, weekly and monthly downloads. So, I added a weekly and monthly column in the recent downloads view and surfaced the data in the `/api/v1/crates/{name}` endpoint.

I have attached links for shields.io badges that show weekly and monthly downloads for each ecosystem. Once this is merged, I will add the same for Crates.io badges.