### PR TITLE
Enable use of Unix sockets to connect to DB  in tests

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,10 @@
 # Location of the *postgres* database. For example, if you have created a
 # blank database locally named `cargo_registry`, this would be
-# `postgres://postgres@localhost/cargo_registry`.
-export DATABASE_URL=
+# `postgres://db_username:db_password@localhost/cargo_registry`.
+# On Unix systems, a shorthand of `postgres:///cargo_registry` can be used
+# to connect via a local Unix socket, with a db_username equal to your Unix
+# account name and does not require a password.
+export DATABASE_URL=postgres:///cargo_registry
 
 # Allowed origins - any origins for which you want to allow browser
 # access to authenticated endpoints.
@@ -18,9 +21,8 @@ export SESSION_KEY=badkeyabcdefghijklmnopqrstuvwxyzabcdef
 # If you will be running the tests, set this to another database that you
 # have created. For example, if your test database is named
 # `cargo_registry_test`, this would look something like
-# `postgres://postgres@localhost/cargo_registry_test`
-# If you don't plan on running the tests, you can leave this blank.
-export TEST_DATABASE_URL=
+# `postgres://db_username:db_password/cargo_registry_test`
+export TEST_DATABASE_URL=postgres:///cargo_registry_test
 
 # Credentials for AWS.
 # export AWS_ACCESS_KEY=

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -33,13 +33,8 @@ impl TemplateDatabase {
         let mut base_url: Url = required_var_parsed("TEST_DATABASE_URL").unwrap();
 
         if base_url.host().is_none() {
-            if cfg!(unix) {
-                // Default to a Unix socket if no hostname is provided.
-                base_url.set_host(Some("%2Frun%2Fpostgresql")).unwrap();
-            } else {
-                // Provide a clear error now rather than when trying to connect.
-                panic!("No host provided in TEST_DATABASE_URL and unix sockets are not available.");
-            }
+            // Default to a Unix socket if no hostname is provided.
+            base_url.set_host(Some("%2Frun%2Fpostgresql")).unwrap();
         }
 
         let prefix = base_url.path().strip_prefix('/');

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -30,7 +30,17 @@ impl TemplateDatabase {
 
     #[instrument]
     fn new() -> Self {
-        let base_url: Url = required_var_parsed("TEST_DATABASE_URL").unwrap();
+        let mut base_url: Url = required_var_parsed("TEST_DATABASE_URL").unwrap();
+
+        if base_url.host().is_none() {
+            if cfg!(unix) {
+                // Default to a Unix socket if no hostname is provided.
+                base_url.set_host(Some("%2Frun%2Fpostgresql")).unwrap();
+            } else {
+                // Provide a clear error now rather than when trying to connect.
+                panic!("No host provided in TEST_DATABASE_URL and unix sockets are not available.");
+            }
+        }
 
         let prefix = base_url.path().strip_prefix('/');
         let prefix = prefix.expect("failed to parse database name").to_string();

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -32,7 +32,7 @@ impl TemplateDatabase {
     fn new() -> Self {
         let mut base_url: Url = required_var_parsed("TEST_DATABASE_URL").unwrap();
 
-        if base_url.host().is_none() {
+        if base_url.host().is_none() && !base_url.query_pairs().any(|(key, _)| key == "host") {
             // Default to a Unix socket if no hostname is provided.
             base_url.set_host(Some("%2Frun%2Fpostgresql")).unwrap();
         }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -293,11 +293,13 @@ linking with `cc` failed: exit code: 1``, you're probably missing some
 
 ##### Environment variables
 
-Copy the `.env.sample` file to `.env`. Modify the settings as appropriate;
-minimally you'll need to specify or modify the value of the `DATABASE_URL` var.
-Try using `postgres://postgres@localhost/cargo_registry` first.
+Copy the `.env.sample` file to `.env` and then modify `.env` as appropriate. On
+Unix systems, the default configuration will use a local Unix socket which does
+not require setting a password for the database user.
 
-> If that doesn't work, change this by filling in this template with the
+On other platforms, or if connecting to your database over IP:
+
+> Change this by filling in this template with the
 > appropriate values where there are `[]`s:
 >
 > ```text
@@ -432,7 +434,7 @@ In your `.env` file, set `TEST_DATABASE_URL` to a value that's the same as
 connection will be used to create new databases for the tests, with names
 prefixed with the database name from `TEST_DATABASE_URL`.
 
-Example: `postgres://postgres@localhost/cargo_registry_test`.
+Example: `postgres:///cargo_registry_test`.
 
 Create the test database by running:
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -26,6 +26,11 @@ pub async fn oneoff_connection() -> anyhow::Result<AsyncPgConnection> {
 pub fn connection_url(config: &config::DbPoolConfig) -> String {
     let mut url = Url::parse(config.url.expose_secret()).expect("Invalid database URL");
 
+    // Support `postgres:///db_name` shorthand for easier local development.
+    if url.host().is_none() {
+        maybe_append_url_param(&mut url, "host", "/run/postgresql");
+    }
+
     if config.enforce_tls {
         maybe_append_url_param(&mut url, "sslmode", "require");
     }

--- a/src/tests/util/chaosproxy.rs
+++ b/src/tests/util/chaosproxy.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 use anyhow::{Context, anyhow};
 use futures_util::FutureExt as _;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-#[cfg(unix)]
-use tokio::net::UnixStream;
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::{TcpListener, TcpStream, UnixStream};
 use tokio::sync::broadcast::Sender;
 use tokio_postgres::Config;
 use tokio_postgres::config::Host;
@@ -145,9 +143,6 @@ impl ChaosProxy {
                     .boxed(),
                 )
             }
-            #[cfg(not(unix))]
-            Host::Unix(_) => panic!("Unix sockets not supported on this platform"),
-            #[cfg(unix)]
             Host::Unix(path) => {
                 let path = path.join(format!(".s.PGSQL.{port}"));
                 let (backend_read, backend_write) = UnixStream::connect(path).await?.into_split();


### PR DESCRIPTION
Currently it is possible to use a Unix socket to connect to the database by providing a URL such as `postgres:///db_name?host=/run/postgresql`. This works as expected, however the 5 `unhealthy_database` tests fail because the `ChaosProxy` assumes a TCP socket will be used. This is addressed in the 2nd commit which adds Unix socket support.

However, with that change it is now briefly possible that while running the tests, another user on the same localhost could potentially connect to the test database without credentials. It is unlikely that this is a realistic thread model for crates.io developers, however I address this in the 4th and 5th commits. See the commit descriptions for additional details and rationale.

The downside of this change is that the test configuration no longer mirrors the TCP configuration used in production. Alternatively, we could fail these 5 tests if a risky configuration is requested. (Or even decide to not worry about this "threat" at all.)

While working on this I noticed that `PgConnection` will automatically fallback to a Unix socket if no hostname is provided, however `AsyncPgConnection` does not. Some fallback logic is added so that the `postgres:///db_name` shorthand is consistently supported.