### PR TITLE
jobs/sync_to_sparse_index: Add Fastly CDN support

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -99,6 +99,9 @@ pub struct Server {
 
     /// Include publication timestamp in index entries (ISO8601 format).
     pub index_include_pubtime: bool,
+
+    /// Enable Fastly CDN invalidation for sparse index files.
+    pub sparse_index_fastly_enabled: bool,
 }
 
 impl Server {
@@ -248,6 +251,8 @@ impl Server {
             disable_token_creation,
             banner_message,
             index_include_pubtime,
+            sparse_index_fastly_enabled: var_parsed("SPARSE_INDEX_FASTLY_ENABLED")?
+                .unwrap_or(false),
         })
     }
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -524,6 +524,7 @@ fn simple_config() -> config::Server {
         disable_token_creation: None,
         banner_message: None,
         index_include_pubtime: false,
+        sparse_index_fastly_enabled: true,
     }
 }
 


### PR DESCRIPTION
This PR adds a `SPARSE_INDEX_FASTLY_ENABLED` environment variable, which tells the `SyncToSparseIndex` background job to also send invalidation requests to Fastly (in addition to Cloudfront).

We are in the process of shifting more traffic towards Fastly for cost reasons, and this PR is part of that effort, since the sparse index had so far been provided exclusively on Cloudfront.