### PR TITLE
Replace `Ember.testing` with `isTesting()`

### DIFF
--- a/app/components/workflow-verification.gjs
+++ b/app/components/workflow-verification.gjs
@@ -1,8 +1,8 @@
 /* eslint-disable ember/no-at-ember-render-modifiers */
+import { isTesting } from '@ember/debug';
 import didInsert from '@ember/render-modifiers/modifiers/did-insert';
 import didUpdate from '@ember/render-modifiers/modifiers/did-update';
 import Component from '@glimmer/component';
-import Ember from 'ember';
 
 import { rawTimeout, restartableTask } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
@@ -10,7 +10,7 @@ import or from 'ember-truth-helpers/helpers/or';
 
 export default class WorkflowVerificationComponent extends Component {
   verifyWorkflowTask = restartableTask(async () => {
-    let timeout = Ember.testing ? 0 : 500;
+    let timeout = isTesting() ? 0 : 500;
     await rawTimeout(timeout);
 
     let { url } = this.args;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,7 +1,7 @@
+import { isTesting } from '@ember/debug';
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import Ember from 'ember';
 
 import { didCancel, dropTask, rawTimeout, task } from 'ember-concurrency';
 
@@ -61,7 +61,7 @@ export default class ApplicationRoute extends Route {
 
   checkReadOnlyStatusTask = dropTask(async () => {
     // delay the status check to let the more relevant data load first
-    let timeout = Ember.testing ? 0 : 1000;
+    let timeout = isTesting() ? 0 : 1000;
     await rawTimeout(timeout);
 
     let { read_only, banner_message } = await ajax('/api/v1/site_metadata');

--- a/app/services/progress.js
+++ b/app/services/progress.js
@@ -1,7 +1,7 @@
+import { isTesting } from '@ember/debug';
 import Service, { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { tracked } from '@glimmer/tracking';
-import Ember from 'ember';
 
 import { didCancel, dropTask, rawTimeout, task } from 'ember-concurrency';
 
@@ -36,7 +36,7 @@ export default class ProgressService extends Service {
   });
 
   updateTask = dropTask(async () => {
-    if (Ember.testing) return;
+    if (isTesting()) return;
 
     let progress = 0;
     this._style = `width: 0%`;


### PR DESCRIPTION
Accessing the property on the `Ember` object is deprecated. Importing the accessor fn from `@ember/debug` should resolve the deprecation warning.

Closes https://github.com/rust-lang/crates.io/pull/12084