### PR TITLE
ember-data: Move `polyfillUUID` config option into `emberData` config

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -18,14 +18,6 @@ module.exports = function (defaults) {
   }
 
   let app = new EmberApp(defaults, {
-    '@embroider/macros': {
-      setConfig: {
-        '@ember-data/store': {
-          polyfillUUID: true,
-        },
-      },
-    },
-
     autoImport: {
       webpack: {
         devtool: isProd ? 'source-map' : 'eval-source-map',
@@ -47,6 +39,8 @@ module.exports = function (defaults) {
     },
 
     emberData: {
+      polyfillUUID: true,
+
       deprecations: {
         DEPRECATE_STORE_EXTENDS_EMBER_OBJECT: false,
       },


### PR DESCRIPTION
The `@embroider/macros` variant had been deprecated and replaced by this alternative.