### PR TITLE
routes/category-slugs: Simplify `model()` fn

### DIFF
--- a/app/routes/category-slugs.js
+++ b/app/routes/category-slugs.js
@@ -4,12 +4,7 @@ import { service } from '@ember/service';
 export default class CategorySlugsRoute extends Route {
   @service store;
 
-  queryParams = {
-    page: { refreshModel: true },
-    sort: { refreshModel: true },
-  };
-
-  model(params) {
-    return this.store.query('category-slug', params);
+  model() {
+    return this.store.findAll('category-slug');
   }
 }


### PR DESCRIPTION
The `GET /api/v1/category_slugs` endpoint does not support pagination or sorting query parameters, so there is no reason for us to use these query parameters.