### PR TITLE
triagebot: Automatically label `A-svelte` pull requests

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -34,3 +34,8 @@ trigger_files = [
     "Cargo.lock",
     "rust-toolchain.toml",
 ]
+
+[autolabel."A-svelte"]
+trigger_files = [
+    "svelte/",
+]


### PR DESCRIPTION
That makes it a bit easier to identify the PRs belonging to the migration.