### PR TITLE
Use `env bash` in `script/import-database-dump.sh`

### DIFF
--- a/script/import-database-dump.sh
+++ b/script/import-database-dump.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Downloads the database dump tarball from crates.io and imports it
 # into the `cargo_registry` database. If the database already exists it


### PR DESCRIPTION
Related to https://github.com/rust-lang/crates.io/pull/12492#discussion_r2618558932

- https://www.shellcheck.net/wiki/SC3040

Other options is to use `/bin/bash` instead of `/bin/sh`