### PR TITLE
svelte: Load "Fira Sans" font family from Mozilla CDN

### DIFF
--- a/svelte/src/app.html
+++ b/svelte/src/app.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css" />
     <link rel="icon" href="/favicon.ico" />
     %sveltekit.head%
   </head>


### PR DESCRIPTION
Same as for the Ember.js app for now...

### Related

- https://github.com/rust-lang/crates.io/issues/12515