### PR TITLE
svelte: Add stub routes for all current Ember.js routes

### DIFF
--- a/svelte/src/routes/accept-invite/[token]/+page.svelte
+++ b/svelte/src/routes/accept-invite/[token]/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Accept Invite</h1>
+<p>Stub route for /accept-invite/:token</p>
+<p>Token: {data.token}</p>

--- a/svelte/src/routes/accept-invite/[token]/+page.ts
+++ b/svelte/src/routes/accept-invite/[token]/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { token: params.token };
+}

--- a/svelte/src/routes/categories/+page.svelte
+++ b/svelte/src/routes/categories/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Categories</h1>
+<p>Stub route for /categories</p>

--- a/svelte/src/routes/categories/[category_id]/+page.svelte
+++ b/svelte/src/routes/categories/[category_id]/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Category: {data.category_id}</h1>
+<p>Stub route for /categories/:category_id</p>

--- a/svelte/src/routes/categories/[category_id]/+page.ts
+++ b/svelte/src/routes/categories/[category_id]/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { category_id: params.category_id };
+}

--- a/svelte/src/routes/category_slugs/+page.svelte
+++ b/svelte/src/routes/category_slugs/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Category Slugs</h1>
+<p>Stub route for /category_slugs</p>

--- a/svelte/src/routes/confirm/[email_token]/+page.svelte
+++ b/svelte/src/routes/confirm/[email_token]/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Confirm Email</h1>
+<p>Stub route for /confirm/:email_token</p>
+<p>Token: {data.email_token}</p>

--- a/svelte/src/routes/confirm/[email_token]/+page.ts
+++ b/svelte/src/routes/confirm/[email_token]/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { email_token: params.email_token };
+}

--- a/svelte/src/routes/crates/+page.svelte
+++ b/svelte/src/routes/crates/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Crates</h1>
+<p>Stub route for /crates</p>

--- a/svelte/src/routes/crates/[crate_id]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Crate: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id</p>

--- a/svelte/src/routes/crates/[crate_id]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Crate: {data.crate_id} v{data.version_num}</h1>
+<p>Stub route for /crates/:crate_id/:version_num</p>

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id, version_num: params.version_num };
+}

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Dependencies: {data.crate_id} v{data.version_num}</h1>
+<p>Stub route for /crates/:crate_id/:version_num/dependencies</p>

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id, version_num: params.version_num };
+}

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/rebuild-docs/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/rebuild-docs/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Rebuild Docs: {data.crate_id} v{data.version_num}</h1>
+<p>Stub route for /crates/:crate_id/:version_num/rebuild-docs</p>

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/rebuild-docs/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/rebuild-docs/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id, version_num: params.version_num };
+}

--- a/svelte/src/routes/crates/[crate_id]/delete/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/delete/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Delete Crate: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id/delete</p>

--- a/svelte/src/routes/crates/[crate_id]/delete/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/delete/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}

--- a/svelte/src/routes/crates/[crate_id]/dependencies/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/dependencies/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Crate Dependencies: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id/dependencies</p>

--- a/svelte/src/routes/crates/[crate_id]/dependencies/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/dependencies/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}

--- a/svelte/src/routes/crates/[crate_id]/docs/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/docs/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Docs: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id/docs (well-known redirect)</p>

--- a/svelte/src/routes/crates/[crate_id]/docs/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/docs/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}

--- a/svelte/src/routes/crates/[crate_id]/owners/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/owners/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Owners: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id/owners</p>

--- a/svelte/src/routes/crates/[crate_id]/owners/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/owners/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}

--- a/svelte/src/routes/crates/[crate_id]/range/[range]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/range/[range]/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Crate: {data.crate_id} range {data.range}</h1>
+<p>Stub route for /crates/:crate_id/range/:range</p>

--- a/svelte/src/routes/crates/[crate_id]/range/[range]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/range/[range]/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id, range: params.range };
+}

--- a/svelte/src/routes/crates/[crate_id]/repo/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/repo/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Repo: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id/repo (well-known redirect)</p>

--- a/svelte/src/routes/crates/[crate_id]/repo/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/repo/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}

--- a/svelte/src/routes/crates/[crate_id]/reverse_dependencies/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/reverse_dependencies/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Reverse Dependencies: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id/reverse_dependencies</p>

--- a/svelte/src/routes/crates/[crate_id]/reverse_dependencies/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/reverse_dependencies/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}

--- a/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Settings: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id/settings</p>

--- a/svelte/src/routes/crates/[crate_id]/settings/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/settings/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}

--- a/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>New Trusted Publisher: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id/settings/new-trusted-publisher</p>

--- a/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}

--- a/svelte/src/routes/crates/[crate_id]/versions/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/versions/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Crate Versions: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id/versions</p>

--- a/svelte/src/routes/crates/[crate_id]/versions/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/versions/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}

--- a/svelte/src/routes/dashboard/+page.svelte
+++ b/svelte/src/routes/dashboard/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Dashboard</h1>
+<p>Stub route for /dashboard</p>

--- a/svelte/src/routes/data-access/+page.svelte
+++ b/svelte/src/routes/data-access/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Data Access</h1>
+<p>Stub route for /data-access</p>

--- a/svelte/src/routes/docs/+page.svelte
+++ b/svelte/src/routes/docs/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Documentation</h1>
+<p>Stub route for /docs</p>

--- a/svelte/src/routes/docs/trusted-publishing/+page.svelte
+++ b/svelte/src/routes/docs/trusted-publishing/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Trusted Publishing</h1>
+<p>Stub route for /docs/trusted-publishing</p>

--- a/svelte/src/routes/install/+page.svelte
+++ b/svelte/src/routes/install/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Install</h1>
+<p>Stub route for /install</p>

--- a/svelte/src/routes/keywords/+page.svelte
+++ b/svelte/src/routes/keywords/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Keywords</h1>
+<p>Stub route for /keywords</p>

--- a/svelte/src/routes/keywords/[keyword_id]/+page.svelte
+++ b/svelte/src/routes/keywords/[keyword_id]/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Keyword: {data.keyword_id}</h1>
+<p>Stub route for /keywords/:keyword_id</p>

--- a/svelte/src/routes/keywords/[keyword_id]/+page.ts
+++ b/svelte/src/routes/keywords/[keyword_id]/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { keyword_id: params.keyword_id };
+}

--- a/svelte/src/routes/me/+page.svelte
+++ b/svelte/src/routes/me/+page.svelte
@@ -1,0 +1,2 @@
+<h1>My Dashboard</h1>
+<p>Stub route for /me</p>

--- a/svelte/src/routes/me/crates/+page.svelte
+++ b/svelte/src/routes/me/crates/+page.svelte
@@ -1,0 +1,2 @@
+<h1>My Crates</h1>
+<p>Stub route for /me/crates</p>

--- a/svelte/src/routes/me/following/+page.svelte
+++ b/svelte/src/routes/me/following/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Following</h1>
+<p>Stub route for /me/following</p>

--- a/svelte/src/routes/me/pending-invites/+page.svelte
+++ b/svelte/src/routes/me/pending-invites/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Pending Invites</h1>
+<p>Stub route for /me/pending-invites</p>

--- a/svelte/src/routes/policies/+page.svelte
+++ b/svelte/src/routes/policies/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Policies</h1>
+<p>Stub route for /policies</p>

--- a/svelte/src/routes/policies/security/+page.svelte
+++ b/svelte/src/routes/policies/security/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Security Policy</h1>
+<p>Stub route for /policies/security</p>

--- a/svelte/src/routes/search/+page.svelte
+++ b/svelte/src/routes/search/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Search</h1>
+<p>Stub route for /search</p>

--- a/svelte/src/routes/security/+page.svelte
+++ b/svelte/src/routes/security/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Security</h1>
+<p>Stub route for /security (redirects to /policies/security)</p>

--- a/svelte/src/routes/settings/+page.svelte
+++ b/svelte/src/routes/settings/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Settings</h1>
+<p>Stub route for /settings</p>

--- a/svelte/src/routes/settings/profile/+page.svelte
+++ b/svelte/src/routes/settings/profile/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Profile Settings</h1>
+<p>Stub route for /settings/profile</p>

--- a/svelte/src/routes/settings/tokens/+page.svelte
+++ b/svelte/src/routes/settings/tokens/+page.svelte
@@ -1,0 +1,2 @@
+<h1>API Tokens</h1>
+<p>Stub route for /settings/tokens</p>

--- a/svelte/src/routes/settings/tokens/new/+page.svelte
+++ b/svelte/src/routes/settings/tokens/new/+page.svelte
@@ -1,0 +1,2 @@
+<h1>New API Token</h1>
+<p>Stub route for /settings/tokens/new</p>

--- a/svelte/src/routes/support/+page.svelte
+++ b/svelte/src/routes/support/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Support</h1>
+<p>Stub route for /support</p>

--- a/svelte/src/routes/teams/[team_id]/+page.svelte
+++ b/svelte/src/routes/teams/[team_id]/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Team: {data.team_id}</h1>
+<p>Stub route for /teams/:team_id</p>

--- a/svelte/src/routes/teams/[team_id]/+page.ts
+++ b/svelte/src/routes/teams/[team_id]/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { team_id: params.team_id };
+}

--- a/svelte/src/routes/users/[user_id]/+page.svelte
+++ b/svelte/src/routes/users/[user_id]/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>User: {data.user_id}</h1>
+<p>Stub route for /users/:user_id</p>

--- a/svelte/src/routes/users/[user_id]/+page.ts
+++ b/svelte/src/routes/users/[user_id]/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { user_id: params.user_id };
+}


### PR DESCRIPTION
This commit/PR recreates the current [Ember.js route structure](https://github.com/rust-lang/crates.io/blob/main/app/router.js) in the Svelte app with stub routes. These routes currently only show the URL parameters. This allows us to use the Svelte `resolve()` fn from now on to create type-checked in-app links.

### Related

- https://github.com/rust-lang/crates.io/issues/12515