### PR TITLE
Create `@crates-io/api-client` JS package

### DIFF
--- a/.github/changed-files.yml
+++ b/.github/changed-files.yml
@@ -52,6 +52,13 @@ msw_test:
   - packages/crates-io-msw/**
   - pnpm-lock.yaml
 
+api_client_test:
+  - .github/workflows/**
+  - packages/crates-io-msw/**
+  - packages/crates-io-api-client/**
+  - src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+  - pnpm-lock.yaml
+
 e2e_test:
   - .github/workflows/**
   - app/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       frontend-lint: ${{ steps.changed-files.outputs.frontend_lint_any_modified }}
       frontend-test: ${{ steps.changed-files.outputs.frontend_test_any_modified }}
       msw-test: ${{ steps.changed-files.outputs.msw_test_any_modified }}
+      api-client-test: ${{ steps.changed-files.outputs.api_client_test_any_modified }}
       e2e-test: ${{ steps.changed-files.outputs.e2e_test_any_modified }}
       svelte: ${{ steps.changed-files.outputs.svelte_any_modified }}
       zizmor: ${{ steps.changed-files.outputs.zizmor_any_modified }}
@@ -289,6 +290,30 @@ jobs:
       - run: pnpm install
 
       - run: pnpm --filter "@crates-io/msw" test
+
+  api-client-test:
+    name: Frontend / Test (@crates-io/api-client)
+    runs-on: ubuntu-24.04
+    needs: filter-jobs
+    if: needs.filter-jobs.outputs.api-client-test == 'true'
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          cache: pnpm
+          node-version-file: package.json
+
+      - run: pnpm install
+
+      - run: pnpm --filter "@crates-io/api-client" test
 
   e2e-test:
     name: Frontend / Test (playwright)

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 dist/
+packages/crates-io-api-client/schema.d.ts
 svelte/

--- a/packages/crates-io-api-client/client.test.ts
+++ b/packages/crates-io-api-client/client.test.ts
@@ -1,0 +1,115 @@
+import { db, handlers } from '@crates-io/msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest';
+
+import { createClient } from './index.js';
+
+const baseUrl = 'https://crates.io/';
+globalThis.location = { href: baseUrl } as Location;
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterEach(() => db.reset());
+afterAll(() => server.close());
+
+test('GET /api/v1/site_metadata', async () => {
+  let client = createClient({ baseUrl });
+  let response = await client.GET('/api/v1/site_metadata');
+
+  expect(response).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "commit": "5048d31943118c6d67359bd207d307c854e82f45",
+        "deployed_sha": "5048d31943118c6d67359bd207d307c854e82f45",
+        "read_only": false,
+      },
+      "response": HttpResponse {
+        "url": "https://crates.io/api/v1/site_metadata",
+        Symbol(bodyType): null,
+      },
+    }
+  `);
+});
+
+test('GET /api/v1/crates/{name}', async () => {
+  let crate = await db.crate.create({ name: 'serde' });
+  await db.version.create({ crate, num: '1.0.0' });
+
+  let client = createClient({ baseUrl });
+  let response = await client.GET('/api/v1/crates/{name}', {
+    params: {
+      path: { name: 'serde' },
+      query: { include: '' },
+    },
+  });
+
+  expect(response.data.crate.name).toBe('serde');
+  expect(response).toMatchInlineSnapshot(`
+    {
+      "data": {
+        "categories": null,
+        "crate": {
+          "badges": [],
+          "categories": null,
+          "created_at": "2010-06-16T21:30:45Z",
+          "default_version": "1.0.0",
+          "description": "This is the description for the crate called "serde"",
+          "documentation": null,
+          "downloads": 37035,
+          "homepage": null,
+          "id": "serde",
+          "keywords": null,
+          "links": {
+            "owner_team": "/api/v1/crates/serde/owner_team",
+            "owner_user": "/api/v1/crates/serde/owner_user",
+            "reverse_dependencies": "/api/v1/crates/serde/reverse_dependencies",
+            "version_downloads": "/api/v1/crates/serde/downloads",
+            "versions": "/api/v1/crates/serde/versions",
+          },
+          "max_stable_version": null,
+          "max_version": "0.0.0",
+          "name": "serde",
+          "newest_version": "0.0.0",
+          "num_versions": 1,
+          "recent_downloads": 321,
+          "repository": null,
+          "trustpub_only": false,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "versions": null,
+          "yanked": false,
+        },
+        "keywords": null,
+        "versions": null,
+      },
+      "response": HttpResponse {
+        "url": "https://crates.io/api/v1/crates/serde?include=",
+        Symbol(bodyType): null,
+      },
+    }
+  `);
+});
+
+test('GET /api/v1/crates/{name} error', async () => {
+  let client = createClient({ baseUrl });
+  let response = await client.GET('/api/v1/crates/{name}', {
+    params: { path: { name: 'serde' } },
+  });
+
+  expect(response).toMatchInlineSnapshot(`
+    {
+      "error": {
+        "errors": [
+          {
+            "detail": "Not Found",
+          },
+        ],
+      },
+      "response": HttpResponse {
+        "url": "https://crates.io/api/v1/crates/serde",
+        Symbol(bodyType): null,
+      },
+    }
+  `);
+});

--- a/packages/crates-io-api-client/index.ts
+++ b/packages/crates-io-api-client/index.ts
@@ -1,0 +1,9 @@
+import createOpenAPIClient, { type ClientOptions } from 'openapi-fetch';
+
+import type { components, operations, paths } from './schema';
+
+export type { components, operations, paths };
+
+export function createClient(options?: ClientOptions) {
+  return createOpenAPIClient<paths>(options);
+}

--- a/packages/crates-io-api-client/package.json
+++ b/packages/crates-io-api-client/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@crates-io/api-client",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "main": "index.ts",
+  "homepage": "https://github.com/rust-lang/crates.io#readme",
+  "bugs": {
+    "url": "https://github.com/rust-lang/crates.io/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rust-lang/crates.io.git"
+  },
+  "license": "(MIT OR Apache-2.0)",
+  "scripts": {
+    "regenerate": "vitest schema.test.ts --run --update",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "openapi-fetch": "0.15.0"
+  },
+  "devDependencies": {
+    "@crates-io/msw": "workspace:*",
+    "msw": "2.12.4",
+    "openapi-typescript": "7.10.1",
+    "vitest": "4.0.15"
+  }
+}

--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -1,0 +1,4023 @@
+/**
+ * This file is auto-generated. Do not edit manually.
+ *
+ * Run `pnpm --filter @crates-io/api-client regenerate` to update this file.
+ */
+
+export interface paths {
+    "/api/private/crate_owner_invitations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all crate owner invitations for a crate or user. */
+        get: operations["list_crate_owner_invitations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/private/session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** End the current session. */
+        delete: operations["end_session"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/private/session/authorize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Complete authentication flow.
+         * @description This route is called from the GitHub API OAuth flow after the user accepted or rejected
+         *     the data access permissions. It will check the `state` parameter and then call the GitHub API
+         *     to exchange the temporary `code` for an API token. The API token is returned together with
+         *     the corresponding user information.
+         *
+         *     see <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>
+         *
+         *     ## Query Parameters
+         *
+         *     - `code` – temporary code received from the GitHub API  **(Required)**
+         *     - `state` – state parameter received from the GitHub API  **(Required)**
+         */
+        get: operations["authorize_session"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/private/session/begin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Begin authentication flow.
+         * @description This route will return an authorization URL for the GitHub OAuth flow including the crates.io
+         *     `client_id` and a randomly generated `state` secret.
+         *
+         *     see <https://developer.github.com/v3/oauth/#redirect-users-to-request-github-access>
+         */
+        get: operations["begin_session"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/categories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all categories. */
+        get: operations["list_categories"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/categories/{category}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get category metadata. */
+        get: operations["find_category"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/category_slugs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all available category slugs. */
+        get: operations["list_category_slugs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/confirm/{email_token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Marks the email belonging to the given token as verified. */
+        put: operations["confirm_user_email"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Returns a list of crates.
+         * @description Called in a variety of scenarios in the front end, including:
+         *     - Alphabetical listing of crates
+         *     - List of crates under a specific owner
+         *     - Listing a user's followed crates
+         */
+        get: operations["list_crates"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/new": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get crate metadata (for the `new` crate).
+         * @description This endpoint works around a small limitation in `axum` and is delegating
+         *     to the `GET /api/v1/crates/{name}` endpoint internally.
+         */
+        get: operations["find_new_crate"];
+        /**
+         * Publish a new crate/version.
+         * @description Used by `cargo publish` to publish a new crate or to publish a new version of an
+         *     existing crate.
+         */
+        put: operations["publish"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get crate metadata. */
+        get: operations["find_crate"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a crate.
+         * @description The crate is immediately deleted from the database, and with a small delay
+         *     from the git and sparse index, and the crate file storage.
+         *
+         *     The crate can only be deleted by the owner of the crate, and only if the
+         *     crate has been published for less than 72 hours, or if the crate has a
+         *     single owner, has been downloaded less than 1000 times for each month it has
+         *     been published, and is not depended upon by any other crate on crates.io.
+         */
+        delete: operations["delete_crate"];
+        options?: never;
+        head?: never;
+        /** Update crate settings. */
+        patch: operations["update_crate"];
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/downloads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the download counts for a crate.
+         * @description This includes the per-day downloads for the last 90 days and for the
+         *     latest 5 versions plus the sum of the rest.
+         */
+        get: operations["get_crate_downloads"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/follow": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Follow a crate. */
+        put: operations["follow_crate"];
+        post?: never;
+        /** Unfollow a crate. */
+        delete: operations["unfollow_crate"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/following": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Check if a crate is followed. */
+        get: operations["get_following_crate"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/owner_team": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List team owners of a crate. */
+        get: operations["get_team_owners"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/owner_user": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List user owners of a crate. */
+        get: operations["get_user_owners"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/owners": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List crate owners. */
+        get: operations["list_owners"];
+        /** Add crate owners. */
+        put: operations["add_owners"];
+        post?: never;
+        /** Remove crate owners. */
+        delete: operations["remove_owners"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/reverse_dependencies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List reverse dependencies of a crate. */
+        get: operations["list_reverse_dependencies"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all versions of a crate. */
+        get: operations["list_versions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/{version}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get crate version metadata. */
+        get: operations["find_version"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update a crate version.
+         * @description This endpoint allows updating the `yanked` state of a version, including a yank message.
+         */
+        patch: operations["update_version"];
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/{version}/authors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get crate version authors.
+         * @deprecated
+         * @description This endpoint was deprecated by [RFC #3052](https://github.com/rust-lang/rfcs/pull/3052)
+         *     and returns an empty list for backwards compatibility reasons.
+         */
+        get: operations["get_version_authors"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/{version}/dependencies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get crate version dependencies.
+         * @description This information can also be obtained directly from the index.
+         *
+         *     In addition to returning cached data from the index, this returns
+         *     fields for `id`, `version_id`, and `downloads` (which appears to always
+         *     be 0)
+         */
+        get: operations["get_version_dependencies"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/{version}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download a crate version.
+         * @description This returns a URL to the location where the crate is stored.
+         */
+        get: operations["download_version"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/{version}/downloads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the download counts for a crate version.
+         * @description This includes the per-day downloads for the last 90 days.
+         */
+        get: operations["get_version_downloads"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/{version}/readme": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the readme of a crate version. */
+        get: operations["get_version_readme"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/{version}/rebuild_docs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger a rebuild for the crate documentation on docs.rs. */
+        post: operations["rebuild_version_docs"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/{version}/unyank": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Unyank a crate version. */
+        put: operations["unyank_version"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/crates/{name}/{version}/yank": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Yank a crate version.
+         * @description This does not delete a crate version, it makes the crate
+         *     version accessible only to crates that already have a
+         *     `Cargo.lock` containing this version.
+         *
+         *     Notes:
+         *
+         *     Version deletion is not implemented to avoid breaking builds,
+         *     and the goal of yanking a crate is to prevent crates
+         *     beginning to depend on the yanked crate version.
+         */
+        delete: operations["yank_version"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/keywords": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all keywords. */
+        get: operations["list_keywords"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/keywords/{keyword}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get keyword metadata. */
+        get: operations["find_keyword"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the currently authenticated user. */
+        get: operations["get_authenticated_user"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/me/crate_owner_invitations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all crate owner invitations for the authenticated user. */
+        get: operations["list_crate_owner_invitations_for_user"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/me/crate_owner_invitations/accept/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Accept a crate owner invitation with a token. */
+        put: operations["accept_crate_owner_invitation_with_token"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/me/crate_owner_invitations/{crate_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Accept or decline a crate owner invitation. */
+        put: operations["handle_crate_owner_invitation"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/me/email_notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Update email notification settings for the authenticated user.
+         * @deprecated
+         * @description This endpoint was implemented for an experimental feature that was never
+         *     fully implemented. It is now deprecated and will be removed in the future.
+         */
+        put: operations["update_email_notifications"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/me/tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all API tokens of the authenticated user. */
+        get: operations["list_api_tokens"];
+        /** Create a new API token. */
+        put: operations["create_api_token"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/me/tokens/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Find API token by id. */
+        get: operations["find_api_token"];
+        put?: never;
+        post?: never;
+        /** Revoke API token. */
+        delete: operations["revoke_api_token"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/me/updates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List versions of crates that the authenticated user follows. */
+        get: operations["get_authenticated_user_updates"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/site_metadata": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get crates.io metadata.
+         * @description Returns the current deployed commit SHA1 (or `unknown`), and whether the
+         *     system is in read-only mode.
+         */
+        get: operations["get_site_metadata"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get front page data.
+         * @description This endpoint returns a summary of the most important data for the front
+         *     page of crates.io.
+         */
+        get: operations["get_summary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/teams/{team}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Find team by login. */
+        get: operations["find_team"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/tokens/current": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Revoke the current API token.
+         * @description This endpoint revokes the API token that is used to authenticate
+         *     the request.
+         */
+        delete: operations["revoke_current_api_token"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/trusted_publishing/github_configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Trusted Publishing configurations for GitHub Actions. */
+        get: operations["list_trustpub_github_configs"];
+        put?: never;
+        /** Create a new Trusted Publishing configuration for GitHub Actions. */
+        post: operations["create_trustpub_github_config"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/trusted_publishing/github_configs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Trusted Publishing configuration for GitHub Actions. */
+        delete: operations["delete_trustpub_github_config"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/trusted_publishing/gitlab_configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Trusted Publishing configurations for GitLab CI/CD. */
+        get: operations["list_trustpub_gitlab_configs"];
+        put?: never;
+        post: operations["create_trustpub_gitlab_config"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/trusted_publishing/gitlab_configs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Trusted Publishing configuration for GitLab CI/CD. */
+        delete: operations["delete_trustpub_gitlab_config"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/trusted_publishing/tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Exchange an OIDC token for a temporary access token. */
+        post: operations["exchange_trustpub_token"];
+        /**
+         * Revoke a temporary access token.
+         * @description The access token is expected to be passed in the `Authorization` header
+         *     as a `Bearer` token, similar to how it is used in the publish endpoint.
+         */
+        delete: operations["revoke_trustpub_token"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/users/{id}/resend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Regenerate and send an email verification token. */
+        put: operations["resend_email_verification"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/users/{id}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get user stats.
+         * @description This currently only returns the total number of downloads for crates owned
+         *     by the user.
+         */
+        get: operations["get_user_stats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/users/{user}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Find user by login. */
+        get: operations["find_user"];
+        /**
+         * Update user settings.
+         * @description This endpoint allows users to update their email address and publish notifications settings.
+         *
+         *     The `id` parameter needs to match the ID of the currently authenticated user.
+         */
+        put: operations["update_user"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        /** @description The model representing a row in the `api_tokens` database table. */
+        ApiToken: {
+            /**
+             * @description `None` or a list of crate scope patterns (see RFC #2947).
+             * @example [
+             *       "serde"
+             *     ]
+             */
+            crate_scopes?: string[] | null;
+            /**
+             * Format: date-time
+             * @description The date and time when the token was created.
+             * @example 2017-01-06T14:23:11Z
+             */
+            created_at: string;
+            /**
+             * @description A list of endpoint scopes or `None` for the `legacy` endpoint scope (see RFC #2947).
+             * @example [
+             *       "publish-update"
+             *     ]
+             */
+            endpoint_scopes?: components["schemas"]["EndpointScope"][] | null;
+            /**
+             * Format: date-time
+             * @description The date and time when the token will expire, or `null`.
+             * @example 2030-10-26T11:32:12Z
+             */
+            expired_at?: string | null;
+            /**
+             * Format: int32
+             * @description An opaque unique identifier for the token.
+             * @example 42
+             */
+            id: number;
+            /**
+             * Format: date-time
+             * @description The date and time when the token was last used.
+             * @example 2021-10-26T11:32:12Z
+             */
+            last_used_at?: string | null;
+            /**
+             * @description The name of the token.
+             * @example Example API Token
+             */
+            name: string;
+        };
+        AuthenticatedUser: {
+            /**
+             * @description The user's avatar URL, if set.
+             * @example https://avatars2.githubusercontent.com/u/1234567?v=4
+             */
+            avatar?: string | null;
+            /**
+             * @description The user's email address, if set.
+             * @example kate@morgan.dev
+             */
+            email?: string | null;
+            /**
+             * @description Whether the user's email address verification email has been sent.
+             * @example true
+             */
+            email_verification_sent: boolean;
+            /**
+             * @description Whether the user's email address has been verified.
+             * @example true
+             */
+            email_verified: boolean;
+            /**
+             * Format: int32
+             * @description An opaque identifier for the user.
+             * @example 42
+             */
+            id: number;
+            /**
+             * @description Whether the user is a crates.io administrator.
+             * @example false
+             */
+            is_admin: boolean;
+            /**
+             * @description The user's login name.
+             * @example ghost
+             */
+            login: string;
+            /**
+             * @description The user's display name, if set.
+             * @example Kate Morgan
+             */
+            name?: string | null;
+            /**
+             * @description Whether the user has opted in to receive publish notifications via email.
+             * @example true
+             */
+            publish_notifications: boolean;
+            /**
+             * @description The user's GitHub profile URL.
+             * @example https://github.com/ghost
+             */
+            url?: string | null;
+        };
+        Category: {
+            /**
+             * @description The name of the category.
+             * @example Game development
+             */
+            category: string;
+            /**
+             * Format: int32
+             * @description The total number of crates that have this category.
+             * @example 42
+             */
+            crates_cnt: number;
+            /**
+             * Format: date-time
+             * @description The date and time this category was created.
+             * @example 2019-12-13T13:46:41Z
+             */
+            created_at: string;
+            /**
+             * @description A description of the category.
+             * @example Libraries for creating games.
+             */
+            description: string;
+            /**
+             * @description An opaque identifier for the category.
+             * @example game-development
+             */
+            id: string;
+            /**
+             * @description The parent categories of this category.
+             *
+             *     This field is only present when the category details are queried,
+             *     but not when listing categories.
+             * @example []
+             */
+            parent_categories?: components["schemas"]["Category"][] | null;
+            /**
+             * @description The "slug" of the category.
+             *
+             *     See <https://crates.io/category_slugs>.
+             * @example game-development
+             */
+            slug: string;
+            /**
+             * @description The subcategories of this category.
+             *
+             *     This field is only present when the category details are queried,
+             *     but not when listing categories.
+             * @example []
+             */
+            subcategories?: components["schemas"]["Category"][] | null;
+        };
+        Crate: {
+            /**
+             * @deprecated
+             * @example []
+             */
+            badges: Record<string, never>[];
+            /**
+             * @description The list of categories belonging to this crate.
+             * @example null
+             */
+            categories?: string[] | null;
+            /**
+             * Format: date-time
+             * @description The date and time this crate was created.
+             * @example 2019-12-13T13:46:41Z
+             */
+            created_at: string;
+            /**
+             * @description The "default" version of this crate.
+             *
+             *     This version will be displayed by default on the crate's page.
+             * @example 1.3.0
+             */
+            default_version?: string | null;
+            /**
+             * @description Description of the crate.
+             * @example A generic serialization/deserialization framework
+             */
+            description?: string | null;
+            /**
+             * @description The URL to the crate's documentation, if set.
+             * @example https://docs.rs/serde
+             */
+            documentation?: string | null;
+            /**
+             * Format: int64
+             * @description The total number of downloads for this crate.
+             * @example 123456789
+             */
+            downloads: number;
+            /**
+             * @deprecated
+             * @description Whether the crate name was an exact match.
+             */
+            exact_match: boolean;
+            /**
+             * @description The URL to the crate's homepage, if set.
+             * @example https://serde.rs
+             */
+            homepage?: string | null;
+            /**
+             * @description An opaque identifier for the crate.
+             * @example serde
+             */
+            id: string;
+            /**
+             * @description The list of keywords belonging to this crate.
+             * @example null
+             */
+            keywords?: string[] | null;
+            /** @description Links to other API endpoints related to this crate. */
+            links: components["schemas"]["CrateLinks"];
+            /**
+             * @deprecated
+             * @description The highest version number for this crate that is not a pre-release.
+             * @example 1.3.0
+             */
+            max_stable_version?: string | null;
+            /**
+             * @deprecated
+             * @description The highest version number for this crate.
+             * @example 2.0.0-beta.1
+             */
+            max_version: string;
+            /**
+             * @description The name of the crate.
+             * @example serde
+             */
+            name: string;
+            /**
+             * @deprecated
+             * @description The most recently published version for this crate.
+             * @example 1.2.3
+             */
+            newest_version: string;
+            /**
+             * Format: int32
+             * @description The total number of versions for this crate.
+             * @example 13
+             */
+            num_versions: number;
+            /**
+             * Format: int64
+             * @description The total number of downloads for this crate in the last 90 days.
+             * @example 456789
+             */
+            recent_downloads?: number | null;
+            /**
+             * @description The URL to the crate's repository, if set.
+             * @example https://github.com/serde-rs/serde
+             */
+            repository?: string | null;
+            /** @description Whether this crate can only be published via Trusted Publishing. */
+            trustpub_only: boolean;
+            /**
+             * Format: date-time
+             * @description The date and time this crate was last updated.
+             * @example 2019-12-13T13:46:41Z
+             */
+            updated_at: string;
+            /**
+             * @description The list of version IDs belonging to this crate.
+             * @example null
+             */
+            versions?: number[] | null;
+            /** @description Whether all versions of this crate have been yanked. */
+            yanked: boolean;
+        };
+        CrateLinks: {
+            /**
+             * @description The API path to this crate's team owners.
+             * @example /api/v1/crates/serde/owner_team
+             */
+            owner_team?: string | null;
+            /**
+             * @description The API path to this crate's user owners.
+             * @example /api/v1/crates/serde/owner_user
+             */
+            owner_user?: string | null;
+            /**
+             * @description The API path to this crate's owners.
+             * @example /api/v1/crates/serde/owners
+             */
+            owners?: string | null;
+            /**
+             * @description The API path to this crate's reverse dependencies.
+             * @example /api/v1/crates/serde/reverse_dependencies
+             */
+            reverse_dependencies: string;
+            /**
+             * @description The API path to this crate's download statistics.
+             * @example /api/v1/crates/serde/downloads
+             */
+            version_downloads: string;
+            /**
+             * @description The API path to this crate's versions.
+             * @example /api/v1/crates/serde/versions
+             */
+            versions?: string | null;
+        };
+        CrateOwnerInvitation: {
+            /**
+             * Format: int32
+             * @description The ID of the crate that the user was invited to be an owner of.
+             * @example 123
+             */
+            crate_id: number;
+            /**
+             * @description The name of the crate that the user was invited to be an owner of.
+             * @example serde
+             */
+            crate_name: string;
+            /**
+             * Format: date-time
+             * @description The date and time this invitation was created.
+             * @example 2019-12-13T13:46:41Z
+             */
+            created_at: string;
+            /**
+             * Format: date-time
+             * @description The date and time this invitation will expire.
+             * @example 2020-01-13T13:46:41Z
+             */
+            expires_at: string;
+            /**
+             * Format: int32
+             * @description The ID of the user who was invited to be a crate owner.
+             * @example 42
+             */
+            invitee_id: number;
+            /**
+             * Format: int32
+             * @description The ID of the user who sent the invitation.
+             * @example 3
+             */
+            inviter_id: number;
+        };
+        EncodableApiTokenWithToken: components["schemas"]["ApiToken"] & {
+            /**
+             * @description The plaintext API token.
+             *
+             *     Only available when the token is created.
+             * @example a1b2c3d4e5f6g7h8i9j0
+             */
+            token: string;
+        };
+        EncodableDependency: {
+            /**
+             * @description The name of the crate this dependency points to.
+             * @example serde
+             */
+            crate_id: string;
+            /**
+             * @description Whether default features are enabled for this dependency.
+             * @example true
+             */
+            default_features: boolean;
+            /**
+             * Format: int64
+             * @description The total number of downloads for the crate this dependency points to.
+             * @example 123456
+             */
+            downloads: number;
+            /** @description The features explicitly enabled for this dependency. */
+            features: string[];
+            /**
+             * Format: int32
+             * @description An opaque identifier for the dependency.
+             * @example 169
+             */
+            id: number;
+            /**
+             * @description The type of dependency this is (normal, dev, or build).
+             * @example normal
+             */
+            kind: string;
+            /** @description Whether this dependency is optional. */
+            optional: boolean;
+            /**
+             * @description The version requirement for this dependency.
+             * @example ^1
+             */
+            req: string;
+            /** @description The target platform for this dependency, if any. */
+            target?: string | null;
+            /**
+             * Format: int32
+             * @description The ID of the version this dependency belongs to.
+             * @example 42
+             */
+            version_id: number;
+        };
+        /** @enum {string} */
+        EndpointScope: "publish-new" | "publish-update" | "trusted-publishing" | "yank" | "change-owners";
+        GitHubConfig: {
+            /** @example regex */
+            crate: string;
+            /** Format: date-time */
+            created_at: string;
+            /** @example null */
+            environment?: string | null;
+            /**
+             * Format: int32
+             * @example 42
+             */
+            id: number;
+            /** @example regex */
+            repository_name: string;
+            /** @example rust-lang */
+            repository_owner: string;
+            /**
+             * Format: int32
+             * @example 5430905
+             */
+            repository_owner_id: number;
+            /** @example ci.yml */
+            workflow_filename: string;
+        };
+        GitLabConfig: {
+            /** @example regex */
+            crate: string;
+            /** Format: date-time */
+            created_at: string;
+            /** @example null */
+            environment?: string | null;
+            /**
+             * Format: int32
+             * @example 42
+             */
+            id: number;
+            /** @example rust-lang */
+            namespace: string;
+            /** @example null */
+            namespace_id?: string | null;
+            /** @example regex */
+            project: string;
+            /** @example .gitlab-ci.yml */
+            workflow_filepath: string;
+        };
+        Keyword: {
+            /**
+             * Format: int32
+             * @description The total number of crates that have this keyword.
+             * @example 42
+             */
+            crates_cnt: number;
+            /**
+             * Format: date-time
+             * @description The date and time this keyword was created.
+             * @example 2017-01-06T14:23:11Z
+             */
+            created_at: string;
+            /**
+             * @description An opaque identifier for the keyword.
+             * @example http
+             */
+            id: string;
+            /**
+             * @description The keyword itself.
+             * @example http
+             */
+            keyword: string;
+        };
+        LegacyCrateOwnerInvitation: {
+            /**
+             * Format: int32
+             * @description The ID of the crate that the user was invited to be an owner of.
+             * @example 123
+             */
+            crate_id: number;
+            /**
+             * @description The name of the crate that the user was invited to be an owner of.
+             * @example serde
+             */
+            crate_name: string;
+            /**
+             * Format: date-time
+             * @description The date and time this invitation was created.
+             * @example 2019-12-13T13:46:41Z
+             */
+            created_at: string;
+            /**
+             * Format: date-time
+             * @description The date and time this invitation will expire.
+             * @example 2020-01-13T13:46:41Z
+             */
+            expires_at: string;
+            /**
+             * @description The username of the user who sent the invitation.
+             * @example ghost
+             */
+            invited_by_username: string;
+            /**
+             * Format: int32
+             * @description The ID of the user who was invited to be a crate owner.
+             * @example 42
+             */
+            invitee_id: number;
+            /**
+             * Format: int32
+             * @description The ID of the user who sent the invitation.
+             * @example 3
+             */
+            inviter_id: number;
+        };
+        NewGitHubConfig: {
+            /** @example regex */
+            crate: string;
+            /** @example null */
+            environment?: string | null;
+            /** @example regex */
+            repository_name: string;
+            /** @example rust-lang */
+            repository_owner: string;
+            /** @example ci.yml */
+            workflow_filename: string;
+        };
+        NewGitLabConfig: {
+            /** @example regex */
+            crate: string;
+            /** @example null */
+            environment?: string | null;
+            /** @example rust-lang */
+            namespace: string;
+            /** @example regex */
+            project: string;
+            /** @example .gitlab-ci.yml */
+            workflow_filepath: string;
+        };
+        Owner: {
+            /**
+             * @description The avatar URL of the team or user.
+             * @example https://avatars2.githubusercontent.com/u/1234567?v=4
+             */
+            avatar?: string | null;
+            /**
+             * Format: int32
+             * @description The opaque identifier for the team or user, depending on the `kind` field.
+             * @example 42
+             */
+            id: number;
+            /**
+             * @description The kind of the owner (`user` or `team`).
+             * @example user
+             */
+            kind: string;
+            /**
+             * @description The login name of the team or user.
+             * @example ghost
+             */
+            login: string;
+            /**
+             * @description The display name of the team or user.
+             * @example Kate Morgan
+             */
+            name?: string | null;
+            /**
+             * @description The URL to the owner's profile.
+             * @example https://github.com/ghost
+             */
+            url?: string | null;
+        };
+        PatchRequest: {
+            /** @description The crate settings to update. */
+            crate: components["schemas"]["PatchRequestCrate"];
+        };
+        PatchRequestCrate: {
+            /** @description Whether this crate can only be published via Trusted Publishing. */
+            trustpub_only?: boolean | null;
+        };
+        PublishWarnings: {
+            /**
+             * @deprecated
+             * @example []
+             */
+            invalid_badges: string[];
+            /** @example [] */
+            invalid_categories: string[];
+            /** @example [] */
+            other: string[];
+        };
+        Slug: {
+            /**
+             * @description A description of the category.
+             * @example Libraries for creating games.
+             */
+            description: string;
+            /**
+             * @description An opaque identifier for the category.
+             * @example game-development
+             */
+            id: string;
+            /**
+             * @description The "slug" of the category.
+             *
+             *     See <https://crates.io/category_slugs>.
+             * @example game-development
+             */
+            slug: string;
+        };
+        Team: {
+            /**
+             * @description The avatar URL of the team.
+             * @example https://avatars2.githubusercontent.com/u/1234567?v=4
+             */
+            avatar?: string | null;
+            /**
+             * Format: int32
+             * @description An opaque identifier for the team.
+             * @example 42
+             */
+            id: number;
+            /**
+             * @description The login name of the team.
+             * @example github:rust-lang:crates-io
+             */
+            login: string;
+            /**
+             * @description The display name of the team.
+             * @example Crates.io team
+             */
+            name?: string | null;
+            /**
+             * @description The GitHub profile URL of the team.
+             * @example https://github.com/rust-lang
+             */
+            url?: string | null;
+        };
+        User: {
+            /**
+             * @description The user's avatar URL, if set.
+             * @example https://avatars2.githubusercontent.com/u/1234567?v=4
+             */
+            avatar?: string | null;
+            /**
+             * Format: int32
+             * @description An opaque identifier for the user.
+             * @example 42
+             */
+            id: number;
+            /**
+             * @description The user's login name.
+             * @example ghost
+             */
+            login: string;
+            /**
+             * @description The user's display name, if set.
+             * @example Kate Morgan
+             */
+            name?: string | null;
+            /**
+             * @description The user's GitHub profile URL.
+             * @example https://github.com/ghost
+             */
+            url: string;
+        };
+        Version: {
+            /** @description A list of actions performed on this version. */
+            audit_actions: {
+                /**
+                 * @description The action that was performed.
+                 * @example publish
+                 */
+                action: string;
+                /**
+                 * Format: date-time
+                 * @description The date and time the action was performed.
+                 * @example 2019-12-13T13:46:41Z
+                 */
+                time: string;
+                /** @description The user who performed the action. */
+                user: components["schemas"]["User"];
+            }[];
+            /**
+             * @description The names of the binaries provided by this version, if any.
+             * @example []
+             */
+            bin_names?: (string | null)[] | null;
+            /**
+             * @description The SHA256 checksum of the compressed crate file encoded as a
+             *     hexadecimal string.
+             * @example e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60
+             */
+            checksum: string;
+            /**
+             * @description The name of the crate.
+             * @example serde
+             */
+            crate: string;
+            /**
+             * Format: int32
+             * @description The size of the compressed crate file in bytes.
+             * @example 1234
+             */
+            crate_size: number;
+            /**
+             * Format: date-time
+             * @description The date and time this version was created.
+             * @example 2019-12-13T13:46:41Z
+             */
+            created_at: string;
+            /**
+             * @description The description of this version of the crate.
+             * @example A generic serialization/deserialization framework
+             */
+            description?: string | null;
+            /**
+             * @description The API path to download the crate.
+             * @example /api/v1/crates/serde/1.0.0/download
+             */
+            dl_path: string;
+            /**
+             * @description The URL to the crate's documentation, if set.
+             * @example https://docs.rs/serde
+             */
+            documentation?: string | null;
+            /**
+             * Format: int32
+             * @description The total number of downloads for this version.
+             * @example 123456
+             */
+            downloads: number;
+            /**
+             * @description The Rust Edition used to compile this version, if set.
+             * @example 2021
+             */
+            edition?: string | null;
+            /** @description The features defined by this version. */
+            features: Record<string, never>;
+            /**
+             * @description Whether this version can be used as a library.
+             * @example true
+             */
+            has_lib?: boolean | null;
+            /**
+             * @description The URL to the crate's homepage, if set.
+             * @example https://serde.rs
+             */
+            homepage?: string | null;
+            /**
+             * Format: int32
+             * @description An opaque identifier for the version.
+             * @example 42
+             */
+            id: number;
+            /**
+             * @description The name of the native library this version links with, if any.
+             * @example git2
+             */
+            lib_links?: string | null;
+            /**
+             * @description The license of this version of the crate.
+             * @example MIT
+             */
+            license?: string | null;
+            /**
+             * @description Line count statistics for this version.
+             *
+             *     Status: **Unstable**
+             *
+             *     This field may be `null` until the version has been analyzed, which
+             *     happens in an asynchronous background job.
+             */
+            linecounts: Record<string, never>;
+            /** @description Links to other API endpoints related to this version. */
+            links: components["schemas"]["VersionLinks"];
+            /**
+             * @description The version number.
+             * @example 1.0.0
+             */
+            num: string;
+            published_by?: null | components["schemas"]["User"];
+            /**
+             * @description The API path to download the crate's README file as HTML code.
+             * @example /api/v1/crates/serde/1.0.0/readme
+             */
+            readme_path: string;
+            /**
+             * @description The URL to the crate's repository, if set.
+             * @example https://github.com/serde-rs/serde
+             */
+            repository?: string | null;
+            /**
+             * @description The minimum version of the Rust compiler required to compile
+             *     this version, if set.
+             * @example 1.31
+             */
+            rust_version?: string | null;
+            /**
+             * @description Information about the trusted publisher that published this version, if any.
+             *
+             *     Status: **Unstable**
+             *
+             *     This field is filled if the version was published via trusted publishing
+             *     (e.g., GitHub Actions) rather than a regular API token.
+             *
+             *     The exact structure of this field depends on the `provider` field
+             *     inside it.
+             */
+            trustpub_data?: Record<string, never> | null;
+            /**
+             * Format: date-time
+             * @description The date and time this version was last updated (i.e. yanked or unyanked).
+             * @example 2019-12-13T13:46:41Z
+             */
+            updated_at: string;
+            /**
+             * @description The message given when this version was yanked, if any.
+             * @example Security vulnerability
+             */
+            yank_message?: string | null;
+            /**
+             * @description Whether this version has been yanked.
+             * @example false
+             */
+            yanked: boolean;
+        };
+        VersionDownload: {
+            /**
+             * @description The date this download count is for.
+             * @example 2019-12-13
+             */
+            date: string;
+            /**
+             * Format: int32
+             * @description The number of downloads for this version on the given date.
+             * @example 123
+             */
+            downloads: number;
+            /**
+             * Format: int32
+             * @description The ID of the version this download count is for.
+             * @example 42
+             */
+            version: number;
+        };
+        VersionLinks: {
+            /**
+             * @deprecated
+             * @description The API path to download this version's authors.
+             * @example /api/v1/crates/serde/1.0.0/authors
+             */
+            authors: string;
+            /**
+             * @description The API path to download this version's dependencies.
+             * @example /api/v1/crates/serde/1.0.0/dependencies
+             */
+            dependencies: string;
+            /**
+             * @description The API path to download this version's download numbers.
+             * @example /api/v1/crates/serde/1.0.0/downloads
+             */
+            version_downloads: string;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    list_crate_owner_invitations: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Filter crate owner invitations by crate name.
+                 *
+                 *     Only crate owners can query pending invitations for their crate.
+                 */
+                crate_name?: string;
+                /**
+                 * @description The ID of the user who was invited to be a crate owner.
+                 *
+                 *     This parameter needs to match the authenticated user's ID.
+                 */
+                invitee_id?: number;
+                /**
+                 * @description The page number to request.
+                 *
+                 *     This parameter is mutually exclusive with `seek` and not supported for
+                 *     all requests.
+                 */
+                page?: number;
+                /** @description The number of items to request per page. */
+                per_page?: number;
+                /**
+                 * @description The seek key to request.
+                 *
+                 *     This parameter is mutually exclusive with `page` and not supported for
+                 *     all requests.
+                 *
+                 *     The seek key can usually be found in the `meta.next_page` field of
+                 *     paginated responses.
+                 */
+                seek?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The list of crate owner invitations. */
+                        invitations: components["schemas"]["CrateOwnerInvitation"][];
+                        meta: {
+                            /**
+                             * @description Query parameter string to fetch the next page of results.
+                             * @example ?seek=c0ffee
+                             */
+                            next_page?: string | null;
+                        };
+                        /** @description The list of users referenced in the crate owner invitations. */
+                        users: components["schemas"]["User"][];
+                    };
+                };
+            };
+        };
+    };
+    end_session: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    authorize_session: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The crates that the authenticated user owns. */
+                        owned_crates: {
+                            /** @deprecated */
+                            email_notifications: boolean;
+                            /**
+                             * Format: int32
+                             * @description The opaque identifier of the crate.
+                             * @example 123
+                             */
+                            id: number;
+                            /**
+                             * @description The name of the crate.
+                             * @example serde
+                             */
+                            name: string;
+                        }[];
+                        /** @description The authenticated user. */
+                        user: components["schemas"]["AuthenticatedUser"];
+                    };
+                };
+            };
+        };
+    };
+    begin_session: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example b84a63c4ea3fcb4ac84 */
+                        state: string;
+                        /** @example https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg */
+                        url: string;
+                    };
+                };
+            };
+        };
+    };
+    list_categories: {
+        parameters: {
+            query?: {
+                /**
+                 * @description The sort order of the categories.
+                 *
+                 *     Valid values: `alpha`, and `crates`.
+                 *
+                 *     Defaults to `alpha`.
+                 */
+                sort?: string;
+                /**
+                 * @description The page number to request.
+                 *
+                 *     This parameter is mutually exclusive with `seek` and not supported for
+                 *     all requests.
+                 */
+                page?: number;
+                /** @description The number of items to request per page. */
+                per_page?: number;
+                /**
+                 * @description The seek key to request.
+                 *
+                 *     This parameter is mutually exclusive with `page` and not supported for
+                 *     all requests.
+                 *
+                 *     The seek key can usually be found in the `meta.next_page` field of
+                 *     paginated responses.
+                 */
+                seek?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The list of categories. */
+                        categories: components["schemas"]["Category"][];
+                        meta: {
+                            /**
+                             * Format: int64
+                             * @description The total number of categories.
+                             * @example 123
+                             */
+                            total: number;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    find_category: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the category */
+                category: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        category: components["schemas"]["Category"];
+                    };
+                };
+            };
+        };
+    };
+    list_category_slugs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The list of category slugs. */
+                        category_slugs: components["schemas"]["Slug"][];
+                    };
+                };
+            };
+        };
+    };
+    confirm_user_email: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Secret verification token sent to the user's email address */
+                email_token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
+            };
+        };
+    };
+    list_crates: {
+        parameters: {
+            query?: {
+                /**
+                 * @description The sort order of the crates.
+                 *
+                 *     Valid values: `alphabetical`, `relevance`, `downloads`,
+                 *     `recent-downloads`, `recent-updates`, `new`.
+                 *
+                 *     Defaults to `relevance` if `q` is set, otherwise `alphabetical`.
+                 */
+                sort?: string;
+                /** @description A search query string. */
+                q?: string;
+                /**
+                 * @description Set to `yes` to include yanked crates.
+                 * @example yes
+                 */
+                include_yanked?: string;
+                /**
+                 * @description If set, only return crates that belong to this category, or one
+                 *     of its subcategories.
+                 */
+                category?: string;
+                /**
+                 * @description If set, only return crates matching all the given keywords.
+                 *
+                 *     This parameter expects a space-separated list of keywords.
+                 */
+                all_keywords?: string;
+                /**
+                 * @description If set, only return crates matching the given keyword
+                 *     (ignored if `all_keywords` is set).
+                 */
+                keyword?: string;
+                /**
+                 * @description If set, only return crates with names that start with the given letter
+                 *     (ignored if `all_keywords` or `keyword` are set).
+                 */
+                letter?: string;
+                /**
+                 * @description If set, only crates owned by the given crates.io user ID are returned
+                 *     (ignored if `all_keywords`, `keyword`, or `letter` are set).
+                 */
+                user_id?: number;
+                /**
+                 * @description If set, only crates owned by the given crates.io team ID are returned
+                 *     (ignored if `all_keywords`, `keyword`, `letter`, or `user_id` are set).
+                 */
+                team_id?: number;
+                /**
+                 * @description If set, only crates owned by users the current user follows are returned
+                 *     (ignored if `all_keywords`, `keyword`, `letter`, `user_id`,
+                 *     or `team_id` are set).
+                 *
+                 *     The exact value of this parameter is ignored, but it must not be empty.
+                 * @example yes
+                 */
+                following?: string;
+                /**
+                 * @description If set, only crates with the specified names are returned (ignored
+                 *     if `all_keywords`, `keyword`, `letter`, `user_id`, `team_id`,
+                 *     or `following` are set).
+                 */
+                "ids[]"?: string[];
+                /**
+                 * @description The page number to request.
+                 *
+                 *     This parameter is mutually exclusive with `seek` and not supported for
+                 *     all requests.
+                 */
+                page?: number;
+                /** @description The number of items to request per page. */
+                per_page?: number;
+                /**
+                 * @description The seek key to request.
+                 *
+                 *     This parameter is mutually exclusive with `page` and not supported for
+                 *     all requests.
+                 *
+                 *     The seek key can usually be found in the `meta.next_page` field of
+                 *     paginated responses.
+                 */
+                seek?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        crates: components["schemas"]["Crate"][];
+                        meta: {
+                            /**
+                             * @description Query string to the next page of results, if any.
+                             * @example ?page=3
+                             */
+                            next_page?: string | null;
+                            /**
+                             * @description Query string to the previous page of results, if any.
+                             * @example ?page=1
+                             */
+                            prev_page?: string | null;
+                            /**
+                             * Format: int64
+                             * @description The total number of crates that match the query.
+                             * @example 123
+                             */
+                            total: number;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    find_new_crate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description The categories of the crate.
+                         * @example null
+                         */
+                        categories?: components["schemas"]["Category"][] | null;
+                        /** @description The crate metadata. */
+                        crate: components["schemas"]["Crate"];
+                        /**
+                         * @description The keywords of the crate.
+                         * @example null
+                         */
+                        keywords?: components["schemas"]["Keyword"][] | null;
+                        /**
+                         * @description The versions of the crate.
+                         * @example null
+                         */
+                        versions?: components["schemas"]["Version"][] | null;
+                    };
+                };
+            };
+        };
+    };
+    publish: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        crate: components["schemas"]["Crate"];
+                        warnings: components["schemas"]["PublishWarnings"];
+                    };
+                };
+            };
+        };
+    };
+    find_crate: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Additional data to include in the response.
+                 *
+                 *     Valid values: `versions`, `keywords`, `categories`, `badges`,
+                 *     `downloads`, `default_version`, or `full`.
+                 *
+                 *     Defaults to `full` for backwards compatibility.
+                 *
+                 *     **Note**: `versions` and `default_version` share the same key `versions`, therefore `default_version` will be ignored if both are provided.
+                 *
+                 *     This parameter expects a comma-separated list of values.
+                 */
+                include?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description The categories of the crate.
+                         * @example null
+                         */
+                        categories?: components["schemas"]["Category"][] | null;
+                        /** @description The crate metadata. */
+                        crate: components["schemas"]["Crate"];
+                        /**
+                         * @description The keywords of the crate.
+                         * @example null
+                         */
+                        keywords?: components["schemas"]["Keyword"][] | null;
+                        /**
+                         * @description The versions of the crate.
+                         * @example null
+                         */
+                        versions?: components["schemas"]["Version"][] | null;
+                    };
+                };
+            };
+        };
+    };
+    delete_crate: {
+        parameters: {
+            query?: {
+                message?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    update_crate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The updated crate metadata. */
+                        crate: components["schemas"]["Crate"];
+                    };
+                };
+            };
+        };
+    };
+    get_crate_downloads: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Additional data to include in the response.
+                 *
+                 *     Valid values: `versions`.
+                 *
+                 *     Defaults to no additional data.
+                 *
+                 *     This parameter expects a comma-separated list of values.
+                 */
+                include?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        meta: {
+                            extra_downloads: {
+                                /**
+                                 * @description The date this download count is for.
+                                 * @example 2019-12-13
+                                 */
+                                date: string;
+                                /**
+                                 * Format: int64
+                                 * @description The number of downloads on the given date.
+                                 * @example 123
+                                 */
+                                downloads: number;
+                            }[];
+                        };
+                        /** @description The per-day download counts for the last 90 days. */
+                        version_downloads: components["schemas"]["VersionDownload"][];
+                        /**
+                         * @description The versions referenced in the download counts, if `?include=versions`
+                         *     was requested.
+                         */
+                        versions?: components["schemas"]["Version"][] | null;
+                    };
+                };
+            };
+        };
+    };
+    follow_crate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
+            };
+        };
+    };
+    unfollow_crate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
+            };
+        };
+    };
+    get_following_crate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Whether the authenticated user is following the crate. */
+                        following: boolean;
+                    };
+                };
+            };
+        };
+    };
+    get_team_owners: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        teams: components["schemas"]["Owner"][];
+                    };
+                };
+            };
+        };
+    };
+    get_user_owners: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        users: components["schemas"]["Owner"][];
+                    };
+                };
+            };
+        };
+    };
+    list_owners: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        users: components["schemas"]["Owner"][];
+                    };
+                };
+            };
+        };
+    };
+    add_owners: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description List of owner login names to add or remove.
+                     *
+                     *     For users, use just the username (e.g., `"octocat"`).
+                     *     For GitHub teams, use the format `github:org:team` (e.g., `"github:rust-lang:owners"`).
+                     * @example [
+                     *       "octocat",
+                     *       "github:rust-lang:owners"
+                     *     ]
+                     */
+                    owners: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A message describing the result of the operation.
+                         * @example user ghost has been invited to be an owner of crate serde
+                         */
+                        msg: string;
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
+            };
+        };
+    };
+    remove_owners: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description List of owner login names to add or remove.
+                     *
+                     *     For users, use just the username (e.g., `"octocat"`).
+                     *     For GitHub teams, use the format `github:org:team` (e.g., `"github:rust-lang:owners"`).
+                     * @example [
+                     *       "octocat",
+                     *       "github:rust-lang:owners"
+                     *     ]
+                     */
+                    owners: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description A message describing the result of the operation.
+                         * @example user ghost has been invited to be an owner of crate serde
+                         */
+                        msg: string;
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
+            };
+        };
+    };
+    list_reverse_dependencies: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The list of reverse dependencies of the crate. */
+                        dependencies: components["schemas"]["EncodableDependency"][];
+                        meta: {
+                            /**
+                             * Format: int64
+                             * @example 32
+                             */
+                            total: number;
+                        };
+                        /** @description The versions referenced in the `dependencies` field. */
+                        versions: components["schemas"]["Version"][];
+                    };
+                };
+            };
+        };
+    };
+    list_versions: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Additional data to include in the response.
+                 *
+                 *     Valid values: `release_tracks`.
+                 *
+                 *     Defaults to no additional data.
+                 *
+                 *     This parameter expects a comma-separated list of values.
+                 */
+                include?: string;
+                /**
+                 * @description The sort order of the versions.
+                 *
+                 *     Valid values: `date`, and `semver`.
+                 *
+                 *     Defaults to `semver`.
+                 */
+                sort?: string;
+                /** @description If set, only versions with the specified semver strings are returned. */
+                "nums[]"?: string[];
+                /**
+                 * @description The page number to request.
+                 *
+                 *     This parameter is mutually exclusive with `seek` and not supported for
+                 *     all requests.
+                 */
+                page?: number;
+                /** @description The number of items to request per page. */
+                per_page?: number;
+                /**
+                 * @description The seek key to request.
+                 *
+                 *     This parameter is mutually exclusive with `page` and not supported for
+                 *     all requests.
+                 *
+                 *     The seek key can usually be found in the `meta.next_page` field of
+                 *     paginated responses.
+                 */
+                seek?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        meta: {
+                            /**
+                             * @description Query string to the next page of results, if any.
+                             * @example ?page=3
+                             */
+                            next_page?: string | null;
+                            /**
+                             * @description Additional data about the crate's release tracks,
+                             *     if `?include=release_tracks` is used.
+                             */
+                            release_tracks?: Record<string, never> | null;
+                            /**
+                             * Format: int64
+                             * @description The total number of versions belonging to the crate.
+                             * @example 123
+                             */
+                            total: number;
+                        };
+                        versions: components["schemas"]["Version"][];
+                    };
+                };
+            };
+        };
+    };
+    find_version: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+                /**
+                 * @description Version number
+                 * @example 1.0.0
+                 */
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        version: components["schemas"]["Version"];
+                    };
+                };
+            };
+        };
+    };
+    update_version: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+                /**
+                 * @description Version number
+                 * @example 1.0.0
+                 */
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        version: components["schemas"]["Version"];
+                    };
+                };
+            };
+        };
+    };
+    get_version_authors: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+                /**
+                 * @description Version number
+                 * @example 1.0.0
+                 */
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_version_dependencies: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+                /**
+                 * @description Version number
+                 * @example 1.0.0
+                 */
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        dependencies: components["schemas"]["EncodableDependency"][];
+                    };
+                };
+            };
+        };
+    };
+    download_version: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+                /**
+                 * @description Version number
+                 * @example 1.0.0
+                 */
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response (for `content-type: application/json`) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description The URL to the crate file.
+                         * @example https://static.crates.io/crates/serde/serde-1.0.0.crate
+                         */
+                        url: string;
+                    };
+                };
+            };
+            /** @description Successful Response (default) */
+            302: {
+                headers: {
+                    /** @description The URL to the crate file. */
+                    location?: string;
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_version_downloads: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Only return download counts before this date.
+                 * @example 2024-06-28
+                 */
+                before_date?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+                /**
+                 * @description Version number
+                 * @example 1.0.0
+                 */
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        version_downloads: components["schemas"]["VersionDownload"][];
+                    };
+                };
+            };
+        };
+    };
+    get_version_readme: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+                /**
+                 * @description Version number
+                 * @example 1.0.0
+                 */
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response (for `content-type: application/json`) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * @description The URL to the readme file.
+                         * @example https://static.crates.io/readmes/serde/serde-1.0.0.html
+                         */
+                        url: string;
+                    };
+                };
+            };
+            /** @description Successful Response (default) */
+            302: {
+                headers: {
+                    /** @description The URL to the readme file. */
+                    location?: string;
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    rebuild_version_docs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+                /**
+                 * @description Version number
+                 * @example 1.0.0
+                 */
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    unyank_version: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+                /**
+                 * @description Version number
+                 * @example 1.0.0
+                 */
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
+            };
+        };
+    };
+    yank_version: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the crate */
+                name: string;
+                /**
+                 * @description Version number
+                 * @example 1.0.0
+                 */
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
+            };
+        };
+    };
+    list_keywords: {
+        parameters: {
+            query?: {
+                /**
+                 * @description The sort order of the keywords.
+                 *
+                 *     Valid values: `alpha`, and `crates`.
+                 *
+                 *     Defaults to `alpha`.
+                 */
+                sort?: string;
+                /**
+                 * @description The page number to request.
+                 *
+                 *     This parameter is mutually exclusive with `seek` and not supported for
+                 *     all requests.
+                 */
+                page?: number;
+                /** @description The number of items to request per page. */
+                per_page?: number;
+                /**
+                 * @description The seek key to request.
+                 *
+                 *     This parameter is mutually exclusive with `page` and not supported for
+                 *     all requests.
+                 *
+                 *     The seek key can usually be found in the `meta.next_page` field of
+                 *     paginated responses.
+                 */
+                seek?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The list of keywords. */
+                        keywords: components["schemas"]["Keyword"][];
+                        meta: {
+                            /**
+                             * Format: int64
+                             * @description The total number of keywords.
+                             * @example 123
+                             */
+                            total: number;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    find_keyword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The keyword to find */
+                keyword: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        keyword: components["schemas"]["Keyword"];
+                    };
+                };
+            };
+        };
+    };
+    get_authenticated_user: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The crates that the authenticated user owns. */
+                        owned_crates: {
+                            /** @deprecated */
+                            email_notifications: boolean;
+                            /**
+                             * Format: int32
+                             * @description The opaque identifier of the crate.
+                             * @example 123
+                             */
+                            id: number;
+                            /**
+                             * @description The name of the crate.
+                             * @example serde
+                             */
+                            name: string;
+                        }[];
+                        /** @description The authenticated user. */
+                        user: components["schemas"]["AuthenticatedUser"];
+                    };
+                };
+            };
+        };
+    };
+    list_crate_owner_invitations_for_user: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The list of crate owner invitations. */
+                        crate_owner_invitations: components["schemas"]["LegacyCrateOwnerInvitation"][];
+                        /** @description The list of users referenced in the crate owner invitations. */
+                        users: components["schemas"]["User"][];
+                    };
+                };
+            };
+        };
+    };
+    accept_crate_owner_invitation_with_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Secret token sent to the user's email address */
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        crate_owner_invitation: {
+                            /**
+                             * @description Whether the invitation was accepted.
+                             * @example true
+                             */
+                            accepted: boolean;
+                            /**
+                             * Format: int32
+                             * @description The opaque identifier for the crate this invitation is for.
+                             * @example 42
+                             */
+                            crate_id: number;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    handle_crate_owner_invitation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the crate */
+                crate_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        crate_owner_invitation: {
+                            /**
+                             * @description Whether the invitation was accepted.
+                             * @example true
+                             */
+                            accepted: boolean;
+                            /**
+                             * Format: int32
+                             * @description The opaque identifier for the crate this invitation is for.
+                             * @example 42
+                             */
+                            crate_id: number;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    update_email_notifications: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
+            };
+        };
+    };
+    list_api_tokens: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        api_tokens: components["schemas"]["ApiToken"][];
+                    };
+                };
+            };
+        };
+    };
+    create_api_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        api_token: components["schemas"]["EncodableApiTokenWithToken"];
+                    };
+                };
+            };
+        };
+    };
+    find_api_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the API token */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        api_token: components["schemas"]["ApiToken"];
+                    };
+                };
+            };
+        };
+    };
+    revoke_api_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the API token */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
+    get_authenticated_user_updates: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        meta: {
+                            /** @description Whether there are more versions to be loaded. */
+                            more: boolean;
+                        };
+                        /** @description The list of recent versions of crates that the authenticated user follows. */
+                        versions: components["schemas"]["Version"][];
+                    };
+                };
+            };
+        };
+    };
+    get_site_metadata: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Optional banner message to display on all pages. */
+                        banner_message?: string | null;
+                        /**
+                         * @description The SHA1 of the currently deployed commit.
+                         * @example 0aebe2cdfacae1229b93853b1c58f9352195f081
+                         */
+                        commit: string;
+                        /**
+                         * @description The SHA1 of the currently deployed commit.
+                         * @example 0aebe2cdfacae1229b93853b1c58f9352195f081
+                         */
+                        deployed_sha: string;
+                        /** @description Whether the crates.io service is in read-only mode. */
+                        read_only: boolean;
+                    };
+                };
+            };
+        };
+    };
+    get_summary: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The 10 most recently updated crates. */
+                        just_updated: components["schemas"]["Crate"][];
+                        /** @description The 10 crates with the highest total number of downloads. */
+                        most_downloaded: components["schemas"]["Crate"][];
+                        /** @description The 10 crates with the highest number of downloads within the last 90 days. */
+                        most_recently_downloaded: components["schemas"]["Crate"][];
+                        /** @description The 10 most recently created crates. */
+                        new_crates: components["schemas"]["Crate"][];
+                        /**
+                         * Format: int64
+                         * @description The total number of crates on crates.io.
+                         * @example 123456
+                         */
+                        num_crates: number;
+                        /**
+                         * Format: int64
+                         * @description The total number of downloads across all crates.
+                         * @example 123456789
+                         */
+                        num_downloads: number;
+                        /** @description The 10 most popular categories. */
+                        popular_categories: components["schemas"]["Category"][];
+                        /** @description The 10 most popular keywords. */
+                        popular_keywords: components["schemas"]["Keyword"][];
+                    };
+                };
+            };
+        };
+    };
+    find_team: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description Name of the team
+                 * @example github:rust-lang:crates-io
+                 */
+                team: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        team: components["schemas"]["Team"];
+                    };
+                };
+            };
+        };
+    };
+    revoke_current_api_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    list_trustpub_github_configs: {
+        parameters: {
+            query?: {
+                /** @description Name of the crate to list Trusted Publishing configurations for. */
+                crate?: string;
+                /** @description User ID to list Trusted Publishing configurations for all crates owned by the user. */
+                user_id?: number;
+                /**
+                 * @description The page number to request.
+                 *
+                 *     This parameter is mutually exclusive with `seek` and not supported for
+                 *     all requests.
+                 */
+                page?: number;
+                /** @description The number of items to request per page. */
+                per_page?: number;
+                /**
+                 * @description The seek key to request.
+                 *
+                 *     This parameter is mutually exclusive with `page` and not supported for
+                 *     all requests.
+                 *
+                 *     The seek key can usually be found in the `meta.next_page` field of
+                 *     paginated responses.
+                 */
+                seek?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        github_configs: components["schemas"]["GitHubConfig"][];
+                        meta: {
+                            /**
+                             * @description Query string to the next page of results, if any.
+                             * @example ?seek=abc123
+                             */
+                            next_page?: string | null;
+                            /**
+                             * Format: int64
+                             * @description The total number of GitHub configs belonging to the crate.
+                             * @example 42
+                             */
+                            total: number;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    create_trustpub_github_config: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    github_config: components["schemas"]["NewGitHubConfig"];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        github_config: components["schemas"]["GitHubConfig"];
+                    };
+                };
+            };
+        };
+    };
+    delete_trustpub_github_config: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the Trusted Publishing configuration */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    list_trustpub_gitlab_configs: {
+        parameters: {
+            query?: {
+                /** @description Name of the crate to list Trusted Publishing configurations for. */
+                crate?: string;
+                /** @description User ID to list Trusted Publishing configurations for all crates owned by the user. */
+                user_id?: number;
+                /**
+                 * @description The page number to request.
+                 *
+                 *     This parameter is mutually exclusive with `seek` and not supported for
+                 *     all requests.
+                 */
+                page?: number;
+                /** @description The number of items to request per page. */
+                per_page?: number;
+                /**
+                 * @description The seek key to request.
+                 *
+                 *     This parameter is mutually exclusive with `page` and not supported for
+                 *     all requests.
+                 *
+                 *     The seek key can usually be found in the `meta.next_page` field of
+                 *     paginated responses.
+                 */
+                seek?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        gitlab_configs: components["schemas"]["GitLabConfig"][];
+                        meta: {
+                            /**
+                             * @description Query string to the next page of results, if any.
+                             * @example ?seek=abc123
+                             */
+                            next_page?: string | null;
+                            /**
+                             * Format: int64
+                             * @description The total number of GitLab configs belonging to the crate.
+                             * @example 42
+                             */
+                            total: number;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    create_trustpub_gitlab_config: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    gitlab_config: components["schemas"]["NewGitLabConfig"];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        gitlab_config: components["schemas"]["GitLabConfig"];
+                    };
+                };
+            };
+        };
+    };
+    delete_trustpub_gitlab_config: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the Trusted Publishing configuration */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    exchange_trustpub_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    jwt: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        token: string;
+                    };
+                };
+            };
+        };
+    };
+    revoke_trustpub_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    resend_email_verification: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the user */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
+            };
+        };
+    };
+    get_user_stats: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the user */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * Format: int64
+                         * @description The total number of downloads for crates owned by the user.
+                         * @example 123456789
+                         */
+                        total_downloads: number;
+                    };
+                };
+            };
+        };
+    };
+    find_user: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Login name of the user */
+                user: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        user: components["schemas"]["User"];
+                    };
+                };
+            };
+        };
+    };
+    update_user: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the user */
+                user: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
+            };
+        };
+    };
+}

--- a/packages/crates-io-api-client/schema.test.ts
+++ b/packages/crates-io-api-client/schema.test.ts
@@ -1,0 +1,35 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import openapiTS, { astToString } from 'openapi-typescript';
+import { expect, test } from 'vitest';
+
+const SNAPSHOT_PATH = '../../src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap';
+
+const HEADER = `/**
+ * This file is auto-generated. Do not edit manually.
+ *
+ * Run \`pnpm --filter @crates-io/api-client regenerate\` to update this file.
+ */
+
+`;
+
+async function generateSchema() {
+  // Read snapshot file
+  let content = await fs.readFile(path.resolve(__dirname, SNAPSHOT_PATH), 'utf8');
+
+  // Strip YAML frontmatter (everything before the first `{`)
+  let jsonStart = content.indexOf('{');
+  let json = content.slice(jsonStart);
+
+  // Parse and generate TypeScript
+  let schema = JSON.parse(json);
+  let ast = await openapiTS(schema);
+  return HEADER + astToString(ast);
+}
+
+test('schema.d.ts is up to date', async () => {
+  let generated = await generateSchema();
+  let schemaPath = path.resolve(__dirname, 'schema.d.ts');
+  await expect(generated).toMatchFileSnapshot(schemaPath);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 4.11.0(playwright-core@1.57.0)
       '@babel/core':
         specifier: 7.28.5
-        version: 7.28.5(supports-color@8.1.1)
+        version: 7.28.5
       '@babel/eslint-parser':
         specifier: 7.28.5
         version: 7.28.5(@babel/core@7.28.5)(eslint@9.39.2(jiti@2.6.1))
@@ -321,6 +321,25 @@ importers:
       webpack:
         specifier: 5.104.1
         version: 5.104.1
+
+  packages/crates-io-api-client:
+    dependencies:
+      openapi-fetch:
+        specifier: 0.15.0
+        version: 0.15.0
+    devDependencies:
+      '@crates-io/msw':
+        specifier: workspace:*
+        version: link:../crates-io-msw
+      msw:
+        specifier: 2.12.4
+        version: 2.12.4(@types/node@24.10.4)(typescript@5.9.3)
+      openapi-typescript:
+        specifier: 7.10.1
+        version: 7.10.1(typescript@5.9.3)
+      vitest:
+        specifier: 4.0.15
+        version: 4.0.15(@types/node@24.10.4)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(yaml@2.8.2)
 
   packages/crates-io-msw:
     dependencies:
@@ -2104,6 +2123,16 @@ packages:
       svelte: '>=5.x'
       vite: '>=5.x || >= 6.x'
 
+  '@redocly/ajv@8.17.1':
+    resolution: {integrity: sha512-EDtsGZS964mf9zAUXAl9Ew16eYbeyAFWhsPr0fX6oaJxgd8rApYlPBf0joyhnUHz88WxrigyFtTaqqzXNzPgqw==}
+
+  '@redocly/config@0.22.2':
+    resolution: {integrity: sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ==}
+
+  '@redocly/openapi-core@1.34.6':
+    resolution: {integrity: sha512-2+O+riuIUgVSuLl3Lyh5AplWZyVMNuG2F98/o6NrutKJfW4/GTZdPpZlIphS0HGgcOHgmWcCSHj+dWFlZaGSHw==}
+    engines: {node: '>=18.17.0', npm: '>=9.5.0'}
+
   '@rollup/pluginutils@5.1.4':
     resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
     engines: {node: '>=14.0.0'}
@@ -2642,6 +2671,9 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/expect@4.0.15':
+    resolution: {integrity: sha512-Gfyva9/GxPAWXIWjyGDli9O+waHDC0Q0jaLdFP1qPAUUfo1FEXPXUfUkp3eZA0sSq340vPycSyOlYUeM15Ft1w==}
+
   '@vitest/expect@4.0.16':
     resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
 
@@ -2650,6 +2682,17 @@ packages:
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@4.0.15':
+    resolution: {integrity: sha512-CZ28GLfOEIFkvCFngN8Sfx5h+Se0zN+h4B7yOsPVCcgtiO7t5jt9xQh2E1UkFep+eb9fjyMfuC5gBypwb07fvQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -2670,11 +2713,20 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
+  '@vitest/pretty-format@4.0.15':
+    resolution: {integrity: sha512-SWdqR8vEv83WtZcrfLNqlqeQXlQLh2iilO1Wk1gv4eiHKjEzvgHb2OVc3mIPyhZE6F+CtfYjNlDJwP5MN6Km7A==}
+
   '@vitest/pretty-format@4.0.16':
     resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
 
+  '@vitest/runner@4.0.15':
+    resolution: {integrity: sha512-+A+yMY8dGixUhHmNdPUxOh0la6uVzun86vAbuMT3hIDxMrAOmn5ILBHm8ajrqHE0t8R9T1dGnde1A5DTnmi3qw==}
+
   '@vitest/runner@4.0.16':
     resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
+
+  '@vitest/snapshot@4.0.15':
+    resolution: {integrity: sha512-A7Ob8EdFZJIBjLjeO0DZF4lqR6U7Ydi5/5LIZ0xcI+23lYlsYJAfGn8PrIWTYdZQRNnSRlzhg0zyGu37mVdy5g==}
 
   '@vitest/snapshot@4.0.16':
     resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
@@ -2682,11 +2734,17 @@ packages:
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@4.0.15':
+    resolution: {integrity: sha512-+EIjOJmnY6mIfdXtE/bnozKEvTC4Uczg19yeZ2vtCz5Yyb0QQ31QWVQ8hswJ3Ysx/K2EqaNsVanjr//2+P3FHw==}
+
   '@vitest/spy@4.0.16':
     resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.0.15':
+    resolution: {integrity: sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA==}
 
   '@vitest/utils@4.0.16':
     resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
@@ -2865,6 +2923,10 @@ packages:
   amdefine@1.0.1:
     resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
     engines: {node: '>=0.4.2'}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
 
   ansi-escapes@3.2.0:
     resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
@@ -3631,6 +3693,9 @@ packages:
   color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   colors@1.0.3:
     resolution: {integrity: sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==}
@@ -5807,6 +5872,10 @@ packages:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
 
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
+
   inflection@2.0.1:
     resolution: {integrity: sha512-wzkZHqpb4eGrOKBl34xy3umnYHx8Si5R1U4fwmdxLo5gdH6mEK8gclckTj/qWqy4Je0bsDYe/qazZYuO7xe3XQ==}
     engines: {node: '>=14.0.0'}
@@ -6167,6 +6236,10 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-levenshtein@1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
 
   js-string-escape@1.0.1:
     resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
@@ -6888,6 +6961,18 @@ packages:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
     engines: {node: '>=8'}
 
+  openapi-fetch@0.15.0:
+    resolution: {integrity: sha512-OjQUdi61WO4HYhr9+byCPMj0+bgste/LtSBEcV6FzDdONTs7x0fWn8/ndoYwzqCsKWIxEZwo4FN/TG1c1rI8IQ==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  openapi-typescript@7.10.1:
+    resolution: {integrity: sha512-rBcU8bjKGGZQT4K2ekSTY2Q5veOQbVG/lTKZ49DeCyT9z62hM2Vj/LLHjDHC9W7LJG8YMHcdXpRZDqC1ojB/lw==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.x
+
   optional-require@1.1.10:
     resolution: {integrity: sha512-0r3OB9EIQsP+a5HVATHq2ExIy2q/Vaffoo4IAikW1spCYswhLxqWQS0i3GwS3AdY/OIP4SWZHLGz8CMU558PGw==}
     engines: {node: '>=4'}
@@ -7003,6 +7088,10 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
 
   parse-passwd@1.0.0:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
@@ -7496,7 +7585,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.14.0:
@@ -8234,6 +8322,10 @@ packages:
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -8785,6 +8877,40 @@ packages:
       svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
       vitest: ^4.0.0
 
+  vitest@4.0.15:
+    resolution: {integrity: sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.15
+      '@vitest/browser-preview': 4.0.15
+      '@vitest/browser-webdriverio': 4.0.15
+      '@vitest/ui': 4.0.15
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vitest@4.0.16:
     resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -9077,6 +9203,9 @@ packages:
     resolution: {integrity: sha512-Hv9xxHtsJ9228wNhk03xnlDReUuWVvHwM4rIbjdAXYvHLs17xjuyF50N6XXFMN6N0omBaqgOok/MCK3At9fTAg==}
     engines: {node: ^4.5 || 6.* || >= 7.*}
 
+  yaml-ast-parser@0.0.43:
+    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
+
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
@@ -9153,6 +9282,26 @@ snapshots:
 
   '@babel/compat-data@7.28.5': {}
 
+  '@babel/core@7.28.5':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helpers': 7.28.4
+      '@babel/parser': 7.28.5
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/core@7.28.5(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -9175,7 +9324,7 @@ snapshots:
 
   '@babel/eslint-parser@7.28.5(@babel/core@7.28.5)(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 9.39.2(jiti@2.6.1)
       eslint-visitor-keys: 2.1.0
@@ -9201,9 +9350,22 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.28.5
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.27.1
@@ -9216,14 +9378,25 @@ snapshots:
 
   '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
+  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      debug: 4.4.3
+      lodash.debounce: 4.0.8
+      resolve: 1.22.11
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       debug: 4.4.3(supports-color@8.1.1)
@@ -9234,9 +9407,23 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    dependencies:
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-member-expression-to-functions@7.28.5(supports-color@8.1.1)':
     dependencies:
       '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -9248,9 +9435,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.28.5(supports-color@8.1.1)
@@ -9263,21 +9459,46 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-wrap-function': 7.28.3
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3(supports-color@8.1.1)
       '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.28.5(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -9293,6 +9514,14 @@ snapshots:
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helper-wrap-function@7.28.3':
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-wrap-function@7.28.3(supports-color@8.1.1)':
     dependencies:
@@ -9311,9 +9540,17 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9321,26 +9558,43 @@ snapshots:
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
       '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9348,16 +9602,16 @@ snapshots:
 
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/core': 7.28.5
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/core': 7.28.5
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
@@ -9365,21 +9619,21 @@ snapshots:
 
   '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/core': 7.28.5
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
 
   '@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5)
     transitivePeerDependencies:
@@ -9387,57 +9641,75 @@ snapshots:
 
   '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)
       '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)
@@ -9446,33 +9718,61 @@ snapshots:
 
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-globals': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-classes@7.28.4(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-globals': 7.28.0
@@ -9484,13 +9784,21 @@ snapshots:
 
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.27.2
 
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.5(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9498,29 +9806,37 @@ snapshots:
 
   '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9528,25 +9844,42 @@ snapshots:
 
   '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.5(supports-color@8.1.1)
@@ -9555,43 +9888,69 @@ snapshots:
 
   '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
@@ -9599,9 +9958,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
@@ -9609,28 +9976,39 @@ snapshots:
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
+      '@babel/traverse': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
@@ -9639,9 +10017,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9649,12 +10035,20 @@ snapshots:
 
   '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9662,20 +10056,37 @@ snapshots:
 
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.27.1
@@ -9684,45 +10095,53 @@ snapshots:
 
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-runtime@7.28.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.5)(supports-color@8.1.1)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.5)(supports-color@8.1.1)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.5)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.5)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.5)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9730,50 +10149,50 @@ snapshots:
 
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@8.1.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
 
@@ -9782,10 +10201,86 @@ snapshots:
       core-js: 2.6.12
       regenerator-runtime: 0.13.11
 
+  '@babel/preset-env@7.28.5(@babel/core@7.28.5)':
+    dependencies:
+      '@babel/compat-data': 7.28.5
+      '@babel/core': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.28.5)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.5)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.28.5)
+      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-block-scoping': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.5)
+      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.28.5)
+      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.28.5)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-modules-systemjs': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.28.5)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.28.5)
+      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.28.5)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.5)
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.5)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.5)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.5)
+      core-js-compat: 3.47.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/preset-env@7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)':
     dependencies:
       '@babel/compat-data': 7.28.5
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
@@ -9860,7 +10355,7 @@ snapshots:
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/types': 7.28.5
       esutils: 2.0.3
@@ -9872,6 +10367,18 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
+
+  '@babel/traverse@7.28.5':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.5
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.5
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.5
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@7.28.5(supports-color@8.1.1)':
     dependencies:
@@ -10416,7 +10923,7 @@ snapshots:
 
   '@ember/render-modifiers@3.0.0(ember-source@6.9.0(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@embroider/macros': 1.19.5
       ember-cli-babel: 8.2.0(@babel/core@7.28.5)
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.5)
@@ -10468,14 +10975,14 @@ snapshots:
   '@embroider/compat@3.9.3(@embroider/core@3.5.9)':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.5)
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
-      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
       '@babel/runtime': 7.28.4
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
       '@embroider/core': 3.5.9
       '@embroider/macros': 1.19.5
       '@types/babel__code-frame': 7.0.6
@@ -10495,12 +11002,12 @@ snapshots:
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       fast-sourcemap-concat: 2.1.1
       fs-extra: 9.1.0
       fs-tree-diff: 2.0.1
-      jsdom: 25.0.1(supports-color@8.1.1)
+      jsdom: 25.0.1
       lodash: 4.17.21
       pkg-up: 3.1.0
       resolve: 1.22.11
@@ -10520,25 +11027,25 @@ snapshots:
 
   '@embroider/core@3.5.9':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/parser': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
       '@embroider/macros': 1.19.5
-      '@embroider/shared-internals': 2.9.2(supports-color@8.1.1)
+      '@embroider/shared-internals': 2.9.2
       assert-never: 1.4.0
       babel-plugin-ember-template-compilation: 2.3.0
       broccoli-node-api: 1.7.0
       broccoli-persistent-filter: 3.1.3
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       fast-sourcemap-concat: 2.1.1
       filesize: 10.1.6
       fs-extra: 9.1.0
       fs-tree-diff: 2.0.1
       handlebars: 4.7.8
       js-string-escape: 1.0.1
-      jsdom: 25.0.1(supports-color@8.1.1)
+      jsdom: 25.0.1
       lodash: 4.17.21
       resolve: 1.22.11
       resolve-package-path: 4.0.3
@@ -10575,6 +11082,23 @@ snapshots:
       mem: 8.1.1
       resolve.exports: 2.0.3
 
+  '@embroider/shared-internals@2.9.2':
+    dependencies:
+      babel-import-util: 2.1.1
+      debug: 4.4.3
+      ember-rfc176-data: 0.3.18
+      fs-extra: 9.1.0
+      is-subdir: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      pkg-entry-points: 1.1.1
+      resolve-package-path: 4.0.3
+      semver: 7.7.3
+      typescript-memoize: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@embroider/shared-internals@2.9.2(supports-color@8.1.1)':
     dependencies:
       babel-import-util: 2.1.1
@@ -10595,7 +11119,7 @@ snapshots:
   '@embroider/shared-internals@3.0.1':
     dependencies:
       babel-import-util: 3.0.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       ember-rfc176-data: 0.3.18
       fs-extra: 9.1.0
       is-subdir: 1.2.0
@@ -10735,7 +11259,7 @@ snapshots:
   '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10755,7 +11279,7 @@ snapshots:
   '@eslint/eslintrc@3.3.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -10967,7 +11491,7 @@ snapshots:
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
       prettier: 3.7.4
       semver: 7.7.3
@@ -11354,6 +11878,29 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
+  '@redocly/ajv@8.17.1':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  '@redocly/config@0.22.2': {}
+
+  '@redocly/openapi-core@1.34.6(supports-color@10.2.2)':
+    dependencies:
+      '@redocly/ajv': 8.17.1
+      '@redocly/config': 0.22.2
+      colorette: 1.4.0
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      js-levenshtein: 1.1.6
+      js-yaml: 4.1.1
+      minimatch: 5.1.6
+      pluralize: 8.0.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - supports-color
+
   '@rollup/pluginutils@5.1.4':
     dependencies:
       '@types/estree': 1.0.8
@@ -11405,7 +11952,7 @@ snapshots:
 
   '@sentry/ember@10.32.1(ember-cli@6.9.1(@types/node@24.10.4)(ejs@3.1.10)(handlebars@4.7.8)(underscore@1.13.7))(webpack@5.104.1)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@embroider/macros': 1.19.5
       '@sentry/browser': 10.32.1
       '@sentry/core': 10.32.1
@@ -11602,7 +12149,7 @@ snapshots:
   '@sveltejs/vite-plugin-svelte-inspector@5.0.1(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.0)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.46.0)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 6.2.1(svelte@5.46.0)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       svelte: 5.46.0
       vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -11611,7 +12158,7 @@ snapshots:
   '@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.0)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@sveltejs/vite-plugin-svelte-inspector': 5.0.1(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.0)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.46.0)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       deepmerge: 4.3.1
       magic-string: 0.30.21
       svelte: 5.46.0
@@ -11934,7 +12481,7 @@ snapshots:
       '@typescript-eslint/types': 8.50.0
       '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.50.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11944,7 +12491,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.50.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -11963,7 +12510,7 @@ snapshots:
       '@typescript-eslint/types': 8.50.0
       '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -11978,7 +12525,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.50.0
       '@typescript-eslint/visitor-keys': 8.50.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 9.0.5
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -12060,6 +12607,15 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@4.0.15':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.15
+      '@vitest/utils': 4.0.15
+      chai: 6.2.1
+      tinyrainbow: 3.0.3
+
   '@vitest/expect@4.0.16':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -12072,6 +12628,15 @@ snapshots:
   '@vitest/mocker@3.2.4(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.4(@types/node@24.10.4)(typescript@5.9.3)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+
+  '@vitest/mocker@4.0.15(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.15
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -12091,13 +12656,28 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@4.0.15':
+    dependencies:
+      tinyrainbow: 3.0.3
+
   '@vitest/pretty-format@4.0.16':
     dependencies:
       tinyrainbow: 3.0.3
 
+  '@vitest/runner@4.0.15':
+    dependencies:
+      '@vitest/utils': 4.0.15
+      pathe: 2.0.3
+
   '@vitest/runner@4.0.16':
     dependencies:
       '@vitest/utils': 4.0.16
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.15':
+    dependencies:
+      '@vitest/pretty-format': 4.0.15
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.0.16':
@@ -12110,6 +12690,8 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
+  '@vitest/spy@4.0.15': {}
+
   '@vitest/spy@4.0.16': {}
 
   '@vitest/utils@3.2.4':
@@ -12117,6 +12699,11 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.0.15':
+    dependencies:
+      '@vitest/pretty-format': 4.0.15
+      tinyrainbow: 3.0.3
 
   '@vitest/utils@4.0.16':
     dependencies:
@@ -12315,7 +12902,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12354,6 +12941,8 @@ snapshots:
       object-hash: 1.3.1
 
   amdefine@1.0.1: {}
+
+  ansi-colors@4.1.3: {}
 
   ansi-escapes@3.2.0: {}
 
@@ -12508,7 +13097,7 @@ snapshots:
 
   async-disk-cache@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       heimdalljs: 0.2.6
       istextorbinary: 2.6.0
       mkdirp: 0.5.6
@@ -12564,7 +13153,7 @@ snapshots:
 
   babel-loader@8.4.1(@babel/core@7.28.5)(webpack@5.104.1):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -12573,24 +13162,24 @@ snapshots:
 
   babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.104.1):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
       webpack: 5.104.1
 
   babel-plugin-debug-macros@0.2.0(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       semver: 5.7.2
 
   babel-plugin-debug-macros@0.3.4(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       semver: 5.7.2
 
   babel-plugin-debug-macros@2.0.0(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       babel-import-util: 2.1.1
       semver: 7.7.3
 
@@ -12636,26 +13225,50 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.11
 
+  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5):
+    dependencies:
+      '@babel/compat-data': 7.28.5
+      '@babel/core': 7.28.5
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5)(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.28.5
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.28.5):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
+      core-js-compat: 3.47.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.28.5)(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)(supports-color@8.1.1)
       core-js-compat: 3.47.0
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.28.5):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.28.5)(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -12664,7 +13277,7 @@ snapshots:
 
   babel-remove-types@1.0.2:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       prettier: 2.8.8
@@ -12796,7 +13409,7 @@ snapshots:
 
   broccoli-babel-transpiler@7.8.1:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/polyfill': 7.12.1
       broccoli-funnel: 2.0.2
       broccoli-merge-trees: 3.0.2
@@ -12813,7 +13426,7 @@ snapshots:
 
   broccoli-babel-transpiler@8.0.2(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       broccoli-persistent-filter: 3.1.3
       clone: 2.1.2
       hash-for-dep: 1.5.1
@@ -12920,7 +13533,7 @@ snapshots:
     dependencies:
       array-equal: 1.0.2
       broccoli-plugin: 4.0.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       fs-tree-diff: 2.0.1
       heimdalljs: 0.2.6
       minimatch: 3.1.2
@@ -13071,7 +13684,7 @@ snapshots:
       broccoli-persistent-filter: 2.3.1
       broccoli-plugin: 2.1.0
       chalk: 2.4.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       ensure-posix-path: 1.1.1
       fs-extra: 8.1.0
       minimatch: 3.1.2
@@ -13393,6 +14006,8 @@ snapshots:
   color-name@1.1.4: {}
 
   color-support@1.1.3: {}
+
+  colorette@1.4.0: {}
 
   colors@1.0.3: {}
 
@@ -13918,6 +14533,16 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3(supports-color@10.2.2):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
+
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -14149,15 +14774,15 @@ snapshots:
 
   ember-auto-import@2.12.0(webpack@5.104.1):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.28.5)
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.5)
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.5)(supports-color@8.1.1)
-      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.5)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
       '@embroider/macros': 1.19.5
       '@embroider/reverse-exports': 0.2.0
-      '@embroider/shared-internals': 2.9.2(supports-color@8.1.1)
+      '@embroider/shared-internals': 2.9.2
       babel-loader: 8.4.1(@babel/core@7.28.5)(webpack@5.104.1)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.4.1
@@ -14169,7 +14794,7 @@ snapshots:
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       css-loader: 5.2.7(webpack@5.104.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       fs-extra: 10.1.0
       fs-tree-diff: 2.0.1
       handlebars: 4.7.8
@@ -14195,17 +14820,17 @@ snapshots:
 
   ember-cli-babel@7.26.11:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.28.5)
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.5)
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.28.5)
       '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/polyfill': 7.12.1
-      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
       '@babel/runtime': 7.28.4
       amd-name-resolver: 1.3.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.5)
@@ -14230,17 +14855,17 @@ snapshots:
 
   ember-cli-babel@8.2.0(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.28.5)
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.5)
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.28.5)
       '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.28.5)
-      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.5)(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.5)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
-      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)(supports-color@8.1.1)
+      '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
       '@babel/runtime': 7.28.4
       amd-name-resolver: 1.3.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.5)
@@ -14263,7 +14888,7 @@ snapshots:
 
   ember-cli-bundle-analyzer@1.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       fast-glob: 2.2.7
       intercept-stdout: 0.1.2
       node-html-light: 1.4.0
@@ -14364,7 +14989,7 @@ snapshots:
   ember-cli-preprocess-registry@5.0.1:
     dependencies:
       broccoli-funnel: 3.0.8
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14385,7 +15010,7 @@ snapshots:
     dependencies:
       ansi-to-html: 0.6.15
       broccoli-stew: 3.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       execa: 4.1.0
       fs-extra: 9.1.0
       resolve: 1.22.11
@@ -14400,7 +15025,7 @@ snapshots:
     dependencies:
       ansi-to-html: 0.6.15
       broccoli-stew: 3.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       execa: 4.1.0
       fs-extra: 9.1.0
       resolve: 1.22.11
@@ -14605,7 +15230,7 @@ snapshots:
 
   ember-concurrency@5.1.0(@babel/core@7.28.5):
     dependencies:
-      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/types': 7.28.5
       '@embroider/addon-shim': 1.10.2
@@ -14656,7 +15281,7 @@ snapshots:
 
   ember-eslint-parser@0.5.13(@babel/core@7.28.5)(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/eslint-parser': 7.28.5(@babel/core@7.28.5)(eslint@9.39.2(jiti@2.6.1))
       '@glimmer/syntax': 0.95.0
       '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.3)
@@ -14679,7 +15304,7 @@ snapshots:
 
   ember-in-element-polyfill@1.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-version-checker: 5.1.2
@@ -14767,7 +15392,7 @@ snapshots:
   ember-router-generator@2.0.0:
     dependencies:
       '@babel/parser': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
       recast: 0.18.10
     transitivePeerDependencies:
       - supports-color
@@ -14805,7 +15430,7 @@ snapshots:
 
   ember-source@6.9.0(@glimmer/component@2.0.0)(rsvp@4.8.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@ember/edition-utils': 1.2.0
       '@embroider/addon-shim': 1.10.2
       '@glimmer/compiler': 0.94.11
@@ -15278,7 +15903,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -15481,7 +16106,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -15923,7 +16548,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16209,7 +16834,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -16231,7 +16863,21 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -16284,6 +16930,8 @@ snapshots:
   indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
+
+  index-to-position@1.2.0: {}
 
   inflection@2.0.1: {}
 
@@ -16610,7 +17258,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -16651,6 +17299,8 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@2.6.1: {}
+
+  js-levenshtein@1.1.6: {}
 
   js-string-escape@1.0.1: {}
 
@@ -16696,6 +17346,34 @@ snapshots:
       whatwg-url: 8.7.0
       ws: 7.5.10
       xml-name-validator: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -17444,6 +18122,22 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openapi-fetch@0.15.0:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-typescript-helpers@0.0.15: {}
+
+  openapi-typescript@7.10.1(typescript@5.9.3):
+    dependencies:
+      '@redocly/openapi-core': 1.34.6(supports-color@10.2.2)
+      ansi-colors: 4.1.3
+      change-case: 5.4.4
+      parse-json: 8.3.0
+      supports-color: 10.2.2
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+
   optional-require@1.1.10:
     dependencies:
       require-at: 1.0.6
@@ -17546,10 +18240,10 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       get-uri: 6.0.5
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       pac-resolver: 7.0.1
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -17576,6 +18270,12 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
 
   parse-passwd@1.0.0: {}
 
@@ -17707,7 +18407,7 @@ snapshots:
   portfinder@1.0.38:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18006,7 +18706,7 @@ snapshots:
 
   prettier-plugin-ember-template-tag@2.1.2(prettier@3.7.4):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       content-tag: 4.0.0
       prettier: 3.7.4
     transitivePeerDependencies:
@@ -18225,7 +18925,7 @@ snapshots:
 
   remove-types@1.0.0:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       prettier: 2.8.8
@@ -18678,7 +19378,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -18763,7 +19463,7 @@ snapshots:
 
   stagehand@1.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18914,6 +19614,8 @@ snapshots:
 
   stylis@4.3.6: {}
 
+  supports-color@10.2.2: {}
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -19026,7 +19728,7 @@ snapshots:
 
   sync-disk-cache@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       heimdalljs: 0.2.6
       mkdirp: 0.5.6
       rimraf: 3.0.2
@@ -19314,7 +20016,7 @@ snapshots:
 
   tree-sync@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       fs-tree-diff: 2.0.1
       mkdirp: 0.5.6
       quick-temp: 0.1.9
@@ -19557,6 +20259,44 @@ snapshots:
       svelte: 5.46.0
       vitest: 4.0.16(@types/node@24.10.4)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(yaml@2.8.2)
 
+  vitest@4.0.15(@types/node@24.10.4)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.15
+      '@vitest/mocker': 4.0.15(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.15
+      '@vitest/runner': 4.0.15
+      '@vitest/snapshot': 4.0.15
+      '@vitest/spy': 4.0.15
+      '@vitest/utils': 4.0.15
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.4
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   vitest@4.0.16(@types/node@24.10.4)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.16
@@ -19582,7 +20322,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.4
       '@vitest/browser-playwright': 4.0.16(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(playwright@1.57.0)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))(vitest@4.0.16)
-      jsdom: 25.0.1(supports-color@8.1.1)
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -19845,7 +20585,7 @@ snapshots:
 
   workerpool@3.1.2:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       object-assign: 4.1.1
       rsvp: 4.8.5
     transitivePeerDependencies:
@@ -19910,6 +20650,8 @@ snapshots:
     dependencies:
       fs-extra: 4.0.3
       lodash.merge: 4.6.2
+
+  yaml-ast-parser@0.0.43: {}
 
   yaml@1.10.2: {}
 


### PR DESCRIPTION
This package uses `openapi-typescript` to derive a TypeScript schema from the OpenAPI spec generated by `utoipa` on the Rust side. It then reexports an API client based on `openapi-fetch` and the generated schema.

### Related 

- https://github.com/rust-lang/crates.io/issues/12515