### PR TITLE
msw/tests: Use inline snapshots for HTTP responses

### DIFF
--- a/packages/crates-io-msw/handlers/api-tokens/create.test.js
+++ b/packages/crates-io-msw/handlers/api-tokens/create.test.js
@@ -22,19 +22,21 @@ test('creates a new API token', async function () {
   let token = db.apiToken.findMany(null)[0];
   expect(token).toBeTruthy();
 
-  expect(await response.json()).toEqual({
-    api_token: {
-      id: 1,
-      crate_scopes: null,
-      created_at: '2017-11-20T11:23:45.000Z',
-      endpoint_scopes: null,
-      expired_at: null,
-      last_used_at: null,
-      name: 'foooo',
-      revoked: false,
-      token: token.token,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "api_token": {
+        "crate_scopes": null,
+        "created_at": "2017-11-20T11:23:45.000Z",
+        "endpoint_scopes": null,
+        "expired_at": null,
+        "id": 1,
+        "last_used_at": null,
+        "name": "foooo",
+        "revoked": false,
+        "token": "6270739405881613",
+      },
+    }
+  `);
 });
 
 test('creates a new API token with scopes', async function () {
@@ -54,19 +56,26 @@ test('creates a new API token with scopes', async function () {
   let token = db.apiToken.findMany(null)[0];
   expect(token).toBeTruthy();
 
-  expect(await response.json()).toEqual({
-    api_token: {
-      id: 1,
-      crate_scopes: ['serde', 'serde-*'],
-      created_at: '2017-11-20T11:23:45.000Z',
-      endpoint_scopes: ['publish-update'],
-      expired_at: null,
-      last_used_at: null,
-      name: 'foooo',
-      revoked: false,
-      token: token.token,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "api_token": {
+        "crate_scopes": [
+          "serde",
+          "serde-*",
+        ],
+        "created_at": "2017-11-20T11:23:45.000Z",
+        "endpoint_scopes": [
+          "publish-update",
+        ],
+        "expired_at": null,
+        "id": 1,
+        "last_used_at": null,
+        "name": "foooo",
+        "revoked": false,
+        "token": "6270739405881613",
+      },
+    }
+  `);
 });
 
 test('creates a new API token with expiry date', async function () {
@@ -85,26 +94,34 @@ test('creates a new API token with expiry date', async function () {
   let token = db.apiToken.findMany(null)[0];
   expect(token).toBeTruthy();
 
-  expect(await response.json()).toEqual({
-    api_token: {
-      id: 1,
-      crate_scopes: null,
-      created_at: '2017-11-20T11:23:45.000Z',
-      endpoint_scopes: null,
-      expired_at: '2023-12-24T12:34:56.000Z',
-      last_used_at: null,
-      name: 'foooo',
-      revoked: false,
-      token: token.token,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "api_token": {
+        "crate_scopes": null,
+        "created_at": "2017-11-20T11:23:45.000Z",
+        "endpoint_scopes": null,
+        "expired_at": "2023-12-24T12:34:56.000Z",
+        "id": 1,
+        "last_used_at": null,
+        "name": "foooo",
+        "revoked": false,
+        "token": "6270739405881613",
+      },
+    }
+  `);
 });
 
 test('returns an error if unauthenticated', async function () {
   let body = JSON.stringify({ api_token: {} });
   let response = await fetch('/api/v1/me/tokens', { method: 'PUT', body });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/api-tokens/delete.test.js
+++ b/packages/crates-io-msw/handlers/api-tokens/delete.test.js
@@ -10,7 +10,7 @@ test('revokes an API token', async function () {
 
   let response = await fetch(`/api/v1/me/tokens/${token.id}`, { method: 'DELETE' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({});
+  expect(await response.json()).toMatchInlineSnapshot(`{}`);
 
   let tokens = db.apiToken.findMany(null);
   expect(tokens.length).toBe(0);
@@ -22,7 +22,13 @@ test('returns an error if unauthenticated', async function () {
 
   let response = await fetch(`/api/v1/me/tokens/${token.id}`, { method: 'DELETE' });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/api-tokens/get.test.js
+++ b/packages/crates-io-msw/handlers/api-tokens/get.test.js
@@ -14,17 +14,24 @@ test('returns the requested token', async function () {
 
   let response = await fetch(`/api/v1/me/tokens/${token.id}`);
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    api_token: {
-      id: 1,
-      crate_scopes: ['serde', 'serde-*'],
-      created_at: '2017-11-19T17:59:22.000Z',
-      endpoint_scopes: ['publish-update'],
-      expired_at: null,
-      last_used_at: null,
-      name: 'API Token 1',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "api_token": {
+        "crate_scopes": [
+          "serde",
+          "serde-*",
+        ],
+        "created_at": "2017-11-19T17:59:22.000Z",
+        "endpoint_scopes": [
+          "publish-update",
+        ],
+        "expired_at": null,
+        "id": 1,
+        "last_used_at": null,
+        "name": "API Token 1",
+      },
+    }
+  `);
 });
 
 test('returns 404 if token not found', async function () {
@@ -33,13 +40,27 @@ test('returns 404 if token not found', async function () {
 
   let response = await fetch('/api/v1/me/tokens/42');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns an error if unauthenticated', async function () {
   let response = await fetch('/api/v1/me/tokens/42');
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/api-tokens/list.test.js
+++ b/packages/crates-io-msw/handlers/api-tokens/list.test.js
@@ -27,37 +27,44 @@ test('returns the list of API token for the authenticated `user`', async functio
 
   let response = await fetch('/api/v1/me/tokens');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    api_tokens: [
-      {
-        id: 3,
-        crate_scopes: null,
-        created_at: '2017-11-19T14:59:22.000Z',
-        endpoint_scopes: null,
-        expired_at: null,
-        last_used_at: null,
-        name: 'API Token 3',
-      },
-      {
-        id: 2,
-        crate_scopes: null,
-        created_at: '2017-11-19T13:59:22.000Z',
-        endpoint_scopes: null,
-        expired_at: '2023-11-20T10:59:22.000Z',
-        last_used_at: null,
-        name: 'API Token 2',
-      },
-      {
-        id: 1,
-        crate_scopes: ['serde', 'serde-*'],
-        created_at: '2017-11-19T12:59:22.000Z',
-        endpoint_scopes: ['publish-update'],
-        expired_at: null,
-        last_used_at: null,
-        name: 'API Token 1',
-      },
-    ],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "api_tokens": [
+        {
+          "crate_scopes": null,
+          "created_at": "2017-11-19T14:59:22.000Z",
+          "endpoint_scopes": null,
+          "expired_at": null,
+          "id": 3,
+          "last_used_at": null,
+          "name": "API Token 3",
+        },
+        {
+          "crate_scopes": null,
+          "created_at": "2017-11-19T13:59:22.000Z",
+          "endpoint_scopes": null,
+          "expired_at": "2023-11-20T10:59:22.000Z",
+          "id": 2,
+          "last_used_at": null,
+          "name": "API Token 2",
+        },
+        {
+          "crate_scopes": [
+            "serde",
+            "serde-*",
+          ],
+          "created_at": "2017-11-19T12:59:22.000Z",
+          "endpoint_scopes": [
+            "publish-update",
+          ],
+          "expired_at": null,
+          "id": 1,
+          "last_used_at": null,
+          "name": "API Token 1",
+        },
+      ],
+    }
+  `);
 });
 
 test('empty list case', async function () {
@@ -66,13 +73,23 @@ test('empty list case', async function () {
 
   let response = await fetch('/api/v1/me/tokens');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ api_tokens: [] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "api_tokens": [],
+    }
+  `);
 });
 
 test('returns an error if unauthenticated', async function () {
   let response = await fetch('/api/v1/me/tokens');
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/categories/get.test.js
+++ b/packages/crates-io-msw/handlers/categories/get.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown categories', async function () {
   let response = await fetch('/api/v1/categories/foo');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns a category object for known categories', async function () {
@@ -16,16 +24,18 @@ test('returns a category object for known categories', async function () {
 
   let response = await fetch('/api/v1/categories/no-std');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    category: {
-      id: 'no-std',
-      category: 'no-std',
-      crates_cnt: 0,
-      created_at: '2010-06-16T21:30:45Z',
-      description: 'Crates that are able to function without the Rust standard library.',
-      slug: 'no-std',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "category": {
+        "category": "no-std",
+        "crates_cnt": 0,
+        "created_at": "2010-06-16T21:30:45Z",
+        "description": "Crates that are able to function without the Rust standard library.",
+        "id": "no-std",
+        "slug": "no-std",
+      },
+    }
+  `);
 });
 
 test('calculates `crates_cnt` correctly', async function () {
@@ -36,14 +46,16 @@ test('calculates `crates_cnt` correctly', async function () {
 
   let response = await fetch('/api/v1/categories/test-cli-category');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    category: {
-      category: 'test-cli-category',
-      crates_cnt: 7,
-      created_at: '2010-06-16T21:30:45Z',
-      description: 'This is the description for the category called "test-cli-category"',
-      id: 'test-cli-category',
-      slug: 'test-cli-category',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "category": {
+        "category": "test-cli-category",
+        "crates_cnt": 7,
+        "created_at": "2010-06-16T21:30:45Z",
+        "description": "This is the description for the category called "test-cli-category"",
+        "id": "test-cli-category",
+        "slug": "test-cli-category",
+      },
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/categories/list-slugs.test.js
+++ b/packages/crates-io-msw/handlers/categories/list-slugs.test.js
@@ -5,9 +5,11 @@ import { db } from '../../index.js';
 test('empty case', async function () {
   let response = await fetch('/api/v1/category_slugs');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    category_slugs: [],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "category_slugs": [],
+    }
+  `);
 });
 
 test('returns a category slugs list', async function () {
@@ -19,25 +21,27 @@ test('returns a category slugs list', async function () {
 
   let response = await fetch('/api/v1/category_slugs');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    category_slugs: [
-      {
-        description: 'This is the description for the category called "Category 2"',
-        id: 'category-2',
-        slug: 'category-2',
-      },
-      {
-        description: 'This is the description for the category called "Category 3"',
-        id: 'category-3',
-        slug: 'category-3',
-      },
-      {
-        description: 'Crates that are able to function without the Rust standard library.',
-        id: 'no-std',
-        slug: 'no-std',
-      },
-    ],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "category_slugs": [
+        {
+          "description": "This is the description for the category called "Category 2"",
+          "id": "category-2",
+          "slug": "category-2",
+        },
+        {
+          "description": "This is the description for the category called "Category 3"",
+          "id": "category-3",
+          "slug": "category-3",
+        },
+        {
+          "description": "Crates that are able to function without the Rust standard library.",
+          "id": "no-std",
+          "slug": "no-std",
+        },
+      ],
+    }
+  `);
 });
 
 test('has no pagination', async function () {

--- a/packages/crates-io-msw/handlers/categories/list.test.js
+++ b/packages/crates-io-msw/handlers/categories/list.test.js
@@ -5,12 +5,14 @@ import { db } from '../../index.js';
 test('empty case', async function () {
   let response = await fetch('/api/v1/categories');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    categories: [],
-    meta: {
-      total: 0,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "categories": [],
+      "meta": {
+        "total": 0,
+      },
+    }
+  `);
 });
 
 test('returns a paginated categories list', async function () {
@@ -22,37 +24,39 @@ test('returns a paginated categories list', async function () {
 
   let response = await fetch('/api/v1/categories');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    categories: [
-      {
-        id: 'category-2',
-        category: 'Category 2',
-        crates_cnt: 0,
-        created_at: '2010-06-16T21:30:45Z',
-        description: 'This is the description for the category called "Category 2"',
-        slug: 'category-2',
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "categories": [
+        {
+          "category": "Category 2",
+          "crates_cnt": 0,
+          "created_at": "2010-06-16T21:30:45Z",
+          "description": "This is the description for the category called "Category 2"",
+          "id": "category-2",
+          "slug": "category-2",
+        },
+        {
+          "category": "Category 3",
+          "crates_cnt": 0,
+          "created_at": "2010-06-16T21:30:45Z",
+          "description": "This is the description for the category called "Category 3"",
+          "id": "category-3",
+          "slug": "category-3",
+        },
+        {
+          "category": "no-std",
+          "crates_cnt": 0,
+          "created_at": "2010-06-16T21:30:45Z",
+          "description": "Crates that are able to function without the Rust standard library.",
+          "id": "no-std",
+          "slug": "no-std",
+        },
+      ],
+      "meta": {
+        "total": 3,
       },
-      {
-        id: 'category-3',
-        category: 'Category 3',
-        crates_cnt: 0,
-        created_at: '2010-06-16T21:30:45Z',
-        description: 'This is the description for the category called "Category 3"',
-        slug: 'category-3',
-      },
-      {
-        id: 'no-std',
-        category: 'no-std',
-        crates_cnt: 0,
-        created_at: '2010-06-16T21:30:45Z',
-        description: 'Crates that are able to function without the Rust standard library.',
-        slug: 'no-std',
-      },
-    ],
-    meta: {
-      total: 3,
-    },
-  });
+    }
+  `);
 });
 
 test('never returns more than 10 results', async function () {
@@ -80,6 +84,14 @@ test('supports `page` and `per_page` parameters', async function () {
 
   let responsePayload = await response.json();
   expect(responsePayload.categories.length).toBe(5);
-  expect(responsePayload.categories.map(it => it.id)).toEqual(['cat-06', 'cat-07', 'cat-08', 'cat-09', 'cat-10']);
+  expect(responsePayload.categories.map(it => it.id)).toMatchInlineSnapshot(`
+    [
+      "cat-06",
+      "cat-07",
+      "cat-08",
+      "cat-09",
+      "cat-10",
+    ]
+  `);
   expect(responsePayload.meta.total).toBe(25);
 });

--- a/packages/crates-io-msw/handlers/crates/add-owners.test.js
+++ b/packages/crates-io-msw/handlers/crates/add-owners.test.js
@@ -7,9 +7,15 @@ const ADD_USER_BODY = JSON.stringify({ owners: ['john-doe'] });
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body: ADD_USER_BODY });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -18,7 +24,15 @@ test('returns 404 for unknown crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body: ADD_USER_BODY });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('can add new owner', async function () {
@@ -33,10 +47,12 @@ test('can add new owner', async function () {
   let body = JSON.stringify({ owners: [user2.login] });
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    ok: true,
-    msg: 'user user-2 has been invited to be an owner of crate foo',
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "msg": "user user-2 has been invited to be an owner of crate foo",
+      "ok": true,
+    }
+  `);
 
   let owners = db.crateOwnership.findMany(q => q.where({ crate: { id: crate.id } }));
   expect(owners.length).toBe(1);
@@ -60,10 +76,12 @@ test('can add team owner', async function () {
   let body = JSON.stringify({ owners: [team.login] });
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    ok: true,
-    msg: 'team github:rust-lang:team-1 has been added as an owner of crate foo',
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "msg": "team github:rust-lang:team-1 has been added as an owner of crate foo",
+      "ok": true,
+    }
+  `);
 
   let owners = db.crateOwnership.findMany(q => q.where({ crate: { id: crate.id } }));
   expect(owners.length).toBe(2);
@@ -90,10 +108,12 @@ test('can add multiple owners', async function () {
   let body = JSON.stringify({ owners: [user2.login, team.login, user3.login] });
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    ok: true,
-    msg: 'user user-2 has been invited to be an owner of crate foo,team github:rust-lang:team-1 has been added as an owner of crate foo,user user-3 has been invited to be an owner of crate foo',
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "msg": "user user-2 has been invited to be an owner of crate foo,team github:rust-lang:team-1 has been added as an owner of crate foo,user user-3 has been invited to be an owner of crate foo",
+      "ok": true,
+    }
+  `);
 
   let owners = db.crateOwnership.findMany(q => q.where({ crate: { id: crate.id } }));
   expect(owners.length).toBe(2);

--- a/packages/crates-io-msw/handlers/crates/delete.test.js
+++ b/packages/crates-io-msw/handlers/crates/delete.test.js
@@ -5,9 +5,15 @@ import { db } from '../../index.js';
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch('/api/v1/crates/foo', { method: 'DELETE' });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -16,7 +22,15 @@ test('returns 404 for unknown crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo', { method: 'DELETE' });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'crate `foo` does not exist' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "crate \`foo\` does not exist",
+        },
+      ],
+    }
+  `);
 });
 
 test('deletes crates', async function () {
@@ -28,7 +42,7 @@ test('deletes crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo', { method: 'DELETE' });
   expect(response.status).toBe(204);
-  expect(await response.text()).toEqual('');
+  expect(await response.text()).toMatchInlineSnapshot(`""`);
 
   expect(db.crate.findFirst(q => q.where({ name: 'foo' }))).toBe(undefined);
 });

--- a/packages/crates-io-msw/handlers/crates/downloads.test.js
+++ b/packages/crates-io-msw/handlers/crates/downloads.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown crates', async function () {
   let response = await fetch('/api/v1/crates/foo/downloads');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('empty case', async function () {
@@ -13,12 +21,14 @@ test('empty case', async function () {
 
   let response = await fetch('/api/v1/crates/rand/downloads');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    version_downloads: [],
-    meta: {
-      extra_downloads: [],
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "meta": {
+        "extra_downloads": [],
+      },
+      "version_downloads": [],
+    }
+  `);
 });
 
 test('returns a list of version downloads belonging to the specified crate version', async function () {
@@ -30,28 +40,30 @@ test('returns a list of version downloads belonging to the specified crate versi
 
   let response = await fetch('/api/v1/crates/rand/downloads');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    version_downloads: [
-      {
-        date: '2020-01-13',
-        downloads: 7035,
-        version: 1,
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "meta": {
+        "extra_downloads": [],
       },
-      {
-        date: '2020-01-14',
-        downloads: 14_070,
-        version: 2,
-      },
-      {
-        date: '2020-01-15',
-        downloads: 21_105,
-        version: 2,
-      },
-    ],
-    meta: {
-      extra_downloads: [],
-    },
-  });
+      "version_downloads": [
+        {
+          "date": "2020-01-13",
+          "downloads": 7035,
+          "version": 1,
+        },
+        {
+          "date": "2020-01-14",
+          "downloads": 14070,
+          "version": 2,
+        },
+        {
+          "date": "2020-01-15",
+          "downloads": 21105,
+          "version": 2,
+        },
+      ],
+    }
+  `);
 });
 
 test('includes related versions', async function () {
@@ -63,109 +75,111 @@ test('includes related versions', async function () {
 
   let response = await fetch('/api/v1/crates/rand/downloads?include=versions');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    version_downloads: [
-      {
-        date: '2020-01-13',
-        downloads: 7035,
-        version: 1,
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "meta": {
+        "extra_downloads": [],
       },
-      {
-        date: '2020-01-14',
-        downloads: 14_070,
-        version: 2,
-      },
-      {
-        date: '2020-01-15',
-        downloads: 21_105,
-        version: 2,
-      },
-    ],
-    versions: [
-      {
-        crate: 'rand',
-        crate_size: 162_963,
-        created_at: '2010-06-16T21:30:45Z',
-        dl_path: '/api/v1/crates/rand/1.0.0/download',
-        downloads: 3702,
-        features: {},
-        id: 1,
-        license: 'MIT',
-        linecounts: {
-          languages: {
-            JavaScript: {
-              code_lines: 325,
-              comment_lines: 80,
-              files: 8,
+      "version_downloads": [
+        {
+          "date": "2020-01-13",
+          "downloads": 7035,
+          "version": 1,
+        },
+        {
+          "date": "2020-01-14",
+          "downloads": 14070,
+          "version": 2,
+        },
+        {
+          "date": "2020-01-15",
+          "downloads": 21105,
+          "version": 2,
+        },
+      ],
+      "versions": [
+        {
+          "crate": "rand",
+          "crate_size": 162963,
+          "created_at": "2010-06-16T21:30:45Z",
+          "dl_path": "/api/v1/crates/rand/1.0.0/download",
+          "downloads": 3702,
+          "features": {},
+          "id": 1,
+          "license": "MIT",
+          "linecounts": {
+            "languages": {
+              "JavaScript": {
+                "code_lines": 325,
+                "comment_lines": 80,
+                "files": 8,
+              },
+              "TypeScript": {
+                "code_lines": 195,
+                "comment_lines": 10,
+                "files": 2,
+              },
             },
-            TypeScript: {
-              code_lines: 195,
-              comment_lines: 10,
-              files: 2,
-            },
+            "total_code_lines": 520,
+            "total_comment_lines": 90,
           },
-          total_code_lines: 520,
-          total_comment_lines: 90,
-        },
-        links: {
-          dependencies: '/api/v1/crates/rand/1.0.0/dependencies',
-          version_downloads: '/api/v1/crates/rand/1.0.0/downloads',
-        },
-        num: '1.0.0',
-        published_by: null,
-        readme_path: '/api/v1/crates/rand/1.0.0/readme',
-        rust_version: null,
-        trustpub_data: null,
-        updated_at: '2017-02-24T12:34:56Z',
-        yank_message: null,
-        yanked: false,
-      },
-      {
-        crate: 'rand',
-        crate_size: 325_926,
-        created_at: '2010-06-16T21:30:45Z',
-        dl_path: '/api/v1/crates/rand/1.0.1/download',
-        downloads: 7404,
-        features: {},
-        id: 2,
-        license: 'Apache-2.0',
-        linecounts: {
-          languages: {
-            CSS: {
-              code_lines: 503,
-              comment_lines: 42,
-              files: 2,
-            },
-            Python: {
-              code_lines: 284,
-              comment_lines: 91,
-              files: 3,
-            },
-            TypeScript: {
-              code_lines: 332,
-              comment_lines: 83,
-              files: 7,
-            },
+          "links": {
+            "dependencies": "/api/v1/crates/rand/1.0.0/dependencies",
+            "version_downloads": "/api/v1/crates/rand/1.0.0/downloads",
           },
-          total_code_lines: 1119,
-          total_comment_lines: 216,
+          "num": "1.0.0",
+          "published_by": null,
+          "readme_path": "/api/v1/crates/rand/1.0.0/readme",
+          "rust_version": null,
+          "trustpub_data": null,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "yank_message": null,
+          "yanked": false,
         },
-        links: {
-          dependencies: '/api/v1/crates/rand/1.0.1/dependencies',
-          version_downloads: '/api/v1/crates/rand/1.0.1/downloads',
+        {
+          "crate": "rand",
+          "crate_size": 325926,
+          "created_at": "2010-06-16T21:30:45Z",
+          "dl_path": "/api/v1/crates/rand/1.0.1/download",
+          "downloads": 7404,
+          "features": {},
+          "id": 2,
+          "license": "Apache-2.0",
+          "linecounts": {
+            "languages": {
+              "CSS": {
+                "code_lines": 503,
+                "comment_lines": 42,
+                "files": 2,
+              },
+              "Python": {
+                "code_lines": 284,
+                "comment_lines": 91,
+                "files": 3,
+              },
+              "TypeScript": {
+                "code_lines": 332,
+                "comment_lines": 83,
+                "files": 7,
+              },
+            },
+            "total_code_lines": 1119,
+            "total_comment_lines": 216,
+          },
+          "links": {
+            "dependencies": "/api/v1/crates/rand/1.0.1/dependencies",
+            "version_downloads": "/api/v1/crates/rand/1.0.1/downloads",
+          },
+          "num": "1.0.1",
+          "published_by": null,
+          "readme_path": "/api/v1/crates/rand/1.0.1/readme",
+          "rust_version": null,
+          "trustpub_data": null,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "yank_message": null,
+          "yanked": false,
         },
-        num: '1.0.1',
-        published_by: null,
-        readme_path: '/api/v1/crates/rand/1.0.1/readme',
-        rust_version: null,
-        trustpub_data: null,
-        updated_at: '2017-02-24T12:34:56Z',
-        yank_message: null,
-        yanked: false,
-      },
-    ],
-    meta: {
-      extra_downloads: [],
-    },
-  });
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/crates/follow.test.js
+++ b/packages/crates-io-msw/handlers/crates/follow.test.js
@@ -5,9 +5,15 @@ import { db } from '../../index.js';
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch('/api/v1/crates/foo/follow', { method: 'PUT' });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -16,7 +22,15 @@ test('returns 404 for unknown crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo/follow', { method: 'PUT' });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('makes the authenticated user follow the crate', async function () {
@@ -25,11 +39,15 @@ test('makes the authenticated user follow the crate', async function () {
   let user = await db.user.create();
   await db.mswSession.create({ user });
 
-  expect(user.followedCrates).toEqual([]);
+  expect(user.followedCrates).toMatchInlineSnapshot(`[]`);
 
   let response = await fetch('/api/v1/crates/rand/follow', { method: 'PUT' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 
   user = db.user.findFirst(q => q.where({ id: user.id }));
   expect(user.followedCrates.length).toBe(1);

--- a/packages/crates-io-msw/handlers/crates/following.test.js
+++ b/packages/crates-io-msw/handlers/crates/following.test.js
@@ -5,9 +5,15 @@ import { db } from '../../index.js';
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch('/api/v1/crates/foo/following');
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -16,7 +22,15 @@ test('returns 404 for unknown crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo/following');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns true if the authenticated user follows the crate', async function () {
@@ -27,7 +41,11 @@ test('returns true if the authenticated user follows the crate', async function 
 
   let response = await fetch('/api/v1/crates/rand/following');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ following: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "following": true,
+    }
+  `);
 });
 
 test('returns false if the authenticated user is not following the crate', async function () {
@@ -38,5 +56,9 @@ test('returns false if the authenticated user is not following the crate', async
 
   let response = await fetch('/api/v1/crates/rand/following');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ following: false });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "following": false,
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/crates/get.test.js
+++ b/packages/crates-io-msw/handlers/crates/get.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown crates', async function () {
   let response = await fetch('/api/v1/crates/foo');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns a crate object for known crates', async function () {
@@ -14,80 +22,84 @@ test('returns a crate object for known crates', async function () {
 
   let response = await fetch('/api/v1/crates/rand');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    categories: [],
-    crate: {
-      badges: [],
-      categories: [],
-      created_at: '2010-06-16T21:30:45Z',
-      default_version: '1.0.0-beta.1',
-      description: 'This is the description for the crate called "rand"',
-      documentation: null,
-      downloads: 37_035,
-      homepage: null,
-      id: 'rand',
-      keywords: [],
-      links: {
-        owner_team: '/api/v1/crates/rand/owner_team',
-        owner_user: '/api/v1/crates/rand/owner_user',
-        reverse_dependencies: '/api/v1/crates/rand/reverse_dependencies',
-        version_downloads: '/api/v1/crates/rand/downloads',
-        versions: '/api/v1/crates/rand/versions',
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "categories": [],
+      "crate": {
+        "badges": [],
+        "categories": [],
+        "created_at": "2010-06-16T21:30:45Z",
+        "default_version": "1.0.0-beta.1",
+        "description": "This is the description for the crate called "rand"",
+        "documentation": null,
+        "downloads": 37035,
+        "homepage": null,
+        "id": "rand",
+        "keywords": [],
+        "links": {
+          "owner_team": "/api/v1/crates/rand/owner_team",
+          "owner_user": "/api/v1/crates/rand/owner_user",
+          "reverse_dependencies": "/api/v1/crates/rand/reverse_dependencies",
+          "version_downloads": "/api/v1/crates/rand/downloads",
+          "versions": "/api/v1/crates/rand/versions",
+        },
+        "max_stable_version": null,
+        "max_version": "1.0.0-beta.1",
+        "name": "rand",
+        "newest_version": "1.0.0-beta.1",
+        "num_versions": 1,
+        "recent_downloads": 321,
+        "repository": null,
+        "trustpub_only": false,
+        "updated_at": "2017-02-24T12:34:56Z",
+        "versions": [
+          1,
+        ],
+        "yanked": false,
       },
-      max_version: '1.0.0-beta.1',
-      max_stable_version: null,
-      name: 'rand',
-      newest_version: '1.0.0-beta.1',
-      num_versions: 1,
-      repository: null,
-      recent_downloads: 321,
-      trustpub_only: false,
-      updated_at: '2017-02-24T12:34:56Z',
-      versions: [1],
-      yanked: false,
-    },
-    keywords: [],
-    versions: [
-      {
-        id: 1,
-        crate: 'rand',
-        crate_size: 162_963,
-        created_at: '2010-06-16T21:30:45Z',
-        dl_path: '/api/v1/crates/rand/1.0.0-beta.1/download',
-        downloads: 3702,
-        features: {},
-        license: 'MIT',
-        linecounts: {
-          languages: {
-            JavaScript: {
-              code_lines: 325,
-              comment_lines: 80,
-              files: 8,
+      "keywords": [],
+      "versions": [
+        {
+          "crate": "rand",
+          "crate_size": 162963,
+          "created_at": "2010-06-16T21:30:45Z",
+          "dl_path": "/api/v1/crates/rand/1.0.0-beta.1/download",
+          "downloads": 3702,
+          "features": {},
+          "id": 1,
+          "license": "MIT",
+          "linecounts": {
+            "languages": {
+              "JavaScript": {
+                "code_lines": 325,
+                "comment_lines": 80,
+                "files": 8,
+              },
+              "TypeScript": {
+                "code_lines": 195,
+                "comment_lines": 10,
+                "files": 2,
+              },
             },
-            TypeScript: {
-              code_lines: 195,
-              comment_lines: 10,
-              files: 2,
-            },
+            "total_code_lines": 520,
+            "total_comment_lines": 90,
           },
-          total_code_lines: 520,
-          total_comment_lines: 90,
+          "links": {
+            "dependencies": "/api/v1/crates/rand/1.0.0-beta.1/dependencies",
+            "version_downloads": "/api/v1/crates/rand/1.0.0-beta.1/downloads",
+          },
+          "num": "1.0.0-beta.1",
+          "published_by": null,
+          "readme_path": "/api/v1/crates/rand/1.0.0-beta.1/readme",
+          "rust_version": null,
+          "trustpub_data": null,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "yank_message": null,
+          "yanked": false,
         },
-        links: {
-          dependencies: '/api/v1/crates/rand/1.0.0-beta.1/dependencies',
-          version_downloads: '/api/v1/crates/rand/1.0.0-beta.1/downloads',
-        },
-        num: '1.0.0-beta.1',
-        published_by: null,
-        readme_path: '/api/v1/crates/rand/1.0.0-beta.1/readme',
-        rust_version: null,
-        trustpub_data: null,
-        updated_at: '2017-02-24T12:34:56Z',
-        yanked: false,
-        yank_message: null,
-      },
-    ],
-  });
+      ],
+    }
+  `);
 });
 
 test('works for non-canonical names', async function () {
@@ -96,80 +108,84 @@ test('works for non-canonical names', async function () {
 
   let response = await fetch('/api/v1/crates/foo_bar');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    categories: [],
-    crate: {
-      badges: [],
-      categories: [],
-      created_at: '2010-06-16T21:30:45Z',
-      default_version: '1.0.0-beta.1',
-      description: 'This is the description for the crate called "foo-bar"',
-      documentation: null,
-      downloads: 37_035,
-      homepage: null,
-      id: 'foo-bar',
-      keywords: [],
-      links: {
-        owner_team: '/api/v1/crates/foo-bar/owner_team',
-        owner_user: '/api/v1/crates/foo-bar/owner_user',
-        reverse_dependencies: '/api/v1/crates/foo-bar/reverse_dependencies',
-        version_downloads: '/api/v1/crates/foo-bar/downloads',
-        versions: '/api/v1/crates/foo-bar/versions',
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "categories": [],
+      "crate": {
+        "badges": [],
+        "categories": [],
+        "created_at": "2010-06-16T21:30:45Z",
+        "default_version": "1.0.0-beta.1",
+        "description": "This is the description for the crate called "foo-bar"",
+        "documentation": null,
+        "downloads": 37035,
+        "homepage": null,
+        "id": "foo-bar",
+        "keywords": [],
+        "links": {
+          "owner_team": "/api/v1/crates/foo-bar/owner_team",
+          "owner_user": "/api/v1/crates/foo-bar/owner_user",
+          "reverse_dependencies": "/api/v1/crates/foo-bar/reverse_dependencies",
+          "version_downloads": "/api/v1/crates/foo-bar/downloads",
+          "versions": "/api/v1/crates/foo-bar/versions",
+        },
+        "max_stable_version": null,
+        "max_version": "1.0.0-beta.1",
+        "name": "foo-bar",
+        "newest_version": "1.0.0-beta.1",
+        "num_versions": 1,
+        "recent_downloads": 321,
+        "repository": null,
+        "trustpub_only": false,
+        "updated_at": "2017-02-24T12:34:56Z",
+        "versions": [
+          1,
+        ],
+        "yanked": false,
       },
-      max_version: '1.0.0-beta.1',
-      max_stable_version: null,
-      name: 'foo-bar',
-      newest_version: '1.0.0-beta.1',
-      num_versions: 1,
-      repository: null,
-      recent_downloads: 321,
-      trustpub_only: false,
-      updated_at: '2017-02-24T12:34:56Z',
-      versions: [1],
-      yanked: false,
-    },
-    keywords: [],
-    versions: [
-      {
-        id: 1,
-        crate: 'foo-bar',
-        crate_size: 162_963,
-        created_at: '2010-06-16T21:30:45Z',
-        dl_path: '/api/v1/crates/foo-bar/1.0.0-beta.1/download',
-        downloads: 3702,
-        features: {},
-        license: 'MIT',
-        linecounts: {
-          languages: {
-            JavaScript: {
-              code_lines: 325,
-              comment_lines: 80,
-              files: 8,
+      "keywords": [],
+      "versions": [
+        {
+          "crate": "foo-bar",
+          "crate_size": 162963,
+          "created_at": "2010-06-16T21:30:45Z",
+          "dl_path": "/api/v1/crates/foo-bar/1.0.0-beta.1/download",
+          "downloads": 3702,
+          "features": {},
+          "id": 1,
+          "license": "MIT",
+          "linecounts": {
+            "languages": {
+              "JavaScript": {
+                "code_lines": 325,
+                "comment_lines": 80,
+                "files": 8,
+              },
+              "TypeScript": {
+                "code_lines": 195,
+                "comment_lines": 10,
+                "files": 2,
+              },
             },
-            TypeScript: {
-              code_lines: 195,
-              comment_lines: 10,
-              files: 2,
-            },
+            "total_code_lines": 520,
+            "total_comment_lines": 90,
           },
-          total_code_lines: 520,
-          total_comment_lines: 90,
+          "links": {
+            "dependencies": "/api/v1/crates/foo-bar/1.0.0-beta.1/dependencies",
+            "version_downloads": "/api/v1/crates/foo-bar/1.0.0-beta.1/downloads",
+          },
+          "num": "1.0.0-beta.1",
+          "published_by": null,
+          "readme_path": "/api/v1/crates/foo-bar/1.0.0-beta.1/readme",
+          "rust_version": null,
+          "trustpub_data": null,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "yank_message": null,
+          "yanked": false,
         },
-        links: {
-          dependencies: '/api/v1/crates/foo-bar/1.0.0-beta.1/dependencies',
-          version_downloads: '/api/v1/crates/foo-bar/1.0.0-beta.1/downloads',
-        },
-        num: '1.0.0-beta.1',
-        published_by: null,
-        readme_path: '/api/v1/crates/foo-bar/1.0.0-beta.1/readme',
-        rust_version: null,
-        trustpub_data: null,
-        updated_at: '2017-02-24T12:34:56Z',
-        yanked: false,
-        yank_message: null,
-      },
-    ],
-  });
+      ],
+    }
+  `);
 });
 
 test('includes related versions', async function () {
@@ -182,123 +198,131 @@ test('includes related versions', async function () {
   expect(response.status).toBe(200);
 
   let responsePayload = await response.json();
-  expect(responsePayload.crate.versions).toEqual([1, 2, 3]);
-  expect(responsePayload.versions).toEqual([
-    {
-      id: 3,
-      crate: 'rand',
-      crate_size: 488_889,
-      created_at: '2010-06-16T21:30:45Z',
-      dl_path: '/api/v1/crates/rand/1.2.0/download',
-      downloads: 11_106,
-      features: {},
-      license: 'MIT/Apache-2.0',
-      linecounts: {
-        languages: {
-          Python: {
-            code_lines: 421,
-            comment_lines: 64,
-            files: 8,
+  expect(responsePayload.crate.versions).toMatchInlineSnapshot(`
+    [
+      1,
+      2,
+      3,
+    ]
+  `);
+  expect(responsePayload.versions).toMatchInlineSnapshot(`
+    [
+      {
+        "crate": "rand",
+        "crate_size": 488889,
+        "created_at": "2010-06-16T21:30:45Z",
+        "dl_path": "/api/v1/crates/rand/1.2.0/download",
+        "downloads": 11106,
+        "features": {},
+        "id": 3,
+        "license": "MIT/Apache-2.0",
+        "linecounts": {
+          "languages": {
+            "Python": {
+              "code_lines": 421,
+              "comment_lines": 64,
+              "files": 8,
+            },
           },
+          "total_code_lines": 421,
+          "total_comment_lines": 64,
         },
-        total_code_lines: 421,
-        total_comment_lines: 64,
-      },
-      links: {
-        dependencies: '/api/v1/crates/rand/1.2.0/dependencies',
-        version_downloads: '/api/v1/crates/rand/1.2.0/downloads',
-      },
-      num: '1.2.0',
-      published_by: null,
-      readme_path: '/api/v1/crates/rand/1.2.0/readme',
-      rust_version: null,
-      trustpub_data: null,
-      updated_at: '2017-02-24T12:34:56Z',
-      yanked: false,
-      yank_message: null,
-    },
-    {
-      id: 2,
-      crate: 'rand',
-      crate_size: 325_926,
-      created_at: '2010-06-16T21:30:45Z',
-      dl_path: '/api/v1/crates/rand/1.1.0/download',
-      downloads: 7404,
-      features: {},
-      license: 'Apache-2.0',
-      linecounts: {
-        languages: {
-          CSS: {
-            code_lines: 503,
-            comment_lines: 42,
-            files: 2,
-          },
-          Python: {
-            code_lines: 284,
-            comment_lines: 91,
-            files: 3,
-          },
-          TypeScript: {
-            code_lines: 332,
-            comment_lines: 83,
-            files: 7,
-          },
+        "links": {
+          "dependencies": "/api/v1/crates/rand/1.2.0/dependencies",
+          "version_downloads": "/api/v1/crates/rand/1.2.0/downloads",
         },
-        total_code_lines: 1119,
-        total_comment_lines: 216,
+        "num": "1.2.0",
+        "published_by": null,
+        "readme_path": "/api/v1/crates/rand/1.2.0/readme",
+        "rust_version": null,
+        "trustpub_data": null,
+        "updated_at": "2017-02-24T12:34:56Z",
+        "yank_message": null,
+        "yanked": false,
       },
-      links: {
-        dependencies: '/api/v1/crates/rand/1.1.0/dependencies',
-        version_downloads: '/api/v1/crates/rand/1.1.0/downloads',
-      },
-      num: '1.1.0',
-      published_by: null,
-      readme_path: '/api/v1/crates/rand/1.1.0/readme',
-      rust_version: null,
-      trustpub_data: null,
-      updated_at: '2017-02-24T12:34:56Z',
-      yanked: false,
-      yank_message: null,
-    },
-    {
-      id: 1,
-      crate: 'rand',
-      crate_size: 162_963,
-      created_at: '2010-06-16T21:30:45Z',
-      dl_path: '/api/v1/crates/rand/1.0.0/download',
-      downloads: 3702,
-      features: {},
-      license: 'MIT',
-      linecounts: {
-        languages: {
-          JavaScript: {
-            code_lines: 325,
-            comment_lines: 80,
-            files: 8,
+      {
+        "crate": "rand",
+        "crate_size": 325926,
+        "created_at": "2010-06-16T21:30:45Z",
+        "dl_path": "/api/v1/crates/rand/1.1.0/download",
+        "downloads": 7404,
+        "features": {},
+        "id": 2,
+        "license": "Apache-2.0",
+        "linecounts": {
+          "languages": {
+            "CSS": {
+              "code_lines": 503,
+              "comment_lines": 42,
+              "files": 2,
+            },
+            "Python": {
+              "code_lines": 284,
+              "comment_lines": 91,
+              "files": 3,
+            },
+            "TypeScript": {
+              "code_lines": 332,
+              "comment_lines": 83,
+              "files": 7,
+            },
           },
-          TypeScript: {
-            code_lines: 195,
-            comment_lines: 10,
-            files: 2,
-          },
+          "total_code_lines": 1119,
+          "total_comment_lines": 216,
         },
-        total_code_lines: 520,
-        total_comment_lines: 90,
+        "links": {
+          "dependencies": "/api/v1/crates/rand/1.1.0/dependencies",
+          "version_downloads": "/api/v1/crates/rand/1.1.0/downloads",
+        },
+        "num": "1.1.0",
+        "published_by": null,
+        "readme_path": "/api/v1/crates/rand/1.1.0/readme",
+        "rust_version": null,
+        "trustpub_data": null,
+        "updated_at": "2017-02-24T12:34:56Z",
+        "yank_message": null,
+        "yanked": false,
       },
-      links: {
-        dependencies: '/api/v1/crates/rand/1.0.0/dependencies',
-        version_downloads: '/api/v1/crates/rand/1.0.0/downloads',
+      {
+        "crate": "rand",
+        "crate_size": 162963,
+        "created_at": "2010-06-16T21:30:45Z",
+        "dl_path": "/api/v1/crates/rand/1.0.0/download",
+        "downloads": 3702,
+        "features": {},
+        "id": 1,
+        "license": "MIT",
+        "linecounts": {
+          "languages": {
+            "JavaScript": {
+              "code_lines": 325,
+              "comment_lines": 80,
+              "files": 8,
+            },
+            "TypeScript": {
+              "code_lines": 195,
+              "comment_lines": 10,
+              "files": 2,
+            },
+          },
+          "total_code_lines": 520,
+          "total_comment_lines": 90,
+        },
+        "links": {
+          "dependencies": "/api/v1/crates/rand/1.0.0/dependencies",
+          "version_downloads": "/api/v1/crates/rand/1.0.0/downloads",
+        },
+        "num": "1.0.0",
+        "published_by": null,
+        "readme_path": "/api/v1/crates/rand/1.0.0/readme",
+        "rust_version": null,
+        "trustpub_data": null,
+        "updated_at": "2017-02-24T12:34:56Z",
+        "yank_message": null,
+        "yanked": false,
       },
-      num: '1.0.0',
-      published_by: null,
-      readme_path: '/api/v1/crates/rand/1.0.0/readme',
-      rust_version: null,
-      trustpub_data: null,
-      updated_at: '2017-02-24T12:34:56Z',
-      yanked: false,
-      yank_message: null,
-    },
-  ]);
+    ]
+  `);
 });
 
 test('includes related categories', async function () {
@@ -311,17 +335,23 @@ test('includes related categories', async function () {
   expect(response.status).toBe(200);
 
   let responsePayload = await response.json();
-  expect(responsePayload.crate.categories).toEqual(['no-std']);
-  expect(responsePayload.categories).toEqual([
-    {
-      id: 'no-std',
-      category: 'no-std',
-      crates_cnt: 1,
-      created_at: '2010-06-16T21:30:45Z',
-      description: 'This is the description for the category called "no-std"',
-      slug: 'no-std',
-    },
-  ]);
+  expect(responsePayload.crate.categories).toMatchInlineSnapshot(`
+    [
+      "no-std",
+    ]
+  `);
+  expect(responsePayload.categories).toMatchInlineSnapshot(`
+    [
+      {
+        "category": "no-std",
+        "crates_cnt": 1,
+        "created_at": "2010-06-16T21:30:45Z",
+        "description": "This is the description for the category called "no-std"",
+        "id": "no-std",
+        "slug": "no-std",
+      },
+    ]
+  `);
 });
 
 test('includes related keywords', async function () {
@@ -334,14 +364,20 @@ test('includes related keywords', async function () {
   expect(response.status).toBe(200);
 
   let responsePayload = await response.json();
-  expect(responsePayload.crate.keywords).toEqual(['no-std']);
-  expect(responsePayload.keywords).toEqual([
-    {
-      crates_cnt: 1,
-      id: 'no-std',
-      keyword: 'no-std',
-    },
-  ]);
+  expect(responsePayload.crate.keywords).toMatchInlineSnapshot(`
+    [
+      "no-std",
+    ]
+  `);
+  expect(responsePayload.keywords).toMatchInlineSnapshot(`
+    [
+      {
+        "crates_cnt": 1,
+        "id": "no-std",
+        "keyword": "no-std",
+      },
+    ]
+  `);
 });
 
 test('without versions included', async function () {

--- a/packages/crates-io-msw/handlers/crates/list.test.js
+++ b/packages/crates-io-msw/handlers/crates/list.test.js
@@ -5,12 +5,14 @@ import { db } from '../../index.js';
 test('empty case', async function () {
   let response = await fetch('/api/v1/crates');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    crates: [],
-    meta: {
-      total: 0,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crates": [],
+      "meta": {
+        "total": 0,
+      },
+    }
+  `);
 });
 
 test('returns a paginated crates list', async function () {
@@ -30,44 +32,46 @@ test('returns a paginated crates list', async function () {
 
   let response = await fetch('/api/v1/crates');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    crates: [
-      {
-        id: 'rand',
-        badges: [],
-        categories: null,
-        created_at: '2010-06-16T21:30:45Z',
-        default_version: '1.0.0',
-        description: 'This is the description for the crate called "rand"',
-        documentation: null,
-        downloads: 37_035,
-        exact_match: false,
-        homepage: null,
-        keywords: null,
-        links: {
-          owner_team: '/api/v1/crates/rand/owner_team',
-          owner_user: '/api/v1/crates/rand/owner_user',
-          reverse_dependencies: '/api/v1/crates/rand/reverse_dependencies',
-          version_downloads: '/api/v1/crates/rand/downloads',
-          versions: '/api/v1/crates/rand/versions',
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crates": [
+        {
+          "badges": [],
+          "categories": null,
+          "created_at": "2010-06-16T21:30:45Z",
+          "default_version": "1.0.0",
+          "description": "This is the description for the crate called "rand"",
+          "documentation": null,
+          "downloads": 37035,
+          "exact_match": false,
+          "homepage": null,
+          "id": "rand",
+          "keywords": null,
+          "links": {
+            "owner_team": "/api/v1/crates/rand/owner_team",
+            "owner_user": "/api/v1/crates/rand/owner_user",
+            "reverse_dependencies": "/api/v1/crates/rand/reverse_dependencies",
+            "version_downloads": "/api/v1/crates/rand/downloads",
+            "versions": "/api/v1/crates/rand/versions",
+          },
+          "max_stable_version": "1.0.0",
+          "max_version": "2.0.0-beta.1",
+          "name": "rand",
+          "newest_version": "2.0.0-beta.1",
+          "num_versions": 2,
+          "recent_downloads": 321,
+          "repository": null,
+          "trustpub_only": false,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "versions": null,
+          "yanked": false,
         },
-        max_version: '2.0.0-beta.1',
-        max_stable_version: '1.0.0',
-        name: 'rand',
-        newest_version: '2.0.0-beta.1',
-        num_versions: 2,
-        repository: null,
-        recent_downloads: 321,
-        trustpub_only: false,
-        updated_at: '2017-02-24T12:34:56Z',
-        versions: null,
-        yanked: false,
+      ],
+      "meta": {
+        "total": 1,
       },
-    ],
-    meta: {
-      total: 1,
-    },
-  });
+    }
+  `);
 });
 
 test('never returns more than 10 results', async function () {
@@ -93,7 +97,15 @@ test('supports `page` and `per_page` parameters', async function () {
 
   let responsePayload = await response.json();
   expect(responsePayload.crates.length).toBe(5);
-  expect(responsePayload.crates.map(it => it.id)).toEqual(['crate-06', 'crate-07', 'crate-08', 'crate-09', 'crate-10']);
+  expect(responsePayload.crates.map(it => it.id)).toMatchInlineSnapshot(`
+    [
+      "crate-06",
+      "crate-07",
+      "crate-08",
+      "crate-09",
+      "crate-10",
+    ]
+  `);
   expect(responsePayload.meta.total).toBe(25);
 });
 
@@ -110,7 +122,12 @@ test('supports a `letter` parameter', async function () {
 
   let responsePayload = await response.json();
   expect(responsePayload.crates.length).toBe(2);
-  expect(responsePayload.crates.map(it => it.id)).toEqual(['bar', 'BAZ']);
+  expect(responsePayload.crates.map(it => it.id)).toMatchInlineSnapshot(`
+    [
+      "bar",
+      "BAZ",
+    ]
+  `);
   expect(responsePayload.meta.total).toBe(2);
 });
 
@@ -127,8 +144,18 @@ test('supports a `q` parameter', async function () {
 
   let responsePayload = await response.json();
   expect(responsePayload.crates.length).toBe(2);
-  expect(responsePayload.crates.map(it => it.id)).toEqual(['123456', '123']);
-  expect(responsePayload.crates.map(it => it.exact_match)).toEqual([false, true]);
+  expect(responsePayload.crates.map(it => it.id)).toMatchInlineSnapshot(`
+    [
+      "123456",
+      "123",
+    ]
+  `);
+  expect(responsePayload.crates.map(it => it.exact_match)).toMatchInlineSnapshot(`
+    [
+      false,
+      true,
+    ]
+  `);
   expect(responsePayload.meta.total).toBe(2);
 });
 

--- a/packages/crates-io-msw/handlers/crates/patch.test.js
+++ b/packages/crates-io-msw/handlers/crates/patch.test.js
@@ -9,9 +9,15 @@ test('returns 403 if unauthenticated', async function () {
     body: JSON.stringify({ crate: { trustpub_only: true } }),
   });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -24,7 +30,15 @@ test('returns 404 for unknown crates', async function () {
     body: JSON.stringify({ crate: { trustpub_only: true } }),
   });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'crate `foo` does not exist' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "crate \`foo\` does not exist",
+        },
+      ],
+    }
+  `);
 });
 
 test('updates trustpub_only flag', async function () {

--- a/packages/crates-io-msw/handlers/crates/remove-owners.test.js
+++ b/packages/crates-io-msw/handlers/crates/remove-owners.test.js
@@ -7,9 +7,15 @@ const REMOVE_USER_BODY = JSON.stringify({ owners: ['john-doe'] });
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'DELETE', body: REMOVE_USER_BODY });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -18,7 +24,15 @@ test('returns 404 for unknown crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'DELETE', body: REMOVE_USER_BODY });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('can remove a user owner', async function () {
@@ -34,7 +48,12 @@ test('can remove a user owner', async function () {
   let body = JSON.stringify({ owners: [user2.login] });
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'DELETE', body });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true, msg: 'owners successfully removed' });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "msg": "owners successfully removed",
+      "ok": true,
+    }
+  `);
 
   let owners = db.crateOwnership.findMany(q => q.where({ crate: { id: crate.id } }));
   expect(owners.length).toBe(1);
@@ -57,7 +76,12 @@ test('can remove a team owner', async function () {
   let body = JSON.stringify({ owners: [team.login] });
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'DELETE', body });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true, msg: 'owners successfully removed' });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "msg": "owners successfully removed",
+      "ok": true,
+    }
+  `);
 
   let owners = db.crateOwnership.findMany(q => q.where({ crate: { id: crate.id } }));
   expect(owners.length).toBe(1);
@@ -84,7 +108,12 @@ test('can remove multiple owners', async function () {
   let body = JSON.stringify({ owners: [user2.login, team.login] });
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'DELETE', body });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true, msg: 'owners successfully removed' });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "msg": "owners successfully removed",
+      "ok": true,
+    }
+  `);
 
   let owners = db.crateOwnership.findMany(q => q.where({ crate: { id: crate.id } }));
   expect(owners.length).toBe(1);

--- a/packages/crates-io-msw/handlers/crates/reverse-dependencies.test.js
+++ b/packages/crates-io-msw/handlers/crates/reverse-dependencies.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown crates', async function () {
   let response = await fetch('/api/v1/crates/foo/reverse_dependencies');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('empty case', async function () {
@@ -13,13 +21,15 @@ test('empty case', async function () {
 
   let response = await fetch('/api/v1/crates/rand/reverse_dependencies');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    dependencies: [],
-    versions: [],
-    meta: {
-      total: 0,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "dependencies": [],
+      "meta": {
+        "total": 0,
+      },
+      "versions": [],
+    }
+  `);
 });
 
 test('returns a paginated list of crate versions depending to the specified crate', async function () {
@@ -41,118 +51,120 @@ test('returns a paginated list of crate versions depending to the specified crat
 
   let response = await fetch('/api/v1/crates/foo/reverse_dependencies');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    dependencies: [
-      {
-        id: 2,
-        crate_id: 'foo',
-        default_features: false,
-        features: [],
-        kind: 'normal',
-        optional: true,
-        req: '0.3.7',
-        target: null,
-        version_id: 2,
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "dependencies": [
+        {
+          "crate_id": "foo",
+          "default_features": false,
+          "features": [],
+          "id": 2,
+          "kind": "normal",
+          "optional": true,
+          "req": "0.3.7",
+          "target": null,
+          "version_id": 2,
+        },
+        {
+          "crate_id": "foo",
+          "default_features": false,
+          "features": [],
+          "id": 1,
+          "kind": "normal",
+          "optional": true,
+          "req": "^2.1.3",
+          "target": null,
+          "version_id": 1,
+        },
+      ],
+      "meta": {
+        "total": 2,
       },
-      {
-        id: 1,
-        crate_id: 'foo',
-        default_features: false,
-        features: [],
-        kind: 'normal',
-        optional: true,
-        req: '^2.1.3',
-        target: null,
-        version_id: 1,
-      },
-    ],
-    versions: [
-      {
-        id: 2,
-        crate: 'baz',
-        crate_size: 325_926,
-        created_at: '2010-06-16T21:30:45Z',
-        dl_path: '/api/v1/crates/baz/1.0.1/download',
-        downloads: 7404,
-        features: {},
-        license: 'Apache-2.0',
-        linecounts: {
-          languages: {
-            CSS: {
-              code_lines: 503,
-              comment_lines: 42,
-              files: 2,
+      "versions": [
+        {
+          "crate": "baz",
+          "crate_size": 325926,
+          "created_at": "2010-06-16T21:30:45Z",
+          "dl_path": "/api/v1/crates/baz/1.0.1/download",
+          "downloads": 7404,
+          "features": {},
+          "id": 2,
+          "license": "Apache-2.0",
+          "linecounts": {
+            "languages": {
+              "CSS": {
+                "code_lines": 503,
+                "comment_lines": 42,
+                "files": 2,
+              },
+              "Python": {
+                "code_lines": 284,
+                "comment_lines": 91,
+                "files": 3,
+              },
+              "TypeScript": {
+                "code_lines": 332,
+                "comment_lines": 83,
+                "files": 7,
+              },
             },
-            Python: {
-              code_lines: 284,
-              comment_lines: 91,
-              files: 3,
-            },
-            TypeScript: {
-              code_lines: 332,
-              comment_lines: 83,
-              files: 7,
-            },
+            "total_code_lines": 1119,
+            "total_comment_lines": 216,
           },
-          total_code_lines: 1119,
-          total_comment_lines: 216,
-        },
-        links: {
-          dependencies: '/api/v1/crates/baz/1.0.1/dependencies',
-          version_downloads: '/api/v1/crates/baz/1.0.1/downloads',
-        },
-        num: '1.0.1',
-        published_by: null,
-        readme_path: '/api/v1/crates/baz/1.0.1/readme',
-        rust_version: null,
-        trustpub_data: null,
-        updated_at: '2017-02-24T12:34:56Z',
-        yanked: false,
-        yank_message: null,
-      },
-      {
-        id: 1,
-        crate: 'bar',
-        crate_size: 162_963,
-        created_at: '2010-06-16T21:30:45Z',
-        dl_path: '/api/v1/crates/bar/1.0.0/download',
-        downloads: 3702,
-        features: {},
-        license: 'MIT',
-        linecounts: {
-          languages: {
-            JavaScript: {
-              code_lines: 325,
-              comment_lines: 80,
-              files: 8,
-            },
-            TypeScript: {
-              code_lines: 195,
-              comment_lines: 10,
-              files: 2,
-            },
+          "links": {
+            "dependencies": "/api/v1/crates/baz/1.0.1/dependencies",
+            "version_downloads": "/api/v1/crates/baz/1.0.1/downloads",
           },
-          total_code_lines: 520,
-          total_comment_lines: 90,
+          "num": "1.0.1",
+          "published_by": null,
+          "readme_path": "/api/v1/crates/baz/1.0.1/readme",
+          "rust_version": null,
+          "trustpub_data": null,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "yank_message": null,
+          "yanked": false,
         },
-        links: {
-          dependencies: '/api/v1/crates/bar/1.0.0/dependencies',
-          version_downloads: '/api/v1/crates/bar/1.0.0/downloads',
+        {
+          "crate": "bar",
+          "crate_size": 162963,
+          "created_at": "2010-06-16T21:30:45Z",
+          "dl_path": "/api/v1/crates/bar/1.0.0/download",
+          "downloads": 3702,
+          "features": {},
+          "id": 1,
+          "license": "MIT",
+          "linecounts": {
+            "languages": {
+              "JavaScript": {
+                "code_lines": 325,
+                "comment_lines": 80,
+                "files": 8,
+              },
+              "TypeScript": {
+                "code_lines": 195,
+                "comment_lines": 10,
+                "files": 2,
+              },
+            },
+            "total_code_lines": 520,
+            "total_comment_lines": 90,
+          },
+          "links": {
+            "dependencies": "/api/v1/crates/bar/1.0.0/dependencies",
+            "version_downloads": "/api/v1/crates/bar/1.0.0/downloads",
+          },
+          "num": "1.0.0",
+          "published_by": null,
+          "readme_path": "/api/v1/crates/bar/1.0.0/readme",
+          "rust_version": null,
+          "trustpub_data": null,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "yank_message": null,
+          "yanked": false,
         },
-        num: '1.0.0',
-        published_by: null,
-        readme_path: '/api/v1/crates/bar/1.0.0/readme',
-        rust_version: null,
-        trustpub_data: null,
-        updated_at: '2017-02-24T12:34:56Z',
-        yanked: false,
-        yank_message: null,
-      },
-    ],
-    meta: {
-      total: 2,
-    },
-  });
+      ],
+    }
+  `);
 });
 
 test('never returns more than 10 results', async function () {
@@ -189,12 +201,14 @@ test('supports `page` and `per_page` parameters', async function () {
 
   let responsePayload = await response.json();
   expect(responsePayload.dependencies.length).toBe(5);
-  expect(responsePayload.versions.map(it => it.crate)).toEqual([
-    'crate-24',
-    'crate-02',
-    'crate-15',
-    'crate-06',
-    'crate-19',
-  ]);
+  expect(responsePayload.versions.map(it => it.crate)).toMatchInlineSnapshot(`
+    [
+      "crate-24",
+      "crate-02",
+      "crate-15",
+      "crate-06",
+      "crate-19",
+    ]
+  `);
   expect(responsePayload.meta.total).toBe(25);
 });

--- a/packages/crates-io-msw/handlers/crates/team-owners.test.js
+++ b/packages/crates-io-msw/handlers/crates/team-owners.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown crates', async function () {
   let response = await fetch('/api/v1/crates/foo/owner_team');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('empty case', async function () {
@@ -13,9 +21,11 @@ test('empty case', async function () {
 
   let response = await fetch('/api/v1/crates/rand/owner_team');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    teams: [],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "teams": [],
+    }
+  `);
 });
 
 test('returns the list of teams that own the specified crate', async function () {
@@ -25,16 +35,18 @@ test('returns the list of teams that own the specified crate', async function ()
 
   let response = await fetch('/api/v1/crates/rand/owner_team');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    teams: [
-      {
-        id: 1,
-        avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-        kind: 'team',
-        login: 'github:rust-lang:maintainers',
-        name: 'maintainers',
-        url: 'https://github.com/rust-lang',
-      },
-    ],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "teams": [
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 1,
+          "kind": "team",
+          "login": "github:rust-lang:maintainers",
+          "name": "maintainers",
+          "url": "https://github.com/rust-lang",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/crates/unfollow.test.js
+++ b/packages/crates-io-msw/handlers/crates/unfollow.test.js
@@ -5,9 +5,15 @@ import { db } from '../../index.js';
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch('/api/v1/crates/foo/follow', { method: 'DELETE' });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -16,7 +22,15 @@ test('returns 404 for unknown crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo/follow', { method: 'DELETE' });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('makes the authenticated user unfollow the crate', async function () {
@@ -30,8 +44,12 @@ test('makes the authenticated user unfollow the crate', async function () {
 
   let response = await fetch('/api/v1/crates/rand/follow', { method: 'DELETE' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 
   user = db.user.findFirst(q => q.where({ id: user.id }));
-  expect(user.followedCrates).toEqual([]);
+  expect(user.followedCrates).toMatchInlineSnapshot(`[]`);
 });

--- a/packages/crates-io-msw/handlers/crates/user-owners.test.js
+++ b/packages/crates-io-msw/handlers/crates/user-owners.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown crates', async function () {
   let response = await fetch('/api/v1/crates/foo/owner_user');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('empty case', async function () {
@@ -13,9 +21,11 @@ test('empty case', async function () {
 
   let response = await fetch('/api/v1/crates/rand/owner_user');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    users: [],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "users": [],
+    }
+  `);
 });
 
 test('returns the list of users that own the specified crate', async function () {
@@ -25,16 +35,18 @@ test('returns the list of users that own the specified crate', async function ()
 
   let response = await fetch('/api/v1/crates/rand/owner_user');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    users: [
-      {
-        id: 1,
-        avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-        kind: 'user',
-        login: 'john-doe',
-        name: 'John Doe',
-        url: 'https://github.com/john-doe',
-      },
-    ],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "users": [
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 1,
+          "kind": "user",
+          "login": "john-doe",
+          "name": "John Doe",
+          "url": "https://github.com/john-doe",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/docs-rs.test.js
+++ b/packages/crates-io-msw/handlers/docs-rs.test.js
@@ -3,5 +3,5 @@ import { expect, test } from 'vitest';
 test('returns 200 OK and an empty object', async function () {
   let response = await fetch('https://docs.rs/crate/foo/0.0.0/status.json');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({});
+  expect(await response.json()).toMatchInlineSnapshot(`{}`);
 });

--- a/packages/crates-io-msw/handlers/invites/legacy-list.test.js
+++ b/packages/crates-io-msw/handlers/invites/legacy-list.test.js
@@ -8,7 +8,12 @@ test('empty case', async function () {
 
   let response = await fetch('/api/v1/me/crate_owner_invitations');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ crate_owner_invitations: [], users: [] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crate_owner_invitations": [],
+      "users": [],
+    }
+  `);
 });
 
 test('returns the list of invitations for the authenticated user', async function () {
@@ -39,55 +44,63 @@ test('returns the list of invitations for the authenticated user', async functio
 
   let response = await fetch('/api/v1/me/crate_owner_invitations');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    crate_owner_invitations: [
-      {
-        crate_id: Number(nanomsg.id),
-        crate_name: 'nanomsg',
-        created_at: '2016-12-24T12:34:56Z',
-        expires_at: '2017-01-24T12:34:56Z',
-        invitee_id: Number(user.id),
-        inviter_id: Number(inviter.id),
-      },
-      {
-        crate_id: Number(ember.id),
-        crate_name: 'ember-rs',
-        created_at: '2020-12-31T12:34:56Z',
-        expires_at: '2017-01-24T12:34:56Z',
-        invitee_id: Number(user.id),
-        inviter_id: Number(inviter2.id),
-      },
-    ],
-    users: [
-      {
-        avatar: user.avatar,
-        id: Number(user.id),
-        login: user.login,
-        name: user.name,
-        url: user.url,
-      },
-      {
-        avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-        id: Number(inviter.id),
-        login: 'janed',
-        name: 'janed',
-        url: 'https://github.com/janed',
-      },
-      {
-        avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-        id: Number(inviter2.id),
-        login: 'wycats',
-        name: 'wycats',
-        url: 'https://github.com/wycats',
-      },
-    ],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crate_owner_invitations": [
+        {
+          "crate_id": 1,
+          "crate_name": "nanomsg",
+          "created_at": "2016-12-24T12:34:56Z",
+          "expires_at": "2017-01-24T12:34:56Z",
+          "invitee_id": 1,
+          "inviter_id": 2,
+        },
+        {
+          "crate_id": 2,
+          "crate_name": "ember-rs",
+          "created_at": "2020-12-31T12:34:56Z",
+          "expires_at": "2017-01-24T12:34:56Z",
+          "invitee_id": 1,
+          "inviter_id": 3,
+        },
+      ],
+      "users": [
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 1,
+          "login": "user-1",
+          "name": "User 1",
+          "url": "https://github.com/user-1",
+        },
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 2,
+          "login": "janed",
+          "name": "janed",
+          "url": "https://github.com/janed",
+        },
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 3,
+          "login": "wycats",
+          "name": "wycats",
+          "url": "https://github.com/wycats",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns an error if unauthenticated', async function () {
   let response = await fetch('/api/v1/me/crate_owner_invitations');
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/invites/list.test.js
+++ b/packages/crates-io-msw/handlers/invites/list.test.js
@@ -30,52 +30,54 @@ test('happy path (invitee_id)', async function () {
 
   let response = await fetch(`/api/private/crate_owner_invitations?invitee_id=${user.id}`);
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    crate_owner_invitations: [
-      {
-        crate_id: Number(nanomsg.id),
-        crate_name: 'nanomsg',
-        created_at: '2016-12-24T12:34:56Z',
-        expires_at: '2017-01-24T12:34:56Z',
-        invitee_id: Number(user.id),
-        inviter_id: Number(inviter.id),
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crate_owner_invitations": [
+        {
+          "crate_id": 1,
+          "crate_name": "nanomsg",
+          "created_at": "2016-12-24T12:34:56Z",
+          "expires_at": "2017-01-24T12:34:56Z",
+          "invitee_id": 1,
+          "inviter_id": 2,
+        },
+        {
+          "crate_id": 2,
+          "crate_name": "ember-rs",
+          "created_at": "2020-12-31T12:34:56Z",
+          "expires_at": "2017-01-24T12:34:56Z",
+          "invitee_id": 1,
+          "inviter_id": 3,
+        },
+      ],
+      "meta": {
+        "next_page": null,
       },
-      {
-        crate_id: Number(ember.id),
-        crate_name: 'ember-rs',
-        created_at: '2020-12-31T12:34:56Z',
-        expires_at: '2017-01-24T12:34:56Z',
-        invitee_id: Number(user.id),
-        inviter_id: Number(inviter2.id),
-      },
-    ],
-    users: [
-      {
-        avatar: user.avatar,
-        id: Number(user.id),
-        login: user.login,
-        name: user.name,
-        url: user.url,
-      },
-      {
-        avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-        id: Number(inviter.id),
-        login: 'janed',
-        name: 'janed',
-        url: 'https://github.com/janed',
-      },
-      {
-        avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-        id: Number(inviter2.id),
-        login: 'wycats',
-        name: 'wycats',
-        url: 'https://github.com/wycats',
-      },
-    ],
-    meta: {
-      next_page: null,
-    },
-  });
+      "users": [
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 1,
+          "login": "user-1",
+          "name": "User 1",
+          "url": "https://github.com/user-1",
+        },
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 2,
+          "login": "janed",
+          "name": "janed",
+          "url": "https://github.com/janed",
+        },
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 3,
+          "login": "wycats",
+          "name": "wycats",
+          "url": "https://github.com/wycats",
+        },
+      ],
+    }
+  `);
 });
 
 test('happy path with empty response (invitee_id)', async function () {
@@ -84,13 +86,15 @@ test('happy path with empty response (invitee_id)', async function () {
 
   let response = await fetch(`/api/private/crate_owner_invitations?invitee_id=${user.id}`);
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    crate_owner_invitations: [],
-    users: [],
-    meta: {
-      next_page: null,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crate_owner_invitations": [],
+      "meta": {
+        "next_page": null,
+      },
+      "users": [],
+    }
+  `);
 });
 
 test('happy path with pagination (invitee_id)', async function () {
@@ -146,45 +150,53 @@ test('happy path (crate_name)', async function () {
 
   let response = await fetch(`/api/private/crate_owner_invitations?crate_name=ember-rs`);
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    crate_owner_invitations: [
-      {
-        crate_id: Number(ember.id),
-        crate_name: 'ember-rs',
-        created_at: '2020-12-31T12:34:56Z',
-        expires_at: '2017-01-24T12:34:56Z',
-        invitee_id: Number(user.id),
-        inviter_id: Number(inviter2.id),
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crate_owner_invitations": [
+        {
+          "crate_id": 2,
+          "crate_name": "ember-rs",
+          "created_at": "2020-12-31T12:34:56Z",
+          "expires_at": "2017-01-24T12:34:56Z",
+          "invitee_id": 1,
+          "inviter_id": 3,
+        },
+      ],
+      "meta": {
+        "next_page": null,
       },
-    ],
-    users: [
-      {
-        avatar: user.avatar,
-        id: Number(user.id),
-        login: user.login,
-        name: user.name,
-        url: user.url,
-      },
-      {
-        avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-        id: Number(inviter2.id),
-        login: 'wycats',
-        name: 'wycats',
-        url: 'https://github.com/wycats',
-      },
-    ],
-    meta: {
-      next_page: null,
-    },
-  });
+      "users": [
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 1,
+          "login": "user-1",
+          "name": "User 1",
+          "url": "https://github.com/user-1",
+        },
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 3,
+          "login": "wycats",
+          "name": "wycats",
+          "url": "https://github.com/wycats",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch(`/api/private/crate_owner_invitations?invitee_id=42`);
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if query params are missing', async function () {
@@ -193,9 +205,15 @@ test('returns 400 if query params are missing', async function () {
 
   let response = await fetch(`/api/private/crate_owner_invitations`);
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'missing or invalid filter' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "missing or invalid filter",
+        },
+      ],
+    }
+  `);
 });
 
 test("returns 404 if crate can't be found", async function () {
@@ -204,9 +222,15 @@ test("returns 404 if crate can't be found", async function () {
 
   let response = await fetch(`/api/private/crate_owner_invitations?crate_name=foo`);
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'Not Found' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 403 if requesting for other user', async function () {
@@ -215,7 +239,13 @@ test('returns 403 if requesting for other user', async function () {
 
   let response = await fetch(`/api/private/crate_owner_invitations?invitee_id=${user.id + 1}`);
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/invites/redeem-by-crate-id.test.js
+++ b/packages/crates-io-msw/handlers/invites/redeem-by-crate-id.test.js
@@ -21,12 +21,14 @@ test('can accept an invitation', async function ({ serde }) {
   let body = JSON.stringify({ crate_owner_invite: { crate_id: serde.id, accepted: true } });
   let response = await fetch('/api/v1/me/crate_owner_invitations/serde', { method: 'PUT', body });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    crate_owner_invitation: {
-      accepted: true,
-      crate_id: serde.id,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crate_owner_invitation": {
+        "accepted": true,
+        "crate_id": 1,
+      },
+    }
+  `);
 
   let invites = db.crateOwnerInvitation.findMany(q =>
     q.where({ crate: { id: serde.id }, invitee: { id: invitee.id } }),
@@ -46,12 +48,14 @@ test('can decline an invitation', async function ({ serde }) {
   let body = JSON.stringify({ crate_owner_invite: { crate_id: serde.id, accepted: false } });
   let response = await fetch('/api/v1/me/crate_owner_invitations/serde', { method: 'PUT', body });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    crate_owner_invitation: {
-      accepted: false,
-      crate_id: serde.id,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crate_owner_invitation": {
+        "accepted": false,
+        "crate_id": 1,
+      },
+    }
+  `);
 
   let invites = db.crateOwnerInvitation.findMany(q =>
     q.where({ crate: { id: serde.id }, invitee: { id: invitee.id } }),
@@ -86,7 +90,13 @@ test('returns an error if unauthenticated', async function ({ serde }) {
   let body = JSON.stringify({ crate_owner_invite: { crate_id: serde.id, accepted: true } });
   let response = await fetch('/api/v1/me/crate_owner_invitations/serde', { method: 'PUT', body });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/invites/redeem-by-token.test.js
+++ b/packages/crates-io-msw/handlers/invites/redeem-by-token.test.js
@@ -14,12 +14,14 @@ test('can accept an invitation', async function () {
 
   let response = await fetch(`/api/v1/me/crate_owner_invitations/accept/${invite.token}`, { method: 'PUT' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    crate_owner_invitation: {
-      accepted: true,
-      crate_id: serde.id,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crate_owner_invitation": {
+        "accepted": true,
+        "crate_id": 1,
+      },
+    }
+  `);
 
   let invites = db.crateOwnerInvitation.findMany(q =>
     q.where({ crate: { id: serde.id }, invitee: { id: invitee.id } }),

--- a/packages/crates-io-msw/handlers/keywords/get.test.js
+++ b/packages/crates-io-msw/handlers/keywords/get.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown keywords', async function () {
   let response = await fetch('/api/v1/keywords/foo');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns a keyword object for known keywords', async function () {
@@ -13,13 +21,15 @@ test('returns a keyword object for known keywords', async function () {
 
   let response = await fetch('/api/v1/keywords/cli');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    keyword: {
-      id: 'cli',
-      crates_cnt: 0,
-      keyword: 'cli',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "keyword": {
+        "crates_cnt": 0,
+        "id": "cli",
+        "keyword": "cli",
+      },
+    }
+  `);
 });
 
 test('calculates `crates_cnt` correctly', async function () {
@@ -30,11 +40,13 @@ test('calculates `crates_cnt` correctly', async function () {
 
   let response = await fetch('/api/v1/keywords/test-cli-keyword');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    keyword: {
-      id: 'test-cli-keyword',
-      crates_cnt: 7,
-      keyword: 'test-cli-keyword',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "keyword": {
+        "crates_cnt": 7,
+        "id": "test-cli-keyword",
+        "keyword": "test-cli-keyword",
+      },
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/keywords/list.test.js
+++ b/packages/crates-io-msw/handlers/keywords/list.test.js
@@ -5,12 +5,14 @@ import { db } from '../../index.js';
 test('empty case', async function () {
   let response = await fetch('/api/v1/keywords');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    keywords: [],
-    meta: {
-      total: 0,
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "keywords": [],
+      "meta": {
+        "total": 0,
+      },
+    }
+  `);
 });
 
 test('returns a paginated keywords list', async function () {
@@ -19,28 +21,30 @@ test('returns a paginated keywords list', async function () {
 
   let response = await fetch('/api/v1/keywords');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    keywords: [
-      {
-        id: 'api',
-        crates_cnt: 0,
-        keyword: 'api',
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "keywords": [
+        {
+          "crates_cnt": 0,
+          "id": "api",
+          "keyword": "api",
+        },
+        {
+          "crates_cnt": 0,
+          "id": "keyword-2",
+          "keyword": "keyword-2",
+        },
+        {
+          "crates_cnt": 0,
+          "id": "keyword-3",
+          "keyword": "keyword-3",
+        },
+      ],
+      "meta": {
+        "total": 3,
       },
-      {
-        id: 'keyword-2',
-        crates_cnt: 0,
-        keyword: 'keyword-2',
-      },
-      {
-        id: 'keyword-3',
-        crates_cnt: 0,
-        keyword: 'keyword-3',
-      },
-    ],
-    meta: {
-      total: 3,
-    },
-  });
+    }
+  `);
 });
 
 test('never returns more than 10 results', async function () {
@@ -64,6 +68,14 @@ test('supports `page` and `per_page` parameters', async function () {
 
   let responsePayload = await response.json();
   expect(responsePayload.keywords.length).toBe(5);
-  expect(responsePayload.keywords.map(it => it.id)).toEqual(['k06', 'k07', 'k08', 'k09', 'k10']);
+  expect(responsePayload.keywords.map(it => it.id)).toMatchInlineSnapshot(`
+    [
+      "k06",
+      "k07",
+      "k08",
+      "k09",
+      "k10",
+    ]
+  `);
   expect(responsePayload.meta.total).toBe(25);
 });

--- a/packages/crates-io-msw/handlers/playground.test.js
+++ b/packages/crates-io-msw/handlers/playground.test.js
@@ -3,5 +3,5 @@ import { expect, test } from 'vitest';
 test('returns 200 OK and an empty array', async function () {
   let response = await fetch('https://play.rust-lang.org/meta/crates');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual([]);
+  expect(await response.json()).toMatchInlineSnapshot(`[]`);
 });

--- a/packages/crates-io-msw/handlers/sessions/delete.test.js
+++ b/packages/crates-io-msw/handlers/sessions/delete.test.js
@@ -8,7 +8,11 @@ test('returns 200 when authenticated', async function () {
 
   let response = await fetch('/api/private/session', { method: 'DELETE' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 
   expect(db.mswSession.findFirst(null)).toBeFalsy();
 });
@@ -16,7 +20,11 @@ test('returns 200 when authenticated', async function () {
 test('returns 200 when unauthenticated', async function () {
   let response = await fetch('/api/private/session', { method: 'DELETE' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 
   expect(db.mswSession.findFirst(null)).toBeFalsy();
 });

--- a/packages/crates-io-msw/handlers/summary.test.js
+++ b/packages/crates-io-msw/handlers/summary.test.js
@@ -5,16 +5,18 @@ import { db } from '../index.js';
 test('empty case', async function () {
   let response = await fetch('/api/v1/summary');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    just_updated: [],
-    most_downloaded: [],
-    most_recently_downloaded: [],
-    new_crates: [],
-    num_crates: 0,
-    num_downloads: 0,
-    popular_categories: [],
-    popular_keywords: [],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "just_updated": [],
+      "most_downloaded": [],
+      "most_recently_downloaded": [],
+      "new_crates": [],
+      "num_crates": 0,
+      "num_downloads": 0,
+      "popular_categories": [],
+      "popular_keywords": [],
+    }
+  `);
 });
 
 test('returns the data for the front page', async function () {
@@ -29,150 +31,162 @@ test('returns the data for the front page', async function () {
   let responsePayload = await response.json();
 
   expect(responsePayload.just_updated.length).toBe(10);
-  expect(responsePayload.just_updated[0]).toEqual({
-    id: 'crate-1',
-    badges: [],
-    categories: null,
-    created_at: '2010-06-16T21:30:45Z',
-    default_version: '1.0.0',
-    description: 'This is the description for the crate called "crate-1"',
-    documentation: null,
-    downloads: 37_035,
-    homepage: null,
-    keywords: null,
-    links: {
-      owner_team: '/api/v1/crates/crate-1/owner_team',
-      owner_user: '/api/v1/crates/crate-1/owner_user',
-      reverse_dependencies: '/api/v1/crates/crate-1/reverse_dependencies',
-      version_downloads: '/api/v1/crates/crate-1/downloads',
-      versions: '/api/v1/crates/crate-1/versions',
-    },
-    max_version: '1.0.0',
-    max_stable_version: '1.0.0',
-    name: 'crate-1',
-    newest_version: '1.0.0',
-    num_versions: 1,
-    recent_downloads: 321,
-    repository: null,
-    trustpub_only: false,
-    updated_at: '2017-02-24T12:34:56Z',
-    versions: null,
-    yanked: false,
-  });
+  expect(responsePayload.just_updated[0]).toMatchInlineSnapshot(`
+    {
+      "badges": [],
+      "categories": null,
+      "created_at": "2010-06-16T21:30:45Z",
+      "default_version": "1.0.0",
+      "description": "This is the description for the crate called "crate-1"",
+      "documentation": null,
+      "downloads": 37035,
+      "homepage": null,
+      "id": "crate-1",
+      "keywords": null,
+      "links": {
+        "owner_team": "/api/v1/crates/crate-1/owner_team",
+        "owner_user": "/api/v1/crates/crate-1/owner_user",
+        "reverse_dependencies": "/api/v1/crates/crate-1/reverse_dependencies",
+        "version_downloads": "/api/v1/crates/crate-1/downloads",
+        "versions": "/api/v1/crates/crate-1/versions",
+      },
+      "max_stable_version": "1.0.0",
+      "max_version": "1.0.0",
+      "name": "crate-1",
+      "newest_version": "1.0.0",
+      "num_versions": 1,
+      "recent_downloads": 321,
+      "repository": null,
+      "trustpub_only": false,
+      "updated_at": "2017-02-24T12:34:56Z",
+      "versions": null,
+      "yanked": false,
+    }
+  `);
 
   expect(responsePayload.most_downloaded.length).toBe(10);
-  expect(responsePayload.most_downloaded[0]).toEqual({
-    id: 'crate-4',
-    badges: [],
-    categories: null,
-    created_at: '2010-06-16T21:30:45Z',
-    default_version: '1.0.3',
-    description: 'This is the description for the crate called "crate-4"',
-    documentation: null,
-    downloads: 148_140,
-    homepage: null,
-    keywords: null,
-    links: {
-      owner_team: '/api/v1/crates/crate-4/owner_team',
-      owner_user: '/api/v1/crates/crate-4/owner_user',
-      reverse_dependencies: '/api/v1/crates/crate-4/reverse_dependencies',
-      version_downloads: '/api/v1/crates/crate-4/downloads',
-      versions: '/api/v1/crates/crate-4/versions',
-    },
-    max_version: '1.0.3',
-    max_stable_version: '1.0.3',
-    name: 'crate-4',
-    newest_version: '1.0.3',
-    num_versions: 1,
-    repository: null,
-    recent_downloads: 963,
-    trustpub_only: false,
-    updated_at: '2017-02-24T12:34:56Z',
-    versions: null,
-    yanked: false,
-  });
+  expect(responsePayload.most_downloaded[0]).toMatchInlineSnapshot(`
+    {
+      "badges": [],
+      "categories": null,
+      "created_at": "2010-06-16T21:30:45Z",
+      "default_version": "1.0.3",
+      "description": "This is the description for the crate called "crate-4"",
+      "documentation": null,
+      "downloads": 148140,
+      "homepage": null,
+      "id": "crate-4",
+      "keywords": null,
+      "links": {
+        "owner_team": "/api/v1/crates/crate-4/owner_team",
+        "owner_user": "/api/v1/crates/crate-4/owner_user",
+        "reverse_dependencies": "/api/v1/crates/crate-4/reverse_dependencies",
+        "version_downloads": "/api/v1/crates/crate-4/downloads",
+        "versions": "/api/v1/crates/crate-4/versions",
+      },
+      "max_stable_version": "1.0.3",
+      "max_version": "1.0.3",
+      "name": "crate-4",
+      "newest_version": "1.0.3",
+      "num_versions": 1,
+      "recent_downloads": 963,
+      "repository": null,
+      "trustpub_only": false,
+      "updated_at": "2017-02-24T12:34:56Z",
+      "versions": null,
+      "yanked": false,
+    }
+  `);
 
   expect(responsePayload.most_recently_downloaded.length).toBe(10);
-  expect(responsePayload.most_recently_downloaded[0]).toEqual({
-    id: 'crate-11',
-    badges: [],
-    categories: null,
-    created_at: '2010-06-16T21:30:45Z',
-    default_version: '1.0.10',
-    description: 'This is the description for the crate called "crate-11"',
-    documentation: null,
-    downloads: 86_415,
-    homepage: null,
-    keywords: null,
-    links: {
-      owner_team: '/api/v1/crates/crate-11/owner_team',
-      owner_user: '/api/v1/crates/crate-11/owner_user',
-      reverse_dependencies: '/api/v1/crates/crate-11/reverse_dependencies',
-      version_downloads: '/api/v1/crates/crate-11/downloads',
-      versions: '/api/v1/crates/crate-11/versions',
-    },
-    max_version: '1.0.10',
-    max_stable_version: '1.0.10',
-    name: 'crate-11',
-    newest_version: '1.0.10',
-    num_versions: 1,
-    repository: null,
-    recent_downloads: 3852,
-    trustpub_only: false,
-    updated_at: '2017-02-24T12:34:56Z',
-    versions: null,
-    yanked: false,
-  });
+  expect(responsePayload.most_recently_downloaded[0]).toMatchInlineSnapshot(`
+    {
+      "badges": [],
+      "categories": null,
+      "created_at": "2010-06-16T21:30:45Z",
+      "default_version": "1.0.10",
+      "description": "This is the description for the crate called "crate-11"",
+      "documentation": null,
+      "downloads": 86415,
+      "homepage": null,
+      "id": "crate-11",
+      "keywords": null,
+      "links": {
+        "owner_team": "/api/v1/crates/crate-11/owner_team",
+        "owner_user": "/api/v1/crates/crate-11/owner_user",
+        "reverse_dependencies": "/api/v1/crates/crate-11/reverse_dependencies",
+        "version_downloads": "/api/v1/crates/crate-11/downloads",
+        "versions": "/api/v1/crates/crate-11/versions",
+      },
+      "max_stable_version": "1.0.10",
+      "max_version": "1.0.10",
+      "name": "crate-11",
+      "newest_version": "1.0.10",
+      "num_versions": 1,
+      "recent_downloads": 3852,
+      "repository": null,
+      "trustpub_only": false,
+      "updated_at": "2017-02-24T12:34:56Z",
+      "versions": null,
+      "yanked": false,
+    }
+  `);
 
   expect(responsePayload.new_crates.length).toBe(10);
-  expect(responsePayload.new_crates[0]).toEqual({
-    id: 'crate-20',
-    badges: [],
-    categories: null,
-    created_at: '2010-06-16T21:30:45Z',
-    default_version: '1.0.19',
-    description: 'This is the description for the crate called "crate-20"',
-    documentation: null,
-    downloads: 98_760,
-    homepage: null,
-    keywords: null,
-    links: {
-      owner_team: '/api/v1/crates/crate-20/owner_team',
-      owner_user: '/api/v1/crates/crate-20/owner_user',
-      reverse_dependencies: '/api/v1/crates/crate-20/reverse_dependencies',
-      version_downloads: '/api/v1/crates/crate-20/downloads',
-      versions: '/api/v1/crates/crate-20/versions',
-    },
-    max_version: '1.0.19',
-    max_stable_version: '1.0.19',
-    name: 'crate-20',
-    newest_version: '1.0.19',
-    num_versions: 1,
-    repository: null,
-    recent_downloads: 1605,
-    trustpub_only: false,
-    updated_at: '2017-02-24T12:34:56Z',
-    versions: null,
-    yanked: false,
-  });
+  expect(responsePayload.new_crates[0]).toMatchInlineSnapshot(`
+    {
+      "badges": [],
+      "categories": null,
+      "created_at": "2010-06-16T21:30:45Z",
+      "default_version": "1.0.19",
+      "description": "This is the description for the crate called "crate-20"",
+      "documentation": null,
+      "downloads": 98760,
+      "homepage": null,
+      "id": "crate-20",
+      "keywords": null,
+      "links": {
+        "owner_team": "/api/v1/crates/crate-20/owner_team",
+        "owner_user": "/api/v1/crates/crate-20/owner_user",
+        "reverse_dependencies": "/api/v1/crates/crate-20/reverse_dependencies",
+        "version_downloads": "/api/v1/crates/crate-20/downloads",
+        "versions": "/api/v1/crates/crate-20/versions",
+      },
+      "max_stable_version": "1.0.19",
+      "max_version": "1.0.19",
+      "name": "crate-20",
+      "newest_version": "1.0.19",
+      "num_versions": 1,
+      "recent_downloads": 1605,
+      "repository": null,
+      "trustpub_only": false,
+      "updated_at": "2017-02-24T12:34:56Z",
+      "versions": null,
+      "yanked": false,
+    }
+  `);
 
   expect(responsePayload.num_crates).toBe(20);
   expect(responsePayload.num_downloads).toBe(1_518_435);
 
   expect(responsePayload.popular_categories.length).toBe(10);
-  expect(responsePayload.popular_categories[0]).toEqual({
-    id: 'category-1',
-    category: 'Category 1',
-    crates_cnt: 0,
-    created_at: '2010-06-16T21:30:45Z',
-    description: 'This is the description for the category called "Category 1"',
-    slug: 'category-1',
-  });
+  expect(responsePayload.popular_categories[0]).toMatchInlineSnapshot(`
+    {
+      "category": "Category 1",
+      "crates_cnt": 0,
+      "created_at": "2010-06-16T21:30:45Z",
+      "description": "This is the description for the category called "Category 1"",
+      "id": "category-1",
+      "slug": "category-1",
+    }
+  `);
 
   expect(responsePayload.popular_keywords.length).toBe(10);
-  expect(responsePayload.popular_keywords[0]).toEqual({
-    id: 'keyword-1',
-    crates_cnt: 0,
-    keyword: 'keyword-1',
-  });
+  expect(responsePayload.popular_keywords[0]).toMatchInlineSnapshot(`
+    {
+      "crates_cnt": 0,
+      "id": "keyword-1",
+      "keyword": "keyword-1",
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/teams/get.test.js
+++ b/packages/crates-io-msw/handlers/teams/get.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown teams', async function () {
   let response = await fetch('/api/v1/teams/foo');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns a team object for known teams', async function () {
@@ -13,13 +21,15 @@ test('returns a team object for known teams', async function () {
 
   let response = await fetch(`/api/v1/teams/${team.login}`);
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    team: {
-      id: 1,
-      avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-      login: 'github:rust-lang:maintainers',
-      name: 'maintainers',
-      url: 'https://github.com/rust-lang',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "team": {
+        "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+        "id": 1,
+        "login": "github:rust-lang:maintainers",
+        "name": "maintainers",
+        "url": "https://github.com/rust-lang",
+      },
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/create.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/create.test.js
@@ -38,18 +38,20 @@ test('happy path', async function () {
   });
 
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    github_config: {
-      id: 1,
-      crate: crate.name,
-      repository_owner: 'rust-lang',
-      repository_owner_id: 5_430_905,
-      repository_name: 'crates.io',
-      workflow_filename: 'ci.yml',
-      environment: null,
-      created_at: '2023-01-01T00:00:00.000Z',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "github_config": {
+        "crate": "test-crate",
+        "created_at": "2023-01-01T00:00:00.000Z",
+        "environment": null,
+        "id": 1,
+        "repository_name": "crates.io",
+        "repository_owner": "rust-lang",
+        "repository_owner_id": 5430905,
+        "workflow_filename": "ci.yml",
+      },
+    }
+  `);
 });
 
 test('happy path with environment', async function () {
@@ -81,18 +83,20 @@ test('happy path with environment', async function () {
   });
 
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    github_config: {
-      id: 1,
-      crate: crate.name,
-      repository_owner: 'rust-lang',
-      repository_owner_id: 5_430_905,
-      repository_name: 'crates.io',
-      workflow_filename: 'ci.yml',
-      environment: 'production',
-      created_at: '2023-02-01T00:00:00.000Z',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "github_config": {
+        "crate": "test-crate-env",
+        "created_at": "2023-02-01T00:00:00.000Z",
+        "environment": "production",
+        "id": 1,
+        "repository_name": "crates.io",
+        "repository_owner": "rust-lang",
+        "repository_owner_id": 5430905,
+        "workflow_filename": "ci.yml",
+      },
+    }
+  `);
 });
 
 test('returns 403 if unauthenticated', async function () {
@@ -109,9 +113,15 @@ test('returns 403 if unauthenticated', async function () {
   });
 
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if request body is invalid', async function () {
@@ -124,9 +134,15 @@ test('returns 400 if request body is invalid', async function () {
   });
 
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'invalid request body' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "invalid request body",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if required fields are missing', async function () {
@@ -143,9 +159,15 @@ test('returns 400 if required fields are missing', async function () {
   });
 
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'missing required fields' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "missing required fields",
+        },
+      ],
+    }
+  `);
 });
 
 test("returns 404 if crate can't be found", async function () {
@@ -165,9 +187,15 @@ test("returns 404 if crate can't be found", async function () {
   });
 
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'Not Found' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if user is not an owner of the crate', async function () {
@@ -190,9 +218,15 @@ test('returns 400 if user is not an owner of the crate', async function () {
   });
 
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'You are not an owner of this crate' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "You are not an owner of this crate",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 403 if user email is not verified', async function () {
@@ -221,7 +255,13 @@ test('returns 403 if user email is not verified', async function () {
   });
 
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'You must verify your email address to create a Trusted Publishing config' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "You must verify your email address to create a Trusted Publishing config",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/delete.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/delete.test.js
@@ -42,9 +42,15 @@ test('returns 403 if unauthenticated', async function () {
   });
 
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 if config ID is invalid', async function () {
@@ -56,9 +62,15 @@ test('returns 404 if config ID is invalid', async function () {
   });
 
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'Not Found' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test("returns 404 if config can't be found", async function () {
@@ -70,9 +82,15 @@ test("returns 404 if config can't be found", async function () {
   });
 
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'Not Found' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if user is not an owner of the crate', async function () {
@@ -103,7 +121,13 @@ test('returns 400 if user is not an owner of the crate', async function () {
   });
 
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'You are not an owner of this crate' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "You are not an owner of this crate",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/create.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/create.test.js
@@ -38,18 +38,20 @@ test('happy path', async function () {
   });
 
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    gitlab_config: {
-      id: 1,
-      crate: crate.name,
-      namespace: 'rust-lang',
-      namespace_id: null,
-      project: 'crates.io',
-      workflow_filepath: '.gitlab-ci.yml',
-      environment: null,
-      created_at: '2023-01-01T00:00:00.000Z',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "gitlab_config": {
+        "crate": "test-crate",
+        "created_at": "2023-01-01T00:00:00.000Z",
+        "environment": null,
+        "id": 1,
+        "namespace": "rust-lang",
+        "namespace_id": null,
+        "project": "crates.io",
+        "workflow_filepath": ".gitlab-ci.yml",
+      },
+    }
+  `);
 });
 
 test('happy path with environment', async function () {
@@ -81,18 +83,20 @@ test('happy path with environment', async function () {
   });
 
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    gitlab_config: {
-      id: 1,
-      crate: crate.name,
-      namespace: 'rust-lang',
-      namespace_id: null,
-      project: 'crates.io',
-      workflow_filepath: '.gitlab-ci.yml',
-      environment: 'production',
-      created_at: '2023-02-01T00:00:00.000Z',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "gitlab_config": {
+        "crate": "test-crate-env",
+        "created_at": "2023-02-01T00:00:00.000Z",
+        "environment": "production",
+        "id": 1,
+        "namespace": "rust-lang",
+        "namespace_id": null,
+        "project": "crates.io",
+        "workflow_filepath": ".gitlab-ci.yml",
+      },
+    }
+  `);
 });
 
 test('returns 403 if unauthenticated', async function () {
@@ -109,9 +113,15 @@ test('returns 403 if unauthenticated', async function () {
   });
 
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if request body is invalid', async function () {
@@ -124,9 +134,15 @@ test('returns 400 if request body is invalid', async function () {
   });
 
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'invalid request body' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "invalid request body",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if required fields are missing', async function () {
@@ -143,9 +159,15 @@ test('returns 400 if required fields are missing', async function () {
   });
 
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'missing required fields' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "missing required fields",
+        },
+      ],
+    }
+  `);
 });
 
 test("returns 404 if crate can't be found", async function () {
@@ -165,9 +187,15 @@ test("returns 404 if crate can't be found", async function () {
   });
 
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'Not Found' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if user is not an owner of the crate', async function () {
@@ -190,9 +218,15 @@ test('returns 400 if user is not an owner of the crate', async function () {
   });
 
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'You are not an owner of this crate' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "You are not an owner of this crate",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 403 if user email is not verified', async function () {
@@ -221,7 +255,13 @@ test('returns 403 if user email is not verified', async function () {
   });
 
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'You must verify your email address to create a Trusted Publishing config' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "You must verify your email address to create a Trusted Publishing config",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/delete.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/delete.test.js
@@ -42,9 +42,15 @@ test('returns 403 if unauthenticated', async function () {
   });
 
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 if config ID is invalid', async function () {
@@ -56,9 +62,15 @@ test('returns 404 if config ID is invalid', async function () {
   });
 
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'Not Found' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test("returns 404 if config can't be found", async function () {
@@ -70,9 +82,15 @@ test("returns 404 if config can't be found", async function () {
   });
 
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'Not Found' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if user is not an owner of the crate', async function () {
@@ -103,7 +121,13 @@ test('returns 400 if user is not an owner of the crate', async function () {
   });
 
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'You are not an owner of this crate' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "You are not an owner of this crate",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.test.js
@@ -16,7 +16,7 @@ test('happy path', async function () {
   });
 
   // Create GitLab configs
-  let config1 = await db.trustpubGitlabConfig.create({
+  await db.trustpubGitlabConfig.create({
     crate,
     namespace: 'rust-lang',
     namespace_id: null,
@@ -25,7 +25,7 @@ test('happy path', async function () {
     created_at: '2023-01-01T00:00:00Z',
   });
 
-  let config2 = await db.trustpubGitlabConfig.create({
+  await db.trustpubGitlabConfig.create({
     crate,
     namespace: 'rust-lang',
     namespace_id: '12345',
@@ -37,30 +37,32 @@ test('happy path', async function () {
 
   let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=${crate.name}`);
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    gitlab_configs: [
-      {
-        id: Number(config1.id),
-        crate: crate.name,
-        namespace: 'rust-lang',
-        namespace_id: null,
-        project: 'crates.io',
-        workflow_filepath: '.gitlab-ci.yml',
-        environment: null,
-        created_at: '2023-01-01T00:00:00Z',
-      },
-      {
-        id: Number(config2.id),
-        crate: crate.name,
-        namespace: 'rust-lang',
-        namespace_id: '12345',
-        project: 'cargo',
-        workflow_filepath: '.gitlab/ci.yml',
-        environment: 'production',
-        created_at: '2023-02-01T00:00:00Z',
-      },
-    ],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "gitlab_configs": [
+        {
+          "crate": "test-crate",
+          "created_at": "2023-01-01T00:00:00Z",
+          "environment": null,
+          "id": 1,
+          "namespace": "rust-lang",
+          "namespace_id": null,
+          "project": "crates.io",
+          "workflow_filepath": ".gitlab-ci.yml",
+        },
+        {
+          "crate": "test-crate",
+          "created_at": "2023-02-01T00:00:00Z",
+          "environment": "production",
+          "id": 2,
+          "namespace": "rust-lang",
+          "namespace_id": "12345",
+          "project": "cargo",
+          "workflow_filepath": ".gitlab/ci.yml",
+        },
+      ],
+    }
+  `);
 });
 
 test('happy path with no configs', async function () {
@@ -78,17 +80,25 @@ test('happy path with no configs', async function () {
 
   let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=${crate.name}`);
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    gitlab_configs: [],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "gitlab_configs": [],
+    }
+  `);
 });
 
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=test-crate`);
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if query params are missing', async function () {
@@ -97,9 +107,15 @@ test('returns 400 if query params are missing', async function () {
 
   let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs`);
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'missing or invalid filter' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "missing or invalid filter",
+        },
+      ],
+    }
+  `);
 });
 
 test("returns 404 if crate can't be found", async function () {
@@ -108,9 +124,15 @@ test("returns 404 if crate can't be found", async function () {
 
   let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=nonexistent`);
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'Not Found' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 if user is not an owner of the crate', async function () {
@@ -122,7 +144,13 @@ test('returns 400 if user is not an owner of the crate', async function () {
 
   let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=${crate.name}`);
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'You are not an owner of this crate' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "You are not an owner of this crate",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/users/confirm-email.test.js
+++ b/packages/crates-io-msw/handlers/users/confirm-email.test.js
@@ -8,7 +8,11 @@ test('returns `ok: true` for a known token (unauthenticated)', async function ()
 
   let response = await fetch('/api/v1/confirm/foo', { method: 'PUT' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 
   user = db.user.findFirst(q => q.where({ id: user.id }));
   expect(user.emailVerified).toBe(true);
@@ -22,7 +26,11 @@ test('returns `ok: true` for a known token (authenticated)', async function () {
 
   let response = await fetch('/api/v1/confirm/foo', { method: 'PUT' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 
   user = db.user.findFirst(q => q.where({ id: user.id }));
   expect(user.emailVerified).toBe(true);
@@ -31,7 +39,13 @@ test('returns `ok: true` for a known token (authenticated)', async function () {
 test('returns an error for unknown tokens', async function () {
   let response = await fetch('/api/v1/confirm/unknown', { method: 'PUT' });
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'Email belonging to token not found.' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Email belonging to token not found.",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/users/get.test.js
+++ b/packages/crates-io-msw/handlers/users/get.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown users', async function () {
   let response = await fetch('/api/v1/users/foo');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns a user object for known users', async function () {
@@ -13,13 +21,15 @@ test('returns a user object for known users', async function () {
 
   let response = await fetch(`/api/v1/users/${user.login}`);
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    user: {
-      id: 1,
-      avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-      login: 'john-doe',
-      name: 'John Doe',
-      url: 'https://github.com/john-doe',
-    },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "user": {
+        "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+        "id": 1,
+        "login": "john-doe",
+        "name": "John Doe",
+        "url": "https://github.com/john-doe",
+      },
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/users/me.test.js
+++ b/packages/crates-io-msw/handlers/users/me.test.js
@@ -8,21 +8,23 @@ test('returns the `user` resource including the private fields', async function 
 
   let response = await fetch('/api/v1/me');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    user: {
-      id: 1,
-      avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-      email: 'user-1@crates.io',
-      email_verification_sent: true,
-      email_verified: true,
-      is_admin: false,
-      login: 'user-1',
-      name: 'User 1',
-      publish_notifications: true,
-      url: 'https://github.com/user-1',
-    },
-    owned_crates: [],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "owned_crates": [],
+      "user": {
+        "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+        "email": "user-1@crates.io",
+        "email_verification_sent": true,
+        "email_verified": true,
+        "id": 1,
+        "is_admin": false,
+        "login": "user-1",
+        "name": "User 1",
+        "publish_notifications": true,
+        "url": "https://github.com/user-1",
+      },
+    }
+  `);
 });
 
 test('returns a list of `owned_crates`', async function () {
@@ -38,10 +40,20 @@ test('returns a list of `owned_crates`', async function () {
   expect(response.status).toBe(200);
 
   let responsePayload = await response.json();
-  expect(responsePayload.owned_crates).toEqual([
-    { id: crate1.id, name: 'crate-1', email_notifications: true },
-    { id: crate3.id, name: 'crate-3', email_notifications: true },
-  ]);
+  expect(responsePayload.owned_crates).toMatchInlineSnapshot(`
+    [
+      {
+        "email_notifications": true,
+        "id": 1,
+        "name": "crate-1",
+      },
+      {
+        "email_notifications": true,
+        "id": 3,
+        "name": "crate-3",
+      },
+    ]
+  `);
 });
 
 test('returns an error if unauthenticated', async function () {
@@ -49,7 +61,13 @@ test('returns an error if unauthenticated', async function () {
 
   let response = await fetch('/api/v1/me');
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/users/resend.test.js
+++ b/packages/crates-io-msw/handlers/users/resend.test.js
@@ -8,7 +8,11 @@ test('returns `ok`', async function () {
 
   let response = await fetch(`/api/v1/users/${user.id}/resend`, { method: 'PUT' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 });
 
 test('returns 403 when not logged in', async function () {
@@ -16,7 +20,15 @@ test('returns 403 when not logged in', async function () {
 
   let response = await fetch(`/api/v1/users/${user.id}/resend`, { method: 'PUT' });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'must be logged in to perform that action' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 400 when requesting the wrong user id', async function () {
@@ -25,5 +37,13 @@ test('returns 400 when requesting the wrong user id', async function () {
 
   let response = await fetch(`/api/v1/users/wrong-id/resend`, { method: 'PUT' });
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'current user does not match requested user' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "current user does not match requested user",
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/users/update.test.js
+++ b/packages/crates-io-msw/handlers/users/update.test.js
@@ -9,7 +9,11 @@ test('updates the user with a new email address', async function () {
   let body = JSON.stringify({ user: { email: 'new@email.com' } });
   let response = await fetch(`/api/v1/users/${user.id}`, { method: 'PUT', body });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 
   user = db.user.findFirst(q => q.where({ id: user.id }));
   expect(user.email).toBe('new@email.com');
@@ -25,7 +29,11 @@ test('updates the `publish_notifications` settings', async function () {
   let body = JSON.stringify({ user: { publish_notifications: false } });
   let response = await fetch(`/api/v1/users/${user.id}`, { method: 'PUT', body });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 
   user = db.user.findFirst(q => q.where({ id: user.id }));
   expect(user.publishNotifications).toBe(false);
@@ -37,7 +45,15 @@ test('returns 403 when not logged in', async function () {
   let body = JSON.stringify({ user: { email: 'new@email.com' } });
   let response = await fetch(`/api/v1/users/${user.id}`, { method: 'PUT', body });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'must be logged in to perform that action' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 
   user = db.user.findFirst(q => q.where({ id: user.id }));
   expect(user.email).toBe('old@email.com');
@@ -50,7 +66,15 @@ test('returns 400 when requesting the wrong user id', async function () {
   let body = JSON.stringify({ user: { email: 'new@email.com' } });
   let response = await fetch(`/api/v1/users/wrong-id`, { method: 'PUT', body });
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'current user does not match requested user' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "current user does not match requested user",
+        },
+      ],
+    }
+  `);
 
   user = db.user.findFirst(q => q.where({ id: user.id }));
   expect(user.email).toBe('old@email.com');
@@ -63,7 +87,15 @@ test('returns 400 when sending an invalid payload', async function () {
   let body = JSON.stringify({});
   let response = await fetch(`/api/v1/users/${user.id}`, { method: 'PUT', body });
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'invalid json request' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "invalid json request",
+        },
+      ],
+    }
+  `);
 
   user = db.user.findFirst(q => q.where({ id: user.id }));
   expect(user.email).toBe('old@email.com');
@@ -76,7 +108,15 @@ test('returns 400 when sending an empty email address', async function () {
   let body = JSON.stringify({ user: { email: '' } });
   let response = await fetch(`/api/v1/users/${user.id}`, { method: 'PUT', body });
   expect(response.status).toBe(400);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'empty email rejected' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "empty email rejected",
+        },
+      ],
+    }
+  `);
 
   user = db.user.findFirst(q => q.where({ id: user.id }));
   expect(user.email).toBe('old@email.com');

--- a/packages/crates-io-msw/handlers/versions/dependencies.test.js
+++ b/packages/crates-io-msw/handlers/versions/dependencies.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown crates', async function () {
   let response = await fetch('/api/v1/crates/foo/1.0.0/dependencies');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown versions', async function () {
@@ -13,7 +21,15 @@ test('returns 404 for unknown versions', async function () {
 
   let response = await fetch('/api/v1/crates/rand/1.0.0/dependencies');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'crate `rand` does not have a version `1.0.0`' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "crate \`rand\` does not have a version \`1.0.0\`",
+        },
+      ],
+    }
+  `);
 });
 
 test('empty case', async function () {
@@ -22,9 +38,11 @@ test('empty case', async function () {
 
   let response = await fetch('/api/v1/crates/rand/1.0.0/dependencies');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    dependencies: [],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "dependencies": [],
+    }
+  `);
 });
 
 test('returns a list of dependencies belonging to the specified crate version', async function () {
@@ -40,41 +58,43 @@ test('returns a list of dependencies belonging to the specified crate version', 
 
   let response = await fetch('/api/v1/crates/rand/1.0.0/dependencies');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    dependencies: [
-      {
-        id: 1,
-        crate_id: 'foo',
-        default_features: false,
-        features: [],
-        kind: 'normal',
-        optional: true,
-        req: '^2.1.3',
-        target: null,
-        version_id: 1,
-      },
-      {
-        id: 2,
-        crate_id: 'bar',
-        default_features: false,
-        features: [],
-        kind: 'normal',
-        optional: true,
-        req: '0.3.7',
-        target: null,
-        version_id: 1,
-      },
-      {
-        id: 3,
-        crate_id: 'baz',
-        default_features: true,
-        features: [],
-        kind: 'dev',
-        optional: false,
-        req: '~5.2.12',
-        target: null,
-        version_id: 1,
-      },
-    ],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "dependencies": [
+        {
+          "crate_id": "foo",
+          "default_features": false,
+          "features": [],
+          "id": 1,
+          "kind": "normal",
+          "optional": true,
+          "req": "^2.1.3",
+          "target": null,
+          "version_id": 1,
+        },
+        {
+          "crate_id": "bar",
+          "default_features": false,
+          "features": [],
+          "id": 2,
+          "kind": "normal",
+          "optional": true,
+          "req": "0.3.7",
+          "target": null,
+          "version_id": 1,
+        },
+        {
+          "crate_id": "baz",
+          "default_features": true,
+          "features": [],
+          "id": 3,
+          "kind": "dev",
+          "optional": false,
+          "req": "~5.2.12",
+          "target": null,
+          "version_id": 1,
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/versions/downloads.test.js
+++ b/packages/crates-io-msw/handlers/versions/downloads.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown crates', async function () {
   let response = await fetch('/api/v1/crates/foo/1.0.0/downloads');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown versions', async function () {
@@ -13,7 +21,15 @@ test('returns 404 for unknown versions', async function () {
 
   let response = await fetch('/api/v1/crates/rand/1.0.0/downloads');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'crate `rand` does not have a version `1.0.0`' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "crate \`rand\` does not have a version \`1.0.0\`",
+        },
+      ],
+    }
+  `);
 });
 
 test('empty case', async function () {
@@ -22,9 +38,11 @@ test('empty case', async function () {
 
   let response = await fetch('/api/v1/crates/rand/1.0.0/downloads');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    version_downloads: [],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "version_downloads": [],
+    }
+  `);
 });
 
 test('returns a list of version downloads belonging to the specified crate version', async function () {
@@ -36,23 +54,25 @@ test('returns a list of version downloads belonging to the specified crate versi
 
   let response = await fetch('/api/v1/crates/rand/1.0.0/downloads');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    version_downloads: [
-      {
-        date: '2020-01-13',
-        downloads: 7035,
-        version: 1,
-      },
-      {
-        date: '2020-01-14',
-        downloads: 14_070,
-        version: 1,
-      },
-      {
-        date: '2020-01-15',
-        downloads: 21_105,
-        version: 1,
-      },
-    ],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "version_downloads": [
+        {
+          "date": "2020-01-13",
+          "downloads": 7035,
+          "version": 1,
+        },
+        {
+          "date": "2020-01-14",
+          "downloads": 14070,
+          "version": 1,
+        },
+        {
+          "date": "2020-01-15",
+          "downloads": 21105,
+          "version": 1,
+        },
+      ],
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/versions/follow-updates.test.js
+++ b/packages/crates-io-msw/handlers/versions/follow-updates.test.js
@@ -5,9 +5,15 @@ import { db } from '../../index.js';
 test('returns 403 for unauthenticated user', async function () {
   let response = await fetch('/api/v1/me/updates');
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns latest versions of followed crates', async function () {
@@ -22,51 +28,53 @@ test('returns latest versions of followed crates', async function () {
 
   let response = await fetch('/api/v1/me/updates');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    versions: [
-      {
-        id: 1,
-        crate: 'foo',
-        crate_size: 162_963,
-        created_at: '2010-06-16T21:30:45Z',
-        dl_path: '/api/v1/crates/foo/1.2.3/download',
-        downloads: 3702,
-        features: {},
-        license: 'MIT',
-        linecounts: {
-          languages: {
-            JavaScript: {
-              code_lines: 325,
-              comment_lines: 80,
-              files: 8,
-            },
-            TypeScript: {
-              code_lines: 195,
-              comment_lines: 10,
-              files: 2,
-            },
-          },
-          total_code_lines: 520,
-          total_comment_lines: 90,
-        },
-        links: {
-          dependencies: '/api/v1/crates/foo/1.2.3/dependencies',
-          version_downloads: '/api/v1/crates/foo/1.2.3/downloads',
-        },
-        num: '1.2.3',
-        published_by: null,
-        readme_path: '/api/v1/crates/foo/1.2.3/readme',
-        rust_version: null,
-        trustpub_data: null,
-        updated_at: '2017-02-24T12:34:56Z',
-        yanked: false,
-        yank_message: null,
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "meta": {
+        "more": false,
       },
-    ],
-    meta: {
-      more: false,
-    },
-  });
+      "versions": [
+        {
+          "crate": "foo",
+          "crate_size": 162963,
+          "created_at": "2010-06-16T21:30:45Z",
+          "dl_path": "/api/v1/crates/foo/1.2.3/download",
+          "downloads": 3702,
+          "features": {},
+          "id": 1,
+          "license": "MIT",
+          "linecounts": {
+            "languages": {
+              "JavaScript": {
+                "code_lines": 325,
+                "comment_lines": 80,
+                "files": 8,
+              },
+              "TypeScript": {
+                "code_lines": 195,
+                "comment_lines": 10,
+                "files": 2,
+              },
+            },
+            "total_code_lines": 520,
+            "total_comment_lines": 90,
+          },
+          "links": {
+            "dependencies": "/api/v1/crates/foo/1.2.3/dependencies",
+            "version_downloads": "/api/v1/crates/foo/1.2.3/downloads",
+          },
+          "num": "1.2.3",
+          "published_by": null,
+          "readme_path": "/api/v1/crates/foo/1.2.3/readme",
+          "rust_version": null,
+          "trustpub_data": null,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "yank_message": null,
+          "yanked": false,
+        },
+      ],
+    }
+  `);
 });
 
 test('empty case', async function () {
@@ -75,10 +83,14 @@ test('empty case', async function () {
 
   let response = await fetch('/api/v1/me/updates');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    versions: [],
-    meta: { more: false },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "meta": {
+        "more": false,
+      },
+      "versions": [],
+    }
+  `);
 });
 
 test('supports pagination', async function () {
@@ -93,6 +105,23 @@ test('supports pagination', async function () {
 
   let responsePayload = await response.json();
   expect(responsePayload.versions.length).toBe(10);
-  expect(responsePayload.versions.map(it => it.id)).toEqual([15, 14, 13, 12, 11, 10, 9, 8, 7, 6]);
-  expect(responsePayload.meta).toEqual({ more: true });
+  expect(responsePayload.versions.map(it => it.id)).toMatchInlineSnapshot(`
+    [
+      15,
+      14,
+      13,
+      12,
+      11,
+      10,
+      9,
+      8,
+      7,
+      6,
+    ]
+  `);
+  expect(responsePayload.meta).toMatchInlineSnapshot(`
+    {
+      "more": true,
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/versions/get.test.js
+++ b/packages/crates-io-msw/handlers/versions/get.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown crates', async function () {
   let response = await fetch('/api/v1/crates/foo/1.0.0-beta.1');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown versions', async function () {
@@ -13,9 +21,15 @@ test('returns 404 for unknown versions', async function () {
   await db.version.create({ crate, num: '1.0.0-alpha.1' });
   let response = await fetch('/api/v1/crates/rand/1.0.0-beta.1');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'crate `rand` does not have a version `1.0.0-beta.1`' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "crate \`rand\` does not have a version \`1.0.0-beta.1\`",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns a version object for known version', async function () {
@@ -24,44 +38,46 @@ test('returns a version object for known version', async function () {
 
   let response = await fetch('/api/v1/crates/rand/1.0.0-beta.1');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    version: {
-      crate: 'rand',
-      crate_size: 162_963,
-      created_at: '2010-06-16T21:30:45Z',
-      dl_path: '/api/v1/crates/rand/1.0.0-beta.1/download',
-      downloads: 3702,
-      features: {},
-      id: 1,
-      license: 'MIT',
-      linecounts: {
-        languages: {
-          JavaScript: {
-            code_lines: 325,
-            comment_lines: 80,
-            files: 8,
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "version": {
+        "crate": "rand",
+        "crate_size": 162963,
+        "created_at": "2010-06-16T21:30:45Z",
+        "dl_path": "/api/v1/crates/rand/1.0.0-beta.1/download",
+        "downloads": 3702,
+        "features": {},
+        "id": 1,
+        "license": "MIT",
+        "linecounts": {
+          "languages": {
+            "JavaScript": {
+              "code_lines": 325,
+              "comment_lines": 80,
+              "files": 8,
+            },
+            "TypeScript": {
+              "code_lines": 195,
+              "comment_lines": 10,
+              "files": 2,
+            },
           },
-          TypeScript: {
-            code_lines: 195,
-            comment_lines: 10,
-            files: 2,
-          },
+          "total_code_lines": 520,
+          "total_comment_lines": 90,
         },
-        total_code_lines: 520,
-        total_comment_lines: 90,
+        "links": {
+          "dependencies": "/api/v1/crates/rand/1.0.0-beta.1/dependencies",
+          "version_downloads": "/api/v1/crates/rand/1.0.0-beta.1/downloads",
+        },
+        "num": "1.0.0-beta.1",
+        "published_by": null,
+        "readme_path": "/api/v1/crates/rand/1.0.0-beta.1/readme",
+        "rust_version": null,
+        "trustpub_data": null,
+        "updated_at": "2017-02-24T12:34:56Z",
+        "yank_message": null,
+        "yanked": false,
       },
-      links: {
-        dependencies: '/api/v1/crates/rand/1.0.0-beta.1/dependencies',
-        version_downloads: '/api/v1/crates/rand/1.0.0-beta.1/downloads',
-      },
-      num: '1.0.0-beta.1',
-      published_by: null,
-      readme_path: '/api/v1/crates/rand/1.0.0-beta.1/readme',
-      rust_version: null,
-      trustpub_data: null,
-      updated_at: '2017-02-24T12:34:56Z',
-      yank_message: null,
-      yanked: false,
-    },
-  });
+    }
+  `);
 });

--- a/packages/crates-io-msw/handlers/versions/list.test.js
+++ b/packages/crates-io-msw/handlers/versions/list.test.js
@@ -5,7 +5,15 @@ import { db } from '../../index.js';
 test('returns 404 for unknown crates', async function () {
   let response = await fetch('/api/v1/crates/foo/versions');
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('empty case', async function () {
@@ -13,10 +21,15 @@ test('empty case', async function () {
 
   let response = await fetch('/api/v1/crates/rand/versions');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    versions: [],
-    meta: { total: 0, next_page: null },
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "meta": {
+        "next_page": null,
+        "total": 0,
+      },
+      "versions": [],
+    }
+  `);
 });
 
 test('returns all versions belonging to the specified crate', async function () {
@@ -28,131 +41,136 @@ test('returns all versions belonging to the specified crate', async function () 
 
   let response = await fetch('/api/v1/crates/rand/versions');
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    versions: [
-      {
-        id: 3,
-        crate: 'rand',
-        crate_size: 488_889,
-        created_at: '2010-06-16T21:30:45Z',
-        dl_path: '/api/v1/crates/rand/1.2.0/download',
-        downloads: 11_106,
-        features: {},
-        license: 'MIT/Apache-2.0',
-        linecounts: {
-          languages: {
-            Python: {
-              code_lines: 421,
-              comment_lines: 64,
-              files: 8,
-            },
-          },
-          total_code_lines: 421,
-          total_comment_lines: 64,
-        },
-        links: {
-          dependencies: '/api/v1/crates/rand/1.2.0/dependencies',
-          version_downloads: '/api/v1/crates/rand/1.2.0/downloads',
-        },
-        num: '1.2.0',
-        published_by: null,
-        readme_path: '/api/v1/crates/rand/1.2.0/readme',
-        rust_version: '1.69',
-        trustpub_data: null,
-        updated_at: '2017-02-24T12:34:56Z',
-        yanked: false,
-        yank_message: null,
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "meta": {
+        "next_page": null,
+        "total": 3,
       },
-      {
-        id: 2,
-        crate: 'rand',
-        crate_size: 325_926,
-        created_at: '2010-06-16T21:30:45Z',
-        dl_path: '/api/v1/crates/rand/1.1.0/download',
-        downloads: 7404,
-        features: {},
-        license: 'Apache-2.0',
-        linecounts: {
-          languages: {
-            CSS: {
-              code_lines: 503,
-              comment_lines: 42,
-              files: 2,
+      "versions": [
+        {
+          "crate": "rand",
+          "crate_size": 488889,
+          "created_at": "2010-06-16T21:30:45Z",
+          "dl_path": "/api/v1/crates/rand/1.2.0/download",
+          "downloads": 11106,
+          "features": {},
+          "id": 3,
+          "license": "MIT/Apache-2.0",
+          "linecounts": {
+            "languages": {
+              "Python": {
+                "code_lines": 421,
+                "comment_lines": 64,
+                "files": 8,
+              },
             },
-            Python: {
-              code_lines: 284,
-              comment_lines: 91,
-              files: 3,
-            },
-            TypeScript: {
-              code_lines: 332,
-              comment_lines: 83,
-              files: 7,
-            },
+            "total_code_lines": 421,
+            "total_comment_lines": 64,
           },
-          total_code_lines: 1119,
-          total_comment_lines: 216,
-        },
-        links: {
-          dependencies: '/api/v1/crates/rand/1.1.0/dependencies',
-          version_downloads: '/api/v1/crates/rand/1.1.0/downloads',
-        },
-        num: '1.1.0',
-        published_by: {
-          id: 1,
-          avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
-          login: 'user-1',
-          name: 'User 1',
-          url: 'https://github.com/user-1',
-        },
-        readme_path: '/api/v1/crates/rand/1.1.0/readme',
-        rust_version: null,
-        trustpub_data: null,
-        updated_at: '2017-02-24T12:34:56Z',
-        yanked: false,
-        yank_message: null,
-      },
-      {
-        id: 1,
-        crate: 'rand',
-        crate_size: 162_963,
-        created_at: '2010-06-16T21:30:45Z',
-        dl_path: '/api/v1/crates/rand/1.0.0/download',
-        downloads: 3702,
-        features: {},
-        license: 'MIT',
-        linecounts: {
-          languages: {
-            JavaScript: {
-              code_lines: 325,
-              comment_lines: 80,
-              files: 8,
-            },
-            TypeScript: {
-              code_lines: 195,
-              comment_lines: 10,
-              files: 2,
-            },
+          "links": {
+            "dependencies": "/api/v1/crates/rand/1.2.0/dependencies",
+            "version_downloads": "/api/v1/crates/rand/1.2.0/downloads",
           },
-          total_code_lines: 520,
-          total_comment_lines: 90,
+          "num": "1.2.0",
+          "published_by": null,
+          "readme_path": "/api/v1/crates/rand/1.2.0/readme",
+          "rust_version": "1.69",
+          "trustpub_data": null,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "yank_message": null,
+          "yanked": false,
         },
-        links: {
-          dependencies: '/api/v1/crates/rand/1.0.0/dependencies',
-          version_downloads: '/api/v1/crates/rand/1.0.0/downloads',
+        {
+          "crate": "rand",
+          "crate_size": 325926,
+          "created_at": "2010-06-16T21:30:45Z",
+          "dl_path": "/api/v1/crates/rand/1.1.0/download",
+          "downloads": 7404,
+          "features": {},
+          "id": 2,
+          "license": "Apache-2.0",
+          "linecounts": {
+            "languages": {
+              "CSS": {
+                "code_lines": 503,
+                "comment_lines": 42,
+                "files": 2,
+              },
+              "Python": {
+                "code_lines": 284,
+                "comment_lines": 91,
+                "files": 3,
+              },
+              "TypeScript": {
+                "code_lines": 332,
+                "comment_lines": 83,
+                "files": 7,
+              },
+            },
+            "total_code_lines": 1119,
+            "total_comment_lines": 216,
+          },
+          "links": {
+            "dependencies": "/api/v1/crates/rand/1.1.0/dependencies",
+            "version_downloads": "/api/v1/crates/rand/1.1.0/downloads",
+          },
+          "num": "1.1.0",
+          "published_by": {
+            "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+            "id": 1,
+            "login": "user-1",
+            "name": "User 1",
+            "url": "https://github.com/user-1",
+          },
+          "readme_path": "/api/v1/crates/rand/1.1.0/readme",
+          "rust_version": null,
+          "trustpub_data": null,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "yank_message": null,
+          "yanked": false,
         },
-        num: '1.0.0',
-        published_by: null,
-        readme_path: '/api/v1/crates/rand/1.0.0/readme',
-        rust_version: null,
-        trustpub_data: null,
-        updated_at: '2017-02-24T12:34:56Z',
-        yanked: false,
-        yank_message: null,
-      },
-    ],
-    meta: { total: 3, next_page: null },
-  });
+        {
+          "crate": "rand",
+          "crate_size": 162963,
+          "created_at": "2010-06-16T21:30:45Z",
+          "dl_path": "/api/v1/crates/rand/1.0.0/download",
+          "downloads": 3702,
+          "features": {},
+          "id": 1,
+          "license": "MIT",
+          "linecounts": {
+            "languages": {
+              "JavaScript": {
+                "code_lines": 325,
+                "comment_lines": 80,
+                "files": 8,
+              },
+              "TypeScript": {
+                "code_lines": 195,
+                "comment_lines": 10,
+                "files": 2,
+              },
+            },
+            "total_code_lines": 520,
+            "total_comment_lines": 90,
+          },
+          "links": {
+            "dependencies": "/api/v1/crates/rand/1.0.0/dependencies",
+            "version_downloads": "/api/v1/crates/rand/1.0.0/downloads",
+          },
+          "num": "1.0.0",
+          "published_by": null,
+          "readme_path": "/api/v1/crates/rand/1.0.0/readme",
+          "rust_version": null,
+          "trustpub_data": null,
+          "updated_at": "2017-02-24T12:34:56Z",
+          "yank_message": null,
+          "yanked": false,
+        },
+      ],
+    }
+  `);
 });
 
 test('supports `sort` parameters', async function () {
@@ -167,21 +185,39 @@ test('supports `sort` parameters', async function () {
     let response = await fetch('/api/v1/crates/rand/versions');
     expect(response.status).toBe(200);
     let json = await response.json();
-    expect(json.versions.map(it => it.num)).toEqual(['2.0.0-alpha', '1.1.0', '1.0.0']);
+    expect(json.versions.map(it => it.num)).toMatchInlineSnapshot(`
+      [
+        "2.0.0-alpha",
+        "1.1.0",
+        "1.0.0",
+      ]
+    `);
   }
 
   {
     let response = await fetch('/api/v1/crates/rand/versions?sort=semver');
     expect(response.status).toBe(200);
     let json = await response.json();
-    expect(json.versions.map(it => it.num)).toEqual(['2.0.0-alpha', '1.1.0', '1.0.0']);
+    expect(json.versions.map(it => it.num)).toMatchInlineSnapshot(`
+      [
+        "2.0.0-alpha",
+        "1.1.0",
+        "1.0.0",
+      ]
+    `);
   }
 
   {
     let response = await fetch('/api/v1/crates/rand/versions?sort=date');
     expect(response.status).toBe(200);
     let json = await response.json();
-    expect(json.versions.map(it => it.num)).toEqual(['1.1.0', '2.0.0-alpha', '1.0.0']);
+    expect(json.versions.map(it => it.num)).toMatchInlineSnapshot(`
+      [
+        "1.1.0",
+        "2.0.0-alpha",
+        "1.0.0",
+      ]
+    `);
   }
 });
 
@@ -194,7 +230,12 @@ test('supports multiple `ids[]` parameters', async function () {
   let response = await fetch('/api/v1/crates/rand/versions?nums[]=1.0.0&nums[]=1.2.0');
   expect(response.status).toBe(200);
   let json = await response.json();
-  expect(json.versions.map(v => v.num)).toEqual(['1.2.0', '1.0.0']);
+  expect(json.versions.map(v => v.num)).toMatchInlineSnapshot(`
+    [
+      "1.2.0",
+      "1.0.0",
+    ]
+  `);
 });
 
 test('supports seek pagination', async function () {
@@ -231,35 +272,80 @@ test('supports seek pagination', async function () {
   // sort by `semver` by default
   {
     let responses = await seek_forwards({ per_page: 1 });
-    expect(responses.map(it => it.versions.map(v => v.num))).toEqual([['2.0.0-alpha'], ['1.1.0'], ['1.0.0'], []]);
-    expect(responses.map(it => it.meta.next_page)).toEqual([
-      '?per_page=1&seek=2.0.0-alpha',
-      '?per_page=1&seek=1.1.0',
-      '?per_page=1&seek=1.0.0',
-      null,
-    ]);
+    expect(responses.map(it => it.versions.map(v => v.num))).toMatchInlineSnapshot(`
+      [
+        [
+          "2.0.0-alpha",
+        ],
+        [
+          "1.1.0",
+        ],
+        [
+          "1.0.0",
+        ],
+        [],
+      ]
+    `);
+    expect(responses.map(it => it.meta.next_page)).toMatchInlineSnapshot(`
+      [
+        "?per_page=1&seek=2.0.0-alpha",
+        "?per_page=1&seek=1.1.0",
+        "?per_page=1&seek=1.0.0",
+        null,
+      ]
+    `);
   }
 
   {
     let responses = await seek_forwards({ per_page: 1, sort: 'semver' });
-    expect(responses.map(it => it.versions.map(v => v.num))).toEqual([['2.0.0-alpha'], ['1.1.0'], ['1.0.0'], []]);
-    expect(responses.map(it => it.meta.next_page)).toEqual([
-      '?per_page=1&sort=semver&seek=2.0.0-alpha',
-      '?per_page=1&sort=semver&seek=1.1.0',
-      '?per_page=1&sort=semver&seek=1.0.0',
-      null,
-    ]);
+    expect(responses.map(it => it.versions.map(v => v.num))).toMatchInlineSnapshot(`
+      [
+        [
+          "2.0.0-alpha",
+        ],
+        [
+          "1.1.0",
+        ],
+        [
+          "1.0.0",
+        ],
+        [],
+      ]
+    `);
+    expect(responses.map(it => it.meta.next_page)).toMatchInlineSnapshot(`
+      [
+        "?per_page=1&sort=semver&seek=2.0.0-alpha",
+        "?per_page=1&sort=semver&seek=1.1.0",
+        "?per_page=1&sort=semver&seek=1.0.0",
+        null,
+      ]
+    `);
   }
 
   {
     let responses = await seek_forwards({ per_page: 1, sort: 'date' });
-    expect(responses.map(it => it.versions.map(v => v.num))).toEqual([['1.1.0'], ['2.0.0-alpha'], ['1.0.0'], []]);
-    expect(responses.map(it => it.meta.next_page)).toEqual([
-      '?per_page=1&sort=date&seek=1.1.0',
-      '?per_page=1&sort=date&seek=2.0.0-alpha',
-      '?per_page=1&sort=date&seek=1.0.0',
-      null,
-    ]);
+    expect(responses.map(it => it.versions.map(v => v.num))).toMatchInlineSnapshot(`
+      [
+        [
+          "1.1.0",
+        ],
+        [
+          "2.0.0-alpha",
+        ],
+        [
+          "1.0.0",
+        ],
+        [],
+      ]
+    `);
+    expect(responses.map(it => it.meta.next_page)).toMatchInlineSnapshot(`
+      [
+        "?per_page=1&sort=date&seek=1.1.0",
+        "?per_page=1&sort=date&seek=2.0.0-alpha",
+        "?per_page=1&sort=date&seek=1.0.0",
+        null,
+      ]
+    `);
   }
 });
 

--- a/packages/crates-io-msw/handlers/versions/patch.test.js
+++ b/packages/crates-io-msw/handlers/versions/patch.test.js
@@ -18,9 +18,15 @@ const UNYANK_BODY = JSON.stringify({
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch('/api/v1/crates/foo/1.0.0', { method: 'PATCH', body: YANK_BODY });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -29,7 +35,15 @@ test('returns 404 for unknown crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0', { method: 'PATCH', body: YANK_BODY });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown versions', async function () {
@@ -40,7 +54,15 @@ test('returns 404 for unknown versions', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0', { method: 'PATCH', body: YANK_BODY });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('yanks the version', async function () {
@@ -54,46 +76,48 @@ test('yanks the version', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0', { method: 'PATCH', body: YANK_BODY });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    version: {
-      crate: 'foo',
-      crate_size: 162_963,
-      created_at: '2010-06-16T21:30:45Z',
-      dl_path: '/api/v1/crates/foo/1.0.0/download',
-      downloads: 3702,
-      features: {},
-      id: 1,
-      license: 'MIT',
-      linecounts: {
-        languages: {
-          JavaScript: {
-            code_lines: 325,
-            comment_lines: 80,
-            files: 8,
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "version": {
+        "crate": "foo",
+        "crate_size": 162963,
+        "created_at": "2010-06-16T21:30:45Z",
+        "dl_path": "/api/v1/crates/foo/1.0.0/download",
+        "downloads": 3702,
+        "features": {},
+        "id": 1,
+        "license": "MIT",
+        "linecounts": {
+          "languages": {
+            "JavaScript": {
+              "code_lines": 325,
+              "comment_lines": 80,
+              "files": 8,
+            },
+            "TypeScript": {
+              "code_lines": 195,
+              "comment_lines": 10,
+              "files": 2,
+            },
           },
-          TypeScript: {
-            code_lines: 195,
-            comment_lines: 10,
-            files: 2,
-          },
+          "total_code_lines": 520,
+          "total_comment_lines": 90,
         },
-        total_code_lines: 520,
-        total_comment_lines: 90,
+        "links": {
+          "dependencies": "/api/v1/crates/foo/1.0.0/dependencies",
+          "version_downloads": "/api/v1/crates/foo/1.0.0/downloads",
+        },
+        "num": "1.0.0",
+        "published_by": null,
+        "readme_path": "/api/v1/crates/foo/1.0.0/readme",
+        "rust_version": null,
+        "trustpub_data": null,
+        "updated_at": "2017-02-24T12:34:56Z",
+        "yank_message": "some reason",
+        "yanked": true,
       },
-      links: {
-        dependencies: '/api/v1/crates/foo/1.0.0/dependencies',
-        version_downloads: '/api/v1/crates/foo/1.0.0/downloads',
-      },
-      num: '1.0.0',
-      published_by: null,
-      readme_path: '/api/v1/crates/foo/1.0.0/readme',
-      rust_version: null,
-      trustpub_data: null,
-      updated_at: '2017-02-24T12:34:56Z',
-      yank_message: 'some reason',
-      yanked: true,
-    },
-  });
+    }
+  `);
 
   version = db.version.findFirst(q => q.where({ id: version.id }));
   expect(version.yanked).toBe(true);
@@ -101,46 +125,48 @@ test('yanks the version', async function () {
 
   response = await fetch('/api/v1/crates/foo/1.0.0', { method: 'PATCH', body: UNYANK_BODY });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({
-    version: {
-      crate: 'foo',
-      crate_size: 162_963,
-      created_at: '2010-06-16T21:30:45Z',
-      dl_path: '/api/v1/crates/foo/1.0.0/download',
-      downloads: 3702,
-      features: {},
-      id: 1,
-      license: 'MIT',
-      linecounts: {
-        languages: {
-          JavaScript: {
-            code_lines: 325,
-            comment_lines: 80,
-            files: 8,
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "version": {
+        "crate": "foo",
+        "crate_size": 162963,
+        "created_at": "2010-06-16T21:30:45Z",
+        "dl_path": "/api/v1/crates/foo/1.0.0/download",
+        "downloads": 3702,
+        "features": {},
+        "id": 1,
+        "license": "MIT",
+        "linecounts": {
+          "languages": {
+            "JavaScript": {
+              "code_lines": 325,
+              "comment_lines": 80,
+              "files": 8,
+            },
+            "TypeScript": {
+              "code_lines": 195,
+              "comment_lines": 10,
+              "files": 2,
+            },
           },
-          TypeScript: {
-            code_lines: 195,
-            comment_lines: 10,
-            files: 2,
-          },
+          "total_code_lines": 520,
+          "total_comment_lines": 90,
         },
-        total_code_lines: 520,
-        total_comment_lines: 90,
+        "links": {
+          "dependencies": "/api/v1/crates/foo/1.0.0/dependencies",
+          "version_downloads": "/api/v1/crates/foo/1.0.0/downloads",
+        },
+        "num": "1.0.0",
+        "published_by": null,
+        "readme_path": "/api/v1/crates/foo/1.0.0/readme",
+        "rust_version": null,
+        "trustpub_data": null,
+        "updated_at": "2017-02-24T12:34:56Z",
+        "yank_message": null,
+        "yanked": false,
       },
-      links: {
-        dependencies: '/api/v1/crates/foo/1.0.0/dependencies',
-        version_downloads: '/api/v1/crates/foo/1.0.0/downloads',
-      },
-      num: '1.0.0',
-      published_by: null,
-      readme_path: '/api/v1/crates/foo/1.0.0/readme',
-      rust_version: null,
-      trustpub_data: null,
-      updated_at: '2017-02-24T12:34:56Z',
-      yank_message: null,
-      yanked: false,
-    },
-  });
+    }
+  `);
 
   version = db.version.findFirst(q => q.where({ id: version.id }));
   expect(version.yanked).toBe(false);

--- a/packages/crates-io-msw/handlers/versions/rebuild-docs.test.js
+++ b/packages/crates-io-msw/handlers/versions/rebuild-docs.test.js
@@ -5,9 +5,15 @@ import { db } from '../../index.js';
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch('/api/v1/crates/foo/1.0.0/rebuild_docs', { method: 'POST' });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -16,7 +22,15 @@ test('returns 404 for unknown crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/rebuild_docs', { method: 'POST' });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown versions', async function () {
@@ -27,7 +41,15 @@ test('returns 404 for unknown versions', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/rebuild_docs', { method: 'POST' });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('triggers a rebuild for the crate documentation', async function () {

--- a/packages/crates-io-msw/handlers/versions/unyank.test.js
+++ b/packages/crates-io-msw/handlers/versions/unyank.test.js
@@ -5,9 +5,15 @@ import { db } from '../../index.js';
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -16,7 +22,15 @@ test('returns 404 for unknown crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown versions', async function () {
@@ -27,7 +41,15 @@ test('returns 404 for unknown versions', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('unyanks the version', async function () {
@@ -41,7 +63,11 @@ test('unyanks the version', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 
   version = db.version.findFirst(q => q.where({ id: version.id }));
   expect(version.yanked).toBe(false);

--- a/packages/crates-io-msw/handlers/versions/yank.test.js
+++ b/packages/crates-io-msw/handlers/versions/yank.test.js
@@ -5,9 +5,15 @@ import { db } from '../../index.js';
 test('returns 403 if unauthenticated', async function () {
   let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });
   expect(response.status).toBe(403);
-  expect(await response.json()).toEqual({
-    errors: [{ detail: 'must be logged in to perform that action' }],
-  });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "must be logged in to perform that action",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown crates', async function () {
@@ -16,7 +22,15 @@ test('returns 404 for unknown crates', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('returns 404 for unknown versions', async function () {
@@ -27,7 +41,15 @@ test('returns 404 for unknown versions', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });
   expect(response.status).toBe(404);
-  expect(await response.json()).toEqual({ errors: [{ detail: 'Not Found' }] });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
 });
 
 test('yanks the version', async function () {
@@ -40,7 +62,11 @@ test('yanks the version', async function () {
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });
   expect(response.status).toBe(200);
-  expect(await response.json()).toEqual({ ok: true });
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
 
   version = db.version.findFirst(q => q.where({ id: version.id }));
   expect(version.yanked).toBe(true);


### PR DESCRIPTION
This is a bit more verbose unfortunately, but makes it much easier to update the snapshots when the content changes.