### PR TITLE
svelte: Derive `hero` argument for `Header` component

### DIFF
--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { page } from '$app/state';
+
   import Footer from '$lib/components/Footer.svelte';
   import Header from '$lib/components/Header.svelte';
 
@@ -7,6 +9,8 @@
   // TODO: import ProgressBar from '$lib/components/ProgressBar.svelte';
 
   let { children } = $props();
+
+  let isIndex = $derived(page.route.id === '/');
 
   // TODO: implement color scheme support
   // TODO: implement notification container
@@ -20,8 +24,7 @@
 <!-- TODO: <NotificationContainer position='top-right' /> -->
 <div id="tooltip-container"></div>
 
-<!-- TODO: pass `hero` prop based on whether we're on the index route -->
-<Header />
+<Header hero={isIndex} />
 
 <main class="main">
   <div class="inner-main width-limit">


### PR DESCRIPTION
This should be equivalent to https://github.com/rust-lang/crates.io/blob/262ad62506591396848543e6ced730fa711ab0c8/app/controllers/application.js#L9-L11

### Related 

- https://github.com/rust-lang/crates.io/issues/12515