### PR TITLE
svelte/SearchForm: Keep focus on search box after submitting

### DIFF
--- a/svelte/src/lib/components/SearchForm.svelte
+++ b/svelte/src/lib/components/SearchForm.svelte
@@ -55,6 +55,7 @@
   class="form"
   class:size-big={size === 'big'}
   onsubmit={search}
+  data-sveltekit-keepfocus
 >
   <!-- Large screen input with keyboard shortcut hint -->
   <input


### PR DESCRIPTION
This makes it possible to quickly fix any typos in the search query.

see https://svelte.dev/docs/kit/link-options#data-sveltekit-keepfocus

### Related

- https://github.com/rust-lang/crates.io/issues/12515