### PR TITLE
msw: Replace `.create()` calls with `.create({})`

### DIFF
--- a/e2e/acceptance/crate-deletion.spec.ts
+++ b/e2e/acceptance/crate-deletion.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@/e2e/helper';
 
 test.describe('Acceptance | crate deletion', { tag: '@acceptance' }, () => {
   test('happy path', async ({ page, msw }) => {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
     let crate = await msw.db.crate.create({ name: 'foo' });

--- a/e2e/acceptance/crates.spec.ts
+++ b/e2e/acceptance/crates.spec.ts
@@ -32,7 +32,7 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
   test('listing crates', async ({ page, msw }) => {
     const per_page = 50;
     for (let i = 1; i <= per_page; i++) {
-      let crate = await msw.db.crate.create();
+      let crate = await msw.db.crate.create({});
       await msw.db.version.create({ crate });
     }
 
@@ -45,7 +45,7 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
   test('navigating to next page of crates', async ({ page, msw }) => {
     const per_page = 50;
     for (let i = 1; i <= per_page + 2; i++) {
-      let crate = await msw.db.crate.create();
+      let crate = await msw.db.crate.create({});
       await msw.db.version.create({ crate });
     }
     const page_start = per_page + 1;

--- a/e2e/acceptance/invites.spec.ts
+++ b/e2e/acceptance/invites.spec.ts
@@ -15,7 +15,7 @@ test.describe('Acceptance | /me/pending-invites', { tag: '@acceptance' }, () => 
     let inviter = await msw.db.user.create({ name: 'janed' });
     let inviter2 = await msw.db.user.create({ name: 'wycats' });
 
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
 
     let nanomsg = await msw.db.crate.create({ name: 'nanomsg' });
     await msw.db.version.create({ crate: nanomsg });

--- a/e2e/acceptance/login.spec.ts
+++ b/e2e/acceptance/login.spec.ts
@@ -19,7 +19,7 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
         expect(url.searchParams.get('code')).toBe('901dd10e07c7e9fa1cd5');
         expect(url.searchParams.get('state')).toBe('fYcUY3FMdUUz00FC7vLT7A');
 
-        let user = await msw.db.user.create();
+        let user = await msw.db.user.create({});
         await msw.db.mswSession.create({ user });
         return HttpResponse.json({ ok: true });
       }),

--- a/e2e/acceptance/publish-notifications.spec.ts
+++ b/e2e/acceptance/publish-notifications.spec.ts
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw';
 
 test.describe('Acceptance | publish notifications', { tag: '@acceptance' }, () => {
   test('unsubscribe and resubscribe', async ({ page, msw }) => {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
     await page.goto('/settings/profile');
@@ -27,7 +27,7 @@ test.describe('Acceptance | publish notifications', { tag: '@acceptance' }, () =
   });
 
   test('loading state', async ({ page, msw }) => {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
     let deferred = defer();
@@ -48,7 +48,7 @@ test.describe('Acceptance | publish notifications', { tag: '@acceptance' }, () =
   });
 
   test('error state', async ({ page, msw }) => {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
     msw.worker.use(http.put('/api/v1/users/:user_id', () => HttpResponse.text('', { status: 500 })));

--- a/e2e/acceptance/rebuild-docs.spec.ts
+++ b/e2e/acceptance/rebuild-docs.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@/e2e/helper';
 
 test.describe('Acceptance | rebuild docs page', { tag: '@acceptance' }, () => {
   test('navigates to rebuild docs confirmation page', async ({ page, msw }) => {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
     let crate = await msw.db.crate.create({ name: 'nanomsg' });
@@ -29,7 +29,7 @@ test.describe('Acceptance | rebuild docs page', { tag: '@acceptance' }, () => {
   });
 
   test('rebuild docs confirmation page shows crate info and allows confirmation', async ({ page, msw }) => {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
     let crate = await msw.db.crate.create({ name: 'nanomsg' });
@@ -52,7 +52,7 @@ test.describe('Acceptance | rebuild docs page', { tag: '@acceptance' }, () => {
   });
 
   test('rebuild docs confirmation page redirects non-owners to error page', async ({ page, msw }) => {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
     let crate = await msw.db.crate.create({ name: 'nanomsg' });

--- a/e2e/acceptance/reverse-dependencies.spec.ts
+++ b/e2e/acceptance/reverse-dependencies.spec.ts
@@ -37,7 +37,7 @@ test.describe('Acceptance | /crates/:crate_id/reverse_dependencies', { tag: '@ac
     let { foo } = await prepare(msw);
 
     for (let i = 0; i < 20; i++) {
-      let crate = await msw.db.crate.create();
+      let crate = await msw.db.crate.create({});
       let version = await msw.db.version.create({ crate });
       await msw.db.dependency.create({ crate: foo, version });
     }

--- a/e2e/acceptance/token-invites.spec.ts
+++ b/e2e/acceptance/token-invites.spec.ts
@@ -36,8 +36,8 @@ test.describe('Acceptance | /accept-invite/:token', { tag: '@acceptance' }, () =
   });
 
   test('shows success for known token', async ({ page, msw, percy }) => {
-    let inviter = await msw.db.user.create();
-    let invitee = await msw.db.user.create();
+    let inviter = await msw.db.user.create({});
+    let invitee = await msw.db.user.create({});
     let crate = await msw.db.crate.create({ name: 'nanomsg' });
     await msw.db.version.create({ crate });
     let invite = await msw.db.crateOwnerInvitation.create({ crate, invitee, inviter });

--- a/e2e/acceptance/versions.spec.ts
+++ b/e2e/acceptance/versions.spec.ts
@@ -33,7 +33,7 @@ test.describe('Acceptance | crate versions page', { tag: '@acceptance' }, () => 
   });
 
   test('shows correct release tracks label after yanking/unyanking', async ({ page, msw, percy }) => {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
     let crate = await msw.db.crate.create({ name: 'nanomsg' });

--- a/e2e/routes/crate/delete.spec.ts
+++ b/e2e/routes/crate/delete.spec.ts
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw';
 
 test.describe('Route: crate.delete', { tag: '@routes' }, () => {
   async function prepare(msw) {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
 
     let crate = await msw.db.crate.create({ name: 'foo' });
     await msw.db.version.create({ crate });
@@ -24,10 +24,10 @@ test.describe('Route: crate.delete', { tag: '@routes' }, () => {
   });
 
   test('not an owner', async ({ msw, page }) => {
-    let user1 = await msw.db.user.create();
+    let user1 = await msw.db.user.create({});
     await msw.authenticateAs(user1);
 
-    let user2 = await msw.db.user.create();
+    let user2 = await msw.db.user.create({});
     let crate = await msw.db.crate.create({ name: 'foo' });
     await msw.db.version.create({ crate });
     await msw.db.crateOwnership.create({ crate, user: user2 });

--- a/e2e/routes/crate/settings.spec.ts
+++ b/e2e/routes/crate/settings.spec.ts
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw';
 
 test.describe('Route | crate.settings', { tag: '@routes' }, () => {
   async function prepare(msw) {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
 
     let crate = await msw.db.crate.create({ name: 'foo' });
     await msw.db.version.create({ crate });
@@ -26,10 +26,10 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
   });
 
   test('not an owner', async ({ msw, page }) => {
-    let user1 = await msw.db.user.create();
+    let user1 = await msw.db.user.create({});
     await msw.authenticateAs(user1);
 
-    let user2 = await msw.db.user.create();
+    let user2 = await msw.db.user.create({});
     let crate = await msw.db.crate.create({ name: 'foo' });
     await msw.db.version.create({ crate });
     await msw.db.crateOwnership.create({ crate, user: user2 });

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw';
 
 test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }, () => {
   async function prepare(msw) {
-    let user = await msw.db.user.create();
+    let user = await msw.db.user.create({});
 
     let crate = await msw.db.crate.create({ name: 'foo' });
     await msw.db.version.create({ crate });

--- a/packages/crates-io-msw/handlers/api-tokens/create.test.js
+++ b/packages/crates-io-msw/handlers/api-tokens/create.test.js
@@ -12,7 +12,7 @@ afterEach(() => {
 });
 
 test('creates a new API token', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let body = JSON.stringify({ api_token: { name: 'foooo' } });
@@ -40,7 +40,7 @@ test('creates a new API token', async function () {
 });
 
 test('creates a new API token with scopes', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let body = JSON.stringify({
@@ -79,7 +79,7 @@ test('creates a new API token with scopes', async function () {
 });
 
 test('creates a new API token with expiry date', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let body = JSON.stringify({

--- a/packages/crates-io-msw/handlers/api-tokens/delete.test.js
+++ b/packages/crates-io-msw/handlers/api-tokens/delete.test.js
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { db } from '../../index.js';
 
 test('revokes an API token', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let token = await db.apiToken.create({ user });
@@ -17,7 +17,7 @@ test('revokes an API token', async function () {
 });
 
 test('returns an error if unauthenticated', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   let token = await db.apiToken.create({ user });
 
   let response = await fetch(`/api/v1/me/tokens/${token.id}`, { method: 'DELETE' });

--- a/packages/crates-io-msw/handlers/api-tokens/get.test.js
+++ b/packages/crates-io-msw/handlers/api-tokens/get.test.js
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { db } from '../../index.js';
 
 test('returns the requested token', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let token = await db.apiToken.create({
@@ -35,7 +35,7 @@ test('returns the requested token', async function () {
 });
 
 test('returns 404 if token not found', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/me/tokens/42');

--- a/packages/crates-io-msw/handlers/api-tokens/list.test.js
+++ b/packages/crates-io-msw/handlers/api-tokens/list.test.js
@@ -12,7 +12,7 @@ afterEach(() => {
 });
 
 test('returns the list of API token for the authenticated `user`', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   await db.apiToken.create({
@@ -68,7 +68,7 @@ test('returns the list of API token for the authenticated `user`', async functio
 });
 
 test('empty list case', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/me/tokens');

--- a/packages/crates-io-msw/handlers/categories/list-slugs.test.js
+++ b/packages/crates-io-msw/handlers/categories/list-slugs.test.js
@@ -17,7 +17,7 @@ test('returns a category slugs list', async function () {
     category: 'no-std',
     description: 'Crates that are able to function without the Rust standard library.',
   });
-  await Promise.all(Array.from({ length: 2 }, () => db.category.create()));
+  await Promise.all(Array.from({ length: 2 }, () => db.category.create({})));
 
   let response = await fetch('/api/v1/category_slugs');
   expect(response.status).toBe(200);
@@ -45,7 +45,7 @@ test('returns a category slugs list', async function () {
 });
 
 test('has no pagination', async function () {
-  await Promise.all(Array.from({ length: 25 }, () => db.category.create()));
+  await Promise.all(Array.from({ length: 25 }, () => db.category.create({})));
 
   let response = await fetch('/api/v1/category_slugs');
   expect(response.status).toBe(200);

--- a/packages/crates-io-msw/handlers/categories/list.test.js
+++ b/packages/crates-io-msw/handlers/categories/list.test.js
@@ -20,7 +20,7 @@ test('returns a paginated categories list', async function () {
     category: 'no-std',
     description: 'Crates that are able to function without the Rust standard library.',
   });
-  await Promise.all(Array.from({ length: 2 }, () => db.category.create()));
+  await Promise.all(Array.from({ length: 2 }, () => db.category.create({})));
 
   let response = await fetch('/api/v1/categories');
   expect(response.status).toBe(200);
@@ -60,7 +60,7 @@ test('returns a paginated categories list', async function () {
 });
 
 test('never returns more than 10 results', async function () {
-  await Promise.all(Array.from({ length: 25 }, () => db.category.create()));
+  await Promise.all(Array.from({ length: 25 }, () => db.category.create({})));
 
   let response = await fetch('/api/v1/categories');
   expect(response.status).toBe(200);

--- a/packages/crates-io-msw/handlers/crates/add-owners.test.js
+++ b/packages/crates-io-msw/handlers/crates/add-owners.test.js
@@ -19,7 +19,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body: ADD_USER_BODY });
@@ -36,13 +36,13 @@ test('returns 404 for unknown crates', async function () {
 });
 
 test('can add new owner', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let crate = await db.crate.create({ name: 'foo' });
   await db.crateOwnership.create({ crate, user });
 
-  let user2 = await db.user.create();
+  let user2 = await db.user.create({});
 
   let body = JSON.stringify({ owners: [user2.login] });
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
@@ -65,13 +65,13 @@ test('can add new owner', async function () {
 });
 
 test('can add team owner', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let crate = await db.crate.create({ name: 'foo' });
   await db.crateOwnership.create({ crate, user });
 
-  let team = await db.team.create();
+  let team = await db.team.create({});
 
   let body = JSON.stringify({ owners: [team.login] });
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
@@ -95,15 +95,15 @@ test('can add team owner', async function () {
 });
 
 test('can add multiple owners', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let crate = await db.crate.create({ name: 'foo' });
   await db.crateOwnership.create({ crate, user });
 
-  let team = await db.team.create();
-  let user2 = await db.user.create();
-  let user3 = await db.user.create();
+  let team = await db.team.create({});
+  let user2 = await db.user.create({});
+  let user3 = await db.user.create({});
 
   let body = JSON.stringify({ owners: [user2.login, team.login, user3.login] });
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });

--- a/packages/crates-io-msw/handlers/crates/delete.test.js
+++ b/packages/crates-io-msw/handlers/crates/delete.test.js
@@ -17,7 +17,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo', { method: 'DELETE' });
@@ -34,7 +34,7 @@ test('returns 404 for unknown crates', async function () {
 });
 
 test('deletes crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let crate = await db.crate.create({ name: 'foo' });

--- a/packages/crates-io-msw/handlers/crates/follow.test.js
+++ b/packages/crates-io-msw/handlers/crates/follow.test.js
@@ -17,7 +17,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/follow', { method: 'PUT' });
@@ -36,7 +36,7 @@ test('returns 404 for unknown crates', async function () {
 test('makes the authenticated user follow the crate', async function () {
   let crate = await db.crate.create({ name: 'rand' });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   expect(user.followedCrates).toMatchInlineSnapshot(`[]`);

--- a/packages/crates-io-msw/handlers/crates/following.test.js
+++ b/packages/crates-io-msw/handlers/crates/following.test.js
@@ -17,7 +17,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/following');
@@ -51,7 +51,7 @@ test('returns true if the authenticated user follows the crate', async function 
 test('returns false if the authenticated user is not following the crate', async function () {
   await db.crate.create({ name: 'rand' });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/rand/following');

--- a/packages/crates-io-msw/handlers/crates/list.test.js
+++ b/packages/crates-io-msw/handlers/crates/list.test.js
@@ -75,7 +75,7 @@ test('returns a paginated crates list', async function () {
 });
 
 test('never returns more than 10 results', async function () {
-  let crates = await Promise.all(Array.from({ length: 25 }, () => db.crate.create()));
+  let crates = await Promise.all(Array.from({ length: 25 }, () => db.crate.create({})));
   await Promise.all(crates.map(crate => db.version.create({ crate })));
 
   let response = await fetch('/api/v1/crates');
@@ -160,8 +160,8 @@ test('supports a `q` parameter', async function () {
 });
 
 test('supports a `user_id` parameter', async function () {
-  let user1 = await db.user.create();
-  let user2 = await db.user.create();
+  let user1 = await db.user.create({});
+  let user2 = await db.user.create({});
 
   let foo = await db.crate.create({ name: 'foo' });
   await db.version.create({ crate: foo });
@@ -182,8 +182,8 @@ test('supports a `user_id` parameter', async function () {
 });
 
 test('supports a `team_id` parameter', async function () {
-  let team1 = await db.team.create();
-  let team2 = await db.team.create();
+  let team1 = await db.team.create({});
+  let team2 = await db.team.create({});
 
   let foo = await db.crate.create({ name: 'foo' });
   await db.version.create({ crate: foo });

--- a/packages/crates-io-msw/handlers/crates/patch.test.js
+++ b/packages/crates-io-msw/handlers/crates/patch.test.js
@@ -21,7 +21,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo', {
@@ -42,7 +42,7 @@ test('returns 404 for unknown crates', async function () {
 });
 
 test('updates trustpub_only flag', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let crate = await db.crate.create({ name: 'foo', trustpubOnly: false });

--- a/packages/crates-io-msw/handlers/crates/remove-owners.test.js
+++ b/packages/crates-io-msw/handlers/crates/remove-owners.test.js
@@ -19,7 +19,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/owners', { method: 'DELETE', body: REMOVE_USER_BODY });
@@ -36,13 +36,13 @@ test('returns 404 for unknown crates', async function () {
 });
 
 test('can remove a user owner', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let crate = await db.crate.create({ name: 'foo' });
   await db.crateOwnership.create({ crate, user });
 
-  let user2 = await db.user.create();
+  let user2 = await db.user.create({});
   await db.crateOwnership.create({ crate, user: user2 });
 
   let body = JSON.stringify({ owners: [user2.login] });
@@ -64,13 +64,13 @@ test('can remove a user owner', async function () {
 });
 
 test('can remove a team owner', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let crate = await db.crate.create({ name: 'foo' });
   await db.crateOwnership.create({ crate, user });
 
-  let team = await db.team.create();
+  let team = await db.team.create({});
   await db.crateOwnership.create({ crate, team });
 
   let body = JSON.stringify({ owners: [team.login] });
@@ -93,16 +93,16 @@ test('can remove a team owner', async function () {
 });
 
 test('can remove multiple owners', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let crate = await db.crate.create({ name: 'foo' });
   await db.crateOwnership.create({ crate, user });
 
-  let team = await db.team.create();
+  let team = await db.team.create({});
   await db.crateOwnership.create({ crate, team });
 
-  let user2 = await db.user.create();
+  let user2 = await db.user.create({});
   await db.crateOwnership.create({ crate, user: user2 });
 
   let body = JSON.stringify({ owners: [user2.login, team.login] });

--- a/packages/crates-io-msw/handlers/crates/unfollow.test.js
+++ b/packages/crates-io-msw/handlers/crates/unfollow.test.js
@@ -17,7 +17,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/follow', { method: 'DELETE' });

--- a/packages/crates-io-msw/handlers/invites/legacy-list.test.js
+++ b/packages/crates-io-msw/handlers/invites/legacy-list.test.js
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { db } from '../../index.js';
 
 test('empty case', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/me/crate_owner_invitations');
@@ -23,7 +23,7 @@ test('returns the list of invitations for the authenticated user', async functio
   let ember = await db.crate.create({ name: 'ember-rs' });
   await db.version.create({ crate: ember });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let inviter = await db.user.create({ name: 'janed' });

--- a/packages/crates-io-msw/handlers/invites/list.test.js
+++ b/packages/crates-io-msw/handlers/invites/list.test.js
@@ -9,7 +9,7 @@ test('happy path (invitee_id)', async function () {
   let ember = await db.crate.create({ name: 'ember-rs' });
   await db.version.create({ crate: ember });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let inviter = await db.user.create({ name: 'janed' });
@@ -81,7 +81,7 @@ test('happy path (invitee_id)', async function () {
 });
 
 test('happy path with empty response (invitee_id)', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/private/crate_owner_invitations?invitee_id=${user.id}`);
@@ -98,13 +98,13 @@ test('happy path with empty response (invitee_id)', async function () {
 });
 
 test('happy path with pagination (invitee_id)', async function () {
-  let inviter = await db.user.create();
+  let inviter = await db.user.create({});
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   for (let i = 0; i < 15; i++) {
-    let crate = await db.crate.create();
+    let crate = await db.crate.create({});
     await db.version.create({ crate });
     await db.crateOwnerInvitation.create({ crate, invitee: user, inviter });
   }
@@ -129,7 +129,7 @@ test('happy path (crate_name)', async function () {
   let ember = await db.crate.create({ name: 'ember-rs' });
   await db.version.create({ crate: ember });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let inviter = await db.user.create({ name: 'janed' });
@@ -200,7 +200,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 400 if query params are missing', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/private/crate_owner_invitations`);
@@ -217,7 +217,7 @@ test('returns 400 if query params are missing', async function () {
 });
 
 test("returns 404 if crate can't be found", async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/private/crate_owner_invitations?crate_name=foo`);
@@ -234,7 +234,7 @@ test("returns 404 if crate can't be found", async function () {
 });
 
 test('returns 403 if requesting for other user', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/private/crate_owner_invitations?invitee_id=${user.id + 1}`);

--- a/packages/crates-io-msw/handlers/invites/redeem-by-crate-id.test.js
+++ b/packages/crates-io-msw/handlers/invites/redeem-by-crate-id.test.js
@@ -12,8 +12,8 @@ let test = _test.extend({
 });
 
 test('can accept an invitation', async function ({ serde }) {
-  let inviter = await db.user.create();
-  let invitee = await db.user.create();
+  let inviter = await db.user.create({});
+  let invitee = await db.user.create({});
   await db.mswSession.create({ user: invitee });
 
   await db.crateOwnerInvitation.create({ crate: serde, invitee, inviter });
@@ -39,8 +39,8 @@ test('can accept an invitation', async function ({ serde }) {
 });
 
 test('can decline an invitation', async function ({ serde }) {
-  let inviter = await db.user.create();
-  let invitee = await db.user.create();
+  let inviter = await db.user.create({});
+  let invitee = await db.user.create({});
   await db.mswSession.create({ user: invitee });
 
   await db.crateOwnerInvitation.create({ crate: serde, invitee, inviter });
@@ -66,7 +66,7 @@ test('can decline an invitation', async function ({ serde }) {
 });
 
 test('returns 404 if invite does not exist', async function ({ serde }) {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let body = JSON.stringify({ crate_owner_invite: { crate_id: serde.id, accepted: true } });
@@ -75,8 +75,8 @@ test('returns 404 if invite does not exist', async function ({ serde }) {
 });
 
 test('returns 404 if invite is for another user', async function ({ serde }) {
-  let inviter = await db.user.create();
-  let invitee = await db.user.create();
+  let inviter = await db.user.create({});
+  let invitee = await db.user.create({});
   await db.mswSession.create({ user: inviter });
 
   await db.crateOwnerInvitation.create({ crate: serde, invitee, inviter });

--- a/packages/crates-io-msw/handlers/invites/redeem-by-token.test.js
+++ b/packages/crates-io-msw/handlers/invites/redeem-by-token.test.js
@@ -6,8 +6,8 @@ test('can accept an invitation', async function () {
   let serde = await db.crate.create({ name: 'serde' });
   await db.version.create({ crate: serde });
 
-  let inviter = await db.user.create();
-  let invitee = await db.user.create();
+  let inviter = await db.user.create({});
+  let invitee = await db.user.create({});
   await db.mswSession.create({ user: invitee });
 
   let invite = await db.crateOwnerInvitation.create({ crate: serde, invitee, inviter });
@@ -32,7 +32,7 @@ test('can accept an invitation', async function () {
 });
 
 test('returns 404 if invite does not exist', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/me/crate_owner_invitations/accept/secret-token', { method: 'PUT' });

--- a/packages/crates-io-msw/handlers/keywords/list.test.js
+++ b/packages/crates-io-msw/handlers/keywords/list.test.js
@@ -17,7 +17,7 @@ test('empty case', async function () {
 
 test('returns a paginated keywords list', async function () {
   await db.keyword.create({ keyword: 'api' });
-  await Promise.all(Array.from({ length: 2 }, () => db.keyword.create()));
+  await Promise.all(Array.from({ length: 2 }, () => db.keyword.create({})));
 
   let response = await fetch('/api/v1/keywords');
   expect(response.status).toBe(200);
@@ -48,7 +48,7 @@ test('returns a paginated keywords list', async function () {
 });
 
 test('never returns more than 10 results', async function () {
-  await Promise.all(Array.from({ length: 25 }, () => db.keyword.create()));
+  await Promise.all(Array.from({ length: 25 }, () => db.keyword.create({})));
 
   let response = await fetch('/api/v1/keywords');
   expect(response.status).toBe(200);

--- a/packages/crates-io-msw/handlers/sessions/delete.test.js
+++ b/packages/crates-io-msw/handlers/sessions/delete.test.js
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { db } from '../../index.js';
 
 test('returns 200 when authenticated', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/private/session', { method: 'DELETE' });

--- a/packages/crates-io-msw/handlers/summary.test.js
+++ b/packages/crates-io-msw/handlers/summary.test.js
@@ -20,9 +20,9 @@ test('empty case', async function () {
 });
 
 test('returns the data for the front page', async function () {
-  await Promise.all(Array.from({ length: 15 }, () => db.category.create()));
-  await Promise.all(Array.from({ length: 25 }, () => db.keyword.create()));
-  let crates = await Promise.all(Array.from({ length: 20 }, () => db.crate.create()));
+  await Promise.all(Array.from({ length: 15 }, () => db.category.create({})));
+  await Promise.all(Array.from({ length: 25 }, () => db.keyword.create({})));
+  let crates = await Promise.all(Array.from({ length: 20 }, () => db.crate.create({})));
   await Promise.all(crates.map(crate => db.version.create({ crate })));
 
   let response = await fetch('/api/v1/summary');

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/create.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/create.test.js
@@ -125,7 +125,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 400 if request body is invalid', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/github_configs', {
@@ -146,7 +146,7 @@ test('returns 400 if request body is invalid', async function () {
 });
 
 test('returns 400 if required fields are missing', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/github_configs', {
@@ -171,7 +171,7 @@ test('returns 400 if required fields are missing', async function () {
 });
 
 test("returns 404 if crate can't be found", async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/github_configs', {
@@ -202,7 +202,7 @@ test('returns 400 if user is not an owner of the crate', async function () {
   let crate = await db.crate.create({ name: 'test-crate-not-owner' });
   await db.version.create({ crate });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/github_configs', {

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/delete.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/delete.test.js
@@ -54,7 +54,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 if config ID is invalid', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/github_configs/invalid', {
@@ -74,7 +74,7 @@ test('returns 404 if config ID is invalid', async function () {
 });
 
 test("returns 404 if config can't be found", async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/github_configs/999999', {
@@ -97,7 +97,7 @@ test('returns 400 if user is not an owner of the crate', async function () {
   let crate = await db.crate.create({ name: 'test-crate-not-owner' });
   await db.version.create({ crate });
 
-  let owner = await db.user.create();
+  let owner = await db.user.create({});
   await db.crateOwnership.create({
     crate,
     user: owner,
@@ -113,7 +113,7 @@ test('returns 400 if user is not an owner of the crate', async function () {
   });
 
   // Login as a different user
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/v1/trusted_publishing/github_configs/${config.id}`, {

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/list.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/list.test.js
@@ -102,7 +102,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 400 if query params are missing', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/v1/trusted_publishing/github_configs`);
@@ -119,7 +119,7 @@ test('returns 400 if query params are missing', async function () {
 });
 
 test("returns 404 if crate can't be found", async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/v1/trusted_publishing/github_configs?crate=nonexistent`);
@@ -139,7 +139,7 @@ test('returns 400 if user is not an owner of the crate', async function () {
   let crate = await db.crate.create({ name: 'test-crate-not-owner' });
   await db.version.create({ crate });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/v1/trusted_publishing/github_configs?crate=${crate.name}`);

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/create.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/create.test.js
@@ -125,7 +125,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 400 if request body is invalid', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/gitlab_configs', {
@@ -146,7 +146,7 @@ test('returns 400 if request body is invalid', async function () {
 });
 
 test('returns 400 if required fields are missing', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/gitlab_configs', {
@@ -171,7 +171,7 @@ test('returns 400 if required fields are missing', async function () {
 });
 
 test("returns 404 if crate can't be found", async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/gitlab_configs', {
@@ -202,7 +202,7 @@ test('returns 400 if user is not an owner of the crate', async function () {
   let crate = await db.crate.create({ name: 'test-crate-not-owner' });
   await db.version.create({ crate });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/gitlab_configs', {

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/delete.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/delete.test.js
@@ -54,7 +54,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 if config ID is invalid', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/gitlab_configs/invalid', {
@@ -74,7 +74,7 @@ test('returns 404 if config ID is invalid', async function () {
 });
 
 test("returns 404 if config can't be found", async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/trusted_publishing/gitlab_configs/999999', {
@@ -97,7 +97,7 @@ test('returns 400 if user is not an owner of the crate', async function () {
   let crate = await db.crate.create({ name: 'test-crate-not-owner' });
   await db.version.create({ crate });
 
-  let owner = await db.user.create();
+  let owner = await db.user.create({});
   await db.crateOwnership.create({
     crate,
     user: owner,
@@ -113,7 +113,7 @@ test('returns 400 if user is not an owner of the crate', async function () {
   });
 
   // Login as a different user
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs/${config.id}`, {

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.test.js
@@ -102,7 +102,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 400 if query params are missing', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs`);
@@ -119,7 +119,7 @@ test('returns 400 if query params are missing', async function () {
 });
 
 test("returns 404 if crate can't be found", async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=nonexistent`);
@@ -139,7 +139,7 @@ test('returns 400 if user is not an owner of the crate', async function () {
   let crate = await db.crate.create({ name: 'test-crate-not-owner' });
   await db.version.create({ crate });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/v1/trusted_publishing/gitlab_configs?crate=${crate.name}`);

--- a/packages/crates-io-msw/handlers/users/me.test.js
+++ b/packages/crates-io-msw/handlers/users/me.test.js
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { db } from '../../index.js';
 
 test('returns the `user` resource including the private fields', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/me');
@@ -28,10 +28,10 @@ test('returns the `user` resource including the private fields', async function 
 });
 
 test('returns a list of `owned_crates`', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
-  let [crate1, , crate3] = await Promise.all(Array.from({ length: 3 }, () => db.crate.create()));
+  let [crate1, , crate3] = await Promise.all(Array.from({ length: 3 }, () => db.crate.create({})));
 
   await db.crateOwnership.create({ crate: crate1, user });
   await db.crateOwnership.create({ crate: crate3, user });
@@ -57,7 +57,7 @@ test('returns a list of `owned_crates`', async function () {
 });
 
 test('returns an error if unauthenticated', async function () {
-  await db.user.create();
+  await db.user.create({});
 
   let response = await fetch('/api/v1/me');
   expect(response.status).toBe(403);

--- a/packages/crates-io-msw/handlers/users/resend.test.js
+++ b/packages/crates-io-msw/handlers/users/resend.test.js
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { db } from '../../index.js';
 
 test('returns `ok`', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/v1/users/${user.id}/resend`, { method: 'PUT' });
@@ -16,7 +16,7 @@ test('returns `ok`', async function () {
 });
 
 test('returns 403 when not logged in', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
 
   let response = await fetch(`/api/v1/users/${user.id}/resend`, { method: 'PUT' });
   expect(response.status).toBe(403);
@@ -32,7 +32,7 @@ test('returns 403 when not logged in', async function () {
 });
 
 test('returns 400 when requesting the wrong user id', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch(`/api/v1/users/wrong-id/resend`, { method: 'PUT' });

--- a/packages/crates-io-msw/handlers/users/update.test.js
+++ b/packages/crates-io-msw/handlers/users/update.test.js
@@ -22,7 +22,7 @@ test('updates the user with a new email address', async function () {
 });
 
 test('updates the `publish_notifications` settings', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
   expect(user.publishNotifications).toBe(true);
 

--- a/packages/crates-io-msw/handlers/versions/follow-updates.test.js
+++ b/packages/crates-io-msw/handlers/versions/follow-updates.test.js
@@ -78,7 +78,7 @@ test('returns latest versions of followed crates', async function () {
 });
 
 test('empty case', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/me/updates');

--- a/packages/crates-io-msw/handlers/versions/list.test.js
+++ b/packages/crates-io-msw/handlers/versions/list.test.js
@@ -33,7 +33,7 @@ test('empty case', async function () {
 });
 
 test('returns all versions belonging to the specified crate', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   let crate = await db.crate.create({ name: 'rand' });
   await db.version.create({ crate, num: '1.0.0' });
   await db.version.create({ crate, num: '1.1.0', publishedBy: user });
@@ -174,7 +174,7 @@ test('returns all versions belonging to the specified crate', async function () 
 });
 
 test('supports `sort` parameters', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   let crate = await db.crate.create({ name: 'rand' });
   await db.version.create({ crate, num: '1.0.0' });
   await db.version.create({ crate, num: '2.0.0-alpha', publishedBy: user });
@@ -222,7 +222,7 @@ test('supports `sort` parameters', async function () {
 });
 
 test('supports multiple `ids[]` parameters', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   let crate = await db.crate.create({ name: 'rand' });
   await db.version.create({ crate, num: '1.0.0' });
   await db.version.create({ crate, num: '1.1.0', publishedBy: user });
@@ -239,7 +239,7 @@ test('supports multiple `ids[]` parameters', async function () {
 });
 
 test('supports seek pagination', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   let crate = await db.crate.create({ name: 'rand' });
   await db.version.create({ crate, num: '1.0.0' });
   await db.version.create({ crate, num: '2.0.0-alpha', publishedBy: user });
@@ -350,7 +350,7 @@ test('supports seek pagination', async function () {
 });
 
 test('include `release_tracks` meta', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   let crate = await db.crate.create({ name: 'rand' });
   await db.version.create({ crate, num: '0.0.1' });
   await db.version.create({ crate, num: '0.0.2', yanked: true });

--- a/packages/crates-io-msw/handlers/versions/patch.test.js
+++ b/packages/crates-io-msw/handlers/versions/patch.test.js
@@ -30,7 +30,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0', { method: 'PATCH', body: YANK_BODY });
@@ -49,7 +49,7 @@ test('returns 404 for unknown crates', async function () {
 test('returns 404 for unknown versions', async function () {
   await db.crate.create({ name: 'foo' });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0', { method: 'PATCH', body: YANK_BODY });
@@ -71,7 +71,7 @@ test('yanks the version', async function () {
   expect(version.yanked).toBe(false);
   expect(version.yank_message).toBe(null);
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0', { method: 'PATCH', body: YANK_BODY });

--- a/packages/crates-io-msw/handlers/versions/rebuild-docs.test.js
+++ b/packages/crates-io-msw/handlers/versions/rebuild-docs.test.js
@@ -17,7 +17,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/rebuild_docs', { method: 'POST' });
@@ -36,7 +36,7 @@ test('returns 404 for unknown crates', async function () {
 test('returns 404 for unknown versions', async function () {
   await db.crate.create({ name: 'foo' });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/rebuild_docs', { method: 'POST' });
@@ -56,7 +56,7 @@ test('triggers a rebuild for the crate documentation', async function () {
   let crate = await db.crate.create({ name: 'foo' });
   await db.version.create({ crate, num: '1.0.0' });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/rebuild_docs', { method: 'POST' });

--- a/packages/crates-io-msw/handlers/versions/unyank.test.js
+++ b/packages/crates-io-msw/handlers/versions/unyank.test.js
@@ -17,7 +17,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });
@@ -36,7 +36,7 @@ test('returns 404 for unknown crates', async function () {
 test('returns 404 for unknown versions', async function () {
   await db.crate.create({ name: 'foo' });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });
@@ -58,7 +58,7 @@ test('unyanks the version', async function () {
   expect(version.yanked).toBe(true);
   expect(version.yank_message).toBe('some reason');
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });

--- a/packages/crates-io-msw/handlers/versions/yank.test.js
+++ b/packages/crates-io-msw/handlers/versions/yank.test.js
@@ -17,7 +17,7 @@ test('returns 403 if unauthenticated', async function () {
 });
 
 test('returns 404 for unknown crates', async function () {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });
@@ -36,7 +36,7 @@ test('returns 404 for unknown crates', async function () {
 test('returns 404 for unknown versions', async function () {
   await db.crate.create({ name: 'foo' });
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });
@@ -57,7 +57,7 @@ test('yanks the version', async function () {
   let version = await db.version.create({ crate, num: '1.0.0', yanked: false });
   expect(version.yanked).toBe(false);
 
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await db.mswSession.create({ user });
 
   let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });

--- a/packages/crates-io-msw/models/api-token.test.js
+++ b/packages/crates-io-msw/models/api-token.test.js
@@ -3,13 +3,13 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `user` is not set', async ({ expect }) => {
-  await expect(() => db.apiToken.create()).rejects.toThrowErrorMatchingInlineSnapshot(
+  await expect(() => db.apiToken.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`user\` relationship on \`api-token\`]`,
   );
 });
 
 test('happy path', async ({ expect }) => {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   let session = await db.apiToken.create({ user });
   expect(session).toMatchInlineSnapshot(`
     {

--- a/packages/crates-io-msw/models/category.test.js
+++ b/packages/crates-io-msw/models/category.test.js
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('default are applied', async ({ expect }) => {
-  let category = await db.category.create();
+  let category = await db.category.create({});
   expect(category).toMatchInlineSnapshot(`
     {
       "category": "Category 1",

--- a/packages/crates-io-msw/models/crate-owner-invitation.test.js
+++ b/packages/crates-io-msw/models/crate-owner-invitation.test.js
@@ -3,33 +3,33 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `crate` is not set', async ({ expect }) => {
-  let inviter = await db.user.create();
-  let invitee = await db.user.create();
+  let inviter = await db.user.create({});
+  let invitee = await db.user.create({});
   await expect(() => db.crateOwnerInvitation.create({ inviter, invitee })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`crate\` relationship on \`crate-owner-invitation\`]`,
   );
 });
 
 test('throws if `inviter` is not set', async ({ expect }) => {
-  let crate = await db.crate.create();
-  let invitee = await db.user.create();
+  let crate = await db.crate.create({});
+  let invitee = await db.user.create({});
   await expect(() => db.crateOwnerInvitation.create({ crate, invitee })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`inviter\` relationship on \`crate-owner-invitation\`]`,
   );
 });
 
 test('throws if `invitee` is not set', async ({ expect }) => {
-  let crate = await db.crate.create();
-  let inviter = await db.user.create();
+  let crate = await db.crate.create({});
+  let inviter = await db.user.create({});
   await expect(() => db.crateOwnerInvitation.create({ crate, inviter })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`invitee\` relationship on \`crate-owner-invitation\`]`,
   );
 });
 
 test('happy path', async ({ expect }) => {
-  let crate = await db.crate.create();
-  let inviter = await db.user.create();
-  let invitee = await db.user.create();
+  let crate = await db.crate.create({});
+  let inviter = await db.user.create({});
+  let invitee = await db.user.create({});
   let invite = await db.crateOwnerInvitation.create({ crate, inviter, invitee });
   expect(invite).toMatchInlineSnapshot(`
     {

--- a/packages/crates-io-msw/models/crate-ownership.test.js
+++ b/packages/crates-io-msw/models/crate-ownership.test.js
@@ -3,31 +3,31 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `crate` is not set', async ({ expect }) => {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   await expect(() => db.crateOwnership.create({ user })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`crate\` relationship on \`crate-ownership\`]`,
   );
 });
 
 test('throws if `team` and `user` are not set', async ({ expect }) => {
-  let crate = await db.crate.create();
+  let crate = await db.crate.create({});
   await expect(() => db.crateOwnership.create({ crate })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`team\` or \`user\` relationship on \`crate-ownership\`]`,
   );
 });
 
 test('throws if `team` and `user` are both set', async ({ expect }) => {
-  let crate = await db.crate.create();
-  let team = await db.team.create();
-  let user = await db.user.create();
+  let crate = await db.crate.create({});
+  let team = await db.team.create({});
+  let user = await db.user.create({});
   await expect(() => db.crateOwnership.create({ crate, team, user })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: \`team\` and \`user\` on a \`crate-ownership\` are mutually exclusive]`,
   );
 });
 
 test('can set `team`', async ({ expect }) => {
-  let crate = await db.crate.create();
-  let team = await db.team.create();
+  let crate = await db.crate.create({});
+  let team = await db.team.create({});
   let ownership = await db.crateOwnership.create({ crate, team });
   expect(ownership).toMatchInlineSnapshot(`
     {
@@ -64,8 +64,8 @@ test('can set `team`', async ({ expect }) => {
 });
 
 test('can set `user`', async ({ expect }) => {
-  let crate = await db.crate.create();
-  let user = await db.user.create();
+  let crate = await db.crate.create({});
+  let user = await db.user.create({});
   let ownership = await db.crateOwnership.create({ crate, user });
   expect(ownership).toMatchInlineSnapshot(`
     {

--- a/packages/crates-io-msw/models/crate.test.js
+++ b/packages/crates-io-msw/models/crate.test.js
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('default are applied', async ({ expect }) => {
-  let crate = await db.crate.create();
+  let crate = await db.crate.create({});
   expect(crate).toMatchInlineSnapshot(`
     {
       "_extra_downloads": [],
@@ -26,9 +26,9 @@ test('default are applied', async ({ expect }) => {
 });
 
 test('attributes can be set', async ({ expect }) => {
-  let category = await db.category.create();
-  let keyword1 = await db.keyword.create();
-  let keyword2 = await db.keyword.create();
+  let category = await db.category.create({});
+  let keyword1 = await db.keyword.create({});
+  let keyword2 = await db.keyword.create({});
 
   let crate = await db.crate.create({
     name: 'crates-io',

--- a/packages/crates-io-msw/models/dependency.test.js
+++ b/packages/crates-io-msw/models/dependency.test.js
@@ -3,22 +3,22 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `crate` is not set', async ({ expect }) => {
-  let version = await db.version.create({ crate: await db.crate.create() });
+  let version = await db.version.create({ crate: await db.crate.create({}) });
   await expect(() => db.dependency.create({ version })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`crate\` relationship on \`dependency:1\`]`,
   );
 });
 
 test('throws if `version` is not set', async ({ expect }) => {
-  let crate = await db.crate.create();
+  let crate = await db.crate.create({});
   await expect(() => db.dependency.create({ crate })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`version\` relationship on \`dependency:1\`]`,
   );
 });
 
 test('happy path', async ({ expect }) => {
-  let crate = await db.crate.create();
-  let version = await db.version.create({ crate: await db.crate.create() });
+  let crate = await db.crate.create({});
+  let version = await db.version.create({ crate: await db.crate.create({}) });
   let dependency = await db.dependency.create({ crate, version });
   expect(dependency).toMatchInlineSnapshot(`
     {

--- a/packages/crates-io-msw/models/keyword.test.js
+++ b/packages/crates-io-msw/models/keyword.test.js
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('default are applied', async ({ expect }) => {
-  let keyword = await db.keyword.create();
+  let keyword = await db.keyword.create({});
   expect(keyword).toMatchInlineSnapshot(`
     {
       "id": "keyword-1",

--- a/packages/crates-io-msw/models/msw-session.test.js
+++ b/packages/crates-io-msw/models/msw-session.test.js
@@ -3,13 +3,13 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `user` is not set', async ({ expect }) => {
-  await expect(() => db.mswSession.create()).rejects.toThrowErrorMatchingInlineSnapshot(
+  await expect(() => db.mswSession.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`user\` relationship]`,
   );
 });
 
 test('happy path', async ({ expect }) => {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   let session = await db.mswSession.create({ user });
   expect(session).toMatchInlineSnapshot(`
     {

--- a/packages/crates-io-msw/models/team.test.js
+++ b/packages/crates-io-msw/models/team.test.js
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('default are applied', async ({ expect }) => {
-  let team = await db.team.create();
+  let team = await db.team.create({});
   expect(team).toMatchInlineSnapshot(`
     {
       "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",

--- a/packages/crates-io-msw/models/trustpub/gitlab-config.test.js
+++ b/packages/crates-io-msw/models/trustpub/gitlab-config.test.js
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { db } from '../../index.js';
 
 test('defaults are applied', async ({ expect }) => {
-  let crate = await db.crate.create();
+  let crate = await db.crate.create({});
   let config = await db.trustpubGitlabConfig.create({ crate });
   expect(config).toMatchInlineSnapshot(`
     {

--- a/packages/crates-io-msw/models/user.test.js
+++ b/packages/crates-io-msw/models/user.test.js
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('default are applied', async ({ expect }) => {
-  let user = await db.user.create();
+  let user = await db.user.create({});
   expect(user).toMatchInlineSnapshot(`
     {
       "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",

--- a/packages/crates-io-msw/models/version-download.test.js
+++ b/packages/crates-io-msw/models/version-download.test.js
@@ -3,13 +3,13 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `version` is not set', async ({ expect }) => {
-  await expect(() => db.versionDownload.create()).rejects.toThrowErrorMatchingInlineSnapshot(
+  await expect(() => db.versionDownload.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`version\` relationship on \`version-download\`]`,
   );
 });
 
 test('happy path', async ({ expect }) => {
-  let crate = await db.crate.create();
+  let crate = await db.crate.create({});
   let version = await db.version.create({ crate });
   let versionDownload = await db.versionDownload.create({ version });
   expect(versionDownload).toMatchInlineSnapshot(`

--- a/packages/crates-io-msw/models/version.test.js
+++ b/packages/crates-io-msw/models/version.test.js
@@ -3,13 +3,13 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `crate` is not set', async ({ expect }) => {
-  await expect(() => db.version.create()).rejects.toThrowErrorMatchingInlineSnapshot(
+  await expect(() => db.version.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Missing \`crate\` relationship on \`version:1.0.0\`]`,
   );
 });
 
 test('happy path', async ({ expect }) => {
-  let crate = await db.crate.create();
+  let crate = await db.crate.create({});
   let version = await db.version.create({ crate });
   expect(version).toMatchInlineSnapshot(`
     {

--- a/packages/crates-io-msw/utils/pre-create-extension.js
+++ b/packages/crates-io-msw/utils/pre-create-extension.js
@@ -6,7 +6,6 @@ export function preCreateExtension(preCreate) {
 
       collection.__originalCreate = collection.create;
       collection.create = async function (attrs) {
-        attrs = attrs ?? {};
         preCreate(attrs, ++collection.__counter);
         return await collection.__originalCreate(attrs);
       };

--- a/tests/acceptance/crate-deletion-test.js
+++ b/tests/acceptance/crate-deletion-test.js
@@ -9,7 +9,7 @@ module('Acceptance | crate deletion', function (hooks) {
   setupApplicationTest(hooks);
 
   test('happy path', async function (assert) {
-    let user = await this.db.user.create();
+    let user = await this.db.user.create({});
     await this.authenticateAs(user);
 
     let crate = await this.db.crate.create({ name: 'foo' });

--- a/tests/acceptance/crates-test.js
+++ b/tests/acceptance/crates-test.js
@@ -43,7 +43,7 @@ module('Acceptance | crates page', function (hooks) {
 
   test('listing crates', async function (assert) {
     for (let i = 1; i <= per_page; i++) {
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
     }
 
@@ -55,7 +55,7 @@ module('Acceptance | crates page', function (hooks) {
 
   test('navigating to next page of crates', async function (assert) {
     for (let i = 1; i <= per_page + 2; i++) {
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
     }
     const page_start = per_page + 1;

--- a/tests/acceptance/dev-mode-test.js
+++ b/tests/acceptance/dev-mode-test.js
@@ -14,7 +14,7 @@ if (s.has('devmode')) {
     setupApplicationTest(hooks);
 
     test('authenticated', async function () {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.authenticateAs(user);
 
       let crate = await this.db.crate.create({ name: 'foo' });

--- a/tests/acceptance/invites-test.js
+++ b/tests/acceptance/invites-test.js
@@ -15,7 +15,7 @@ module('Acceptance | /me/pending-invites', function (hooks) {
     let inviter = await context.db.user.create({ name: 'janed' });
     let inviter2 = await context.db.user.create({ name: 'wycats' });
 
-    let user = await context.db.user.create();
+    let user = await context.db.user.create({});
 
     let nanomsg = await context.db.crate.create({ name: 'nanomsg' });
     await context.db.version.create({ crate: nanomsg });

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -36,7 +36,7 @@ module('Acceptance | Login', function (hooks) {
         assert.strictEqual(url.searchParams.get('code'), '901dd10e07c7e9fa1cd5');
         assert.strictEqual(url.searchParams.get('state'), 'fYcUY3FMdUUz00FC7vLT7A');
 
-        let user = await db.user.create();
+        let user = await db.user.create({});
         await db.mswSession.create({ user });
         return HttpResponse.json({ ok: true });
       }),

--- a/tests/acceptance/publish-notifications-test.js
+++ b/tests/acceptance/publish-notifications-test.js
@@ -11,7 +11,7 @@ module('Acceptance | publish notifications', function (hooks) {
   setupApplicationTest(hooks);
 
   test('unsubscribe and resubscribe', async function (assert) {
-    let user = await this.db.user.create();
+    let user = await this.db.user.create({});
 
     await this.authenticateAs(user);
     assert.true(user.publishNotifications);
@@ -36,7 +36,7 @@ module('Acceptance | publish notifications', function (hooks) {
   });
 
   test('loading and error state', async function (assert) {
-    let user = await this.db.user.create();
+    let user = await this.db.user.create({});
 
     let deferred = defer();
     this.worker.use(http.put('/api/v1/users/:user_id', () => deferred.promise));

--- a/tests/acceptance/rebuild-docs-test.js
+++ b/tests/acceptance/rebuild-docs-test.js
@@ -9,7 +9,7 @@ module('Acceptance | rebuild docs page', function (hooks) {
   setupApplicationTest(hooks);
 
   test('navigates to rebuild docs confirmation page', async function (assert) {
-    let user = await this.db.user.create();
+    let user = await this.db.user.create({});
     await this.authenticateAs(user);
 
     let crate = await this.db.crate.create({ name: 'nanomsg' });
@@ -34,7 +34,7 @@ module('Acceptance | rebuild docs page', function (hooks) {
   });
 
   test('rebuild docs confirmation page shows crate info and allows confirmation', async function (assert) {
-    let user = await this.db.user.create();
+    let user = await this.db.user.create({});
     await this.authenticateAs(user);
 
     let crate = await this.db.crate.create({ name: 'nanomsg' });
@@ -57,7 +57,7 @@ module('Acceptance | rebuild docs page', function (hooks) {
   });
 
   test('rebuilds docs confirmation page redirects non-owners to error page', async function (assert) {
-    let user = await this.db.user.create();
+    let user = await this.db.user.create({});
     await this.authenticateAs(user);
 
     let crate = await this.db.crate.create({ name: 'nanomsg' });

--- a/tests/acceptance/reverse-dependencies-test.js
+++ b/tests/acceptance/reverse-dependencies-test.js
@@ -42,7 +42,7 @@ module('Acceptance | /crates/:crate_id/reverse_dependencies', function (hooks) {
     let { foo } = await prepare(this);
 
     for (let i = 0; i < 20; i++) {
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       let version = await this.db.version.create({ crate });
       await this.db.dependency.create({ crate: foo, version });
     }

--- a/tests/acceptance/token-invites-test.js
+++ b/tests/acceptance/token-invites-test.js
@@ -47,8 +47,8 @@ module('Acceptance | /accept-invite/:token', function (hooks) {
   });
 
   test('shows success for known token', async function (assert) {
-    let inviter = await this.db.user.create();
-    let invitee = await this.db.user.create();
+    let inviter = await this.db.user.create({});
+    let invitee = await this.db.user.create({});
 
     let crate = await this.db.crate.create({ name: 'nanomsg' });
     await this.db.version.create({ crate });

--- a/tests/acceptance/versions-test.js
+++ b/tests/acceptance/versions-test.js
@@ -38,7 +38,7 @@ module('Acceptance | crate versions page', function (hooks) {
   });
 
   test('shows correct release tracks label after yanking/unyanking', async function (assert) {
-    let user = await this.db.user.create();
+    let user = await this.db.user.create({});
     await this.authenticateAs(user);
 
     let crate = await this.db.crate.create({ name: 'nanomsg' });

--- a/tests/components/owners-list-test.gjs
+++ b/tests/components/owners-list-test.gjs
@@ -10,10 +10,10 @@ module('Component | OwnersList', function (hooks) {
   setupMsw(hooks);
 
   test('single user', async function (assert) {
-    let crate = await this.db.crate.create();
+    let crate = await this.db.crate.create({});
     await this.db.version.create({ crate });
 
-    let user = await this.db.user.create();
+    let user = await this.db.user.create({});
     await this.db.crateOwnership.create({ crate, user });
 
     let store = this.owner.lookup('service:store');
@@ -33,7 +33,7 @@ module('Component | OwnersList', function (hooks) {
   });
 
   test('user without `name`', async function (assert) {
-    let crate = await this.db.crate.create();
+    let crate = await this.db.crate.create({});
     await this.db.version.create({ crate });
 
     let user = await this.db.user.create({ name: null, login: 'anonymous' });
@@ -56,11 +56,11 @@ module('Component | OwnersList', function (hooks) {
   });
 
   test('five users', async function (assert) {
-    let crate = await this.db.crate.create();
+    let crate = await this.db.crate.create({});
     await this.db.version.create({ crate });
 
     for (let i = 0; i < 5; i++) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.db.crateOwnership.create({ crate, user });
     }
 
@@ -78,11 +78,11 @@ module('Component | OwnersList', function (hooks) {
   });
 
   test('six users', async function (assert) {
-    let crate = await this.db.crate.create();
+    let crate = await this.db.crate.create({});
     await this.db.version.create({ crate });
 
     for (let i = 0; i < 6; i++) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.db.crateOwnership.create({ crate, user });
     }
 
@@ -100,11 +100,11 @@ module('Component | OwnersList', function (hooks) {
   });
 
   test('teams mixed with users', async function (assert) {
-    let crate = await this.db.crate.create();
+    let crate = await this.db.crate.create({});
     await this.db.version.create({ crate });
 
     for (let i = 0; i < 3; i++) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.db.crateOwnership.create({ crate, user });
     }
     for (let i = 0; i < 2; i++) {

--- a/tests/components/privileged-action-test.gjs
+++ b/tests/components/privileged-action-test.gjs
@@ -33,7 +33,7 @@ module('Component | PrivilegedAction', hooks => {
   });
 
   test('unprivileged block is shown to a logged in user without access', async function (assert) {
-    const user = await this.db.user.create();
+    const user = await this.db.user.create({});
     await this.authenticateAs(user);
 
     await this.renderComponent(false);
@@ -43,7 +43,7 @@ module('Component | PrivilegedAction', hooks => {
   });
 
   test('privileged block is shown to a logged in user with access', async function (assert) {
-    const user = await this.db.user.create();
+    const user = await this.db.user.create({});
     await this.authenticateAs(user);
 
     await this.renderComponent(true);

--- a/tests/models/crate-test.js
+++ b/tests/models/crate-test.js
@@ -15,7 +15,7 @@ module('Model | Crate', function (hooks) {
 
   module('setTrustpubOnlyTask', function () {
     test('enables trustpub_only', async function (assert) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.authenticateAs(user);
 
       let crate = await this.db.crate.create({ trustpubOnly: false });
@@ -31,7 +31,7 @@ module('Model | Crate', function (hooks) {
     });
 
     test('disables trustpub_only', async function (assert) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.authenticateAs(user);
 
       let crate = await this.db.crate.create({ trustpubOnly: true });
@@ -47,7 +47,7 @@ module('Model | Crate', function (hooks) {
     });
 
     test('requires authentication', async function (assert) {
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
 
       let crateRecord = await this.store.findRecord('crate', crate.name);
@@ -61,13 +61,13 @@ module('Model | Crate', function (hooks) {
 
   module('inviteOwner()', function () {
     test('happy path', async function (assert) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.authenticateAs(user);
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
 
-      let user2 = await this.db.user.create();
+      let user2 = await this.db.user.create({});
 
       let crateRecord = await this.store.findRecord('crate', crate.name);
 
@@ -76,10 +76,10 @@ module('Model | Crate', function (hooks) {
     });
 
     test('error handling', async function (assert) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.authenticateAs(user);
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
 
       let crateRecord = await this.store.findRecord('crate', crate.name);
@@ -93,13 +93,13 @@ module('Model | Crate', function (hooks) {
 
   module('removeOwner()', function () {
     test('happy path', async function (assert) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.authenticateAs(user);
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
 
-      let user2 = await this.db.user.create();
+      let user2 = await this.db.user.create({});
       await this.db.crateOwnership.create({ crate, user: user2 });
 
       let crateRecord = await this.store.findRecord('crate', crate.name);
@@ -109,10 +109,10 @@ module('Model | Crate', function (hooks) {
     });
 
     test('error handling', async function (assert) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.authenticateAs(user);
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
 
       let crateRecord = await this.store.findRecord('crate', crate.name);

--- a/tests/models/trustpub-github-config-test.js
+++ b/tests/models/trustpub-github-config-test.js
@@ -15,10 +15,10 @@ module('Model | TrustpubGitHubConfig', function (hooks) {
 
   module('query()', function () {
     test('fetches GitHub configs for a crate', async function (assert) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.authenticateAs(user);
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
       await this.db.crateOwnership.create({ crate, user });
 
@@ -39,7 +39,7 @@ module('Model | TrustpubGitHubConfig', function (hooks) {
     });
 
     test('returns an error if the user is not authenticated', async function (assert) {
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
 
       await assert.rejects(this.store.query('trustpub-github-config', { crate: crate.name }), function (error) {
@@ -49,10 +49,10 @@ module('Model | TrustpubGitHubConfig', function (hooks) {
     });
 
     test('returns an error if the user is not an owner of the crate', async function (assert) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.authenticateAs(user);
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
 
       await assert.rejects(this.store.query('trustpub-github-config', { crate: crate.name }), function (error) {
@@ -67,7 +67,7 @@ module('Model | TrustpubGitHubConfig', function (hooks) {
       let user = await this.db.user.create({ emailVerified: true });
       await this.authenticateAs(user);
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
       await this.db.crateOwnership.create({ crate, user });
 
@@ -86,7 +86,7 @@ module('Model | TrustpubGitHubConfig', function (hooks) {
     });
 
     test('returns an error if the user is not authenticated', async function (assert) {
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
 
       let config = this.store.createRecord('trustpub-github-config', {
@@ -106,7 +106,7 @@ module('Model | TrustpubGitHubConfig', function (hooks) {
       let user = await this.db.user.create({ emailVerified: true });
       await this.authenticateAs(user);
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
 
       let config = this.store.createRecord('trustpub-github-config', {
@@ -126,7 +126,7 @@ module('Model | TrustpubGitHubConfig', function (hooks) {
       let user = await this.db.user.create({ emailVerified: false });
       await this.authenticateAs(user);
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
       await this.db.crateOwnership.create({ crate, user });
 
@@ -147,10 +147,10 @@ module('Model | TrustpubGitHubConfig', function (hooks) {
 
   module('deleteRecord()', function () {
     test('deletes a GitHub config', async function (assert) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
       await this.authenticateAs(user);
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
       await this.db.crateOwnership.create({ crate, user });
 
@@ -172,9 +172,9 @@ module('Model | TrustpubGitHubConfig', function (hooks) {
     });
 
     test('returns an error if the user is not authenticated', async function (assert) {
-      let user = await this.db.user.create();
+      let user = await this.db.user.create({});
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
       await this.db.crateOwnership.create({ crate, user });
 
@@ -199,10 +199,10 @@ module('Model | TrustpubGitHubConfig', function (hooks) {
     });
 
     test('returns an error if the user is not an owner of the crate', async function (assert) {
-      let user1 = await this.db.user.create();
-      let user2 = await this.db.user.create();
+      let user1 = await this.db.user.create({});
+      let user2 = await this.db.user.create({});
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
       await this.db.crateOwnership.create({ crate, user: user1 });
 

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -19,7 +19,7 @@ module('Model | Version', function (hooks) {
   test('isNew', async function (assert) {
     let { db, store } = this;
 
-    let crate = await db.crate.create();
+    let crate = await db.crate.create({});
     await db.version.create({ crate, created_at: '2010-06-16T21:30:45Z' });
 
     let crateRecord = await store.findRecord('crate', crate.name);
@@ -77,7 +77,7 @@ module('Model | Version', function (hooks) {
     async function prepare(context, { num }) {
       let { db, store } = context;
 
-      let crate = await db.crate.create();
+      let crate = await db.crate.create({});
       await db.version.create({ crate, num });
 
       let crateRecord = await store.findRecord('crate', crate.name);
@@ -167,7 +167,7 @@ module('Model | Version', function (hooks) {
         '0.1.1',
       ];
 
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       for (let num of nums.toReversed()) {
         await this.db.version.create({ crate, num });
       }
@@ -199,7 +199,7 @@ module('Model | Version', function (hooks) {
     });
 
     test('ignores yanked versions', async function (assert) {
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate, num: '0.4.0' });
       await this.db.version.create({ crate, num: '0.4.1' });
       await this.db.version.create({ crate, num: '0.4.2', yanked: true });
@@ -219,7 +219,7 @@ module('Model | Version', function (hooks) {
     });
 
     test('handles newly released versions correctly', async function (assert) {
-      let crate = await this.db.crate.create();
+      let crate = await this.db.crate.create({});
       await this.db.version.create({ crate, num: '0.4.0' });
       await this.db.version.create({ crate, num: '0.4.1' });
 
@@ -257,7 +257,7 @@ module('Model | Version', function (hooks) {
     async function prepare(context, { features }) {
       let { db, store } = context;
 
-      let crate = await db.crate.create();
+      let crate = await db.crate.create({});
       await db.version.create({ crate, features });
 
       let crateRecord = await store.findRecord('crate', crate.name);
@@ -337,7 +337,7 @@ module('Model | Version', function (hooks) {
   test('`published_by` relationship is assigned correctly', async function (assert) {
     let user = await this.db.user.create({ name: 'JD' });
 
-    let crate = await this.db.crate.create();
+    let crate = await this.db.crate.create({});
     await this.db.version.create({ crate, publishedBy: user });
 
     let crateRecord = await this.store.findRecord('crate', crate.name);

--- a/tests/routes/crate/delete-test.js
+++ b/tests/routes/crate/delete-test.js
@@ -14,7 +14,7 @@ module('Route: crate.delete', function (hooks) {
   setupApplicationTest(hooks);
 
   async function prepare(context) {
-    let user = await context.db.user.create();
+    let user = await context.db.user.create({});
 
     let crate = await context.db.crate.create({ name: 'foo' });
     await context.db.version.create({ crate });
@@ -36,10 +36,10 @@ module('Route: crate.delete', function (hooks) {
   });
 
   test('not an owner', async function (assert) {
-    let user1 = await this.db.user.create();
+    let user1 = await this.db.user.create({});
     await this.authenticateAs(user1);
 
-    let user2 = await this.db.user.create();
+    let user2 = await this.db.user.create({});
     let crate = await this.db.crate.create({ name: 'foo' });
     await this.db.version.create({ crate });
     await this.db.crateOwnership.create({ crate, user: user2 });

--- a/tests/routes/crate/settings-test.js
+++ b/tests/routes/crate/settings-test.js
@@ -14,7 +14,7 @@ module('Route | crate.settings', hooks => {
   setupApplicationTest(hooks);
 
   async function prepare(context) {
-    const user = await context.db.user.create();
+    const user = await context.db.user.create({});
 
     const crate = await context.db.crate.create({ name: 'foo' });
     await context.db.version.create({ crate });
@@ -36,7 +36,7 @@ module('Route | crate.settings', hooks => {
   test('not an owner', async function (assert) {
     const { crate } = await prepare(this);
 
-    const otherUser = await this.db.user.create();
+    const otherUser = await this.db.user.create({});
     await this.authenticateAs(otherUser);
 
     await visit(`/crates/${crate.name}/settings`);

--- a/tests/routes/crate/settings/new-trusted-publisher-test.js
+++ b/tests/routes/crate/settings/new-trusted-publisher-test.js
@@ -14,7 +14,7 @@ module('Route | crate.settings.new-trusted-publisher', hooks => {
   setupApplicationTest(hooks);
 
   async function prepare(context) {
-    let user = await context.db.user.create();
+    let user = await context.db.user.create({});
 
     let crate = await context.db.crate.create({ name: 'foo' });
     await context.db.version.create({ crate });


### PR DESCRIPTION
`@msw/data` unconditionally requires an argument in the `create()` implementation. Our `preCreateExtension()` monkey patch removed that requirement, but that creates issues when using the library in a TypeScript context. This commit adds the empty object argument to all previously empty `create()` calls to fix the issue.