### PR TITLE
msw: Migrate from `zod` to `valibot`

### DIFF
--- a/packages/crates-io-msw/models/api-token.js
+++ b/packages/crates-io-msw/models/api-token.js
@@ -1,23 +1,23 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
 import { seededRandom } from '../utils/random.js';
 
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  crateScopes: z.array(z.any()).nullable(),
-  createdAt: z.string(),
-  endpointScopes: z.array(z.any()).nullable(),
-  expiredAt: z.string().nullable(),
-  lastUsedAt: z.string().nullable(),
-  name: z.string(),
-  token: z.string(),
-  revoked: z.boolean(),
+  crateScopes: v.nullable(v.array(v.any())),
+  createdAt: v.string(),
+  endpointScopes: v.nullable(v.array(v.any())),
+  expiredAt: v.nullable(v.string()),
+  lastUsedAt: v.nullable(v.string()),
+  name: v.string(),
+  token: v.string(),
+  revoked: v.boolean(),
 
-  user: z.any(),
+  user: v.any(),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/category.js
+++ b/packages/crates-io-msw/models/category.js
@@ -1,18 +1,18 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
 import { dasherize } from '../utils/strings.js';
 
-const schema = z.object({
-  id: z.string(),
+const schema = v.object({
+  id: v.string(),
 
-  category: z.string(),
-  slug: z.string(),
-  description: z.string(),
-  created_at: z.string(),
-  crates_cnt: z.number().nullable(),
+  category: v.string(),
+  slug: v.string(),
+  description: v.string(),
+  created_at: v.string(),
+  crates_cnt: v.nullable(v.number()),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/crate-owner-invitation.js
+++ b/packages/crates-io-msw/models/crate-owner-invitation.js
@@ -1,19 +1,19 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
 
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  createdAt: z.string(),
-  expiresAt: z.string(),
-  token: z.string(),
+  createdAt: v.string(),
+  expiresAt: v.string(),
+  token: v.string(),
 
-  crate: z.any(),
-  invitee: z.any(),
-  inviter: z.any(),
+  crate: v.any(),
+  invitee: v.any(),
+  inviter: v.any(),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/crate-ownership.js
+++ b/packages/crates-io-msw/models/crate-ownership.js
@@ -1,17 +1,17 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
 
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  emailNotifications: z.boolean(),
+  emailNotifications: v.boolean(),
 
-  crate: z.any(),
-  team: z.any().nullable(),
-  user: z.any().nullable(),
+  crate: v.any(),
+  team: v.any(),
+  user: v.any(),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/crate.js
+++ b/packages/crates-io-msw/models/crate.js
@@ -1,28 +1,28 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
 
-const schema = z.object({
-  // `z.string()` is used to support some of our old fixture that use strings here for some reason
-  id: z.number().or(z.string()),
+const schema = v.object({
+  // `v.string()` is used to support some of our old fixtures that use strings here for some reason
+  id: v.union([v.number(), v.string()]),
 
-  name: z.string(),
-  description: z.string(),
-  downloads: z.number(),
-  recent_downloads: z.number(),
-  documentation: z.string().nullable(),
-  homepage: z.string().nullable(),
-  repository: z.string().nullable(),
-  created_at: z.string(),
-  updated_at: z.string(),
-  badges: z.array(z.any()),
-  _extra_downloads: z.array(z.any()),
-  trustpubOnly: z.boolean(),
+  name: v.string(),
+  description: v.string(),
+  downloads: v.number(),
+  recent_downloads: v.number(),
+  documentation: v.nullable(v.string()),
+  homepage: v.nullable(v.string()),
+  repository: v.nullable(v.string()),
+  created_at: v.string(),
+  updated_at: v.string(),
+  badges: v.array(v.any()),
+  _extra_downloads: v.array(v.any()),
+  trustpubOnly: v.boolean(),
 
-  categories: z.array(z.any()).default(() => []),
-  keywords: z.array(z.any()).default(() => []),
+  categories: v.optional(v.array(v.any()), () => []),
+  keywords: v.optional(v.array(v.any()), () => []),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/dependency.js
+++ b/packages/crates-io-msw/models/dependency.js
@@ -1,23 +1,23 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
 
 const REQS = ['^0.1.0', '^2.1.3', '0.3.7', '~5.2.12'];
 
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  default_features: z.boolean(),
-  features: z.array(z.any()),
-  kind: z.string(),
-  optional: z.boolean(),
-  req: z.string(),
-  target: z.string().nullable(),
+  default_features: v.boolean(),
+  features: v.array(v.any()),
+  kind: v.string(),
+  optional: v.boolean(),
+  req: v.string(),
+  target: v.nullable(v.string()),
 
-  crate: z.any(),
-  version: z.any(),
+  crate: v.any(),
+  version: v.any(),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/keyword.js
+++ b/packages/crates-io-msw/models/keyword.js
@@ -1,12 +1,12 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
 
-const schema = z.object({
-  id: z.string(),
-  keyword: z.string(),
+const schema = v.object({
+  id: v.string(),
+  keyword: v.string(),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/msw-session.js
+++ b/packages/crates-io-msw/models/msw-session.js
@@ -1,5 +1,5 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
@@ -12,10 +12,10 @@ import { preCreateExtension } from '../utils/pre-create-extension.js';
  * This mock implementation means that there can only ever exist one
  * session at a time.
  */
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  user: z.any(),
+  user: v.any(),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/team.js
+++ b/packages/crates-io-msw/models/team.js
@@ -1,19 +1,19 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
 
 const ORGS = ['rust-lang', 'emberjs', 'rust-random', 'georust', 'actix'];
 
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  name: z.string(),
-  org: z.string(),
-  login: z.string(),
-  url: z.string(),
-  avatar: z.string(),
+  name: v.string(),
+  org: v.string(),
+  login: v.string(),
+  url: v.string(),
+  avatar: v.string(),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/trustpub/github-config.js
+++ b/packages/crates-io-msw/models/trustpub/github-config.js
@@ -1,19 +1,19 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../../utils/defaults.js';
 import { preCreateExtension } from '../../utils/pre-create-extension.js';
 
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  crate: z.any().nullable(),
-  repository_owner: z.string(),
-  repository_owner_id: z.number(),
-  repository_name: z.string(),
-  workflow_filename: z.string(),
-  environment: z.string().nullable(),
-  created_at: z.string(),
+  crate: v.any(),
+  repository_owner: v.string(),
+  repository_owner_id: v.number(),
+  repository_name: v.string(),
+  workflow_filename: v.string(),
+  environment: v.nullable(v.string()),
+  created_at: v.string(),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/trustpub/gitlab-config.js
+++ b/packages/crates-io-msw/models/trustpub/gitlab-config.js
@@ -1,19 +1,19 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../../utils/defaults.js';
 import { preCreateExtension } from '../../utils/pre-create-extension.js';
 
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  crate: z.any().nullable(),
-  namespace: z.string(),
-  namespace_id: z.string().nullable(),
-  project: z.string(),
-  workflow_filepath: z.string(),
-  environment: z.string().nullable(),
-  created_at: z.string(),
+  crate: v.any(),
+  namespace: v.string(),
+  namespace_id: v.nullable(v.string()),
+  project: v.string(),
+  workflow_filepath: v.string(),
+  environment: v.nullable(v.string()),
+  created_at: v.string(),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/user.js
+++ b/packages/crates-io-msw/models/user.js
@@ -1,24 +1,24 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
 import { dasherize } from '../utils/strings.js';
 
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  name: z.string().nullable(),
-  login: z.string(),
-  url: z.string(),
-  avatar: z.string(),
-  email: z.string().nullable(),
-  emailVerificationToken: z.string().nullable(),
-  emailVerified: z.boolean(),
-  isAdmin: z.boolean(),
-  publishNotifications: z.boolean(),
+  name: v.nullable(v.string()),
+  login: v.string(),
+  url: v.string(),
+  avatar: v.string(),
+  email: v.nullable(v.string()),
+  emailVerificationToken: v.nullable(v.string()),
+  emailVerified: v.boolean(),
+  isAdmin: v.boolean(),
+  publishNotifications: v.boolean(),
 
-  followedCrates: z.array(z.any()).default(() => []),
+  followedCrates: v.optional(v.array(v.any()), () => []),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/version-download.js
+++ b/packages/crates-io-msw/models/version-download.js
@@ -1,16 +1,16 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
 
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  date: z.string(),
-  downloads: z.number(),
+  date: v.string(),
+  downloads: v.number(),
 
-  version: z.any(),
+  version: v.any(),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/models/version.js
+++ b/packages/crates-io-msw/models/version.js
@@ -1,5 +1,5 @@
 import { Collection } from '@msw/data';
-import { z } from 'zod';
+import * as v from 'valibot';
 
 import { applyDefault } from '../utils/defaults.js';
 import { preCreateExtension } from '../utils/pre-create-extension.js';
@@ -8,25 +8,25 @@ const LICENSES = ['MIT/Apache-2.0', 'MIT', 'Apache-2.0'];
 
 const LANGUAGES = ['Rust', 'JavaScript', 'TypeScript', 'Python', 'CSS', 'HTML', 'Shell'];
 
-const schema = z.object({
-  id: z.number(),
+const schema = v.object({
+  id: v.number(),
 
-  num: z.string(),
-  created_at: z.string(),
-  updated_at: z.string(),
-  yanked: z.boolean(),
-  yank_message: z.string().nullable(),
-  license: z.string(),
-  downloads: z.number(),
-  features: z.record(z.string(), z.any()).default(() => ({})),
-  crate_size: z.number(),
-  readme: z.string().nullable(),
-  rust_version: z.string().nullable(),
-  trustpub_data: z.any().nullable(),
-  linecounts: z.any().nullable(),
+  num: v.string(),
+  created_at: v.string(),
+  updated_at: v.string(),
+  yanked: v.boolean(),
+  yank_message: v.nullable(v.string()),
+  license: v.string(),
+  downloads: v.number(),
+  features: v.optional(v.record(v.string(), v.any()), () => ({})),
+  crate_size: v.number(),
+  readme: v.nullable(v.string()),
+  rust_version: v.nullable(v.string()),
+  trustpub_data: v.any(),
+  linecounts: v.any(),
 
-  crate: z.any(),
-  publishedBy: z.any().nullable().default(null),
+  crate: v.any(),
+  publishedBy: v.optional(v.any(), null),
 });
 
 function preCreate(attrs, counter) {

--- a/packages/crates-io-msw/package.json
+++ b/packages/crates-io-msw/package.json
@@ -21,7 +21,7 @@
     "@msw/data": "1.1.2",
     "msw": "2.12.4",
     "semver": "7.7.3",
-    "zod": "4.1.13"
+    "valibot": "1.1.0"
   },
   "devDependencies": {
     "vitest": "4.0.15"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,9 +333,9 @@ importers:
       semver:
         specifier: 7.7.3
         version: 7.7.3
-      zod:
-        specifier: 4.1.13
-        version: 4.1.13
+      valibot:
+        specifier: 1.1.0
+        version: 1.1.0(typescript@5.9.3)
     devDependencies:
       vitest:
         specifier: 4.0.15
@@ -8282,6 +8282,14 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
+  valibot@1.1.0:
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-name@6.0.2:
     resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -8678,9 +8686,6 @@ packages:
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
-
-  zod@4.1.13:
-    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
 
 snapshots:
 
@@ -18645,6 +18650,10 @@ snapshots:
 
   uuid@8.3.2: {}
 
+  valibot@1.1.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   validate-npm-package-name@6.0.2: {}
 
   validate-peer-dependencies@2.2.0:
@@ -19035,5 +19044,3 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   zimmerframe@1.1.4: {}
-
-  zod@4.1.13: {}


### PR DESCRIPTION
see https://valibot.dev/

The API is fairly similar, but valibot appears to have a more type-safe `transform()` implementation, that will allow us to get rid of the `preCreateExtension` monkey patching madness in the future.