### PR TITLE
Use `.tool-versions` file to pin Node.js and pnpm versions

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/heroku/heroku-buildpack-apt
-https://github.com/Turbo87/heroku-buildpack-crates-io#548cef4ec86eda61bfbf62d0546269dc4632175f
+https://github.com/Turbo87/heroku-buildpack-crates-io#76b621d6189070f88dbf0f90879c4843fcbf3e08

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,6 @@
+# `.tool-versions` file for asdf version manager
+#
+# This file specifies the versions of various tools to be used in this project.
+# These versions are also used by our Heroku buildpack setup.
+pnpm 10.26.0
+nodejs 24.12.0

--- a/package.json
+++ b/package.json
@@ -207,8 +207,8 @@
     "last 1 years"
   ],
   "engines": {
-    "node": "24.12.0",
-    "pnpm": "10.26.0"
+    "node": "^24",
+    "pnpm": "^10"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
The `.tool-versions` file is a conventional format from the `asdf` tool (see https://asdf-vm.com/guide/getting-started.html#_6-set-a-version) and is essentially a simple `<tool> <version>` mapping. 

https://github.com/Turbo87/heroku-buildpack-crates-io/commit/76b621d6189070f88dbf0f90879c4843fcbf3e08 adjusts our buildpack to read the Node.js and pnpm versions from that files instead of `pnpm`, which also means that we no longer need to install `jq` since `grep` + `awk` is sufficient. Note that the parser is very basic at the moment and currently does not support trailing comments after the version string.

As for the "why": it has been fairly annoying to locally always have to update the Node.js and pnpm versions to match what crates.io has pinned. This PR also relaxes the `engines` declarations, so that now only the major version needs to match for local development, while the deployment process and CI are using the pinned versions.