### PR TITLE
msw/tests: Use `@ts-expect-error` for expected type errors

### DIFF
--- a/packages/crates-io-msw/models/api-token.test.js
+++ b/packages/crates-io-msw/models/api-token.test.js
@@ -3,6 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `user` is not set', async ({ expect }) => {
+  // @ts-expect-error
   await expect(() => db.apiToken.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/crate-owner-invitation.test.js
+++ b/packages/crates-io-msw/models/crate-owner-invitation.test.js
@@ -5,6 +5,7 @@ import { db } from '../index.js';
 test('throws if `crate` is not set', async ({ expect }) => {
   let inviter = await db.user.create({});
   let invitee = await db.user.create({});
+  // @ts-expect-error
   await expect(() => db.crateOwnerInvitation.create({ inviter, invitee })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );
@@ -13,6 +14,7 @@ test('throws if `crate` is not set', async ({ expect }) => {
 test('throws if `inviter` is not set', async ({ expect }) => {
   let crate = await db.crate.create({});
   let invitee = await db.user.create({});
+  // @ts-expect-error
   await expect(() => db.crateOwnerInvitation.create({ crate, invitee })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );
@@ -21,6 +23,7 @@ test('throws if `inviter` is not set', async ({ expect }) => {
 test('throws if `invitee` is not set', async ({ expect }) => {
   let crate = await db.crate.create({});
   let inviter = await db.user.create({});
+  // @ts-expect-error
   await expect(() => db.crateOwnerInvitation.create({ crate, inviter })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/crate-ownership.test.js
+++ b/packages/crates-io-msw/models/crate-ownership.test.js
@@ -4,6 +4,7 @@ import { db } from '../index.js';
 
 test('throws if `crate` is not set', async ({ expect }) => {
   let user = await db.user.create({});
+  // @ts-expect-error
   await expect(() => db.crateOwnership.create({ user })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/dependency.test.js
+++ b/packages/crates-io-msw/models/dependency.test.js
@@ -4,6 +4,7 @@ import { db } from '../index.js';
 
 test('throws if `crate` is not set', async ({ expect }) => {
   let version = await db.version.create({ crate: await db.crate.create({}) });
+  // @ts-expect-error
   await expect(() => db.dependency.create({ version })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );
@@ -11,6 +12,7 @@ test('throws if `crate` is not set', async ({ expect }) => {
 
 test('throws if `version` is not set', async ({ expect }) => {
   let crate = await db.crate.create({});
+  // @ts-expect-error
   await expect(() => db.dependency.create({ crate })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/msw-session.test.js
+++ b/packages/crates-io-msw/models/msw-session.test.js
@@ -3,6 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `user` is not set', async ({ expect }) => {
+  // @ts-expect-error
   await expect(() => db.mswSession.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/version-download.test.js
+++ b/packages/crates-io-msw/models/version-download.test.js
@@ -3,6 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `version` is not set', async ({ expect }) => {
+  // @ts-expect-error
   await expect(() => db.versionDownload.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/version.test.js
+++ b/packages/crates-io-msw/models/version.test.js
@@ -3,6 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `crate` is not set', async ({ expect }) => {
+  // @ts-expect-error
   await expect(() => db.version.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );


### PR DESCRIPTION
We're not using TypeScript for the `@crates-io/msw` library yet (because using it as TS in the Ember.js app is complicated), but this fixes a couple of legitimate type warnings. Since these tests explicitly test what happens if a required key is not passed it, we can safely ignore these warnings and tell the TypeScript compiler that we actually expect these warnings to exist.