### PR TITLE
svelte: Improve `$props()` usage

### DIFF
--- a/svelte/src/lib/components/PageHeader.svelte
+++ b/svelte/src/lib/components/PageHeader.svelte
@@ -11,10 +11,10 @@
     children?: Snippet;
   }
 
-  let { title, suffix, showSpinner = false, children, ...others }: Props = $props();
+  let { title, suffix, showSpinner = false, children, class: className, ...others }: Props = $props();
 </script>
 
-<div data-test-page-header class="header" {...others}>
+<div data-test-page-header class={['header', className]} {...others}>
   {#if children}
     {@render children()}
   {:else}

--- a/svelte/src/lib/components/TextContent.svelte
+++ b/svelte/src/lib/components/TextContent.svelte
@@ -7,10 +7,10 @@
     children: Snippet;
   }
 
-  let { boxed = false, children, ...others }: Props = $props();
+  let { boxed = false, children, class: className, ...others }: Props = $props();
 </script>
 
-<div class="wrapper" class:boxed {...others}>
+<div class={['wrapper', className, { boxed }]} {...others}>
   {@render children()}
 </div>
 


### PR DESCRIPTION
This replaces `[key: string]: unknown;` in the `Props` interfaces with `HTMLAttributes<HTMLDivElement>`. That allows us to get proper auto-completion for the regular HTML element props.

This PR also ensures that the `class` attributes of the components are merged correctly when passed in from the outside.

### Related

- https://github.com/rust-lang/crates.io/issues/12515