### PR TITLE
svelte/Header: Uncomment `/crates` link

### DIFF
--- a/svelte/src/lib/components/Header.svelte
+++ b/svelte/src/lib/components/Header.svelte
@@ -46,11 +46,8 @@
     <nav class="nav">
       <!-- TODO: <ColorSchemeMenu class="color-scheme-menu" /> -->
 
-      <!-- TODO: add `/crates` route -->
-      <!--
       <a href={resolve('/crates')} data-test-all-crates-link> Browse All Crates </a>
       <span class="sep">|</span>
-      -->
 
       <!-- TODO: implement authenticated user menu -->
       <!-- {#if currentUser} -->


### PR DESCRIPTION
The route exists now, so the link no longer needs to be commented out.

### Related

- https://github.com/rust-lang/crates.io/issues/12515