### PR TITLE
svelte: Proxy `/api` requests to `https://crates.io`

### DIFF
--- a/svelte/package.json
+++ b/svelte/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
+    "dev:docker": "API_HOST=http://backend:8888 vite dev",
+    "dev:live": "vite dev",
+    "dev:local": "API_HOST=http://127.0.0.1:8888 vite dev",
+    "dev:staging": "API_HOST=https://staging.crates.io vite dev",
     "build": "vite build",
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -3,8 +3,16 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
+const API_HOST = process.env.API_HOST ?? 'https://crates.io';
+
 export default defineConfig({
   plugins: [sveltekit(), svg()],
+
+  server: {
+    proxy: {
+      '/api': API_HOST,
+    },
+  },
 
   test: {
     expect: { requireAssertions: true },


### PR DESCRIPTION
... or other hosts defined via `API_HOST`.

This roughly matches the `start:live`, `start:staging`, ... scripts that we have in the Ember.js app.

### Related

- https://github.com/rust-lang/crates.io/issues/12515