### PR TITLE
ESLint: Exclude `_` prefix from `no-unused-vars` rule

### DIFF
--- a/svelte/eslint.config.js
+++ b/svelte/eslint.config.js
@@ -28,6 +28,16 @@ export default defineConfig(
       // typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
       // see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
       'no-undef': 'off',
+
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
This matches the Rust rules and should make it straight-forward to understand for any Rust developers :)