### PR TITLE
playwright: Add missing `await` keywords on `msw.worker.use()` calls

### DIFF
--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -87,7 +87,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
   });
 
   test('other crate loading error shows an error message', async ({ page, msw }) => {
-    msw.worker.use(http.get('/api/v1/crates/:crate_name', () => HttpResponse.json({}, { status: 500 })));
+    await msw.worker.use(http.get('/api/v1/crates/:crate_name', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/crates/nanomsg');
     await expect(page).toHaveURL('/crates/nanomsg');

--- a/e2e/acceptance/front-page.spec.ts
+++ b/e2e/acceptance/front-page.spec.ts
@@ -53,7 +53,7 @@ test.describe('Acceptance | front page', { tag: '@acceptance' }, () => {
     await msw.worker.resetHandlers();
 
     let deferred = defer();
-    msw.worker.use(http.get('/api/v1/summary', () => deferred.promise));
+    await msw.worker.use(http.get('/api/v1/summary', () => deferred.promise));
 
     const button = page.locator('[data-test-try-again-button]');
     await button.click();

--- a/e2e/acceptance/login.spec.ts
+++ b/e2e/acceptance/login.spec.ts
@@ -11,7 +11,7 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
       };
     });
 
-    msw.worker.use(
+    await msw.worker.use(
       http.get('/api/private/session/begin', () => HttpResponse.json({ url: 'url-to-github-including-state-secret' })),
       http.get('/api/private/session/authorize', async ({ request }) => {
         let url = new URL(request.url);
@@ -69,7 +69,7 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
       };
     });
 
-    msw.worker.use(
+    await msw.worker.use(
       http.get('/api/private/session/begin', () => HttpResponse.json({ url: 'url-to-github-including-state-secret' })),
       http.get('/api/private/session/authorize', () =>
         HttpResponse.json({ errors: [{ detail: 'Forbidden' }] }, { status: 403 }),

--- a/e2e/acceptance/publish-notifications.spec.ts
+++ b/e2e/acceptance/publish-notifications.spec.ts
@@ -31,7 +31,7 @@ test.describe('Acceptance | publish notifications', { tag: '@acceptance' }, () =
     await msw.authenticateAs(user);
 
     let deferred = defer();
-    msw.worker.use(http.put('/api/v1/users/:user_id', () => deferred.promise));
+    await msw.worker.use(http.put('/api/v1/users/:user_id', () => deferred.promise));
 
     await page.goto('/settings/profile');
     await expect(page).toHaveURL('/settings/profile');
@@ -51,7 +51,7 @@ test.describe('Acceptance | publish notifications', { tag: '@acceptance' }, () =
     let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
-    msw.worker.use(http.put('/api/v1/users/:user_id', () => HttpResponse.text('', { status: 500 })));
+    await msw.worker.use(http.put('/api/v1/users/:user_id', () => HttpResponse.text('', { status: 500 })));
 
     await page.goto('/settings/profile');
     await expect(page).toHaveURL('/settings/profile');

--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -146,7 +146,9 @@ test.describe('Acceptance | README rendering', { tag: '@acceptance' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0', readme: 'foo' });
 
     // Simulate a server error when fetching the README
-    msw.worker.use(http.get('/api/v1/crates/:name/:version/readme', () => HttpResponse.html('', { status: 500 })));
+    await msw.worker.use(
+      http.get('/api/v1/crates/:name/:version/readme', () => HttpResponse.html('', { status: 500 })),
+    );
 
     await page.goto('/crates/serde');
     await expect(page.locator('[data-test-readme-error]')).toBeVisible();

--- a/e2e/acceptance/search.spec.ts
+++ b/e2e/acceptance/search.spec.ts
@@ -163,7 +163,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
   });
 
   test('passes query parameters to the backend', async ({ page, msw }) => {
-    msw.worker.use(
+    await msw.worker.use(
       http.get('/api/v1/crates', function ({ request }) {
         let url = new URL(request.url);
         expect(Object.fromEntries(url.searchParams.entries())).toEqual({
@@ -182,7 +182,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
   });
 
   test('supports `keyword:bla` filters', async ({ page, msw }) => {
-    msw.worker.use(
+    await msw.worker.use(
       http.get('/api/v1/crates', function ({ request }) {
         let url = new URL(request.url);
         expect(Object.fromEntries(url.searchParams.entries())).toEqual({
@@ -201,7 +201,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
   });
 
   test('`all_keywords` query parameter takes precedence over `keyword` filters', async ({ page, msw }) => {
-    msw.worker.use(
+    await msw.worker.use(
       http.get('/api/v1/crates', function ({ request }) {
         let url = new URL(request.url);
         expect(Object.fromEntries(url.searchParams.entries())).toEqual({

--- a/e2e/routes/category.spec.ts
+++ b/e2e/routes/category.spec.ts
@@ -12,7 +12,7 @@ test.describe('Route | category', { tag: '@routes' }, () => {
   });
 
   test('server error causes the error page to be shown', async ({ page, msw }) => {
-    msw.worker.use(http.get('/api/v1/categories/:categoryId', () => HttpResponse.json({}, { status: 500 })));
+    await msw.worker.use(http.get('/api/v1/categories/:categoryId', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/categories/foo');
     await expect(page).toHaveURL('/categories/foo');

--- a/e2e/routes/crate/delete.spec.ts
+++ b/e2e/routes/crate/delete.spec.ts
@@ -65,7 +65,7 @@ test.describe('Route: crate.delete', { tag: '@routes' }, () => {
     await prepare(msw);
 
     let deferred = defer();
-    msw.worker.use(http.delete('/api/v1/crates/:name', () => deferred.promise));
+    await msw.worker.use(http.delete('/api/v1/crates/:name', () => deferred.promise));
 
     await page.goto('/crates/foo/delete');
     await page.fill('[data-test-reason]', "I don't need this crate anymore");
@@ -83,7 +83,7 @@ test.describe('Route: crate.delete', { tag: '@routes' }, () => {
     await prepare(msw);
 
     let payload = { errors: [{ detail: 'only crates without reverse dependencies can be deleted after 72 hours' }] };
-    msw.worker.use(http.delete('/api/v1/crates/:name', () => HttpResponse.json(payload, { status: 422 })));
+    await msw.worker.use(http.delete('/api/v1/crates/:name', () => HttpResponse.json(payload, { status: 422 })));
 
     await page.goto('/crates/foo/delete');
     await page.fill('[data-test-reason]', "I don't need this crate anymore");

--- a/e2e/routes/crate/range.spec.ts
+++ b/e2e/routes/crate/range.spec.ts
@@ -82,7 +82,7 @@ test.describe('Route | crate.range', { tag: '@routes' }, () => {
   });
 
   test('shows an error page if crate fails to load', async ({ page, msw }) => {
-    msw.worker.use(http.get('/api/v1/crates/:crate_name', () => HttpResponse.json({}, { status: 500 })));
+    await msw.worker.use(http.get('/api/v1/crates/:crate_name', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/crates/foo/range/^3');
     await expect(page).toHaveURL('/crates/foo/range/%5E3');
@@ -111,7 +111,7 @@ test.describe('Route | crate.range', { tag: '@routes' }, () => {
     let crate = await msw.db.crate.create({ name: 'foo' });
     await msw.db.version.create({ crate, num: '3.2.1' });
 
-    msw.worker.use(http.get('/api/v1/crates/:crate_name/versions', () => HttpResponse.json({}, { status: 500 })));
+    await msw.worker.use(http.get('/api/v1/crates/:crate_name/versions', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/crates/foo/range/^3');
     await expect(page).toHaveURL('/crates/foo/range/%5E3');

--- a/e2e/routes/crate/settings.spec.ts
+++ b/e2e/routes/crate/settings.spec.ts
@@ -506,7 +506,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
         });
 
         let deferred = defer();
-        msw.worker.use(http.patch('/api/v1/crates/:name', () => deferred.promise));
+        await msw.worker.use(http.patch('/api/v1/crates/:name', () => deferred.promise));
 
         await page.goto('/crates/foo/settings');
 

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
@@ -245,7 +245,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
 
       // Mock the server to return an error
       let deferred = defer();
-      msw.worker.use(http.post('/api/v1/trusted_publishing/github_configs', () => deferred.promise));
+      await msw.worker.use(http.post('/api/v1/trusted_publishing/github_configs', () => deferred.promise));
 
       await page.goto(`/crates/${crate.name}/settings/new-trusted-publisher`);
       await expect(page).toHaveURL(`/crates/${crate.name}/settings/new-trusted-publisher`);
@@ -463,7 +463,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
 
       // Mock the server to return an error
       let deferred = defer();
-      msw.worker.use(http.post('/api/v1/trusted_publishing/gitlab_configs', () => deferred.promise));
+      await msw.worker.use(http.post('/api/v1/trusted_publishing/gitlab_configs', () => deferred.promise));
 
       await page.goto(`/crates/${crate.name}/settings/new-trusted-publisher`);
       await expect(page).toHaveURL(`/crates/${crate.name}/settings/new-trusted-publisher`);

--- a/e2e/routes/crate/version/docs-link.spec.ts
+++ b/e2e/routes/crate/version/docs-link.spec.ts
@@ -18,7 +18,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('not found', { status: 404 });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.getByRole('link', { name: 'crates.io', exact: true })).toHaveCount(1);
@@ -37,7 +37,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
       doc_status: true,
       version: '1.0.0',
     });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-docs-link] a')).toHaveAttribute('href', 'https://docs.rs/foo/1.0.0');
@@ -51,7 +51,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('not found', { status: 404 });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-docs-link] a')).toHaveAttribute('href', 'https://docs.rs/foo/0.6.2');
@@ -68,7 +68,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
       doc_status: true,
       version: '1.0.0',
     });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-docs-link] a')).toHaveAttribute('href', 'https://docs.rs/foo/1.0.0');
@@ -79,7 +79,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('error', { status: 500 });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-docs-link] a')).toHaveAttribute('href', 'https://docs.rs/foo/0.6.2');
@@ -90,7 +90,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '0.6.2' });
 
     let response = HttpResponse.json({});
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-docs-link] a')).toHaveAttribute('href', 'https://docs.rs/foo/0.6.2');

--- a/e2e/routes/keyword.spec.ts
+++ b/e2e/routes/keyword.spec.ts
@@ -10,7 +10,7 @@ test.describe('Route | keyword', { tag: '@routes' }, () => {
 
   test('server error causes the error page to be shown', async ({ page, msw }) => {
     let error = HttpResponse.json({}, { status: 500 });
-    msw.worker.use(http.get('/api/v1/crates', () => error));
+    await msw.worker.use(http.get('/api/v1/crates', () => error));
 
     await page.goto('/keywords/foo');
     await expect(page).toHaveURL('/keywords/foo');

--- a/e2e/routes/settings/tokens/new.spec.ts
+++ b/e2e/routes/settings/tokens/new.spec.ts
@@ -235,7 +235,7 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     await prepare(msw);
 
     let deferred = defer();
-    msw.worker.use(http.put('/api/v1/me/tokens', () => deferred.promise));
+    await msw.worker.use(http.put('/api/v1/me/tokens', () => deferred.promise));
 
     await page.goto('/settings/tokens/new');
     await expect(page).toHaveURL('/settings/tokens/new');

--- a/e2e/routes/team.spec.ts
+++ b/e2e/routes/team.spec.ts
@@ -12,7 +12,7 @@ test.describe('Route | team', { tag: '@routes' }, () => {
   });
 
   test('server error causes the error page to be shown', async ({ page, msw }) => {
-    msw.worker.use(http.get('/api/v1/teams/:id', () => HttpResponse.json({}, { status: 500 })));
+    await msw.worker.use(http.get('/api/v1/teams/:id', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/teams/foo');
     await expect(page).toHaveURL('/teams/foo');

--- a/e2e/routes/user.spec.ts
+++ b/e2e/routes/user.spec.ts
@@ -12,7 +12,7 @@ test.describe('Route | user', { tag: '@routes' }, () => {
   });
 
   test('server error causes the error page to be shown', async ({ page, msw }) => {
-    msw.worker.use(http.get('/api/v1/users/:id', () => HttpResponse.json({}, { status: 500 })));
+    await msw.worker.use(http.get('/api/v1/users/:id', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/users/foo');
     await expect(page).toHaveURL('/users/foo');


### PR DESCRIPTION
This fixes a couple of IDE warnings about function calls not being awaited properly. It might also fix the occasional flakiness in the Playwright test suite. 🤷‍♂️ 