### PR TITLE
Remove route name assertions

### DIFF
--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -17,7 +17,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-heading] [data-test-crate-version]')).toHaveText('v0.6.1');
   });
 
-  test('visiting /crates/nanomsg', async ({ page, msw, ember, percy, a11y }) => {
+  test('visiting /crates/nanomsg', async ({ page, msw, percy, a11y }) => {
     let crate = await msw.db.crate.create({ name: 'nanomsg' });
     await msw.db.version.create({ crate, num: '0.6.0' });
     await msw.db.version.create({ crate, num: '0.6.1', rust_version: '1.69' });
@@ -26,9 +26,6 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
 
     await expect(page).toHaveURL('/crates/nanomsg');
     await expect(page).toHaveTitle('nanomsg - crates.io: Rust Package Registry');
-    // TODO: Add the following as a method to EmberPage fixture
-    const currentRouteName = await ember.evaluate(owner => owner.lookup('router:main').currentRouteName);
-    expect(currentRouteName).toBe('crate.index');
 
     await expect(page.locator('[data-test-heading] [data-test-crate-name]')).toHaveText('nanomsg');
     await expect(page.locator('[data-test-heading] [data-test-crate-version]')).toHaveText('v0.6.1');
@@ -38,7 +35,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await a11y.audit();
   });
 
-  test('visiting /crates/nanomsg/', async ({ page, msw, ember }) => {
+  test('visiting /crates/nanomsg/', async ({ page, msw }) => {
     let crate = await msw.db.crate.create({ name: 'nanomsg' });
     await msw.db.version.create({ crate, num: '0.6.0' });
     await msw.db.version.create({ crate, num: '0.6.1' });
@@ -47,16 +44,13 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
 
     await expect(page).toHaveURL('/crates/nanomsg/');
     await expect(page).toHaveTitle('nanomsg - crates.io: Rust Package Registry');
-    // TODO: Add the following as a method to EmberPage fixture
-    const currentRouteName = await ember.evaluate(owner => owner.lookup('router:main').currentRouteName);
-    expect(currentRouteName).toBe('crate.index');
 
     await expect(page.locator('[data-test-heading] [data-test-crate-name]')).toHaveText('nanomsg');
     await expect(page.locator('[data-test-heading] [data-test-crate-version]')).toHaveText('v0.6.1');
     await expect(page.locator('[data-test-crate-stats-label]')).toHaveText('Stats Overview');
   });
 
-  test('visiting /crates/nanomsg/0.6.0', async ({ page, msw, ember, percy, a11y }) => {
+  test('visiting /crates/nanomsg/0.6.0', async ({ page, msw, percy, a11y }) => {
     let crate = await msw.db.crate.create({ name: 'nanomsg' });
     await msw.db.version.create({ crate, num: '0.6.0' });
     await msw.db.version.create({ crate, num: '0.6.1' });
@@ -65,9 +59,6 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
 
     await expect(page).toHaveURL('/crates/nanomsg/0.6.0');
     await expect(page).toHaveTitle('nanomsg - crates.io: Rust Package Registry');
-    // TODO: Add the following as a method to EmberPage fixture
-    const currentRouteName = await ember.evaluate(owner => owner.lookup('router:main').currentRouteName);
-    expect(currentRouteName).toBe('crate.version');
 
     await expect(page.locator('[data-test-heading] [data-test-crate-name]')).toHaveText('nanomsg');
     await expect(page.locator('[data-test-heading] [data-test-crate-version]')).toHaveText('v0.6.0');

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -1,4 +1,4 @@
-import { click, currentRouteName, currentURL, fillIn, triggerEvent, waitFor } from '@ember/test-helpers';
+import { click, currentURL, fillIn, triggerEvent, waitFor } from '@ember/test-helpers';
 import { module, skip, test } from 'qunit';
 
 import { loadFixtures } from '@crates-io/msw/fixtures.js';
@@ -37,7 +37,6 @@ module('Acceptance | crate page', function (hooks) {
     await visit('/crates/nanomsg');
 
     assert.strictEqual(currentURL(), '/crates/nanomsg');
-    assert.strictEqual(currentRouteName(), 'crate.index');
     assert.strictEqual(getPageTitle(), 'nanomsg - crates.io: Rust Package Registry');
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
@@ -56,7 +55,6 @@ module('Acceptance | crate page', function (hooks) {
     await visit('/crates/nanomsg/');
 
     assert.strictEqual(currentURL(), '/crates/nanomsg/');
-    assert.strictEqual(currentRouteName(), 'crate.index');
     assert.strictEqual(getPageTitle(), 'nanomsg - crates.io: Rust Package Registry');
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
@@ -72,7 +70,6 @@ module('Acceptance | crate page', function (hooks) {
     await visit('/crates/nanomsg/0.6.0');
 
     assert.strictEqual(currentURL(), '/crates/nanomsg/0.6.0');
-    assert.strictEqual(currentRouteName(), 'crate.version');
     assert.strictEqual(getPageTitle(), 'nanomsg - crates.io: Rust Package Registry');
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
@@ -124,7 +121,6 @@ module('Acceptance | crate page', function (hooks) {
     await visit('/crates/foo_bar');
 
     assert.strictEqual(currentURL(), '/crates/foo_bar');
-    assert.strictEqual(currentRouteName(), 'crate.index');
     assert.strictEqual(getPageTitle(), 'foo-bar - crates.io: Rust Package Registry');
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('foo-bar');


### PR DESCRIPTION
The internal state of the Ember.js router doesn't matter much to us. We only really care about the URL and what is displayed on the page.

This commit removes the corresponding assertions.

This also makes the tests more portable to other frameworks, since they now don't rely on Ember.js-specific things anymore.