### PR TITLE
tests: Use black-box assertions in email confirmation tests

### DIFF
--- a/e2e/acceptance/email-confirmation.spec.ts
+++ b/e2e/acceptance/email-confirmation.spec.ts
@@ -13,7 +13,7 @@ test.describe('Acceptance | Email Confirmation', { tag: '@acceptance' }, () => {
     await expect(user.emailVerified).toBe(true);
   });
 
-  test('authenticated happy path', async ({ page, msw, ember }) => {
+  test('authenticated happy path', async ({ page, msw }) => {
     let user = await msw.db.user.create({ emailVerificationToken: 'badc0ffee' });
 
     await msw.authenticateAs(user);
@@ -23,14 +23,11 @@ test.describe('Acceptance | Email Confirmation', { tag: '@acceptance' }, () => {
     await expect(page).toHaveURL('/');
     await expect(page.locator('[data-test-notification-message="success"]')).toBeVisible();
 
-    const emailVerified = await ember.evaluate(owner => {
-      const { currentUser } = owner.lookup('service:session');
-      return currentUser.email_verified;
-    });
-    expect(emailVerified).toBe(true);
-
     user = msw.db.user.findFirst(q => q.where({ id: user.id }));
     await expect(user.emailVerified).toBe(true);
+
+    await page.goto('/settings/profile');
+    await expect(page.locator('[data-test-verified]')).toBeVisible();
   });
 
   test('error case', async ({ page }) => {

--- a/tests/acceptance/email-confirmation-test.js
+++ b/tests/acceptance/email-confirmation-test.js
@@ -30,11 +30,11 @@ module('Acceptance | Email Confirmation', function (hooks) {
     assert.strictEqual(currentURL(), '/');
     assert.dom('[data-test-notification-message="success"]').exists();
 
-    let { currentUser } = this.owner.lookup('service:session');
-    assert.true(currentUser.email_verified);
-
     user = this.db.user.findFirst(q => q.where({ id: user.id }));
     assert.true(user.emailVerified);
+
+    await visit('/settings/profile');
+    assert.dom('[data-test-verified]').exists();
   });
 
   test('error case', async function (assert) {


### PR DESCRIPTION
Replace direct access to internal session state with UI-based assertions. This makes the tests reusable across different frontend implementations (Ember, Svelte) by treating the application as a black box.