### PR TITLE
svelte: Integrate `vite-bundle-analyzer` dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,9 @@ importers:
       vite:
         specifier: 7.3.0
         version: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
+      vite-bundle-analyzer:
+        specifier: 1.3.2
+        version: 1.3.2
       vitest:
         specifier: 4.0.16
         version: 4.0.16(@types/node@24.10.4)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(yaml@2.8.2)
@@ -8794,6 +8797,10 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vite-bundle-analyzer@1.3.2:
+    resolution: {integrity: sha512-Od4ILUKRvBV3LuO/E+S+c1XULlxdkRZPSf6Vzzu+UAXG0D3hZYUu9imZIkSj/PU4e1FB14yB+av8g3KiljH8zQ==}
+    hasBin: true
 
   vite@7.3.0:
     resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
@@ -20132,6 +20139,8 @@ snapshots:
       semver: 7.7.3
 
   vary@1.1.2: {}
+
+  vite-bundle-analyzer@1.3.2: {}
 
   vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2):
     dependencies:

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -52,6 +52,7 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.50.0",
     "vite": "7.3.0",
+    "vite-bundle-analyzer": "1.3.2",
     "vitest": "4.0.16",
     "vitest-browser-svelte": "2.0.1"
   }

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -4,14 +4,20 @@ import svg from '@poppanator/sveltekit-svg';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { playwright } from '@vitest/browser-playwright';
 import { createLogger } from 'vite';
+import { analyzer } from 'vite-bundle-analyzer';
 import { defineConfig } from 'vitest/config';
 
 const API_HOST = process.env.API_HOST ?? 'https://crates.io';
 
 const proxyLogger = createLogger('info', { prefix: '[proxy]' });
 
+const plugins = [sveltekit(), svg()];
+if (process.env.BUNDLE_ANALYSIS) {
+  plugins.push(analyzer({ analyzerMode: 'static' }));
+}
+
 export default defineConfig({
-  plugins: [sveltekit(), svg()],
+  plugins,
 
   server: {
     proxy: {


### PR DESCRIPTION
Using `BUNDLE_ANALYSIS=true pnpm build` will generate a `build/stats.html` page, which shows an overview of the bundles and their sizes.