### PR TITLE
email: Add view actions

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -353,6 +353,24 @@ mod tests {
         <p>You can also go to <a href="https://crates.io/me/pending-invites">https://crates.io/me/pending-invites</a> to manage all of your crate ownership invitations.</p>
 
         <p>--<br>The crates.io Team</p>
+        <script type="application/ld+json">
+        {
+          "@context": "http://schema.org",
+          "@type": "EmailMessage",
+          "potentialAction": {
+            "@type": "ViewAction",
+            "target": "https://crates.io/accept-invite/abc123",
+            "url": "https://crates.io/accept-invite/abc123",
+            "name": "Accept Invitation"
+          },
+          "description": "Accept the crate ownership invitation",
+          "publisher": {
+            "@type": "Organization",
+            "name": "crates.io",
+            "url": "https://crates.io"
+          }
+        }
+        </script>
         "#);
     }
 

--- a/src/email/templates/base.html.j2
+++ b/src/email/templates/base.html.j2
@@ -1,2 +1,24 @@
+{%- macro view_action(url, name, description) -%}
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "{{ url | safe }}",
+    "url": "{{ url | safe }}",
+    "name": "{{ name }}"
+  },
+  "description": "{{ description }}",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
+{%- endmacro -%}
+
 {% block content %}{% endblock %}
 <p>--<br>The crates.io Team</p>
+{%- block action %}{% endblock -%}

--- a/src/email/templates/owner_invite/body.html.j2
+++ b/src/email/templates/owner_invite/body.html.j2
@@ -1,9 +1,17 @@
 {% extends "base.html.j2" %}
+{% from "base.html.j2" import view_action %}
+
+{% set accept_url = "https://" ~ domain ~ "/accept-invite/" ~ token %}
+{% set invites_url = "https://" ~ domain ~ "/me/pending-invites" %}
 
 {% block content %}
 <p>{{ inviter }} has invited you to become an owner of the crate <strong>{{ crate_name }}</strong>!</p>
 
-<p>Visit <a href="https://{{ domain }}/accept-invite/{{ token }}">https://{{ domain }}/accept-invite/{{ token }}</a> to accept this invitation.</p>
+<p>Visit <a href="{{ accept_url | safe }}">{{ accept_url | safe }}</a> to accept this invitation.</p>
 
-<p>You can also go to <a href="https://{{ domain }}/me/pending-invites">https://{{ domain }}/me/pending-invites</a> to manage all of your crate ownership invitations.</p>
+<p>You can also go to <a href="{{ invites_url | safe }}">{{ invites_url | safe }}</a> to manage all of your crate ownership invitations.</p>
 {% endblock %}
+
+{%- block action %}
+{{ view_action(accept_url, "Accept Invitation", "Accept the crate ownership invitation") }}
+{%- endblock %}

--- a/src/email/templates/publish_notification/body.html.j2
+++ b/src/email/templates/publish_notification/body.html.j2
@@ -1,11 +1,18 @@
 {% extends "base.html.j2" %}
+{% from "base.html.j2" import view_action %}
+
+{% set version_url = "https://" ~ domain ~ "/crates/" ~ krate ~ "/" ~ version %}
 
 {% block content %}
 <p>Hello {{ recipient }}!</p>
 
 <p>A new version of the <strong>{{ krate }}</strong> crate was published{{ publisher_info }} at {{ publish_time }}.</p>
 
-<p>View v{{ version }} here: <a href="https://{{ domain }}/crates/{{ krate }}/{{ version }}">https://{{ domain }}/crates/{{ krate }}/{{ version }}</a></p>
+<p>View v{{ version }} here: <a href="{{ version_url | safe }}">{{ version_url | safe }}</a></p>
 
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 {% endblock %}
+
+{%- block action %}
+{{ view_action(version_url, "View Release", "View the newly published crate version") }}
+{%- endblock %}

--- a/src/email/templates/user_confirm/body.html.j2
+++ b/src/email/templates/user_confirm/body.html.j2
@@ -1,11 +1,18 @@
 {% extends "base.html.j2" %}
+{% from "base.html.j2" import view_action %}
+
+{% set confirm_url = "https://" ~ domain ~ "/confirm/" ~ token %}
 
 {% block content %}
 <p>Hello {{ user_name }}!</p>
 
 <p>Welcome to crates.io. Please click the link below to verify your email address:</p>
 
-<p><a href="https://{{ domain }}/confirm/{{ token }}">https://{{ domain }}/confirm/{{ token }}</a></p>
+<p><a href="{{ confirm_url | safe }}">{{ confirm_url | safe }}</a></p>
 
 <p>Thank you!</p>
 {% endblock %}
+
+{%- block action %}
+{{ view_action(confirm_url, "Confirm Verification", "Confirm your email address for crates.io") }}
+{%- endblock %}

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate-5.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__basics__new_krate-5.snap
@@ -38,4 +38,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo_new/1.0.0",
+    "url": "https://crates.io/crates/foo_new/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_github__full_flow-11.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_github__full_flow-11.snap
@@ -38,6 +38,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.0.0",
+    "url": "https://crates.io/crates/foo/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -122,4 +140,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.1.0",
+    "url": "https://crates.io/crates/foo/1.1.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_gitlab__full_flow-11.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__trustpub_gitlab__full_flow-11.snap
@@ -38,6 +38,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.0.0",
+    "url": "https://crates.io/crates/foo/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -122,4 +140,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.1.0",
+    "url": "https://crates.io/crates/foo/1.1.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_new_crate-3.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_new_crate-3.snap
@@ -38,6 +38,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.0.0",
+    "url": "https://crates.io/crates/foo/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_old_crate-3.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_old_crate-3.snap
@@ -38,6 +38,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.0.0",
+    "url": "https://crates.io/crates/foo/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_really_old_crate-3.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__delete__happy_path_really_old_crate-3.snap
@@ -38,6 +38,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.0.0",
+    "url": "https://crates.io/crates/foo/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------

--- a/src/tests/routes/users/snapshots/integration__routes__users__email_verification__happy_path-3.snap
+++ b/src/tests/routes/users/snapshots/integration__routes__users__email_verification__happy_path-3.snap
@@ -38,4 +38,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>Thank you!</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/confirm/[confirm-token]",
+    "url": "https://crates.io/confirm/[confirm-token]",
+    "name": "Confirm Verification"
+  },
+  "description": "Confirm your email address for crates.io",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--

--- a/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-11.snap
+++ b/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-11.snap
@@ -38,6 +38,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.0.0",
+    "url": "https://crates.io/crates/foo/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -114,4 +132,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.2.0",
+    "url": "https://crates.io/crates/foo/1.2.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--

--- a/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-2.snap
+++ b/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-2.snap
@@ -38,4 +38,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.0.0",
+    "url": "https://crates.io/crates/foo/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--

--- a/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-5.snap
+++ b/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-5.snap
@@ -38,6 +38,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.0.0",
+    "url": "https://crates.io/crates/foo/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------

--- a/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-7.snap
+++ b/src/tests/routes/users/update/snapshots/integration__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-7.snap
@@ -38,6 +38,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo/1.0.0",
+    "url": "https://crates.io/crates/foo/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------

--- a/src/tests/snapshots/integration__owners__modify_multiple_owners-10.snap
+++ b/src/tests/snapshots/integration__owners__modify_multiple_owners-10.snap
@@ -34,6 +34,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>You can also go to <a href="https://crates.io/me/pending-invites">https://crates.io/me/pending-invites</a> to manage all of your crate ownership invitations.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/accept-invite/[invite-token]",
+    "url": "https://crates.io/accept-invite/[invite-token]",
+    "name": "Accept Invitation"
+  },
+  "description": "Accept the crate ownership invitation",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -70,6 +88,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>You can also go to <a href="https://crates.io/me/pending-invites">https://crates.io/me/pending-invites</a> to manage all of your crate ownership invitations.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/accept-invite/[invite-token]",
+    "url": "https://crates.io/accept-invite/[invite-token]",
+    "name": "Accept Invitation"
+  },
+  "description": "Accept the crate ownership invitation",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -106,6 +142,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>You can also go to <a href="https://crates.io/me/pending-invites">https://crates.io/me/pending-invites</a> to manage all of your crate ownership invitations.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/accept-invite/[invite-token]",
+    "url": "https://crates.io/accept-invite/[invite-token]",
+    "name": "Accept Invitation"
+  },
+  "description": "Accept the crate ownership invitation",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -142,4 +196,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>You can also go to <a href="https://crates.io/me/pending-invites">https://crates.io/me/pending-invites</a> to manage all of your crate ownership invitations.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/accept-invite/[invite-token]",
+    "url": "https://crates.io/accept-invite/[invite-token]",
+    "name": "Accept Invitation"
+  },
+  "description": "Accept the crate ownership invitation",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--

--- a/src/tests/snapshots/integration__owners__modify_multiple_owners.snap
+++ b/src/tests/snapshots/integration__owners__modify_multiple_owners.snap
@@ -34,6 +34,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>You can also go to <a href="https://crates.io/me/pending-invites">https://crates.io/me/pending-invites</a> to manage all of your crate ownership invitations.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/accept-invite/[invite-token]",
+    "url": "https://crates.io/accept-invite/[invite-token]",
+    "name": "Accept Invitation"
+  },
+  "description": "Accept the crate ownership invitation",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -70,4 +88,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>You can also go to <a href="https://crates.io/me/pending-invites">https://crates.io/me/pending-invites</a> to manage all of your crate ownership invitations.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/accept-invite/[invite-token]",
+    "url": "https://crates.io/accept-invite/[invite-token]",
+    "name": "Accept Invitation"
+  },
+  "description": "Accept the crate ownership invitation",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--

--- a/src/tests/snapshots/integration__owners__new_crate_owner-2.snap
+++ b/src/tests/snapshots/integration__owners__new_crate_owner-2.snap
@@ -38,6 +38,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo_owner/1.0.0",
+    "url": "https://crates.io/crates/foo_owner/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -74,6 +92,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>You can also go to <a href="https://crates.io/me/pending-invites">https://crates.io/me/pending-invites</a> to manage all of your crate ownership invitations.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/accept-invite/[invite-token]",
+    "url": "https://crates.io/accept-invite/[invite-token]",
+    "name": "Accept Invitation"
+  },
+  "description": "Accept the crate ownership invitation",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -114,6 +150,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo_owner/2.0.0",
+    "url": "https://crates.io/crates/foo_owner/2.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -154,4 +208,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo_owner/2.0.0",
+    "url": "https://crates.io/crates/foo_owner/2.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--

--- a/src/tests/snapshots/integration__owners__new_crate_owner.snap
+++ b/src/tests/snapshots/integration__owners__new_crate_owner.snap
@@ -38,6 +38,24 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo_owner/1.0.0",
+    "url": "https://crates.io/crates/foo_owner/1.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--
 
 ----------------------------------------
@@ -74,4 +92,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>You can also go to <a href="https://crates.io/me/pending-invites">https://crates.io/me/pending-invites</a> to manage all of your crate ownership invitations.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/accept-invite/[invite-token]",
+    "url": "https://crates.io/accept-invite/[invite-token]",
+    "name": "Accept Invitation"
+  },
+  "description": "Accept the crate ownership invitation",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--

--- a/src/tests/snapshots/integration__team__publish_owned.snap
+++ b/src/tests/snapshots/integration__team__publish_owned.snap
@@ -38,4 +38,22 @@ Content-Transfer-Encoding: quoted-printable
 <p>If you have questions or security concerns, you can contact us at <a href="mailto:help@crates.io">help@crates.io</a>. If you would like to stop receiving these security notifications, you can disable them in your account settings.</p>
 
 <p>--<br>The crates.io Team</p>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "target": "https://crates.io/crates/foo_team_owned/2.0.0",
+    "url": "https://crates.io/crates/foo_team_owned/2.0.0",
+    "name": "View Release"
+  },
+  "description": "View the newly published crate version",
+  "publisher": {
+    "@type": "Organization",
+    "name": "crates.io",
+    "url": "https://crates.io"
+  }
+}
+</script>
 --[boundary]--


### PR DESCRIPTION
This commit adds "view actions" based on schema.org linked data to some of our email templates. This causes some email clients like Gmail to display a corresponding button in the email list.

This was inspired by GitHub doing something similar with e.g. "View Discussion" view actions:

<img width="305" height="75" alt="Bildschirmfoto 2025-12-27 um 07 27 26" src="https://github.com/user-attachments/assets/e55b5dbb-7688-482a-a8c7-17c043a97c8f" />

/cc @paolobarbolini 

### Related

- https://github.com/rust-lang/crates.io/pull/12583