### PR TITLE
playwright: Add `TEST_APP` env var to allow testing Svelte app

### DIFF
--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -10,6 +10,8 @@ import { EmberPage, EmberPageOptions } from './fixtures/ember';
 import { FakeTimers, FakeTimersOptions } from './fixtures/fake-timers';
 import { PercyPage } from './fixtures/percy';
 
+const TEST_APP = process.env.TEST_APP ?? 'ember';
+
 export type AppOptions = {
   clockOptions: FakeTimersOptions;
   emberOptions: EmberPageOptions;
@@ -72,7 +74,7 @@ export const test = base.extend<AppOptions & AppFixtures>({
       await ember.setup(emberOptions);
       await use(ember);
     },
-    { auto: true, scope: 'test' },
+    { auto: TEST_APP === 'ember', scope: 'test' },
   ],
   percy: async ({ page }, use, testInfo) => {
     let percy = new PercyPage(page, testInfo);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "start:local": "ember serve --proxy http://127.0.0.1:8888",
     "start:staging": "ember serve --proxy https://staging-crates-io.herokuapp.com",
     "test": "ember test",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "e2e:svelte": "TEST_APP=svelte playwright test"
   },
   "prettier": {
     "plugins": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,28 @@ import { defineConfig, devices } from '@playwright/test';
 // require('dotenv').config();
 
 /**
+ * TEST_APP controls which frontend app to test:
+ * - 'ember' (default): Test the Ember.js app on port 4200
+ * - 'svelte': Test the SvelteKit app on port 5173
+ */
+const TEST_APP = process.env.TEST_APP ?? 'ember';
+
+const APP_CONFIG = {
+  ember: {
+    url: 'http://127.0.0.1:4200',
+    command: 'pnpm start',
+  },
+  svelte: {
+    url: 'http://localhost:4173',
+    command: 'npm run build && npm run preview',
+    cwd: './svelte',
+    env: { PLAYWRIGHT: '1' },
+  },
+} as const;
+
+const appConfig = APP_CONFIG[TEST_APP] ?? APP_CONFIG.ember;
+
+/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
@@ -26,7 +48,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://127.0.0.1:4200',
+    baseURL: appConfig.url,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -77,8 +99,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'pnpm start',
-    url: 'http://127.0.0.1:4200',
+    ...appConfig,
     reuseExistingServer: !process.env.CI,
     timeout: 5 * 60 * 1000,
   },

--- a/svelte/svelte.config.js
+++ b/svelte/svelte.config.js
@@ -16,7 +16,8 @@ const config = {
     paths: {
       // We are serving the app from the `/svelte` subdirectory for now
       // to be able to serve it alongside the Ember.js app at `/`.
-      base: process.env.VITEST ? '' : '/svelte',
+      // Use empty base path for tests (Vitest unit tests and Playwright e2e tests).
+      base: process.env.VITEST || process.env.PLAYWRIGHT ? '' : '/svelte',
     },
   },
 };


### PR DESCRIPTION
This allows us to use the same Playwright test suite for the Ember.js and Svelte applications. `pnpm e2e` keeps testing the Ember.js app, while `pnpm e2e:svelte` runs the same test against the Svelte application. ~CI is configured to run both, but allows the Svelte run to fail until the Svelte implementation has caught up with the Ember.js app.~

Removed the CI commit again since it wastes too much time on CI and then times out.

### Related

- https://github.com/rust-lang/crates.io/issues/12515