### PR TITLE
ESLint: Integrate `eslint-plugin-prefer-let` plugin

### DIFF
--- a/app/components/download-graph.gjs
+++ b/app/components/download-graph.gjs
@@ -260,11 +260,11 @@ function midnightForDate(date) {
 // The specific implementation is based on @bertho-zero's here:
 // https://github.com/date-fns/date-fns/issues/571#issuecomment-602496322
 function subDays(date, amount) {
-  const originalTZO = date.getTimezoneOffset();
-  const endDate = brokenSubDays(date, amount);
-  const endTZO = endDate.getTimezoneOffset();
+  let originalTZO = date.getTimezoneOffset();
+  let endDate = brokenSubDays(date, amount);
+  let endTZO = endDate.getTimezoneOffset();
 
-  const dstDiff = originalTZO - endTZO;
+  let dstDiff = originalTZO - endTZO;
 
   return dstDiff >= 0 ? addMinutes(endDate, dstDiff) : subMinutes(endDate, Math.abs(dstDiff));
 }

--- a/app/controllers/crate/settings/index.js
+++ b/app/controllers/crate/settings/index.js
@@ -38,7 +38,7 @@ export default class CrateSettingsController extends Controller {
   }
 
   addOwnerTask = task(async () => {
-    const username = this.username;
+    let username = this.username;
 
     try {
       await this.crate.inviteOwner(username);

--- a/app/helpers/format-short-num.js
+++ b/app/helpers/format-short-num.js
@@ -1,6 +1,9 @@
 import Helper from '@ember/component/helper';
 import { service } from '@ember/service';
 
+const THRESHOLD = 1500;
+const UNITS = ['', 'K', 'M'];
+
 /**
  * This matches the implementation in https://github.com/rust-lang/crates_io_og_image/blob/v0.2.1/src/formatting.rs
  * to ensure that we render roughly the same values in our user interface and the generated OpenGraph images.
@@ -9,9 +12,6 @@ export default class FormatShortNumHelper extends Helper {
   @service intl;
 
   compute([value]) {
-    const THRESHOLD = 1500;
-    const UNITS = ['', 'K', 'M'];
-
     let numValue = Number(value);
     let unitIndex = 0;
 

--- a/app/initializers/app-hook.js
+++ b/app/initializers/app-hook.js
@@ -8,7 +8,7 @@ export function initialize(app) {
   }
 
   // This is not available in Ember test
-  const owner = app.__container__?.owner;
+  let owner = app.__container__?.owner;
   if (!owner) {
     return;
   }
@@ -26,7 +26,7 @@ export function initialize(app) {
 }
 
 async function processHooks(owner, app) {
-  const hooks = window[Symbol.for(APP_HOOK_KEY)];
+  let hooks = window[Symbol.for(APP_HOOK_KEY)];
   if (hooks && Array.isArray(hooks)) {
     for (let hook of hooks) {
       await hook(owner, app);

--- a/app/initializers/hashchange.js
+++ b/app/initializers/hashchange.js
@@ -25,8 +25,8 @@ function hashchange() {
     return;
   }
 
-  const hash = decodeFragmentValue(location.hash);
-  const target = findElementByFragmentName(document, `user-content-${hash}`);
+  let hash = decodeFragmentValue(location.hash);
+  let target = findElementByFragmentName(document, `user-content-${hash}`);
   if (target) {
     target.scrollIntoView();
   }

--- a/app/routes/me/crates.js
+++ b/app/routes/me/crates.js
@@ -7,8 +7,8 @@ export default class MeCratesRoute extends AuthenticatedRoute {
 
   redirect(model, transition) {
     // Redirect to the user's profile page (/users/{username}) with the same query parameters
-    const username = this.session.currentUser.login;
-    const queryParams = transition.to.queryParams;
+    let username = this.session.currentUser.login;
+    let queryParams = transition.to.queryParams;
 
     this.router.transitionTo('user', username, { queryParams });
   }

--- a/app/routes/settings/tokens/new.js
+++ b/app/routes/settings/tokens/new.js
@@ -32,7 +32,7 @@ export default class TokenListRoute extends Route {
   setupController(controller, model) {
     super.setupController(controller, model);
     if (model) {
-      const { name, endpoint_scopes, crate_scopes } = model;
+      let { name, endpoint_scopes, crate_scopes } = model;
 
       controller.name = name;
       if (endpoint_scopes) {

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -13,7 +13,7 @@ export default class TeamRoute extends Route {
   };
 
   async model(params, transition) {
-    const { team_id } = params;
+    let { team_id } = params;
 
     try {
       let team = await this.store.queryRecord('team', { team_id });

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -14,7 +14,7 @@ export default class UserRoute extends Route {
   };
 
   async model(params, transition) {
-    const { user_id } = params;
+    let { user_id } = params;
     try {
       let user = await this.store.queryRecord('user', { user_id });
 

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -203,7 +203,7 @@ export default class SessionService extends Service {
     // If the user is an admin, we need to look up whether they have enabled
     // sudo mode.
     if (currentUser?.is_admin) {
-      const expiry = localStorage.getItem('sudo');
+      let expiry = localStorage.getItem('sudo');
       if (expiry !== null) {
         try {
           // Trigger sudoTask, but without waiting for it to complete.
@@ -222,7 +222,7 @@ export default class SessionService extends Service {
 
   sudoTask = restartableTask(async until => {
     try {
-      const now = Date.now();
+      let now = Date.now();
 
       if (until > now) {
         // Since this task will replace any running task, we should update local

--- a/app/utils/purl.js
+++ b/app/utils/purl.js
@@ -16,7 +16,7 @@ export function addRegistryUrl(purl) {
   }
 
   // Add repository_url query parameter
-  const repositoryUrl = `https://${host}/`;
-  const separator = purl.includes('?') ? '&' : '?';
+  let repositoryUrl = `https://${host}/`;
+  let separator = purl.includes('?') ? '&' : '?';
   return `${purl}${separator}repository_url=${encodeURIComponent(repositoryUrl)}`;
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,8 +8,8 @@ module.exports = function (defaults) {
 
   let extraPublicTrees = [];
   if (!isProd) {
-    const path = require('node:path');
-    const funnel = require('broccoli-funnel');
+    let path = require('node:path');
+    let funnel = require('broccoli-funnel');
 
     let mswPath = require.resolve('msw/mockServiceWorker.js');
     let mswParentPath = path.dirname(mswPath);
@@ -59,7 +59,7 @@ module.exports = function (defaults) {
   // app.import('node_modules/normalize.css/normalize.css');
   app.import('vendor/qunit.css', { type: 'test' });
 
-  const { Webpack } = require('@embroider/webpack');
+  let { Webpack } = require('@embroider/webpack');
   return require('@embroider/compat').compatBuild(app, Webpack, {
     extraPublicTrees,
     staticAddonTrees: true,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ import js from '@eslint/js';
 import emberEslintParser from 'ember-eslint-parser';
 import ember from 'eslint-plugin-ember';
 import emberConcurrency from 'eslint-plugin-ember-concurrency';
+import preferLet from 'eslint-plugin-prefer-let';
 import prettier from 'eslint-plugin-prettier';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 import globals from 'globals';
@@ -58,6 +59,7 @@ export default [
     plugins: {
       ember,
       'ember-concurrency': emberConcurrency,
+      'prefer-let': preferLet,
       prettier,
     },
 
@@ -89,6 +91,9 @@ export default [
     rules: {
       // it's fine to use `return` without a value and rely on the implicit `undefined` return value
       'getter-return': 'off',
+
+      'prefer-const': 'off',
+      'prefer-let/prefer-let': 'error',
 
       'prettier/prettier': 'error',
 

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-ember": "12.7.5",
     "eslint-plugin-ember-concurrency": "0.5.1",
+    "eslint-plugin-prefer-let": "^4.0.0",
     "eslint-plugin-prettier": "5.5.4",
     "eslint-plugin-qunit": "8.2.5",
     "eslint-plugin-qunit-dom": "0.2.0",

--- a/packages/crates-io-msw/handlers/crates/list.js
+++ b/packages/crates-io-msw/handlers/crates/list.js
@@ -8,7 +8,7 @@ import { getSession } from '../../utils/session.js';
 export default http.get('/api/v1/crates', async ({ request }) => {
   let url = new URL(request.url);
 
-  const { start, end } = pageParams(request);
+  let { start, end } = pageParams(request);
 
   let crates = db.crate.findMany();
 

--- a/packages/crates-io-msw/handlers/crates/reverse-dependencies.test.js
+++ b/packages/crates-io-msw/handlers/crates/reverse-dependencies.test.js
@@ -172,8 +172,8 @@ test('never returns more than 10 results', async function () {
 
   await Promise.all(
     Array.from({ length: 25 }, async () => {
-      const depCrate = await db.crate.create({ name: 'bar' });
-      const version = await db.version.create({ crate: depCrate });
+      let depCrate = await db.crate.create({ name: 'bar' });
+      let version = await db.version.create({ crate: depCrate });
       return db.dependency.create({ crate, version });
     }),
   );

--- a/packages/crates-io-msw/models/version.js
+++ b/packages/crates-io-msw/models/version.js
@@ -50,25 +50,25 @@ function generateLinecounts(id) {
     return null;
   }
 
-  const languages = {};
+  let languages = {};
   let totalCodeLines = 0;
   let totalCommentLines = 0;
 
   // Generate 1-3 random languages per version
-  const numLanguages = (id % 3) + 1;
-  const selectedLanguages = [];
+  let numLanguages = (id % 3) + 1;
+  let selectedLanguages = [];
 
   for (let i = 0; i < numLanguages; i++) {
-    const langIndex = (id + i) % LANGUAGES.length;
+    let langIndex = (id + i) % LANGUAGES.length;
     selectedLanguages.push(LANGUAGES[langIndex]);
   }
 
-  for (const language of selectedLanguages) {
+  for (let language of selectedLanguages) {
     // Generate pseudo-random but deterministic line counts based on id and language
-    const seed = id + language.codePointAt(0);
-    const codeLines = ((seed * 137) % 500) + 50; // 50-550 lines
-    const commentLines = ((seed * 73) % 100) + 5; // 5-105 lines
-    const files = ((seed * 29) % 8) + 1; // 1-8 files
+    let seed = id + language.codePointAt(0);
+    let codeLines = ((seed * 137) % 500) + 50; // 50-550 lines
+    let commentLines = ((seed * 73) % 100) + 5; // 5-105 lines
+    let files = ((seed * 29) % 8) + 1; // 1-8 files
 
     languages[language] = {
       code_lines: codeLines,

--- a/packages/crates-io-msw/serializers/category.js
+++ b/packages/crates-io-msw/serializers/category.js
@@ -4,7 +4,7 @@ import { serializeModel } from '../utils/serializers.js';
 export function serializeCategory(category) {
   let serialized = serializeModel(category);
 
-  const crateCount = db.crate.findMany(q => q.where(crate => crate.categories.some(c => c.id === category.id))).length;
+  let crateCount = db.crate.findMany(q => q.where(crate => crate.categories.some(c => c.id === category.id))).length;
   serialized.crates_cnt ??= crateCount;
 
   return serialized;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       eslint-plugin-ember-concurrency:
         specifier: 0.5.1
         version: 0.5.1(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-prefer-let:
+        specifier: ^4.0.0
+        version: 4.0.0
       eslint-plugin-prettier:
         specifier: 5.5.4
         version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@3.7.4)
@@ -423,6 +426,9 @@ importers:
       eslint-config-prettier:
         specifier: 10.1.8
         version: 10.1.8(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-prefer-let:
+        specifier: ^4.0.0
+        version: 4.0.0
       eslint-plugin-storybook:
         specifier: 10.1.10
         version: 10.1.10(eslint@9.39.2(jiti@2.6.1))(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
@@ -5028,6 +5034,10 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
+
+  eslint-plugin-prefer-let@4.0.0:
+    resolution: {integrity: sha512-X4ep5PMO1320HKaNC9DM5+p6XvOhwv+RcqGjhv3aiw9iAtHhiFtdIUB5l0Zya0iM22ys2BGKzrNI9Xpw/ZHooQ==}
+    engines: {node: '>=0.10.0'}
 
   eslint-plugin-prettier@5.5.4:
     resolution: {integrity: sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==}
@@ -15786,6 +15796,10 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - typescript
+
+  eslint-plugin-prefer-let@4.0.0:
+    dependencies:
+      requireindex: 1.2.0
 
   eslint-plugin-prettier@5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@3.7.4):
     dependencies:

--- a/script/generate-deploy-changelog.mjs
+++ b/script/generate-deploy-changelog.mjs
@@ -19,7 +19,7 @@ function isClaudeAvailable() {
 }
 
 function parseGitHubCompareUrl(url) {
-  const compareMatch = url.match(/compare\/([a-f0-9]+)\.\.\.([a-f0-9]+)/);
+  let compareMatch = url.match(/compare\/([a-f0-9]+)\.\.\.([a-f0-9]+)/);
   if (!compareMatch) {
     throw new Error('Invalid GitHub compare URL. Expected format: https://github.com/owner/repo/compare/hash1...hash2');
   }
@@ -30,24 +30,24 @@ function parseGitHubCompareUrl(url) {
 }
 
 function getCommits(from, to) {
-  const format = '%H%x00%an%x00%s';
-  const output = exec(`git log --format="${format}" ${from}..${to}`);
+  let format = '%H%x00%an%x00%s';
+  let output = exec(`git log --format="${format}" ${from}..${to}`);
 
   return output
     .trim()
     .split('\n')
     .filter(Boolean)
     .map(line => {
-      const [sha, author, message] = line.split('\u0000');
+      let [sha, author, message] = line.split('\u0000');
       return { sha, author, message };
     });
 }
 
 function getMigrations(from, to) {
   try {
-    const files = exec(`git log --name-only --format="" ${from}..${to} -- migrations/`);
+    let files = exec(`git log --name-only --format="" ${from}..${to} -- migrations/`);
 
-    const migrationFiles = files
+    let migrationFiles = files
       .trim()
       .split('\n')
       .filter(Boolean)
@@ -57,12 +57,12 @@ function getMigrations(from, to) {
       return [];
     }
 
-    const migrations = [];
-    const migrationDirs = new Set(migrationFiles.map(file => file.split('/').slice(0, 2).join('/')));
+    let migrations = [];
+    let migrationDirs = new Set(migrationFiles.map(file => file.split('/').slice(0, 2).join('/')));
 
-    for (const dir of migrationDirs) {
-      const upFile = `${dir}/up.sql`;
-      const downFile = `${dir}/down.sql`;
+    for (let dir of migrationDirs) {
+      let upFile = `${dir}/up.sql`;
+      let downFile = `${dir}/down.sql`;
 
       let upContent = '';
       let downContent = '';
@@ -110,7 +110,7 @@ function formatMigrations(migrations) {
     output += `\nNo database migrations`;
   }
 
-  for (const migration of migrations) {
+  for (let migration of migrations) {
     output += `\n\n${migration.dir}\n`;
     output += '-'.repeat(80);
 
@@ -129,10 +129,10 @@ function formatMigrations(migrations) {
 }
 
 function generateChangelog(commits, migrations, url) {
-  const commitList = formatCommits(commits);
-  const migrationInfo = formatMigrations(migrations);
+  let commitList = formatCommits(commits);
+  let migrationInfo = formatMigrations(migrations);
 
-  const prompt = `You are generating a deployment changelog for crates.io based on git commit history and database migrations.
+  let prompt = `You are generating a deployment changelog for crates.io based on git commit history and database migrations.
 
 Generate a deployment announcement in this exact style:
 
@@ -175,7 +175,7 @@ Generate only the deployment announcement, no additional explanation.`;
 }
 
 function main() {
-  const url = process.argv[2];
+  let url = process.argv[2];
 
   if (!url) {
     console.error('Usage: script/generate-deploy-changelog.mjs <github-compare-url>');
@@ -186,15 +186,15 @@ function main() {
   }
 
   try {
-    const { from, to } = parseGitHubCompareUrl(url);
-    const commits = getCommits(from, to);
+    let { from, to } = parseGitHubCompareUrl(url);
+    let commits = getCommits(from, to);
 
     if (commits.length === 0) {
       console.log('No commits found in range');
       return;
     }
 
-    const migrations = getMigrations(from, to);
+    let migrations = getMigrations(from, to);
 
     console.log(`Found ${commits.length} commit${commits.length === 1 ? '' : 's'}:\n`);
     console.log(formatCommits(commits));
@@ -203,7 +203,7 @@ function main() {
     if (isClaudeAvailable()) {
       console.log(`\n${'='.repeat(80)}`);
       console.log('Generating deployment changelog...\n');
-      const changelog = generateChangelog(commits, migrations, url);
+      let changelog = generateChangelog(commits, migrations, url);
       console.log(changelog);
     }
   } catch (error) {

--- a/svelte/eslint.config.js
+++ b/svelte/eslint.config.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { includeIgnoreFile } from '@eslint/compat';
 import js from '@eslint/js';
 import prettier from 'eslint-config-prettier';
+import preferLet from 'eslint-plugin-prefer-let';
 import storybook from 'eslint-plugin-storybook';
 import svelte from 'eslint-plugin-svelte';
 import { defineConfig } from 'eslint/config';
@@ -22,9 +23,16 @@ export default defineConfig(
   ...svelte.configs.prettier,
   ...storybook.configs['flat/recommended'],
   {
+    plugins: {
+      'prefer-let': preferLet,
+    },
+
     languageOptions: { globals: { ...globals.browser, ...globals.node } },
 
     rules: {
+      'prefer-const': 'off',
+      'prefer-let/prefer-let': 'error',
+
       // typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
       // see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
       'no-undef': 'off',

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -43,6 +43,7 @@
     "@vitest/coverage-v8": "4.0.16",
     "eslint": "9.39.2",
     "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-prefer-let": "^4.0.0",
     "eslint-plugin-storybook": "10.1.10",
     "eslint-plugin-svelte": "3.13.1",
     "globals": "16.5.0",

--- a/svelte/src/routes/+page.ts
+++ b/svelte/src/routes/+page.ts
@@ -15,7 +15,7 @@ let cachedSummary: SummaryResponse | undefined;
  * before rendering.
  */
 export async function load({ fetch }) {
-  const client = createClient({ fetch });
+  let client = createClient({ fetch });
 
   return { summary: fetchSummary(client) };
 }
@@ -25,7 +25,7 @@ async function fetchSummary(client: ReturnType<typeof createClient>): Promise<Su
     return cachedSummary;
   }
 
-  const response = await client.GET('/api/v1/summary');
+  let response = await client.GET('/api/v1/summary');
   if (response.error) {
     throw new Error('Failed to fetch summary data');
   }

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
               level = 'warn';
             }
 
-            const msg = `${req.method} ${req.url} → ${proxyRes.statusCode} ${proxyRes.statusMessage}`;
+            let msg = `${req.method} ${req.url} → ${proxyRes.statusCode} ${proxyRes.statusMessage}`;
             proxyLogger[level](msg, { timestamp: true });
           });
         },

--- a/tests/acceptance/crates-test.js
+++ b/tests/acceptance/crates-test.js
@@ -16,7 +16,7 @@ module('Acceptance | crates page', function (hooks) {
   setupApplicationTest(hooks);
 
   // should match the default set in the crates controller
-  const per_page = 50;
+  let per_page = 50;
 
   test('visiting the crates page from the front page', async function (assert) {
     await loadFixtures(this.db);
@@ -58,8 +58,8 @@ module('Acceptance | crates page', function (hooks) {
       let crate = await this.db.crate.create({});
       await this.db.version.create({ crate });
     }
-    const page_start = per_page + 1;
-    const total = per_page + 2;
+    let page_start = per_page + 1;
+    let total = per_page + 2;
 
     await visit('/crates');
     await click('[data-test-pagination-next]');

--- a/tests/acceptance/sudo-test.js
+++ b/tests/acceptance/sudo-test.js
@@ -11,7 +11,7 @@ module('Acceptance | sudo', function (hooks) {
   setupApplicationTest(hooks);
 
   async function prepare(context, isAdmin) {
-    const user = await context.db.user.create({
+    let user = await context.db.user.create({
       login: 'johnnydee',
       name: 'John Doe',
       email: 'john@doe.com',
@@ -19,12 +19,12 @@ module('Acceptance | sudo', function (hooks) {
       isAdmin,
     });
 
-    const crate = await context.db.crate.create({
+    let crate = await context.db.crate.create({
       name: 'foo',
       newest_version: '0.1.0',
     });
 
-    const version = await context.db.version.create({
+    let version = await context.db.version.create({
       crate,
       num: '0.1.0',
     });
@@ -73,7 +73,7 @@ module('Acceptance | sudo', function (hooks) {
 
     await visit('/crates/foo/versions');
 
-    const untilAbout = Date.now() + 6 * 60 * 60 * 1000;
+    let untilAbout = Date.now() + 6 * 60 * 60 * 1000;
     await click('[data-test-enable-admin-actions]');
 
     // Test the various header elements.
@@ -83,10 +83,10 @@ module('Acceptance | sudo', function (hooks) {
 
     // Test that the expiry time is sensible. We'll allow a minute either way in
     // case of slow tests or slightly wonky clocks.
-    const disable = find('[data-test-disable-admin-actions] > div');
+    let disable = find('[data-test-disable-admin-actions] > div');
     let seen = 0;
-    for (const ts of [untilAbout - 60 * 1000, untilAbout, untilAbout + 60 * 1000]) {
-      const time = format(new Date(ts), 'HH:mm');
+    for (let ts of [untilAbout - 60 * 1000, untilAbout, untilAbout + 60 * 1000]) {
+      let time = format(new Date(ts), 'HH:mm');
       if (disable.textContent.includes(time)) {
         seen += 1;
       }
@@ -111,12 +111,12 @@ module('Acceptance | sudo', function (hooks) {
     await click('[data-test-version-yank-button="0.1.0"]');
 
     await waitFor('[data-test-version-unyank-button="0.1.0"]');
-    const crate = this.db.crate.findFirst(q => q.where({ name: 'foo' }));
-    const version = this.db.version.findFirst(q => q.where(v => v.crate.id === crate.id && v.num === '0.1.0'));
+    let crate = this.db.crate.findFirst(q => q.where({ name: 'foo' }));
+    let version = this.db.version.findFirst(q => q.where(v => v.crate.id === crate.id && v.num === '0.1.0'));
     assert.true(version.yanked, 'The version should be yanked');
     assert.dom('[data-test-version-unyank-button="0.1.0"]').exists();
     await click('[data-test-version-unyank-button="0.1.0"]');
-    const updatedVersion = this.db.version.findFirst(q => q.where(v => v.crate.id === crate.id && v.num === '0.1.0'));
+    let updatedVersion = this.db.version.findFirst(q => q.where(v => v.crate.id === crate.id && v.num === '0.1.0'));
     assert.false(updatedVersion.yanked, 'The version should be unyanked');
 
     await waitFor('[data-test-version-yank-button="0.1.0"]');

--- a/tests/acceptance/support-test.js
+++ b/tests/acceptance/support-test.js
@@ -32,7 +32,7 @@ module('Acceptance | support', function (hooks) {
     assert.dom('[data-test-id="support-main-content"] section').exists({ count: 1 });
     assert.dom('[data-test-id="inquire-list-section"]').exists();
     assert.dom('[data-test-id="inquire-list"]').exists();
-    const listitem = findAll('[data-test-id="inquire-list"] li');
+    let listitem = findAll('[data-test-id="inquire-list"] li');
     assert.deepEqual(
       listitem.map(item => item.textContent.trim()),
       ['Report a crate that violates policies'].concat([
@@ -52,7 +52,7 @@ module('Acceptance | support', function (hooks) {
     assert.dom('[data-test-id="support-main-content"] section').exists({ count: 1 });
     assert.dom('[data-test-id="inquire-list-section"]').exists();
     assert.dom('[data-test-id="inquire-list"]').exists();
-    const listitem = findAll('[data-test-id="inquire-list"] li');
+    let listitem = findAll('[data-test-id="inquire-list"] li');
     assert.deepEqual(
       listitem.map(item => item.textContent.trim()),
       ['Report a crate that violates policies'].concat([
@@ -210,7 +210,7 @@ test detail
         console.error(error);
         console.log(getSettledState());
         // display DOM tree for debugging
-        const walker = document.createTreeWalker(
+        let walker = document.createTreeWalker(
           document.querySelector('main'),
           NodeFilter.SHOW_ELEMENT + NodeFilter.SHOW_TEXT,
         );

--- a/tests/components/privileged-action-test.gjs
+++ b/tests/components/privileged-action-test.gjs
@@ -33,7 +33,7 @@ module('Component | PrivilegedAction', hooks => {
   });
 
   test('unprivileged block is shown to a logged in user without access', async function (assert) {
-    const user = await this.db.user.create({});
+    let user = await this.db.user.create({});
     await this.authenticateAs(user);
 
     await this.renderComponent(false);
@@ -43,7 +43,7 @@ module('Component | PrivilegedAction', hooks => {
   });
 
   test('privileged block is shown to a logged in user with access', async function (assert) {
-    const user = await this.db.user.create({});
+    let user = await this.db.user.create({});
     await this.authenticateAs(user);
 
     await this.renderComponent(true);
@@ -53,10 +53,10 @@ module('Component | PrivilegedAction', hooks => {
   });
 
   test('placeholder block is shown to a logged in admin without sudo', async function (assert) {
-    const user = await this.db.user.create({ isAdmin: true });
+    let user = await this.db.user.create({ isAdmin: true });
     await this.authenticateAs(user);
 
-    const session = this.owner.lookup('service:session');
+    let session = this.owner.lookup('service:session');
     let { currentUser } = await session.loadUserTask.perform();
     assert.true(currentUser.is_admin);
     assert.false(session.isSudoEnabled);
@@ -68,10 +68,10 @@ module('Component | PrivilegedAction', hooks => {
   });
 
   test('privileged block is shown to a logged in admin without sudo with access', async function (assert) {
-    const user = await this.db.user.create({ isAdmin: true });
+    let user = await this.db.user.create({ isAdmin: true });
     await this.authenticateAs(user);
 
-    const session = this.owner.lookup('service:session');
+    let session = this.owner.lookup('service:session');
     let { currentUser } = await session.loadUserTask.perform();
     assert.true(currentUser.is_admin);
     assert.false(session.isSudoEnabled);
@@ -83,10 +83,10 @@ module('Component | PrivilegedAction', hooks => {
   });
 
   test('privileged block is shown to a logged in admin with sudo', async function (assert) {
-    const user = await this.db.user.create({ isAdmin: true });
+    let user = await this.db.user.create({ isAdmin: true });
     await this.authenticateAs(user);
 
-    const session = this.owner.lookup('service:session');
+    let session = this.owner.lookup('service:session');
     let { currentUser } = await session.loadUserTask.perform();
     assert.true(currentUser.is_admin);
     session.setSudo(86_400_000);
@@ -99,10 +99,10 @@ module('Component | PrivilegedAction', hooks => {
   });
 
   test('automatic placeholder block', async function (assert) {
-    const user = await this.db.user.create({ isAdmin: true });
+    let user = await this.db.user.create({ isAdmin: true });
     await this.authenticateAs(user);
 
-    const session = this.owner.lookup('service:session');
+    let session = this.owner.lookup('service:session');
     let { currentUser } = await session.loadUserTask.perform();
     assert.true(currentUser.is_admin);
     assert.false(session.isSudoEnabled);

--- a/tests/routes/crate/settings-test.js
+++ b/tests/routes/crate/settings-test.js
@@ -14,9 +14,9 @@ module('Route | crate.settings', hooks => {
   setupApplicationTest(hooks);
 
   async function prepare(context) {
-    const user = await context.db.user.create({});
+    let user = await context.db.user.create({});
 
-    const crate = await context.db.crate.create({ name: 'foo' });
+    let crate = await context.db.crate.create({ name: 'foo' });
     await context.db.version.create({ crate });
     await context.db.crateOwnership.create({ crate, user });
 
@@ -24,7 +24,7 @@ module('Route | crate.settings', hooks => {
   }
 
   test('unauthenticated', async function (assert) {
-    const crate = await this.db.crate.create({ name: 'foo' });
+    let crate = await this.db.crate.create({ name: 'foo' });
     await this.db.version.create({ crate });
 
     await visit('/crates/foo/settings');
@@ -34,9 +34,9 @@ module('Route | crate.settings', hooks => {
   });
 
   test('not an owner', async function (assert) {
-    const { crate } = await prepare(this);
+    let { crate } = await prepare(this);
 
-    const otherUser = await this.db.user.create({});
+    let otherUser = await this.db.user.create({});
     await this.authenticateAs(otherUser);
 
     await visit(`/crates/${crate.name}/settings`);
@@ -46,7 +46,7 @@ module('Route | crate.settings', hooks => {
   });
 
   test('happy path', async function (assert) {
-    const { crate, user } = await prepare(this);
+    let { crate, user } = await prepare(this);
     await this.authenticateAs(user);
 
     await visit(`/crates/${crate.name}/settings`);
@@ -66,7 +66,7 @@ module('Route | crate.settings', hooks => {
 
   module('Trusted Publishing', function () {
     test('mixed GitHub and GitLab configs', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.authenticateAs(user);
 
       // Create GitHub configs
@@ -114,7 +114,7 @@ module('Route | crate.settings', hooks => {
 
     module('GitHub', function () {
       test('happy path', async function (assert) {
-        const { crate, user } = await prepare(this);
+        let { crate, user } = await prepare(this);
         await this.authenticateAs(user);
 
         // Create two GitHub configs for the crate
@@ -194,7 +194,7 @@ module('Route | crate.settings', hooks => {
 
     module('GitLab', function () {
       test('happy path', async function (assert) {
-        const { crate, user } = await prepare(this);
+        let { crate, user } = await prepare(this);
         await this.authenticateAs(user);
 
         // Create two GitLab configs for the crate
@@ -279,7 +279,7 @@ module('Route | crate.settings', hooks => {
 
   module('trustpub_only warning banner', function () {
     test('hidden when flag is false', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.authenticateAs(user);
 
       await visit(`/crates/${crate.name}/settings`);
@@ -288,7 +288,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('hidden when flag is true and configs exist', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.db.crate.update(q => q.where({ id: crate.id }), {
         data(c) {
           c.trustpubOnly = true;
@@ -309,7 +309,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('shown when flag is true but no configs exist', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.db.crate.update(q => q.where({ id: crate.id }), {
         data(c) {
           c.trustpubOnly = true;
@@ -328,7 +328,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('disappears when checkbox is unchecked', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.db.crate.update(q => q.where({ id: crate.id }), {
         data(c) {
           c.trustpubOnly = true;
@@ -346,7 +346,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('appears when checkbox is checked with no configs', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.db.crate.update(q => q.where({ id: crate.id }), {
         data(c) {
           c.trustpubOnly = true;
@@ -375,7 +375,7 @@ module('Route | crate.settings', hooks => {
 
   module('trustpub_only checkbox', function () {
     test('hidden when no configs and flag is false', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.authenticateAs(user);
 
       await visit(`/crates/${crate.name}/settings`);
@@ -384,7 +384,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('visible when GitHub configs exist', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.authenticateAs(user);
 
       await this.db.trustpubGithubConfig.create({
@@ -401,7 +401,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('visible when GitLab configs exist', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.authenticateAs(user);
 
       await this.db.trustpubGitlabConfig.create({
@@ -418,7 +418,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('visible when flag is true but no configs', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.db.crate.update(q => q.where({ id: crate.id }), {
         data(c) {
           c.trustpubOnly = true;
@@ -433,7 +433,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('stays visible after disabling when no configs exist', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.db.crate.update(q => q.where({ id: crate.id }), {
         data(c) {
           c.trustpubOnly = true;
@@ -460,7 +460,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('enabling trustpub_only', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.authenticateAs(user);
 
       await this.db.trustpubGithubConfig.create({
@@ -482,7 +482,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('disabling trustpub_only', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.db.crate.update(q => q.where({ id: crate.id }), {
         data(c) {
           c.trustpubOnly = true;
@@ -509,7 +509,7 @@ module('Route | crate.settings', hooks => {
     });
 
     test('loading and error state', async function (assert) {
-      const { crate, user } = await prepare(this);
+      let { crate, user } = await prepare(this);
       await this.authenticateAs(user);
 
       await this.db.trustpubGithubConfig.create({

--- a/tests/routes/support-test.js
+++ b/tests/routes/support-test.js
@@ -60,8 +60,8 @@ module('Route | support', function (hooks) {
   });
 
   test('must reset query when existing', async function (assert) {
-    const route = this.owner.lookup('route:support');
-    const originResetController = route.resetController;
+    let route = this.owner.lookup('route:support');
+    let originResetController = route.resetController;
     // query params of LinkTo support's in footer will not be cleared
     class MockService extends Service {
       paramsFor() {

--- a/tests/utils/license-test.js
+++ b/tests/utils/license-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { parseLicense } from '../../utils/license';
 
 module('parseLicense()', function () {
-  const TESTS = [
+  let TESTS = [
     ['MIT', [{ isKeyword: false, link: 'https://choosealicense.com/licenses/mit', text: 'MIT' }]],
     [
       'MIT OR Apache-2.0',

--- a/tests/utils/search-test.js
+++ b/tests/utils/search-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { processSearchQuery } from '../../utils/search';
 
 module('processSearchQuery()', function () {
-  const TESTS = [
+  let TESTS = [
     ['foo', { q: 'foo' }],
     ['  foo    bar     ', { q: 'foo bar' }],
     ['foo keyword:bar', { q: 'foo', keyword: 'bar' }],


### PR DESCRIPTION
Add `eslint-plugin-prefer-let` to both Ember and Svelte ESLint configs to enforce using `let` instead of `const` for non-top-level declarations.

`const` in JS instead the same as `let` without `mut` in Rust. `const` just means that the variable binding is immutable, but the object it refers to can still be mutated. Since this makes the distinction between `let` and `const` in JS essentially meaningless from a technical point of view, we may as well use these keywords in a more useful way: `let` for variables, and `const` for module-level constants.