### PR TITLE
Replace `pristine-query` service with const import

### DIFF
--- a/app/components/footer.gjs
+++ b/app/components/footer.gjs
@@ -1,62 +1,54 @@
 import { LinkTo } from '@ember/routing';
-import { service } from '@ember/service';
-import Component from '@glimmer/component';
 
+import { SUPPORT_QUERY_PARAMS } from '../controllers/support';
 import svgJar from 'ember-svg-jar/helpers/svg-jar';
 
-export default class Footer extends Component {
-  @service pristineQuery;
+const EMPTY_SUPPORT_QUERY_PARAMS = Object.fromEntries(SUPPORT_QUERY_PARAMS.map(k => [k, null]));
 
-  get pristineSupportQuery() {
-    let params = this.pristineQuery.paramsFor('support');
-    return params;
-  }
-
-  <template>
-    <footer class='footer'>
-      <div class='content width-limit'>
-        <div>
-          <h1>Rust</h1>
-          <ul role='list'>
-            <li><a href='https://www.rust-lang.org/'>rust-lang.org</a></li>
-            <li><a href='https://foundation.rust-lang.org/'>Rust Foundation</a></li>
-            <li><a href='https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io'>The crates.io team</a></li>
-          </ul>
-        </div>
-
-        <div>
-          <h1>Get Help</h1>
-          <ul role='list'>
-            <li><a href='https://doc.rust-lang.org/cargo/'>The Cargo Book</a></li>
-            <li>
-              <LinkTo @route='support' @query={{this.pristineSupportQuery}} data-test-support-link>Support</LinkTo>
-            </li>
-            <li><a href='https://status.crates.io/'>System Status</a></li>
-            <li><a href='https://github.com/rust-lang/crates.io/issues/new/choose'>Report a bug</a></li>
-          </ul>
-        </div>
-
-        <div>
-          <h1>Policies</h1>
-          <ul role='list'>
-            <li><LinkTo @route='policies'>Usage Policy</LinkTo></li>
-            <li><LinkTo @route='policies.security'>Security</LinkTo></li>
-            <li><a href='https://foundation.rust-lang.org/policies/privacy-policy/'>Privacy Policy</a></li>
-            <li><a href='https://www.rust-lang.org/policies/code-of-conduct'>Code of Conduct</a></li>
-            <li><LinkTo @route='data-access'>Data Access</LinkTo></li>
-          </ul>
-        </div>
-
-        <div>
-          <h1>Social</h1>
-          <ul role='list'>
-            <li><a href='https://github.com/rust-lang/crates.io/'>{{svgJar 'github'}} rust-lang/crates.io</a></li>
-            <li><a href='https://rust-lang.zulipchat.com/#streams/318791/t-crates-io'>{{svgJar 'zulip'}}
-                #t-crates-io</a></li>
-            <li><a href='https://twitter.com/cratesiostatus'>{{svgJar 'twitter'}} @cratesiostatus</a></li>
-          </ul>
-        </div>
+<template>
+  <footer class='footer'>
+    <div class='content width-limit'>
+      <div>
+        <h1>Rust</h1>
+        <ul role='list'>
+          <li><a href='https://www.rust-lang.org/'>rust-lang.org</a></li>
+          <li><a href='https://foundation.rust-lang.org/'>Rust Foundation</a></li>
+          <li><a href='https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io'>The crates.io team</a></li>
+        </ul>
       </div>
-    </footer>
-  </template>
-}
+
+      <div>
+        <h1>Get Help</h1>
+        <ul role='list'>
+          <li><a href='https://doc.rust-lang.org/cargo/'>The Cargo Book</a></li>
+          <li>
+            <LinkTo @route='support' @query={{EMPTY_SUPPORT_QUERY_PARAMS}} data-test-support-link>Support</LinkTo>
+          </li>
+          <li><a href='https://status.crates.io/'>System Status</a></li>
+          <li><a href='https://github.com/rust-lang/crates.io/issues/new/choose'>Report a bug</a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h1>Policies</h1>
+        <ul role='list'>
+          <li><LinkTo @route='policies'>Usage Policy</LinkTo></li>
+          <li><LinkTo @route='policies.security'>Security</LinkTo></li>
+          <li><a href='https://foundation.rust-lang.org/policies/privacy-policy/'>Privacy Policy</a></li>
+          <li><a href='https://www.rust-lang.org/policies/code-of-conduct'>Code of Conduct</a></li>
+          <li><LinkTo @route='data-access'>Data Access</LinkTo></li>
+        </ul>
+      </div>
+
+      <div>
+        <h1>Social</h1>
+        <ul role='list'>
+          <li><a href='https://github.com/rust-lang/crates.io/'>{{svgJar 'github'}} rust-lang/crates.io</a></li>
+          <li><a href='https://rust-lang.zulipchat.com/#streams/318791/t-crates-io'>{{svgJar 'zulip'}}
+              #t-crates-io</a></li>
+          <li><a href='https://twitter.com/cratesiostatus'>{{svgJar 'twitter'}} @cratesiostatus</a></li>
+        </ul>
+      </div>
+    </div>
+  </footer>
+</template>

--- a/app/controllers/support.js
+++ b/app/controllers/support.js
@@ -10,8 +10,10 @@ const SUPPORTS = [
 
 const VALID_INQUIRE = new Set(SUPPORTS.map(s => s.inquire));
 
+export const SUPPORT_QUERY_PARAMS = ['inquire', 'crate'];
+
 export default class SupportController extends Controller {
-  queryParams = ['inquire', 'crate'];
+  queryParams = SUPPORT_QUERY_PARAMS;
 
   @tracked inquire;
   @tracked crate;

--- a/app/services/pristine-query.js
+++ b/app/services/pristine-query.js
@@ -1,9 +1,0 @@
-import { getOwner } from '@ember/owner';
-import Service from '@ember/service';
-
-export default class PristineParamsService extends Service {
-  paramsFor(route) {
-    let params = getOwner(this).lookup(`controller:${route}`)?.queryParams || [];
-    return Object.fromEntries(params.map(k => [k, null]));
-  }
-}


### PR DESCRIPTION
This PR builds on #12598 and simplifies the "pristine query parameters" concept by removing the corresponding service and instead just importing the relevant query parameter list directly. While this is less flexible than the previous solution, it is also less complex, and since we are only using it in a single place, the complexity does not seem worth it.