### PR TITLE
svelte: Move Fira Sans import to `global.css` file

### DIFF
--- a/svelte/src/app.html
+++ b/svelte/src/app.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css" />
     <link rel="icon" href="/favicon.ico" />
     %sveltekit.head%
   </head>

--- a/svelte/src/lib/css/global.css
+++ b/svelte/src/lib/css/global.css
@@ -3,6 +3,7 @@
 @import './shared/forms.css';
 @import './shared/sort-by.css';
 @import './shared/typography.css';
+@import 'https://code.cdn.mozilla.net/fonts/fira.css';
 
 /*
  * The `normalize.css` file does not use CSS layers, so we need to vendor it


### PR DESCRIPTION
This ensures that the Storybook setup is also showing the right font.

### Related

- https://github.com/rust-lang/crates.io/issues/12515