### PR TITLE
cloudfront: Route invalidations to correct distribution

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -41,9 +41,9 @@ export TEST_DATABASE_URL=
 # export S3_INDEX_REGION=
 
 # Configuration for invalidating cached files on CloudFront. You can leave these
-# commented out if you're not using CloudFront caching for the index files.
-# Uses AWS credentials.
-# export CLOUDFRONT_DISTRIBUTION=
+# commented out if you're not using CloudFront. Uses AWS credentials.
+# export CLOUDFRONT_DISTRIBUTION_ID_INDEX=  # Distribution for index.crates.io
+# export CLOUDFRONT_DISTRIBUTION_ID_STATIC= # Distribution for static.crates.io
 
 # Configuration for the CDN log queue. You can leave these commented out if
 # you're not using the CDN log queue.

--- a/crates/crates_io_database/src/models/cloudfront_invalidation_queue.rs
+++ b/crates/crates_io_database/src/models/cloudfront_invalidation_queue.rs
@@ -1,12 +1,67 @@
 use crate::schema::cloudfront_invalidation_queue;
+use diesel::AsExpression;
+use diesel::deserialize::{self, FromSql, FromSqlRow};
+use diesel::pg::Pg;
 use diesel::prelude::*;
+use diesel::serialize::{self, IsNull, Output, ToSql};
+use diesel::sql_types::Text;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use std::io::Write;
+use std::str::FromStr;
+
+/// CloudFront distribution identifier.
+///
+/// Used to route invalidation requests to the correct CloudFront distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AsExpression, FromSqlRow)]
+#[diesel(sql_type = Text)]
+pub enum CloudFrontDistribution {
+    /// The index.crates.io distribution (sparse index metadata)
+    Index,
+    /// The static.crates.io distribution (crate files, readmes, etc.)
+    Static,
+}
+
+impl CloudFrontDistribution {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Index => "index",
+            Self::Static => "static",
+        }
+    }
+}
+
+impl FromStr for CloudFrontDistribution {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "index" => Ok(Self::Index),
+            "static" => Ok(Self::Static),
+            _ => Err(format!("Unknown CloudFront distribution: {s}")),
+        }
+    }
+}
+
+impl ToSql<Text, Pg> for CloudFrontDistribution {
+    fn to_sql(&self, out: &mut Output<'_, '_, Pg>) -> serialize::Result {
+        out.write_all(self.as_str().as_bytes())?;
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<Text, Pg> for CloudFrontDistribution {
+    fn from_sql(bytes: diesel::pg::PgValue<'_>) -> deserialize::Result<Self> {
+        let value = <String as FromSql<Text, Pg>>::from_sql(bytes)?;
+        Ok(value.parse()?)
+    }
+}
 
 #[derive(Debug, Identifiable, HasQuery, QueryableByName)]
 #[diesel(table_name = cloudfront_invalidation_queue)]
 pub struct CloudFrontInvalidationQueueItem {
     pub id: i64,
     pub path: String,
+    pub distribution: CloudFrontDistribution,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -14,14 +69,19 @@ pub struct CloudFrontInvalidationQueueItem {
 #[diesel(table_name = cloudfront_invalidation_queue, check_for_backend(diesel::pg::Pg))]
 pub struct NewCloudFrontInvalidationQueueItem<'a> {
     pub path: &'a str,
+    pub distribution: CloudFrontDistribution,
 }
 
 impl CloudFrontInvalidationQueueItem {
     /// Queue multiple invalidation paths for later processing
-    pub async fn queue_paths(conn: &mut AsyncPgConnection, paths: &[String]) -> QueryResult<usize> {
+    pub async fn queue_paths(
+        conn: &mut AsyncPgConnection,
+        distribution: CloudFrontDistribution,
+        paths: &[String],
+    ) -> QueryResult<usize> {
         let new_items: Vec<_> = paths
             .iter()
-            .map(|path| NewCloudFrontInvalidationQueueItem { path })
+            .map(|path| NewCloudFrontInvalidationQueueItem { path, distribution })
             .collect();
 
         diesel::insert_into(cloudfront_invalidation_queue::table)
@@ -30,13 +90,15 @@ impl CloudFrontInvalidationQueueItem {
             .await
     }
 
-    /// Fetch the oldest paths from the queue
+    /// Fetch the oldest paths from the queue for a specific distribution
     pub async fn fetch_batch(
         conn: &mut AsyncPgConnection,
+        distribution: CloudFrontDistribution,
         limit: i64,
     ) -> QueryResult<Vec<CloudFrontInvalidationQueueItem>> {
         // Fetch the oldest entries up to the limit
         Self::query()
+            .filter(cloudfront_invalidation_queue::distribution.eq(distribution))
             .order(cloudfront_invalidation_queue::created_at.asc())
             .limit(limit)
             .load(conn)

--- a/crates/crates_io_database/src/models/mod.rs
+++ b/crates/crates_io_database/src/models/mod.rs
@@ -1,6 +1,8 @@
 pub use self::action::{NewVersionOwnerAction, VersionAction, VersionOwnerAction};
 pub use self::category::{Category, CrateCategory, NewCategory};
-pub use self::cloudfront_invalidation_queue::CloudFrontInvalidationQueueItem;
+pub use self::cloudfront_invalidation_queue::{
+    CloudFrontDistribution, CloudFrontInvalidationQueueItem,
+};
 pub use self::crate_owner_invitation::{
     CrateOwnerInvitation, NewCrateOwnerInvitation, NewCrateOwnerInvitationOutcome,
 };

--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -186,6 +186,8 @@ diesel::table! {
     cloudfront_invalidation_queue (id) {
         /// Timestamp when the path was queued for invalidation
         created_at -> Timestamptz,
+        /// CloudFront distribution to invalidate: "index" for index.crates.io, "static" for static.crates.io
+        distribution -> Text,
         /// Unique identifier for each queued invalidation path
         id -> Int8,
         /// CloudFront path to invalidate (e.g. /crates/serde/serde-1.0.0.crate)

--- a/crates/crates_io_database_dump/src/dump-db.toml
+++ b/crates/crates_io_database_dump/src/dump-db.toml
@@ -51,6 +51,7 @@ path = "public"
 
 [cloudfront_invalidation_queue.columns]
 id = "private"
+distribution = "private"
 path = "private"
 created_at = "private"
 

--- a/migrations/2025-12-29-110242-0000_add_distribution_to_cloudfront_invalidation_queue/down.sql
+++ b/migrations/2025-12-29-110242-0000_add_distribution_to_cloudfront_invalidation_queue/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cloudfront_invalidation_queue
+    DROP COLUMN distribution;

--- a/migrations/2025-12-29-110242-0000_add_distribution_to_cloudfront_invalidation_queue/up.sql
+++ b/migrations/2025-12-29-110242-0000_add_distribution_to_cloudfront_invalidation_queue/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE cloudfront_invalidation_queue
+    ADD COLUMN distribution TEXT NOT NULL DEFAULT 'index';
+
+COMMENT ON COLUMN cloudfront_invalidation_queue.distribution IS 'CloudFront distribution to invalidate: "index" for index.crates.io, "static" for static.crates.io';

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -1,5 +1,6 @@
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
+use crates_io_database::models::CloudFrontDistribution;
 use crates_io_database_dump::{DumpDirectory, create_archives};
 use crates_io_worker::BackgroundJob;
 use secrecy::ExposeSecret;
@@ -48,7 +49,9 @@ impl BackgroundJob for DumpDb {
 
         info!("Invalidating CDN caches…");
         let mut conn = env.deadpool.get().await?;
-        if let Err(error) = env.invalidate_cdns(&mut conn, TAR_PATH).await {
+        let dist = CloudFrontDistribution::Static;
+
+        if let Err(error) = env.invalidate_cdns(&mut conn, dist, TAR_PATH).await {
             warn!("Failed to invalidate CDN caches: {error}");
         }
 
@@ -59,7 +62,7 @@ impl BackgroundJob for DumpDb {
         info!("Database dump zip file uploaded");
 
         info!("Invalidating CDN caches…");
-        if let Err(error) = env.invalidate_cdns(&mut conn, ZIP_PATH).await {
+        if let Err(error) = env.invalidate_cdns(&mut conn, dist, ZIP_PATH).await {
             warn!("Failed to invalidate CDN caches: {error}");
         }
 

--- a/src/worker/jobs/invalidate_cdns.rs
+++ b/src/worker/jobs/invalidate_cdns.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use crates_io_database::models::CloudFrontInvalidationQueueItem;
+use crates_io_database::models::{CloudFrontDistribution, CloudFrontInvalidationQueueItem};
 use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
 
@@ -54,7 +54,9 @@ impl BackgroundJob for InvalidateCdns {
         if ctx.cloudfront().is_some() {
             let mut conn = ctx.deadpool.get().await?;
 
-            let result = CloudFrontInvalidationQueueItem::queue_paths(&mut conn, &self.paths).await;
+            let dist = CloudFrontDistribution::Static;
+            let result =
+                CloudFrontInvalidationQueueItem::queue_paths(&mut conn, dist, &self.paths).await;
             result.context("Failed to queue CloudFront invalidation paths")?;
 
             // Schedule the processing job to handle the queued paths

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -2,6 +2,7 @@ use crate::schema::{crates, versions};
 use crate::storage::FeedId;
 use crate::worker::Environment;
 use chrono::{Duration, Utc};
+use crates_io_database::models::CloudFrontDistribution;
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -79,8 +80,9 @@ impl BackgroundJob for SyncCrateFeed {
         info!("Uploading feed to storage…");
         ctx.storage.upload_feed(&feed_id, &channel).await?;
 
+        let dist = CloudFrontDistribution::Static;
         let path = object_store::path::Path::from(&feed_id);
-        if let Err(error) = ctx.invalidate_cdns(&mut conn, path.as_ref()).await {
+        if let Err(error) = ctx.invalidate_cdns(&mut conn, dist, path.as_ref()).await {
             warn!("Failed to invalidate CDN caches: {error}");
         }
 

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -2,6 +2,7 @@ use crate::schema::crates;
 use crate::storage::FeedId;
 use crate::worker::Environment;
 use chrono::{Duration, Utc};
+use crates_io_database::models::CloudFrontDistribution;
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -66,8 +67,9 @@ impl BackgroundJob for SyncCratesFeed {
         info!("Uploading feed to storage…");
         ctx.storage.upload_feed(&feed_id, &channel).await?;
 
+        let dist = CloudFrontDistribution::Static;
         let path = object_store::path::Path::from(&feed_id);
-        if let Err(error) = ctx.invalidate_cdns(&mut conn, path.as_ref()).await {
+        if let Err(error) = ctx.invalidate_cdns(&mut conn, dist, path.as_ref()).await {
             warn!("Failed to invalidate CDN caches: {error}");
         }
 


### PR DESCRIPTION
Add support for two CloudFront distributions (index.crates.io and static.crates.io) instead of using a single distribution for all invalidations.

- Add `distribution` column to `cloudfront_invalidation_queue` table
- Create `CloudFrontDistribution` enum with Diesel traits for type-safe database operations
- Update `CloudFront` client to require both distribution IDs via `CLOUDFRONT_DISTRIBUTION_ID_INDEX` and `CLOUDFRONT_DISTRIBUTION_ID_STATIC`
- Route index metadata invalidations to the index distribution
- Route static file invalidations (crates, readmes, OG images, db dumps, RSS feeds) to the static distribution

Fixes #12609