### PR TITLE
svelte: Extract `SearchForm` context

### DIFF
--- a/svelte/.storybook/preview.ts
+++ b/svelte/.storybook/preview.ts
@@ -3,9 +3,10 @@ import type { Preview } from '@storybook/sveltekit';
 import '../src/lib/css/global.css';
 
 import ColorSchemeDecorator from '../src/lib/storybook/ColorSchemeDecorator.svelte';
+import HeaderSearchDecorator from '../src/lib/storybook/HeaderSearchDecorator.svelte';
 
 const preview: Preview = {
-  decorators: [() => ColorSchemeDecorator],
+  decorators: [() => ColorSchemeDecorator, () => HeaderSearchDecorator],
   initialGlobals: {
     backgrounds: { value: 'content' },
   },

--- a/svelte/src/lib/components/SearchForm.svelte
+++ b/svelte/src/lib/components/SearchForm.svelte
@@ -3,6 +3,7 @@
   import { resolve } from '$app/paths';
 
   import SearchIcon from '$lib/assets/search.svg?component';
+  import { getSearchFormContext } from '$lib/search-form.svelte';
 
   interface Props {
     size?: 'big';
@@ -11,18 +12,17 @@
 
   let { size, autofocus = false }: Props = $props();
 
-  // TODO: move search state into header context instead
-  let searchValue = $state('');
+  let searchFormContext = getSearchFormContext();
   let inputElement: HTMLInputElement | undefined = $state();
 
   function updateSearchValue(event: Event) {
-    searchValue = (event.target as HTMLInputElement).value;
+    searchFormContext.value = (event.target as HTMLInputElement).value;
   }
 
   function search(event: SubmitEvent) {
     event.preventDefault();
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() doesn't support query params
-    goto(`${resolve('/search')}?q=${encodeURIComponent(searchValue)}&page=1`);
+    goto(`${resolve('/search')}?q=${encodeURIComponent(searchFormContext.value)}&page=1`);
   }
 
   function handleKeydown(event: KeyboardEvent) {
@@ -67,7 +67,7 @@
     id="cargo-desktop-search"
     placeholder="Type 'S' or '/' to search"
     autocorrect="off"
-    value={searchValue}
+    value={searchFormContext.value}
     oninput={updateSearchValue}
     {autofocus}
     required
@@ -83,7 +83,7 @@
     name="q"
     placeholder="Search"
     autocorrect="off"
-    value={searchValue}
+    value={searchFormContext.value}
     oninput={updateSearchValue}
     required
     aria-label="Search"

--- a/svelte/src/lib/search-form.svelte.ts
+++ b/svelte/src/lib/search-form.svelte.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'svelte';
+
+export class SearchFormContext {
+  value = $state('');
+}
+
+export const [getSearchFormContext, setSearchFormContext] = createContext<SearchFormContext>();

--- a/svelte/src/lib/storybook/HeaderSearchDecorator.svelte
+++ b/svelte/src/lib/storybook/HeaderSearchDecorator.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  import { SearchFormContext, setSearchFormContext } from '$lib/search-form.svelte';
+
+  let { children }: { children: Snippet } = $props();
+
+  let searchFormContext = new SearchFormContext();
+  setSearchFormContext(searchFormContext);
+</script>
+
+{@render children()}

--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import { ColorSchemeState, setColorScheme } from '$lib/color-scheme.svelte';
   import Footer from '$lib/components/Footer.svelte';
   import Header from '$lib/components/Header.svelte';
+  import { SearchFormContext, setSearchFormContext } from '$lib/search-form.svelte';
 
   import '$lib/css/global.css';
 
@@ -19,6 +20,9 @@
   $effect(() => {
     document.documentElement.dataset.colorScheme = colorScheme.resolvedScheme;
   });
+
+  let searchFormContext = new SearchFormContext();
+  setSearchFormContext(searchFormContext);
 
   // TODO: implement notification container
 </script>

--- a/svelte/src/routes/search/+page.svelte
+++ b/svelte/src/routes/search/+page.svelte
@@ -1,2 +1,19 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/state';
+
+  import { getSearchFormContext } from '$lib/search-form.svelte';
+
+  let searchFormContext = getSearchFormContext();
+
+  // Sync URL ?q= param to header search state
+  $effect(() => {
+    searchFormContext.value = page.url.searchParams.get('q') ?? '';
+  });
+  onMount(() => () => {
+    searchFormContext.value = '';
+  });
+</script>
+
 <h1>Search</h1>
 <p>Stub route for /search</p>


### PR DESCRIPTION
This allows us to overwrite the search field value from within other routes (e.g. the category route like in the Ember.js app).

### Related

- https://github.com/rust-lang/crates.io/issues/12515