### PR TITLE
svelte: Define `__TEST__` constant if running in Playwright or Vitest

### DIFF
--- a/svelte/src/app.d.ts
+++ b/svelte/src/app.d.ts
@@ -1,3 +1,5 @@
+/* eslint-disable prefer-let/prefer-let */
+
 import '@poppanator/sveltekit-svg/dist/svg.d.ts';
 
 // See https://svelte.dev/docs/kit/types#app.d.ts
@@ -10,6 +12,8 @@ declare global {
     // interface PageState {}
     // interface Platform {}
   }
+
+  const __TEST__: boolean;
 }
 
 export {};

--- a/svelte/src/test-constant.spec.ts
+++ b/svelte/src/test-constant.spec.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest';
+
+describe('__TEST__ constant', () => {
+  it('is set to true when running in Vitest', () => {
+    expect(__TEST__).toBe(true);
+  });
+});

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -17,6 +17,10 @@ if (process.env.BUNDLE_ANALYSIS) {
 }
 
 export default defineConfig({
+  define: {
+    __TEST__: Boolean(process.env.PLAYWRIGHT || process.env.VITEST),
+  },
+
   plugins,
 
   server: {


### PR DESCRIPTION
We have a couple of codepaths in the Ember.js app that are disabled in test mode (e.g. the loading progress bar at the top and some debounce timeouts). This PR configures Vite to define a global `__TEST__` constant that will be `true` if the app is running under Playwright or Vitest.

### Related

- https://github.com/rust-lang/crates.io/issues/12515