### PR TITLE
Add disclaimer about not being able to republish package soon after deletion

### DIFF
--- a/app/templates/crate/delete.gjs
+++ b/app/templates/crate/delete.gjs
@@ -19,7 +19,6 @@ import LoadingSpinner from 'crates-io/components/loading-spinner';
       <Alert @variant='warning'>
         <strong>Important:</strong>
         This action will permanently delete the crate and its associated versions. Deleting a crate cannot be reversed!
-        Additionally, you will be blocked from republishing a crate with this name for up to 36 hours.
       </Alert>
 
       <div class='impact'>
@@ -28,6 +27,7 @@ import LoadingSpinner from 'crates-io/components/loading-spinner';
           <li>Users will no longer be able to download this crate.</li>
           <li>Any dependencies or projects relying on this crate will be broken.</li>
           <li>Deleted crates cannot be restored.</li>
+          <li>Publishing a crate with the same name will be blocked for 24 hours.</li>
         </ul>
       </div>
 


### PR DESCRIPTION
I recently deleted a test crate I published. When I tried to re-publish it, I got this error:

```
$ cargo publish
    Updating crates.io index
   Packaging ... v0.1.0 (/Users/alichtman/Desktop/Development/...)
   Uploading ... v0.1.0 (/Users/alichtman/Desktop/Development/...)
error: failed to publish ... v0.1.0 to registry at https://crates.io

Caused by:
  the remote server responded with an error (status 400 Bad Request): A crate with the name `...` was recently deleted. Reuse of this name will be available after 2025-12-31T09:35:20Z.
```

Having this warning message would have prevented me from making this mistake
