### PR TITLE
admin: Add command for sending test publish notification emails

### DIFF
--- a/src/bin/crates-admin/main.rs
+++ b/src/bin/crates-admin/main.rs
@@ -11,6 +11,7 @@ mod migrate;
 mod populate;
 mod render_og_images;
 mod render_readmes;
+mod test_email;
 mod transfer_crates;
 mod upload_index;
 mod verify_token;
@@ -25,6 +26,7 @@ enum Command {
     DeleteVersion(delete_version::Opts),
     Populate(populate::Opts),
     RenderReadmes(render_readmes::Opts),
+    TestEmail(test_email::Opts),
     TransferCrates(transfer_crates::Opts),
     VerifyToken(verify_token::Opts),
     Migrate(migrate::Opts),
@@ -56,6 +58,7 @@ async fn main() -> anyhow::Result<()> {
         Command::DeleteVersion(opts) => delete_version::run(opts).await,
         Command::Populate(opts) => populate::run(opts).await,
         Command::RenderReadmes(opts) => render_readmes::run(opts).await,
+        Command::TestEmail(opts) => test_email::run(opts).await,
         Command::TransferCrates(opts) => transfer_crates::run(opts).await,
         Command::VerifyToken(opts) => verify_token::run(opts).await,
         Command::Migrate(opts) => migrate::run(opts).await,

--- a/src/bin/crates-admin/test_email.rs
+++ b/src/bin/crates-admin/test_email.rs
@@ -1,0 +1,74 @@
+use anyhow::Context;
+use chrono::{SecondsFormat, Utc};
+use crates_io::config::Server;
+use crates_io::email::{EmailMessage, Emails};
+use minijinja::context;
+
+#[derive(clap::Parser, Debug)]
+#[command(
+    name = "test-email",
+    about = "Send a test publish notification email.",
+    long_about = "Send a test publish notification email to the specified address. \
+        This is useful for verifying that the email system is working correctly. \
+        All template parameters can be customized, or defaults will be used."
+)]
+pub struct Opts {
+    /// The email address to send the test email to
+    #[arg(long, short)]
+    email: String,
+
+    /// The recipient name to use in the email greeting
+    #[arg(long, default_value = "testuser")]
+    recipient: String,
+
+    /// The crate name to use in the email
+    #[arg(long = "crate", default_value = "test-crate")]
+    krate: String,
+
+    /// The version number to use in the email
+    #[arg(long, default_value = "1.0.0")]
+    version: String,
+
+    /// The publisher info string
+    #[arg(long, default_value = " by testpublisher")]
+    publisher_info: String,
+}
+
+pub async fn run(opts: Opts) -> anyhow::Result<()> {
+    let config = Server::from_environment().context("Failed to load server configuration")?;
+    let emails = Emails::from_environment(&config);
+
+    let publish_time = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    let email = EmailMessage::from_template(
+        "publish_notification",
+        context! {
+            recipient => opts.recipient,
+            krate => opts.krate,
+            version => opts.version,
+            publish_time => publish_time,
+            publisher_info => opts.publisher_info,
+            domain => emails.domain
+        },
+    )
+    .context("Failed to render email template")?;
+
+    println!(
+        "Sending test publish notification email to {}...",
+        opts.email
+    );
+    println!();
+    println!("Subject: {}", email.subject);
+    println!();
+    println!("Body:");
+    println!("{}", email.body_text);
+
+    emails
+        .send(&opts.email, email)
+        .await
+        .context("Failed to send email")?;
+
+    println!("Email sent successfully!");
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a new `test-email` admin command that allows sending test publish notification emails to verify the email system is working correctly.

The command accepts:
- `--email` (required): The recipient email address
- `--recipient`: The name to use in the email greeting (default: "testuser")
- `--crate`: The crate name to use in the email (default: "test-crate")
- `--version`: The version number to use (default: "1.0.0")
- `--publisher-info`: The publisher info string (default: " by testpublisher")

Example usage:

```sh
crates-admin test-email --email test@example.com
crates-admin test-email --email test@example.com --crate my-crate --version 2.0.0
```

### Related

- #12597