### PR TITLE
svelte: Implement `/keywords/[keyword_id]` route

### DIFF
--- a/svelte/src/routes/keywords/[keyword_id]/+page.svelte
+++ b/svelte/src/routes/keywords/[keyword_id]/+page.svelte
@@ -1,6 +1,66 @@
 <script lang="ts">
+  import CrateList from '$lib/components/CrateList.svelte';
+  import PageHeader from '$lib/components/PageHeader.svelte';
+  import Pagination from '$lib/components/Pagination.svelte';
+  import ResultsCount from '$lib/components/ResultsCount.svelte';
+  import * as SortDropdown from '$lib/components/sort-dropdown';
+  import { calculatePagination } from '$lib/utils/pagination';
+
   let { data } = $props();
+
+  let pagination = $derived(calculatePagination(data.page, data.perPage, data.crates.meta.total, data.maxPages));
+
+  let currentSortBy = $derived.by(() => {
+    switch (data.sort) {
+      case 'alpha':
+        return 'Alphabetical';
+      case 'downloads':
+        return 'All-Time Downloads';
+      case 'recent-updates':
+        return 'Recent Updates';
+      case 'new':
+        return 'Newly Added';
+      default:
+        return 'Recent Downloads';
+    }
+  });
 </script>
 
-<h1>Keyword: {data.keyword_id}</h1>
-<p>Stub route for /keywords/:keyword_id</p>
+<svelte:head>
+  <title>{data.keyword} - Keywords - crates.io</title>
+</svelte:head>
+
+<PageHeader title="All Crates" suffix="for keyword '{data.keyword}'" />
+
+<div class="results-meta">
+  <ResultsCount
+    start={pagination.currentPageStart}
+    end={pagination.currentPageEnd}
+    total={data.crates.meta.total}
+    data-test-keyword-nav
+  />
+
+  <div data-test-keyword-sort class="sort-by-v-center">
+    <span class="text--small">Sort by</span>
+    <SortDropdown.Root current={currentSortBy}>
+      <SortDropdown.Option query={{ sort: 'alpha' }}>Alphabetical</SortDropdown.Option>
+      <SortDropdown.Option query={{ sort: 'downloads' }}>All-Time Downloads</SortDropdown.Option>
+      <SortDropdown.Option query={{ sort: 'recent-downloads' }}>Recent Downloads</SortDropdown.Option>
+      <SortDropdown.Option query={{ sort: 'recent-updates' }}>Recent Updates</SortDropdown.Option>
+      <SortDropdown.Option query={{ sort: 'new' }}>Newly Added</SortDropdown.Option>
+    </SortDropdown.Root>
+  </div>
+</div>
+
+<CrateList crates={data.crates.crates} style="margin-bottom: var(--space-s);" />
+
+<Pagination {pagination} />
+
+<style>
+  .results-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-s);
+  }
+</style>

--- a/svelte/src/routes/keywords/[keyword_id]/+page.ts
+++ b/svelte/src/routes/keywords/[keyword_id]/+page.ts
@@ -1,3 +1,36 @@
-export function load({ params }) {
-  return { keyword_id: params.keyword_id };
+import { createClient } from '@crates-io/api-client';
+
+const MAX_PAGES = 20;
+
+export async function load({ fetch, url, params }) {
+  let client = createClient({ fetch });
+
+  let keyword = params.keyword_id;
+  let page = parseInt(url.searchParams.get('page') ?? '1', 10);
+  let perPage = 10;
+  let sort = url.searchParams.get('sort') ?? 'recent-downloads';
+
+  let response = await client.GET('/api/v1/crates', {
+    params: {
+      query: {
+        keyword,
+        page,
+        per_page: perPage,
+        sort,
+      },
+    },
+  });
+
+  if (response.error) {
+    throw new Error(`Failed to fetch crates for keyword "${keyword}"`);
+  }
+
+  return {
+    keyword,
+    crates: response.data,
+    page,
+    perPage,
+    sort,
+    maxPages: MAX_PAGES,
+  };
 }


### PR DESCRIPTION
<img width="968" height="864" alt="Bildschirmfoto 2025-12-30 um 18 26 49" src="https://github.com/user-attachments/assets/2ce73c9c-2428-49e0-a997-4bf346b2c4a9" />


### Related

- https://github.com/rust-lang/crates.io/issues/12515