### PR TITLE
storybook: Use `normal` theme for docs pages

### DIFF
--- a/svelte/.storybook/preview.ts
+++ b/svelte/.storybook/preview.ts
@@ -1,5 +1,7 @@
 import type { Preview } from '@storybook/sveltekit';
 
+import { themes } from 'storybook/theming';
+
 import '../src/lib/css/global.css';
 
 import ColorSchemeDecorator from '../src/lib/storybook/ColorSchemeDecorator.svelte';
@@ -29,6 +31,11 @@ const preview: Preview = {
         color: /(background|color)$/i,
         date: /Date$/i,
       },
+    },
+    docs: {
+      // Storybook's docs pages default to light theme regardless of system preference.
+      // The `normal` theme adapts to system preference, so we set it here to keep things consistent.
+      theme: themes.normal,
     },
   },
 };


### PR DESCRIPTION
For some reason the `light` theme is the default for Storybook, even though the sidebar switches to dark mode according to system preferences. This change adjusts the theme used by the generated docs pages to also support dark mode.

### Related

- https://github.com/rust-lang/crates.io/issues/12515