### PR TITLE
svelte: Add custom `getByCSS()` locator

### DIFF
--- a/svelte/src/test/setup-browser.ts
+++ b/svelte/src/test/setup-browser.ts
@@ -1,0 +1,15 @@
+import type { Locator } from 'vitest/browser';
+
+import { locators } from 'vitest/browser';
+
+declare module 'vitest/browser' {
+  interface LocatorSelectors {
+    getByCSS(css: string): Locator;
+  }
+}
+
+locators.extend({
+  getByCSS(css: string) {
+    return `css=${css}`;
+  },
+});

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
 
         test: {
           name: 'client',
+          setupFiles: ['./src/test/setup-browser.ts'],
 
           browser: {
             enabled: true,


### PR DESCRIPTION
This allows us to keep using the `data-test-foo="bar"` test selector pattern for now and makes it easier to migrate the existing tests.

### Related

- https://github.com/rust-lang/crates.io/issues/12515