### PR TITLE
svelte: Add `crate-sidebar/Link` component

### DIFF
--- a/svelte/src/lib/components/crate-sidebar/Link.stories.svelte
+++ b/svelte/src/lib/components/crate-sidebar/Link.stories.svelte
@@ -1,0 +1,17 @@
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Link from './Link.svelte';
+
+  const { Story } = defineMeta({
+    title: 'crate-sidebar/Link',
+    component: Link,
+    tags: ['autodocs'],
+  });
+</script>
+
+<Story name="Generic Link" args={{ title: 'Homepage', url: 'https://www.rust-lang.org' }} />
+<Story name="GitHub Link" args={{ title: 'Repository', url: 'https://github.com/rust-lang/crates.io' }} />
+<Story name="GitLab Link" args={{ title: 'Repository', url: 'https://gitlab.com/example/project' }} />
+<Story name="Codeberg Link" args={{ title: 'Repository', url: 'https://codeberg.org/example/project' }} />
+<Story name="docs.rs Link" args={{ title: 'Documentation', url: 'https://docs.rs/tracing' }} />

--- a/svelte/src/lib/components/crate-sidebar/Link.svelte
+++ b/svelte/src/lib/components/crate-sidebar/Link.svelte
@@ -1,0 +1,82 @@
+<script module lang="ts">
+  export function simplifyUrl(url: string): string {
+    if (url.startsWith('https://')) {
+      url = url.slice('https://'.length);
+    }
+    if (url.startsWith('www.')) {
+      url = url.slice('www.'.length);
+    }
+    if (url.endsWith('/')) {
+      url = url.slice(0, -1);
+    }
+    if (url.startsWith('github.com/') && url.endsWith('.git')) {
+      url = url.slice(0, -4);
+    }
+
+    return url;
+  }
+</script>
+
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  import CodebergIcon from '$lib/assets/codeberg.svg?component';
+  import DocsRsIcon from '$lib/assets/docs-rs.svg?component';
+  import GitHubIcon from '$lib/assets/github.svg?component';
+  import GitLabIcon from '$lib/assets/gitlab.svg?component';
+  import LinkIcon from '$lib/assets/link.svg?component';
+
+  interface Props extends HTMLAttributes<HTMLDivElement> {
+    title: string;
+    url: string;
+  }
+
+  let { url, title, ...restProps }: Props = $props();
+
+  let text = $derived(simplifyUrl(url));
+</script>
+
+<div {...restProps}>
+  <h2 class="title" data-test-title>{title}</h2>
+  <div class="content">
+    {#if text.startsWith('docs.rs/')}
+      <DocsRsIcon class="icon" data-test-icon="docs-rs" />
+    {:else if text.startsWith('github.com/')}
+      <GitHubIcon class="icon" data-test-icon="github" />
+    {:else if text.startsWith('gitlab.com/')}
+      <GitLabIcon class="icon" data-test-icon="gitlab" />
+    {:else if text.startsWith('codeberg.org/')}
+      <CodebergIcon class="icon" data-test-icon="codeberg" />
+    {:else}
+      <LinkIcon class="icon" data-test-icon="link" />
+    {/if}
+
+    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+    <a href={url} class="link" data-test-link>{text}</a>
+  </div>
+</div>
+
+<style>
+  .content {
+    display: flex;
+    align-items: center;
+  }
+
+  .title {
+    font-size: 1.17em;
+    margin: 0 0 var(--space-s);
+  }
+
+  .content :global(.icon) {
+    flex-shrink: 0;
+    height: 1em;
+    width: auto;
+    margin-right: var(--space-2xs);
+  }
+
+  .link {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/svelte/src/lib/components/crate-sidebar/Link.svelte.test.ts
+++ b/svelte/src/lib/components/crate-sidebar/Link.svelte.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+import Link, { simplifyUrl } from './Link.svelte';
+
+describe('simplifyUrl', () => {
+  it('strips https:// prefix', () => {
+    expect(simplifyUrl('https://rust-lang.org')).toBe('rust-lang.org');
+  });
+
+  it('strips www. prefix', () => {
+    expect(simplifyUrl('https://www.rust-lang.org')).toBe('rust-lang.org');
+  });
+
+  it('does not strip http:// prefix', () => {
+    expect(simplifyUrl('http://www.rust-lang.org')).toBe('http://www.rust-lang.org');
+  });
+
+  it('strips trailing slashes', () => {
+    expect(simplifyUrl('https://www.rust-lang.org/')).toBe('rust-lang.org');
+  });
+
+  it('strips trailing .git from GitHub project URLs', () => {
+    expect(simplifyUrl('https://github.com/rust-lang/crates.io.git')).toBe('github.com/rust-lang/crates.io');
+  });
+
+  it('does not strip trailing .git from non-GitHub URLs', () => {
+    expect(simplifyUrl('https://foo.git/')).toBe('foo.git');
+  });
+});
+
+describe('Link component', () => {
+  it('renders title and link', async () => {
+    render(Link, { title: 'Homepage', url: 'https://www.rust-lang.org' });
+
+    await expect.element(page.getByCSS('[data-test-title]')).toHaveTextContent('Homepage');
+    await expect.element(page.getByCSS('[data-test-icon]')).toHaveAttribute('data-test-icon', 'link');
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveAttribute('href', 'https://www.rust-lang.org');
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveTextContent('rust-lang.org');
+  });
+
+  it('renders GitHub icon for GitHub links', async () => {
+    render(Link, { title: 'Repository', url: 'https://github.com/rust-lang/crates.io' });
+
+    await expect.element(page.getByCSS('[data-test-icon]')).toHaveAttribute('data-test-icon', 'github');
+    await expect
+      .element(page.getByCSS('[data-test-link]'))
+      .toHaveAttribute('href', 'https://github.com/rust-lang/crates.io');
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveTextContent('github.com/rust-lang/crates.io');
+  });
+
+  it('renders docs.rs icon for docs.rs links', async () => {
+    render(Link, { title: 'Documentation', url: 'https://docs.rs/tracing' });
+
+    await expect.element(page.getByCSS('[data-test-icon]')).toHaveAttribute('data-test-icon', 'docs-rs');
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveAttribute('href', 'https://docs.rs/tracing');
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveTextContent('docs.rs/tracing');
+  });
+
+  it('renders GitLab icon for GitLab links', async () => {
+    render(Link, { title: 'Repository', url: 'https://gitlab.com/example/project' });
+
+    await expect.element(page.getByCSS('[data-test-icon]')).toHaveAttribute('data-test-icon', 'gitlab');
+  });
+
+  it('renders Codeberg icon for Codeberg links', async () => {
+    render(Link, { title: 'Repository', url: 'https://codeberg.org/example/project' });
+
+    await expect.element(page.getByCSS('[data-test-icon]')).toHaveAttribute('data-test-icon', 'codeberg');
+  });
+
+  it('does not shorten HTTP links', async () => {
+    render(Link, { title: 'Homepage', url: 'http://www.rust-lang.org' });
+
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveAttribute('href', 'http://www.rust-lang.org');
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveTextContent('http://www.rust-lang.org');
+  });
+
+  it('strips trailing slashes', async () => {
+    render(Link, { title: 'Homepage', url: 'https://www.rust-lang.org/' });
+
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveAttribute('href', 'https://www.rust-lang.org/');
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveTextContent('rust-lang.org');
+  });
+
+  it('strips trailing .git from GitHub project URLs', async () => {
+    render(Link, { title: 'Repository', url: 'https://github.com/rust-lang/crates.io.git' });
+
+    await expect
+      .element(page.getByCSS('[data-test-link]'))
+      .toHaveAttribute('href', 'https://github.com/rust-lang/crates.io.git');
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveTextContent('github.com/rust-lang/crates.io');
+  });
+
+  it('does not strip trailing .git from non-GitHub URLs', async () => {
+    render(Link, { title: 'Homepage', url: 'https://foo.git/' });
+
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveAttribute('href', 'https://foo.git/');
+    await expect.element(page.getByCSS('[data-test-link]')).toHaveTextContent('foo.git');
+  });
+});


### PR DESCRIPTION
<img width="839" height="925" alt="Bildschirmfoto 2026-01-04 um 14 03 10" src="https://github.com/user-attachments/assets/45ded0d6-91b5-4044-8cb2-174c1ed57302" />

### Related

- https://github.com/rust-lang/crates.io/issues/12515