### PR TITLE
svelte: Prefix tooltip container element ID to avoid conflicts

### DIFF
--- a/svelte/src/lib/storybook/TooltipDecorator.svelte
+++ b/svelte/src/lib/storybook/TooltipDecorator.svelte
@@ -5,9 +5,9 @@
   import { setTooltipContext } from '$lib/tooltip.svelte';
 
   let { children }: { children: Snippet } = $props();
+  let propsId = $props.id();
 
-  let tooltipContainerId = $props.id();
-  setTooltipContext({ containerId: tooltipContainerId });
+  setTooltipContext({ containerId: `tooltip-container-${propsId}` });
 </script>
 
 {@render children()}

--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
   import '$lib/css/global.css';
 
   let { children } = $props();
+  let propsId = $props.id();
 
   let isIndex = $derived(page.route.id === '/');
 
@@ -37,8 +38,7 @@
     }
   });
 
-  let tooltipContainerId = $props.id();
-  setTooltipContext({ containerId: tooltipContainerId });
+  setTooltipContext({ containerId: `tooltip-container-${propsId}` });
 
   let notifications = new NotificationsState();
   setNotifications(notifications);


### PR DESCRIPTION
### Related

- https://github.com/rust-lang/crates.io/issues/12515