### PR TITLE
svelte: Migrate `Alert` component

### DIFF
--- a/svelte/src/lib/components/Alert.stories.svelte
+++ b/svelte/src/lib/components/Alert.stories.svelte
@@ -1,0 +1,28 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Alert from './Alert.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Alert',
+    component: Alert,
+    tags: ['autodocs'],
+    argTypes: {
+      children: { table: { disable: true } },
+    },
+  });
+</script>
+
+<Story name="Note" args={{ variant: 'note' }}>This is a note alert with some informational content.</Story>
+
+<Story name="Success" args={{ variant: 'success' }}>This action completed successfully!</Story>
+
+<Story name="Tip" args={{ variant: 'tip' }}>Here's a helpful tip for you.</Story>
+
+<Story name="Important" args={{ variant: 'important' }}>This is an important message that requires attention.</Story>
+
+<Story name="Warning" args={{ variant: 'warning' }}>Warning: Please review before proceeding.</Story>
+
+<Story name="Caution" args={{ variant: 'caution' }}>Caution: This action cannot be undone.</Story>
+
+<Story name="Without Icon" args={{ variant: 'note', hideIcon: true }}>This alert has no icon displayed.</Story>

--- a/svelte/src/lib/components/Alert.svelte
+++ b/svelte/src/lib/components/Alert.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  import AlertCautionIcon from '$lib/assets/alert-caution.svg?component';
+  import AlertImportantIcon from '$lib/assets/alert-important.svg?component';
+  import AlertNoteIcon from '$lib/assets/alert-note.svg?component';
+  import AlertTipIcon from '$lib/assets/alert-tip.svg?component';
+  import AlertWarningIcon from '$lib/assets/alert-warning.svg?component';
+  import CheckCircleIcon from '$lib/assets/check-circle.svg?component';
+
+  interface Props extends HTMLAttributes<HTMLDivElement> {
+    variant: 'note' | 'success' | 'tip' | 'important' | 'warning' | 'caution';
+    hideIcon?: boolean;
+    children: Snippet;
+  }
+
+  let { variant, hideIcon = false, children, class: className, ...others }: Props = $props();
+</script>
+
+<div data-test-alert class={['alert', className]} data-variant={variant} {...others}>
+  {#if !hideIcon}
+    {#if variant === 'note'}
+      <AlertNoteIcon />
+    {:else if variant === 'success'}
+      <CheckCircleIcon />
+    {:else if variant === 'tip'}
+      <AlertTipIcon />
+    {:else if variant === 'important'}
+      <AlertImportantIcon />
+    {:else if variant === 'warning'}
+      <AlertWarningIcon />
+    {:else if variant === 'caution'}
+      <AlertCautionIcon />
+    {/if}
+  {/if}
+  <div class="alert-content">
+    {@render children()}
+  </div>
+</div>
+
+<style>
+  .alert {
+    display: flex;
+    padding: var(--space-xs);
+    border-left-style: solid;
+    border-left-width: 4px;
+    border-radius: var(--space-3xs);
+  }
+
+  .alert :global(svg) {
+    flex-shrink: 0;
+    width: 1em;
+    height: 1em;
+    margin-right: var(--space-xs);
+  }
+
+  .alert[data-variant='note'] {
+    background-color: light-dark(hsl(213, 93%, 90%), hsl(213, 50%, 20%));
+    border-color: hsl(213, 93%, 62%);
+  }
+
+  .alert[data-variant='note'] :global(svg) {
+    color: hsl(213, 93%, 62%);
+  }
+
+  .alert[data-variant='tip'],
+  .alert[data-variant='success'] {
+    background-color: light-dark(hsl(128, 49%, 90%), hsl(128, 30%, 20%));
+    border-color: hsl(128, 49%, 49%);
+  }
+
+  .alert[data-variant='tip'] :global(svg),
+  .alert[data-variant='success'] :global(svg) {
+    color: hsl(128, 49%, 49%);
+  }
+
+  .alert[data-variant='important'] {
+    background-color: light-dark(hsl(262, 90%, 90%), hsl(262, 50%, 20%));
+    border-color: hsl(262, 90%, 73%);
+  }
+
+  .alert[data-variant='important'] :global(svg) {
+    color: hsl(262, 90%, 73%);
+  }
+
+  .alert[data-variant='warning'] {
+    background-color: light-dark(var(--yellow100), var(--yellow900));
+    border-color: var(--yellow500);
+  }
+
+  .alert[data-variant='warning'] :global(svg) {
+    color: var(--yellow500);
+  }
+
+  .alert[data-variant='caution'] {
+    background-color: light-dark(hsl(3, 93%, 90%), hsl(3, 50%, 20%));
+    border-color: hsl(3, 93%, 63%);
+  }
+
+  .alert[data-variant='caution'] :global(svg) {
+    color: hsl(3, 93%, 63%);
+  }
+
+  .alert-content {
+    text-wrap: pretty;
+  }
+</style>


### PR DESCRIPTION
<img width="849" height="846" alt="Bildschirmfoto 2026-01-04 um 18 58 50" src="https://github.com/user-attachments/assets/e3fe8152-0ef8-4fa5-aaca-4ff6590f70af" />

### Related

- https://github.com/rust-lang/crates.io/issues/12515