### PR TITLE
svelte: Migrate `/search` route

### DIFF
--- a/svelte/src/lib/utils/search.test.ts
+++ b/svelte/src/lib/utils/search.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+
+import { hasMultiCategoryFilter, processSearchQuery } from './search';
+
+describe('processSearchQuery', () => {
+  test.for([
+    ['foo', { q: 'foo' }],
+    ['  foo    bar     ', { q: 'foo bar' }],
+    ['foo keyword:bar', { q: 'foo', keyword: 'bar' }],
+    ['foo keyword:', { q: 'foo' }],
+    ['keyword:bar foo', { q: 'foo', keyword: 'bar' }],
+    ['foo \t   keyword:bar    baz', { q: 'foo baz', keyword: 'bar' }],
+    ['foo keyword:bar keyword:baz', { q: 'foo', all_keywords: 'bar baz' }],
+    ['foo category:', { q: 'foo' }],
+    ['foo category:no-std', { q: 'foo', category: 'no-std' }],
+    ['foo category:no-std keyword:bar keyword:baz', { q: 'foo', all_keywords: 'bar baz', category: 'no-std' }],
+  ] as const)('%s', ([input, expected]) => {
+    expect(processSearchQuery(input)).toEqual(expected);
+  });
+});
+
+describe('hasMultiCategoryFilter', () => {
+  test.for([
+    ['foo bar', false],
+    ['foo category:bar', false],
+    ['foo category:bar category:baz', true],
+    ['foo category:', false],
+  ] as const)('%s → %s', ([input, expected]) => {
+    expect(hasMultiCategoryFilter(input)).toBe(expected);
+  });
+});

--- a/svelte/src/lib/utils/search.ts
+++ b/svelte/src/lib/utils/search.ts
@@ -1,0 +1,64 @@
+const CATEGORY_PREFIX = 'category:';
+const KEYWORD_PREFIX = 'keyword:';
+
+export interface SearchParams {
+  q: string;
+  keyword?: string;
+  all_keywords?: string;
+  category?: string;
+}
+
+/**
+ * Process a search query string and extract filters like `keyword:` and `category:`.
+ *
+ * Examples:
+ * - "rust database" → { q: "rust database" }
+ * - "rust keyword:async" → { q: "rust", keyword: "async" }
+ * - "keyword:async keyword:web" → { q: "", all_keywords: "async web" }
+ * - "rust category:algorithms" → { q: "rust", category: "algorithms" }
+ */
+export function processSearchQuery(query: string): SearchParams {
+  let tokens = query.trim().split(/\s+/);
+
+  let queries: string[] = [];
+  let keywords: string[] = [];
+  let category: string | null = null;
+
+  for (let token of tokens) {
+    if (token.startsWith(CATEGORY_PREFIX)) {
+      let value = token.slice(CATEGORY_PREFIX.length).trim();
+      if (value) {
+        category = value;
+      }
+    } else if (token.startsWith(KEYWORD_PREFIX)) {
+      let value = token.slice(KEYWORD_PREFIX.length).trim();
+      if (value) {
+        keywords.push(value);
+      }
+    } else {
+      queries.push(token);
+    }
+  }
+
+  let result: SearchParams = { q: queries.join(' ') };
+
+  if (keywords.length === 1) {
+    result.keyword = keywords[0];
+  } else if (keywords.length !== 0) {
+    result.all_keywords = keywords.join(' ');
+  }
+
+  if (category) {
+    result.category = category;
+  }
+
+  return result;
+}
+
+/**
+ * Check if the query contains multiple category: filters (which is not yet supported).
+ */
+export function hasMultiCategoryFilter(query: string): boolean {
+  let tokens = query.trim().split(/\s+/);
+  return tokens.filter(token => token.startsWith(CATEGORY_PREFIX)).length > 1;
+}

--- a/svelte/src/routes/search/+page.svelte
+++ b/svelte/src/routes/search/+page.svelte
@@ -2,7 +2,19 @@
   import { onMount } from 'svelte';
   import { page } from '$app/state';
 
+  import Alert from '$lib/components/Alert.svelte';
+  import CrateList from '$lib/components/CrateList.svelte';
+  import PageHeader from '$lib/components/PageHeader.svelte';
+  import Pagination from '$lib/components/Pagination.svelte';
+  import ResultsCount from '$lib/components/ResultsCount.svelte';
+  import * as SortDropdown from '$lib/components/sort-dropdown';
   import { getSearchFormContext } from '$lib/search-form.svelte';
+  import { calculatePagination } from '$lib/utils/pagination';
+  import { hasMultiCategoryFilter } from '$lib/utils/search';
+
+  const MAX_PAGES = 20;
+
+  let { data } = $props();
 
   let searchFormContext = getSearchFormContext();
 
@@ -13,7 +25,74 @@
   onMount(() => () => {
     searchFormContext.value = '';
   });
+
+  let pagination = $derived(calculatePagination(data.page, data.perPage, data.cratesResponse.meta.total, MAX_PAGES));
+
+  let currentSortBy = $derived.by(() => {
+    switch (data.sort) {
+      case 'downloads':
+        return 'All-Time Downloads';
+      case 'recent-downloads':
+        return 'Recent Downloads';
+      case 'recent-updates':
+        return 'Recent Updates';
+      case 'new':
+        return 'Newly Added';
+      default:
+        return 'Relevance';
+    }
+  });
+
+  let pageTitle = $derived('Search Results' + (data.q ? ` for '${data.q}'` : ''));
 </script>
 
-<h1>Search</h1>
-<p>Stub route for /search</p>
+<svelte:head>
+  <title>{pageTitle} - crates.io</title>
+</svelte:head>
+
+<PageHeader title="Search Results" suffix={data.q ? `for '${data.q}'` : undefined} data-test-header />
+
+{#if hasMultiCategoryFilter(data.q)}
+  <Alert variant="warning">
+    Support for using multiple <code>category:</code> filters is not yet implemented.
+  </Alert>
+{/if}
+
+{#if data.cratesResponse.meta.total > 0}
+  <div class="results-meta">
+    <ResultsCount
+      start={pagination.currentPageStart}
+      end={pagination.currentPageEnd}
+      total={data.cratesResponse.meta.total}
+      data-test-search-nav
+    />
+
+    <div data-test-search-sort class="sort-by-v-center">
+      <span class="text--small">Sort by</span>
+      <SortDropdown.Root current={currentSortBy}>
+        <SortDropdown.Option query={{ page: '1', sort: 'relevance' }}>Relevance</SortDropdown.Option>
+        <SortDropdown.Option query={{ page: '1', sort: 'downloads' }}>All-Time Downloads</SortDropdown.Option>
+        <SortDropdown.Option query={{ page: '1', sort: 'recent-downloads' }}>Recent Downloads</SortDropdown.Option>
+        <SortDropdown.Option query={{ page: '1', sort: 'recent-updates' }}>Recent Updates</SortDropdown.Option>
+        <SortDropdown.Option query={{ page: '1', sort: 'new' }}>Newly Added</SortDropdown.Option>
+      </SortDropdown.Root>
+    </div>
+  </div>
+
+  <CrateList crates={data.cratesResponse.crates} style="margin-bottom: var(--space-s);" />
+
+  <Pagination {pagination} />
+{:else}
+  <h2>
+    0 crates found. <a href="https://doc.rust-lang.org/cargo/getting-started/">Get started</a> and create your own.
+  </h2>
+{/if}
+
+<style>
+  .results-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-s);
+  }
+</style>

--- a/svelte/src/routes/search/+page.ts
+++ b/svelte/src/routes/search/+page.ts
@@ -1,0 +1,50 @@
+import type { paths } from '@crates-io/api-client';
+
+import { createClient } from '@crates-io/api-client';
+import { error } from '@sveltejs/kit';
+
+import { processSearchQuery } from '$lib/utils/search';
+
+export async function load({ fetch, url }) {
+  let client = createClient({ fetch });
+
+  let q = url.searchParams.get('q') ?? '';
+  let page = parseInt(url.searchParams.get('page') ?? '1', 10);
+  let perPage = 10;
+  let sort = url.searchParams.get('sort') ?? 'relevance';
+  let allKeywords = url.searchParams.get('all_keywords');
+
+  let query = q.trim();
+
+  let searchParams = allKeywords
+    ? { page, per_page: perPage, sort, q: query, all_keywords: allKeywords }
+    : { page, per_page: perPage, sort, ...processSearchQuery(query) };
+
+  let cratesResponse = await loadCrates(client, searchParams);
+
+  return { q, cratesResponse, page, perPage, sort };
+}
+
+function loadCratesError(status: number): never {
+  error(status, { message: 'Failed to load search results', tryAgain: true });
+}
+
+async function loadCrates(
+  client: ReturnType<typeof createClient>,
+  query: paths['/api/v1/crates']['get']['parameters']['query'],
+) {
+  let response;
+  try {
+    response = await client.GET('/api/v1/crates', { params: { query } });
+  } catch (_error) {
+    // Network errors are treated as `504 Gateway Timeout`
+    loadCratesError(504);
+  }
+
+  let status = response.response.status;
+  if (response.error) {
+    loadCratesError(status);
+  }
+
+  return response.data;
+}


### PR DESCRIPTION
This data loading implementation is intentionally simplified compared to the Ember.js app, but with the advantage of supporting server-side rendering and reduced complexity.

### Related

- https://github.com/rust-lang/crates.io/issues/12515