### PR TITLE
svelte: Add empty `/crates/[crate_id]/security` route

### DIFF
--- a/svelte/src/routes/crates/[crate_id]/security/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/security/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<h1>Crate Security: {data.crate_id}</h1>
+<p>Stub route for /crates/:crate_id/security</p>

--- a/svelte/src/routes/crates/[crate_id]/security/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/security/+page.ts
@@ -1,0 +1,3 @@
+export function load({ params }) {
+  return { crate_id: params.crate_id };
+}


### PR DESCRIPTION
### Related

- https://github.com/rust-lang/crates.io/issues/12515
- #12311