### PR TITLE
svelte: Add `.markdown-alert` styles to `TextContent` component

### DIFF
--- a/svelte/src/lib/components/TextContent.stories.svelte
+++ b/svelte/src/lib/components/TextContent.stories.svelte
@@ -19,3 +19,38 @@
   <h2>Boxed Content</h2>
   <p>This content appears in a boxed container with padding and background color.</p>
 </Story>
+
+<Story name="Alerts">
+  <div class="markdown-alert markdown-alert-note">
+    <p class="markdown-alert-title">Note</p>
+    <p>Useful information that users should know, even when skimming content.</p>
+  </div>
+  <div class="markdown-alert markdown-alert-tip">
+    <p class="markdown-alert-title">Tip</p>
+    <p>Helpful advice for doing things better or more easily.</p>
+  </div>
+  <div class="markdown-alert markdown-alert-important">
+    <p class="markdown-alert-title">Important</p>
+    <p>Key information users need to know to achieve their goal.</p>
+  </div>
+  <div class="markdown-alert markdown-alert-warning">
+    <p class="markdown-alert-title">Warning</p>
+    <p>Urgent info that needs immediate user attention to avoid problems.</p>
+  </div>
+  <div class="markdown-alert markdown-alert-caution">
+    <p class="markdown-alert-title">Caution</p>
+    <p>Advises about risks or negative outcomes of certain actions.</p>
+  </div>
+
+  <div class="markdown-alert markdown-alert-note">
+    <p class="markdown-alert-title">Note</p>
+    <div class="markdown-alert markdown-alert-important">
+      <p class="markdown-alert-title">Important</p>
+      <div class="markdown-alert markdown-alert-caution">
+        <p class="markdown-alert-title">Caution</p>
+        <p>Rick roll</p>
+        <p>Never gonna give you up</p>
+      </div>
+    </div>
+  </div>
+</Story>

--- a/svelte/src/lib/components/TextContent.svelte
+++ b/svelte/src/lib/components/TextContent.svelte
@@ -192,5 +192,107 @@
       color: light-dark(#b31d28, #ffdcd7);
       background-color: light-dark(#ffeef0, #67060c);
     }
+
+    /* alerts */
+    :global(.markdown-alert) {
+      --fg-color-note: #4494f8;
+      --fg-color-tip: #3fb950;
+      --fg-color-important: #ab7df8;
+      --fg-color-warning: #d29922;
+      --fg-color-caution: #f85149;
+
+      padding: 0.5rem 1rem;
+      margin-bottom: 1rem;
+      color: inherit;
+      border-left: .25em solid var(--gray-border);
+
+      & > :first-child {
+        margin-top: 0;
+      }
+
+      & > :last-child {
+        margin-bottom: 0;
+      }
+
+      :global(.markdown-alert-title) {
+        display: flex;
+        font-weight: 500;
+        align-items: center;
+        line-height: 1;
+      }
+
+      & > :global(.markdown-alert-title)::before {
+        content: '';
+        margin-right: .5rem;
+        background-color: var(--gray-border);
+        width: 1em;
+        height: 1em;
+      }
+
+      &:global(.markdown-alert-note) {
+        border-left-color: var(--fg-color-note);
+
+        & > :global(.markdown-alert-title) {
+          color: var(--fg-color-note);
+
+          &:before {
+            mask: url("$lib/assets/alert-note.svg");
+            background-color: var(--fg-color-note);
+          }
+        }
+      }
+
+      &:global(.markdown-alert-tip) {
+        border-left-color: var(--fg-color-tip);
+
+        & > :global(.markdown-alert-title) {
+          color: var(--fg-color-tip);
+
+          &:before {
+            mask: url("$lib/assets/alert-tip.svg");
+            background-color: var(--fg-color-tip);
+          }
+        }
+      }
+
+      &:global(.markdown-alert-important) {
+        border-left-color: var(--fg-color-important);
+
+        & > :global(.markdown-alert-title) {
+          color: var(--fg-color-important);
+
+          &:before {
+            mask: url("$lib/assets/alert-important.svg");
+            background-color: var(--fg-color-important);
+          }
+        }
+      }
+
+      &:global(.markdown-alert-warning) {
+        border-left-color: var(--fg-color-warning);
+
+        & > :global(.markdown-alert-title) {
+          color: var(--fg-color-warning);
+
+          &:before {
+            mask: url("$lib/assets/alert-warning.svg");
+            background-color: var(--fg-color-warning);
+          }
+        }
+      }
+
+      &:global(.markdown-alert-caution) {
+        border-left-color: var(--fg-color-caution);
+
+        & > :global(.markdown-alert-title) {
+          color: var(--fg-color-caution);
+
+          &:before {
+            mask: url("$lib/assets/alert-caution.svg");
+            background-color: var(--fg-color-caution);
+          }
+        }
+      }
+    }
   }
 </style>


### PR DESCRIPTION
### Related

- https://github.com/rust-lang/crates.io/issues/12515
- #12687
