### PR TITLE
playwright: Add missing `await` to `msw.worker.use()` calls

### DIFF
--- a/e2e/routes/crate/version/source-link.spec.ts
+++ b/e2e/routes/crate/version/source-link.spec.ts
@@ -10,7 +10,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
       doc_status: false,
       version: '1.0.0',
     });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveAttribute(
@@ -24,7 +24,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('not found', { status: 404 });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.getByRole('link', { name: 'crates.io', exact: true })).toHaveCount(1);
@@ -43,7 +43,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
       doc_status: true,
       version: '1.0.0',
     });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveAttribute(
@@ -60,7 +60,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('not found', { status: 404 });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveCount(0);
@@ -77,7 +77,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
       doc_status: true,
       version: '1.0.0',
     });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveAttribute(
@@ -91,7 +91,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('error', { status: 500 });
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveCount(0);
@@ -102,7 +102,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '0.6.2' });
 
     let response = HttpResponse.json({});
-    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveAttribute(


### PR DESCRIPTION
It doesn't seem to make a difference at the moment, but it makes TypeScript happy, and if it's supposed to be used with `await` then we should probably do so 😅 