### PR TITLE
svelte: Add `now` attribute to `DownloadChart` component

### DIFF
--- a/svelte/src/lib/components/download-chart/DownloadChart.stories.svelte
+++ b/svelte/src/lib/components/download-chart/DownloadChart.stories.svelte
@@ -14,12 +14,11 @@
     },
   });
 
-  function generateData(): DownloadChartData {
+  function generateData(now: Date): DownloadChartData {
     let versionCount = 5;
     let daysBack = 90;
     let baseDownloads = 10000;
 
-    let now = new Date();
     let versions: Version[] = [];
     let versionDownloads: VersionDownload[] = [];
     let extraDownloads: { date: string; downloads: number }[] = [];
@@ -106,11 +105,12 @@
     };
   }
 
-  let defaultData = generateData();
+  let now = new Date('2020-12-30T12:34:56Z');
+  let defaultData = generateData(now);
 </script>
 
-<Story name="Default" args={{ data: defaultData, stacked: true }} />
+<Story name="Default" args={{ data: defaultData, now, stacked: true }} />
 
-<Story name="Unstacked" args={{ data: defaultData, stacked: false }} />
+<Story name="Unstacked" args={{ data: defaultData, now, stacked: false }} />
 
-<Story name="No Data" args={{ data: null, stacked: true }} />
+<Story name="No Data" args={{ data: null, now, stacked: true }} />

--- a/svelte/src/lib/components/download-chart/DownloadChart.svelte
+++ b/svelte/src/lib/components/download-chart/DownloadChart.svelte
@@ -11,12 +11,13 @@
 
   interface Props {
     data: DownloadChartData | null;
+    now?: Date;
     /** Whether to display the chart as a stacked area chart */
     stacked?: boolean;
     onReload?: () => void;
   }
 
-  let { data, stacked = true, onReload = () => location.reload() }: Props = $props();
+  let { data, now = new Date(), stacked = true, onReload = () => location.reload() }: Props = $props();
 
   let colorScheme = getColorScheme();
 
@@ -27,7 +28,7 @@
   // Load Chart.js and capture the constructor when ready
   let chartPromise = loadChart().then(Chart => (ChartConstructor = Chart));
 
-  let chartData = $derived(toChartData(data));
+  let chartData = $derived(toChartData(data, now));
   let fontColor = $derived(colorScheme.isDark ? '#ADBABD' : '#666');
   let borderColor = $derived(colorScheme.isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)');
 

--- a/svelte/src/lib/components/download-chart/data.test.ts
+++ b/svelte/src/lib/components/download-chart/data.test.ts
@@ -1,22 +1,14 @@
 import type { DownloadChartData, Version, VersionDownload } from './data';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { toChartData } from './data';
 
 describe('toChartData()', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2020-12-30T12:34:56Z'));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it('converts raw download data to Chart.js format', () => {
     let data = exampleData();
-    let result = toChartData(data);
+    let now = new Date('2020-12-30T12:34:56Z');
+    let result = toChartData(data, now);
 
     expect(result).toMatchObject({
       datasets: [

--- a/svelte/src/lib/components/download-chart/data.ts
+++ b/svelte/src/lib/components/download-chart/data.ts
@@ -23,7 +23,7 @@ const BG_COLORS = ['#d3b5bc', '#eabdc0', '#f3d0ca', '#fce4d9', '#deedf5', '#c9de
 
 const ONE_DAY = 24 * 60 * 60 * 1000;
 
-export function toChartData(data: DownloadChartData | null): { datasets: DownloadChartDataset[] } {
+export function toChartData(data: DownloadChartData | null, now: Date): { datasets: DownloadChartDataset[] } {
   if (!data) {
     return { datasets: [] };
   }
@@ -35,7 +35,6 @@ export function toChartData(data: DownloadChartData | null): { datasets: Downloa
   let versions = new Map<string, Version>();
   let versionsById = new Map(data.versions.map(v => [v.id, v]));
 
-  let now = new Date();
   for (let i = 0; i < 90; i++) {
     let date = subDays(now, i);
     dates[date.toISOString().slice(0, 10)] = { date, cnt: {} };


### PR DESCRIPTION
The introduction of visual regression testing revealed that this component in the Storybook currently is creating unstable output, due to it relying on the current date.

This commit changes the `DownloadChart` component to accept an optional `now` attribute, which is then used in the Storybook file to generate stable output.

### Related

- https://github.com/rust-lang/crates.io/issues/12515