### PR TITLE
svelte: Load crate owners from API

### DIFF
--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -23,13 +23,26 @@
     crate: Crate;
     version: Version;
     keywords?: Keyword[];
-    owners: Owner[];
+    ownersPromise: Promise<Owner[]>;
     requestedVersion?: string;
     readmePromise: Promise<string | null>;
     downloadsPromise: Promise<DownloadChartData>;
   }
 
-  let { crate, version, keywords = [], owners, requestedVersion, readmePromise, downloadsPromise }: Props = $props();
+  let {
+    crate,
+    version,
+    keywords = [],
+    ownersPromise,
+    requestedVersion,
+    readmePromise,
+    downloadsPromise,
+  }: Props = $props();
+  let owners: Owner[] = $state([]);
+
+  $effect(() => {
+    ownersPromise.then(data => (owners = data)).catch(() => (owners = []));
+  });
 
   let numberFormat = new Intl.NumberFormat();
   let stackedGraph = $state(true);

--- a/svelte/src/routes/crates/[crate_id]/+layout.ts
+++ b/svelte/src/routes/crates/[crate_id]/+layout.ts
@@ -6,11 +6,12 @@ export async function load({ fetch, params }) {
 
   let crateName = params.crate_id;
 
-  let [crateData, owners] = await Promise.all([loadCrate(client, crateName), loadOwners(client, crateName)]);
+  let cratePromise = loadCrate(client, crateName);
+  let ownersPromise = loadOwners(client, crateName);
 
-  let { crate, categories, keywords, defaultVersion } = crateData;
+  let { crate, categories, keywords, defaultVersion } = await cratePromise;
 
-  return { crate, categories, keywords, defaultVersion, owners };
+  return { crate, categories, keywords, defaultVersion, ownersPromise };
 }
 
 async function loadOwners(client: ReturnType<typeof createClient>, name: string) {

--- a/svelte/src/routes/crates/[crate_id]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/+page.svelte
@@ -12,7 +12,7 @@
   crate={data.crate}
   version={data.defaultVersion}
   keywords={data.keywords}
-  owners={data.owners}
+  ownersPromise={data.ownersPromise}
   readmePromise={data.readmePromise}
   {downloadsPromise}
 />

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
@@ -12,7 +12,7 @@
   crate={data.crate}
   version={data.version}
   keywords={data.keywords}
-  owners={data.owners}
+  ownersPromise={data.ownersPromise}
   requestedVersion={data.requestedVersion}
   readmePromise={data.readmePromise}
   {downloadsPromise}


### PR DESCRIPTION
This resolves the two "load owners" `TODO` comments. The owners list is loaded in `routes/crates/[crate_id]/+layout.ts?` so that it can be shared with all subpages. This will allow the crate header to only show the "Settings" tab if the authenticated user (still TODO) is part of the owners list, similar to the Ember.js app.

### Related

- https://github.com/rust-lang/crates.io/issues/12515