### PR TITLE
svelte: Fix unstable `DownloadChart` storybook again…

### DIFF
--- a/svelte/src/lib/components/download-chart/DownloadChart.stories.svelte
+++ b/svelte/src/lib/components/download-chart/DownloadChart.stories.svelte
@@ -113,4 +113,4 @@
 
 <Story name="Unstacked" args={{ data: defaultData, now, stacked: false }} />
 
-<Story name="No Data" args={{ data: null, now, stacked: true }} />
+<Story name="No Data" args={{ data: null, now, stacked: true }} parameters={{ chromatic: { disableSnapshot: true } }} />


### PR DESCRIPTION
Turns out that if the component receives `null` data, it will still show the real current date instead of `now`. This commit disabled the snapshot for the `data: null` state to fix the problem.
### Related

- https://github.com/rust-lang/crates.io/issues/12515