### PR TITLE
svelte: Add categories section to `CrateSidebar`

### DIFF
--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -17,12 +17,14 @@
 
   type Crate = components['schemas']['Crate'];
   type Version = components['schemas']['Version'];
+  type Category = components['schemas']['Category'];
   type Keyword = components['schemas']['Keyword'];
   type Owner = components['schemas']['Owner'];
 
   interface Props {
     crate: Crate;
     version: Version;
+    categories?: Category[];
     keywords?: Keyword[];
     ownersPromise: Promise<Owner[]>;
     requestedVersion?: string;
@@ -34,6 +36,7 @@
   let {
     crate,
     version,
+    categories = [],
     keywords = [],
     ownersPromise,
     requestedVersion,
@@ -92,6 +95,7 @@
     <CrateSidebar
       {crate}
       {version}
+      {categories}
       {owners}
       requestedVersion={requestedVersion !== undefined}
       {playgroundCratesPromise}

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebar.stories.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebar.stories.svelte
@@ -14,6 +14,7 @@
 
   type Crate = components['schemas']['Crate'];
   type Version = components['schemas']['Version'];
+  type Category = components['schemas']['Category'];
   type Owner = components['schemas']['Owner'];
 
   const playgroundCrates: PlaygroundCrate[] = [{ name: 'serde', version: '1.0.215', id: 'serde' }];
@@ -73,6 +74,25 @@
     },
   };
 
+  const baseCategories: Category[] = [
+    {
+      id: 'encoding',
+      slug: 'encoding',
+      category: 'Encoding',
+      description: 'Encoding and/or decoding data from one data format to another.',
+      crates_cnt: 1234,
+      created_at: '2014-11-05T00:00:00Z',
+    },
+    {
+      id: 'no-std',
+      slug: 'no-std',
+      category: 'No standard library',
+      description: 'Crates that are able to function without the Rust standard library.',
+      crates_cnt: 5678,
+      created_at: '2014-11-05T00:00:00Z',
+    },
+  ];
+
   const baseOwners: Owner[] = [
     {
       id: 1,
@@ -99,11 +119,26 @@
   ];
 </script>
 
-<Story name="Default" args={{ crate: baseCrate, version: baseVersion, owners: baseOwners, playgroundCratesPromise }} />
+<Story
+  name="Default"
+  args={{
+    crate: baseCrate,
+    version: baseVersion,
+    categories: baseCategories,
+    owners: baseOwners,
+    playgroundCratesPromise,
+  }}
+/>
 
 <Story
   name="Yanked"
-  args={{ crate: baseCrate, version: { ...baseVersion, yanked: true }, owners: baseOwners, playgroundCratesPromise }}
+  args={{
+    crate: baseCrate,
+    version: { ...baseVersion, yanked: true },
+    categories: baseCategories,
+    owners: baseOwners,
+    playgroundCratesPromise,
+  }}
 />
 
 <Story
@@ -111,6 +146,7 @@
   args={{
     crate: { ...baseCrate, id: 'cargo-watch', name: 'cargo-watch' },
     version: { ...baseVersion, bin_names: ['cargo-watch'], has_lib: false },
+    categories: baseCategories,
     owners: baseOwners,
     playgroundCratesPromise,
   }}
@@ -118,7 +154,13 @@
 
 <Story
   name="Many Owners"
-  args={{ crate: baseCrate, version: baseVersion, owners: manyOwners, playgroundCratesPromise }}
+  args={{
+    crate: baseCrate,
+    version: baseVersion,
+    categories: baseCategories,
+    owners: manyOwners,
+    playgroundCratesPromise,
+  }}
 />
 
 <Story
@@ -130,6 +172,7 @@
       repository: 'https://github.com/serde-rs/serde',
     },
     version: baseVersion,
+    categories: baseCategories,
     owners: baseOwners,
     playgroundCratesPromise,
   }}
@@ -140,6 +183,7 @@
   args={{
     crate: { ...baseCrate, homepage: null, repository: null },
     version: { ...baseVersion, rust_version: null, edition: null, license: null, crate_size: 0 },
+    categories: [],
     owners: baseOwners,
     playgroundCratesPromise,
   }}

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
@@ -31,17 +31,19 @@
 
   type Crate = components['schemas']['Crate'];
   type Version = components['schemas']['Version'];
+  type Category = components['schemas']['Category'];
   type Owner = components['schemas']['Owner'];
 
   interface Props {
     crate: Crate;
     version: Version;
+    categories: Category[];
     owners: Owner[];
     requestedVersion?: boolean;
     playgroundCratesPromise: Promise<PlaygroundCrate[]>;
   }
 
-  let { crate, version, owners, requestedVersion = false, playgroundCratesPromise }: Props = $props();
+  let { crate, version, categories, owners, requestedVersion = false, playgroundCratesPromise }: Props = $props();
 
   let canHover = new MediaQuery('hover: hover', false);
 
@@ -177,17 +179,16 @@
     <OwnersList {owners} />
   </div>
 
-  <!-- TODO: Categories section
-       Requires categories data loaded with the crate and routing to /categories/{slug}
-  <div>
-    <h2 class="heading">Categories</h2>
-    <ul class="categories">
-      {#each crate.categories as category}
-        <li><a href={resolve('/categories/[slug]', { slug: category.slug })}>{category.category}</a></li>
-      {/each}
-    </ul>
-  </div>
-  -->
+  {#if categories.length > 0}
+    <div>
+      <h2 class="heading">Categories</h2>
+      <ul class="categories">
+        {#each categories as category (category.id)}
+          <li><a href={resolve('/categories/[category_id]', { category_id: category.id })}>{category.category}</a></li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
 
   <div>
     {#await playgroundCratesPromise then playgroundCrates}
@@ -341,13 +342,11 @@
     }
   }
 
-  /* TODO: Uncomment when categories section is implemented
   .categories {
     margin: 0;
     padding-left: 20px;
     line-height: 1.5;
   }
-  */
 
   .report-button,
   .playground-button {

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebarTestWrapper.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebarTestWrapper.svelte
@@ -7,20 +7,22 @@
 
   type Crate = components['schemas']['Crate'];
   type Version = components['schemas']['Version'];
+  type Category = components['schemas']['Category'];
   type Owner = components['schemas']['Owner'];
 
   interface Props {
     crate: Crate;
     version: Version;
+    categories?: Category[];
     owners: Owner[];
     requestedVersion?: boolean;
     playgroundCratesPromise: Promise<PlaygroundCrate[]>;
   }
 
-  let { crate, version, owners, playgroundCratesPromise, requestedVersion = false }: Props = $props();
+  let { crate, version, categories = [], owners, playgroundCratesPromise, requestedVersion = false }: Props = $props();
 
   let notifications = new NotificationsState();
   setNotifications(notifications);
 </script>
 
-<CrateSidebar {crate} {version} {owners} {playgroundCratesPromise} {requestedVersion} />
+<CrateSidebar {crate} {version} {categories} {owners} {playgroundCratesPromise} {requestedVersion} />

--- a/svelte/src/routes/crates/[crate_id]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/+page.svelte
@@ -11,6 +11,7 @@
 <CrateVersionPage
   crate={data.crate}
   version={data.defaultVersion}
+  categories={data.categories}
   keywords={data.keywords}
   ownersPromise={data.ownersPromise}
   readmePromise={data.readmePromise}

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
@@ -11,6 +11,7 @@
 <CrateVersionPage
   crate={data.crate}
   version={data.version}
+  categories={data.categories}
   keywords={data.keywords}
   ownersPromise={data.ownersPromise}
   requestedVersion={data.requestedVersion}


### PR DESCRIPTION
We were already loading them, just not displaying them yet. This PR changes that.

### Related

- https://github.com/rust-lang/crates.io/issues/12515