### PR TITLE
Allow running background-worker even if AWS vars aren't set

### DIFF
--- a/src/cloudfront.rs
+++ b/src/cloudfront.rs
@@ -44,8 +44,20 @@ pub struct CloudFront {
 
 impl CloudFront {
     pub fn from_environment() -> Option<Self> {
-        let access_key = dotenvy::var("AWS_ACCESS_KEY").expect("missing AWS_ACCESS_KEY");
-        let secret_key = dotenvy::var("AWS_SECRET_KEY").expect("missing AWS_SECRET_KEY");
+        let access_key = match dotenvy::var("AWS_ACCESS_KEY") {
+            Ok(a) => a,
+            Err(_) => {
+                warn!("Missing AWS_ACCESS_KEY environment variable");
+                return None;
+            }
+        };
+        let secret_key = match dotenvy::var("AWS_SECRET_KEY") {
+            Ok(s) => s,
+            Err(_) => {
+                warn!("Missing AWS_SECRET_KEY environment variable");
+                return None;
+            }
+        };
 
         let index_distribution_id = match dotenvy::var("CLOUDFRONT_DISTRIBUTION_ID_INDEX") {
             Ok(id) => id,


### PR DESCRIPTION
# What happened

I tried to run `cargo run --bin background-worker` locally and it panicked: 

```
thread 'main' (7897342) panicked at src/cloudfront.rs:47:57:
missing AWS_ACCESS_KEY: EnvVar(NotPresent)
```

# What I expected

I see some things have changed since I was last running the background worker locally, but I didn't see anything saying it was required to have AWS credentials in your `.env` to start up the background worker process, so I expected to be able to start up the background worker and just not have cloudfront working with my local crates.io. 

Because `CloudFront::from_environment` was already returning `None` if `CLOUDFRONT_DISTRIBUTION_ID_INDEX` or `CLOUDFRONT_DISTRIBUTION_ID_STATIC` weren't set, I made that function also return `None` if `AWS_ACCESS_KEY` or `AWS_SECRET_KEY` were not set (and log a warning, as with the other vars) rather than panicking.

I could see an argument that we'd want the background worker to fail loudly if the AWS variables weren't set in production, but I think we'd have bigger problems and we'd definitely notice if that were the case ;)

It looks like this was changed in ed4e08f701 because before that commit, if you didn't have `CLOUDFRONT_DISTRIBUTION` set, `CloudFront::from_environment` would return `None` before checking the AWS vars.