### PR TITLE
Add CVSS scores to Security tab (WASM version)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,10 @@ jobs:
           cache: pnpm
           node-version-file: package.json
 
+      - uses: taiki-e/install-action@735e5933943122c5ac182670a935f54a949265c1 # v2.52.4
+        with:
+          tool: wasm-pack
+
       - run: pnpm install
 
       - run: pnpm lint:hbs
@@ -259,6 +263,10 @@ jobs:
         with:
           cache: pnpm
           node-version-file: package.json
+
+      - uses: taiki-e/install-action@735e5933943122c5ac182670a935f54a949265c1 # v2.52.4
+        with:
+          tool: wasm-pack
 
       - run: pnpm install
 
@@ -346,6 +354,10 @@ jobs:
         with:
           cache: pnpm
           node-version-file: package.json
+
+      - uses: taiki-e/install-action@735e5933943122c5ac182670a935f54a949265c1 # v2.52.4
+        with:
+          tool: wasm-pack
 
       - run: pnpm install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,6 +1536,17 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "crates_io_cvss_wasm"
+version = "0.0.0"
+dependencies = [
+ "console_error_panic_hook",
+ "cvss",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2058,6 +2079,12 @@ checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "cvss"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fb220d3ce1b565af39cee5b89e47fd8dd1dab162900ee4363c8ee4169ee8a2"
 
 [[package]]
 name = "darling"
@@ -3706,9 +3733,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5756,6 +5783,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7069,25 +7107,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
- "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -7096,9 +7146,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7106,22 +7156,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
- "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
+ "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
@@ -7141,9 +7191,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/app/templates/crate/security.css
+++ b/app/templates/crate/security.css
@@ -65,3 +65,44 @@
 .cvss strong {
   margin-right: var(--space-2xs);
 }
+
+
+.cvss a {
+  font-family: monospace;
+  font-size: 0.9em;
+}
+
+:global(.severity-none),
+:global(.severity-low),
+:global(.severity-medium),
+:global(.severity-high),
+:global(.severity-critical) {
+  font-weight: 600;
+  padding: var(--space-4xs) var(--space-2xs);
+  border-radius: var(--space-4xs);
+}
+
+:global(.severity-none) {
+  background-color: light-dark(#e0e0e0, #424242);
+  color: light-dark(#616161, #bdbdbd);
+}
+
+:global(.severity-low) {
+  background-color: light-dark(#c8e6c9, #1b5e20);
+  color: light-dark(#2e7d32, #a5d6a7);
+}
+
+:global(.severity-medium) {
+  background-color: light-dark(#fff3e0, #e65100);
+  color: light-dark(#e65100, #ffe0b2);
+}
+
+:global(.severity-high) {
+  background-color: light-dark(#ffccbc, #bf360c);
+  color: light-dark(#d84315, #ffab91);
+}
+
+:global(.severity-critical) {
+  background-color: light-dark(#ffcdd2, #b71c1c);
+  color: light-dark(#c62828, #ef9a9a);
+}

--- a/app/utils/cvss.js
+++ b/app/utils/cvss.js
@@ -1,0 +1,39 @@
+// Lazy-loaded CVSS WASM module
+let cvssModule = null;
+let loadingPromise = null;
+
+/**
+ * Load the CVSS WASM module.
+ * Returns a cached promise if already loading/loaded.
+ */
+export async function loadCvssModule() {
+  if (cvssModule) {
+    return cvssModule;
+  }
+
+  if (loadingPromise) {
+    return loadingPromise;
+  }
+
+  loadingPromise = import('crates_io_cvss_wasm')
+    .then(module => {
+      cvssModule = module;
+      return module;
+    })
+    .catch(error => {
+      console.error('Failed to load CVSS WASM module:', error);
+      throw error;
+    });
+
+  return loadingPromise;
+}
+
+/**
+ * Parse a CVSS vector and get score information.
+ * @param {string} vector - CVSS vector string
+ * @returns {Promise<{score: number, severity: string, version: string, valid: boolean, error?: string}>}
+ */
+export async function parseCvss(vector) {
+  let module = await loadCvssModule();
+  return module.parse_cvss(vector);
+}

--- a/crates/crates_io_cvss_wasm/Cargo.toml
+++ b/crates/crates_io_cvss_wasm/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "crates_io_cvss_wasm"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/crates.io"
+description = "WASM module for CVSS score calculation"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+path = "lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+cvss = "2.2.0"
+wasm-bindgen = "0.2.100"
+serde = { version = "1.0.228", features = ["derive"] }
+serde-wasm-bindgen = "0.6.5"
+console_error_panic_hook = "0.1.7"

--- a/crates/crates_io_cvss_wasm/lib.rs
+++ b/crates/crates_io_cvss_wasm/lib.rs
@@ -1,0 +1,114 @@
+//! WASM module for CVSS (Common Vulnerability Scoring System) score calculation.
+//!
+//! Provides functions to parse CVSS vector strings (v3.0, v3.1, v4.0)
+//! and calculate their scores and severity ratings.
+
+use std::{convert::Infallible, str::FromStr};
+
+use cvss::Cvss;
+use wasm_bindgen::prelude::*;
+
+/// Parse a CVSS vector string and calculate its score.
+///
+/// Supports CVSS v3.0, v3.1, and v4.0 vector strings.
+///
+/// # Arguments
+/// * `vector` - A CVSS vector string (e.g., "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+///
+/// # Returns
+/// A JavaScript object with score, severity, version, valid flag, and optional error.
+#[wasm_bindgen]
+pub fn parse_cvss(vector: &str) -> JsValue {
+    let result = CvssResult::from_str(vector).unwrap();
+    serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
+}
+
+/// Result of parsing and scoring a CVSS vector.
+#[derive(serde::Serialize)]
+pub struct CvssResult {
+    /// The calculated CVSS score (0.0 - 10.0)
+    pub score: f64,
+    /// The severity rating (None, Low, Medium, High, Critical)
+    pub severity: String,
+    /// The CVSS version (e.g., "3.0", "3.1", "4.0")
+    pub version: String,
+    /// Whether parsing was successful
+    pub valid: bool,
+    /// Error message if parsing failed
+    pub error: Option<String>,
+}
+
+impl FromStr for CvssResult {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match Cvss::from_str(s) {
+            Ok(cvss) => Ok(Self {
+                score: cvss.score(),
+                severity: cvss.severity().to_string(),
+                version: match cvss {
+                    Cvss::CvssV30(_) => "3.0".to_string(),
+                    Cvss::CvssV31(_) => "3.1".to_string(),
+                    Cvss::CvssV40(_) => "4.0".to_string(),
+                    _ => "Unknown".to_string(),
+                },
+                valid: true,
+                error: None,
+            }),
+            Err(error) => Ok(CvssResult {
+                score: 0.0,
+                severity: "Unknown".to_string(),
+                version: "Unknown".to_string(),
+                valid: false,
+                error: Some(error.to_string()),
+            }),
+        }
+    }
+}
+
+/// Initialize the WASM module with better panic messages.
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cvss_v31_critical() {
+        let vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
+        let result = CvssResult::from_str(vector).unwrap();
+        assert!(result.valid);
+        assert_eq!(result.score, 9.8);
+        assert_eq!(result.severity, "critical");
+        assert_eq!(result.version, "3.1");
+    }
+
+    #[test]
+    fn test_cvss_v30() {
+        let vector = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H";
+        let result = CvssResult::from_str(vector).unwrap();
+        assert!(result.valid);
+        assert_eq!(result.score, 9.8);
+        assert_eq!(result.version, "3.0");
+    }
+
+    #[test]
+    fn test_cvss_v4() {
+        let vector = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N";
+        let result = CvssResult::from_str(vector).unwrap();
+        assert!(result.valid);
+        assert_eq!(result.version, "4.0");
+        assert!(result.score > 0.0);
+    }
+
+    #[test]
+    fn test_invalid_vector() {
+        let vector = "invalid";
+        let result = CvssResult::from_str(vector).unwrap();
+        assert!(!result.valid);
+        assert!(result.error.is_some());
+    }
+}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -47,7 +47,7 @@ module.exports = function (defaults) {
     },
 
     fingerprint: {
-      extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg', 'ttf', 'woff', 'woff2'],
+      extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg', 'ttf', 'woff', 'woff2', 'wasm'],
     },
 
     sourcemaps: {
@@ -67,6 +67,9 @@ module.exports = function (defaults) {
     staticModifiers: true,
     packagerOptions: {
       webpackConfig: {
+        experiments: {
+          asyncWebAssembly: true,
+        },
         externals: ({ request, context }, callback) => {
           // Prevent `@mswjs/data` from bundling the `msw` package.
           //

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ export default [
     ignores: [
       '.git/**/*',
       'crates/',
+      'packages/crates-io-cvss-wasm/',
       'playwright-report/',
       'svelte/',
       'target/',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build --environment=production && node ./script/precompress-assets.mjs",
+    "build": "pnpm build:wasm && ember build --environment=production && node ./script/precompress-assets.mjs",
+    "build:wasm": "wasm-pack build crates/crates_io_cvss_wasm --target bundler --out-dir ../../packages/crates-io-cvss-wasm --out-name cvss",
+    "postbuild:wasm": "prettier --write packages/crates-io-cvss-wasm/*.js",
+    "prelint:deps": "pnpm build:wasm",
     "lint:deps": "ember dependency-lint",
     "lint:hbs": "ember-template-lint app",
     "lint:js": "eslint . --cache",
@@ -29,7 +32,9 @@
     "start:live": "ember serve --proxy https://crates.io",
     "start:local": "ember serve --proxy http://127.0.0.1:8888",
     "start:staging": "ember serve --proxy https://staging-crates-io.herokuapp.com",
+    "pretest": "pnpm build:wasm",
     "test": "ember test",
+    "pree2e": "pnpm build:wasm",
     "e2e": "playwright test",
     "e2e:svelte": "TEST_APP=svelte playwright test"
   },
@@ -66,6 +71,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "1.7.4",
+    "crates_io_cvss_wasm": "workspace:*",
     "@juggle/resize-observer": "3.4.0",
     "@sentry/ember": "10.36.0",
     "chart.js": "4.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       chart.js:
         specifier: 4.5.1
         version: 4.5.1
+      crates_io_cvss_wasm:
+        specifier: workspace:*
+        version: link:packages/crates-io-cvss-wasm
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
@@ -350,6 +353,8 @@ importers:
       vitest:
         specifier: 4.0.18
         version: 4.0.18(@types/node@24.10.9)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@25.0.1)(msw@2.12.7(@types/node@24.10.9)(typescript@5.9.3))(terser@5.46.0)(yaml@2.8.2)
+
+  packages/crates-io-cvss-wasm: {}
 
   packages/crates-io-msw:
     dependencies:
@@ -2363,8 +2368,8 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/wasm-node@4.57.0':
-    resolution: {integrity: sha512-EmuVEJWCxlkA/HIe9IJUSSXUXj3mw3w/4NDHhdu2KLCfBUOsjHMOWWrVzTGySmdaua0E120LSQ5ojDGfi+tA/Q==}
+  '@rollup/wasm-node@4.57.1':
+    resolution: {integrity: sha512-b0rcJH8ykEanfgTeDtlPubhphIUOx0oaAek+3hizTaFkoC1FBSTsY0GixwB4D5HZ5r3Gt2yI9c8M13OcW/kW5A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -12485,7 +12490,7 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.3
 
-  '@rollup/wasm-node@4.57.0':
+  '@rollup/wasm-node@4.57.1':
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
@@ -21168,7 +21173,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: '@rollup/wasm-node@4.57.0'
+      rollup: '@rollup/wasm-node@4.57.1'
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.10.9

--- a/script/precompress-assets.mjs
+++ b/script/precompress-assets.mjs
@@ -5,9 +5,10 @@ import { constants, createBrotliCompress, createGzip } from 'node:zlib';
 
 import { globby } from 'globby';
 
-let paths = await globby(['**/*.css', '**/*.html', '**/*.js', '**/*.map', '**/*.svg', '**/*.txt', '**/*.xml'], {
-  cwd: 'dist',
-});
+let paths = await globby(
+  ['**/*.css', '**/*.html', '**/*.js', '**/*.map', '**/*.svg', '**/*.txt', '**/*.wasm', '**/*.xml'],
+  { cwd: 'dist' },
+);
 
 for (let path of paths) {
   let fullPath = `dist/${path}`;


### PR DESCRIPTION
This seems like a potentially interesting alternative to

- #12820 

Pros/cons:

- Use the same score calculation as RustSec upstream
- No forked scoring implementation to maintain
- Does need extra WASM infrastructure

Not sure if CI needs tweaks to install wasm-pack? Otherwise, I quite like this setup.