### PR TITLE
version-list: Compute `isOwner` once in the controller

### DIFF
--- a/app/components/version-list/row.gjs
+++ b/app/components/version-list/row.gjs
@@ -2,7 +2,6 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
-import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -26,14 +25,7 @@ import dateFormatIso from 'crates-io/helpers/date-format-iso';
 import prettyBytes from 'crates-io/helpers/pretty-bytes';
 
 export default class VersionRow extends Component {
-  @service session;
-
   @tracked focused = false;
-
-  get isOwner() {
-    let userId = this.session.currentUser?.id;
-    return this.args.version.crate.hasOwnerUser(userId);
-  }
 
   get features() {
     let features = this.args.version.featureList;
@@ -200,7 +192,7 @@ export default class VersionRow extends Component {
         {{/if}}
       </div>
 
-      <PrivilegedAction @userAuthorised={{this.isOwner}} class='actions'>
+      <PrivilegedAction @userAuthorised={{@isOwner}} class='actions'>
         <Dropdown class='dropdown' data-test-actions-menu as |dd|>
           <dd.Trigger @hideArrow={{true}} class='trigger' data-test-actions-toggle>
             {{svgJar 'ellipsis-circle' class=(scopedClass 'icon')}}

--- a/app/controllers/crate/versions.js
+++ b/app/controllers/crate/versions.js
@@ -14,6 +14,7 @@ function defaultVersionsContext() {
 export default class SearchController extends Controller {
   @service releaseTracks;
   @service sentry;
+  @service session;
   @service store;
 
   queryParams = ['per_page', 'sort'];
@@ -44,6 +45,11 @@ export default class SearchController extends Controller {
   get sortedVersions() {
     let { loadedVersionsById: versions } = this.crate;
     return this.data.map(id => versions.get(id));
+  }
+
+  get isOwner() {
+    let userId = this.session.currentUser?.id;
+    return this.crate.hasOwnerUser(userId);
   }
 
   loadMoreTask = dropTask(async () => {

--- a/app/templates/crate/versions.gjs
+++ b/app/templates/crate/versions.gjs
@@ -42,7 +42,7 @@ import dateFormat from 'crates-io/helpers/date-format';
     <ul class='list'>
       {{#each @controller.sortedVersions as |version|}}
         <li>
-          <Row @version={{version}} class='row' data-test-version={{version.num}} />
+          <Row @version={{version}} @isOwner={{@controller.isOwner}} class='row' data-test-version={{version.num}} />
         </li>
       {{/each}}
     </ul>


### PR DESCRIPTION
Ownership is per-crate, not per-version, so computing it in every row was wasteful. This moves the check to the versions controller and passes it down as a prop instead.