### PR TITLE
pnpm: Enable `ignore-workspace-root-check` setting

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 shell-emulator=true
+ignore-workspace-root-check=true


### PR DESCRIPTION
`pnpm add` currently fails with an error about not wanting to add packages to the workspace root. Since our workspace root is currently also the Ember.js app, this is a warning we can ignore for now.