### PR TITLE
version-list: Remove unused CSS class declaration

### DIFF
--- a/app/templates/crate/versions.gjs
+++ b/app/templates/crate/versions.gjs
@@ -42,7 +42,7 @@ import dateFormat from 'crates-io/helpers/date-format';
     <ul class='list'>
       {{#each @controller.sortedVersions as |version|}}
         <li>
-          <Row @version={{version}} @isOwner={{@controller.isOwner}} class='row' data-test-version={{version.num}} />
+          <Row @version={{version}} @isOwner={{@controller.isOwner}} data-test-version={{version.num}} />
         </li>
       {{/each}}
     </ul>


### PR DESCRIPTION
There is no `.row` CSS class in the corresponding stylesheet...