### PR TITLE
svelte: Fix `dev:msw` mode

### DIFF
--- a/svelte/src/hooks.client.ts
+++ b/svelte/src/hooks.client.ts
@@ -24,7 +24,7 @@ export async function init() {
     await loadFixtures(db);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let user = db.user.findFirst((q: any) => q.where({ id: { equals: 1 } }));
+    let user = db.user.findFirst((q: any) => q.where({ id: 2 }));
     if (user) {
       await db.mswSession.create({ user });
       localStorage.setItem('isLoggedIn', '1');


### PR DESCRIPTION
I'm fairly sure I tested this when I implemented it (see 906c8d9), but apparently I still screwed it up… 😅

1. there is no `id: 1` user in the test fixtures and 
2. the syntax for the `where()` call is outdated and no longer correct with the current `@msw/data` library 🙈

### Related

- https://github.com/rust-lang/crates.io/issues/12515