### PR TITLE
OpenAPI: Add query parameters to `GET /api/private/session/authorize` endpoint

### DIFF
--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -1927,7 +1927,18 @@ export interface operations {
     };
     authorize_session: {
         parameters: {
-            query?: never;
+            query: {
+                /**
+                 * @description Temporary code received from the GitHub API.
+                 * @example 901dd10e07c7e9fa1cd5
+                 */
+                code: string;
+                /**
+                 * @description State parameter received from the GitHub API.
+                 * @example fYcUY3FMdUUz00FC7vLT7A
+                 */
+                state: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -58,10 +58,15 @@ pub async fn begin_session(app: AppState, session: SessionExtension) -> Json<Beg
     Json(BeginResponse { url, state })
 }
 
-#[derive(Clone, Debug, Deserialize, FromRequestParts)]
+#[derive(Clone, Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
 #[from_request(via(Query))]
+#[into_params(parameter_in = Query)]
 pub struct AuthorizeQuery {
+    /// Temporary code received from the GitHub API.
+    #[param(value_type = String, example = "901dd10e07c7e9fa1cd5")]
     code: AuthorizationCode,
+    /// State parameter received from the GitHub API.
+    #[param(value_type = String, example = "fYcUY3FMdUUz00FC7vLT7A")]
     state: CsrfToken,
 }
 
@@ -82,6 +87,7 @@ pub struct AuthorizeQuery {
     get,
     path = "/api/private/session/authorize",
     tag = "session",
+    params(AuthorizeQuery),
     responses((status = 200, description = "Successful Response", body = inline(EncodableMe))),
 )]
 pub async fn authorize_session(

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -1539,6 +1539,28 @@ expression: response.json()
       "get": {
         "description": "This route is called from the GitHub API OAuth flow after the user accepted or rejected\nthe data access permissions. It will check the `state` parameter and then call the GitHub API\nto exchange the temporary `code` for an API token. The API token is returned together with\nthe corresponding user information.\n\nsee <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>\n\n## Query Parameters\n\n- `code` – temporary code received from the GitHub API  **(Required)**\n- `state` – state parameter received from the GitHub API  **(Required)**",
         "operationId": "authorize_session",
+        "parameters": [
+          {
+            "description": "Temporary code received from the GitHub API.",
+            "example": "901dd10e07c7e9fa1cd5",
+            "in": "query",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "State parameter received from the GitHub API.",
+            "example": "fYcUY3FMdUUz00FC7vLT7A",
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {


### PR DESCRIPTION
This PR adjusts our `GET /api/private/session/authorize` endpoint implementation to use the right utoipa annotations so that the `state` and `code` query parameters also show up in the OpenAPI description. The generated `@crates-io/api-client` package is updated accordingly, so that we can use these query parameters for the endpoint.