### PR TITLE
svelte: Implement authentication

### DIFF
--- a/svelte/.storybook/preview.ts
+++ b/svelte/.storybook/preview.ts
@@ -7,6 +7,7 @@ import '../src/lib/css/global.css';
 import ColorSchemeDecorator from '../src/lib/storybook/ColorSchemeDecorator.svelte';
 import HeaderSearchDecorator from '../src/lib/storybook/HeaderSearchDecorator.svelte';
 import NotificationDecorator from '../src/lib/storybook/NotificationDecorator.svelte';
+import SessionDecorator from '../src/lib/storybook/SessionDecorator.svelte';
 import TooltipDecorator from '../src/lib/storybook/TooltipDecorator.svelte';
 
 const THEME_ITEMS = [
@@ -28,6 +29,7 @@ const preview: Preview = {
     },
     () => HeaderSearchDecorator,
     () => NotificationDecorator,
+    () => SessionDecorator,
     () => TooltipDecorator,
   ],
   globalTypes: {

--- a/svelte/src/lib/components/Header.stories.svelte
+++ b/svelte/src/lib/components/Header.stories.svelte
@@ -3,6 +3,7 @@
 
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
+  import SessionDecorator from '$lib/storybook/SessionDecorator.svelte';
   import Header from './Header.svelte';
 
   const { Story } = defineMeta({
@@ -40,8 +41,16 @@
 
 <Story name="Default" />
 
-<Story name="Authenticated" args={{ currentUser: baseUser }} />
+<Story name="Authenticated" asChild>
+  <SessionDecorator user={baseUser}>
+    <Header />
+  </SessionDecorator>
+</Story>
 
 <Story name="Hero" args={{ hero: true }} />
 
-<Story name="Hero (Authenticated Admin)" args={{ hero: true, currentUser: adminUser }} />
+<Story name="Hero (Authenticated Admin)" asChild>
+  <SessionDecorator user={adminUser}>
+    <Header hero />
+  </SessionDecorator>
+</Story>

--- a/svelte/src/lib/storybook/SessionDecorator.svelte
+++ b/svelte/src/lib/storybook/SessionDecorator.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { AuthenticatedUser } from '$lib/utils/session.svelte';
+  import type { Snippet } from 'svelte';
+
+  import { createClient } from '@crates-io/api-client';
+
+  import { SessionState, setSession } from '$lib/utils/session.svelte';
+
+  let { children, user }: { children: Snippet; user?: AuthenticatedUser } = $props();
+
+  // svelte-ignore state_referenced_locally
+  let userPromise = Promise.resolve(user ?? null);
+  let session = new SessionState(createClient({ fetch }), userPromise);
+  setSession(session);
+</script>
+
+{@render children()}

--- a/svelte/src/lib/utils/session.svelte.ts
+++ b/svelte/src/lib/utils/session.svelte.ts
@@ -1,0 +1,181 @@
+import type { operations } from '@crates-io/api-client';
+import type { NotificationsContext } from '$lib/notifications.svelte';
+
+import { createContext } from 'svelte';
+import { resolve } from '$app/paths';
+import { createClient } from '@crates-io/api-client';
+
+import * as localStorage from './local-storage';
+
+const LOGIN_KEY = 'isLoggedIn';
+
+const POPUP_FEATURES = [
+  'width=1000',
+  'height=450',
+  'toolbar=0',
+  'scrollbars=1',
+  'status=1',
+  'resizable=1',
+  'location=1',
+  'menuBar=0',
+].join(',');
+
+type ApiClient = ReturnType<typeof createClient>;
+
+export type AuthenticatedUser =
+  operations['get_authenticated_user']['responses']['200']['content']['application/json']['user'];
+
+export function isLoggedIn(): boolean {
+  return localStorage.getItem(LOGIN_KEY) === '1';
+}
+
+export async function loadUser(client: ApiClient): Promise<AuthenticatedUser | null> {
+  if (!isLoggedIn()) {
+    return null;
+  }
+
+  try {
+    let response = await client.GET('/api/v1/me');
+    if (response.error) {
+      return null;
+    }
+    return response.data.user;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Waits for either a postMessage from the OAuth popup or for the popup
+ * to be closed by the user. Returns the OAuth callback parameters if
+ * the message is received, or `{ closed: true }` if the popup was closed.
+ */
+function waitForOAuthCallback(popup: Window): Promise<{ code: string; state: string } | { closed: true }> {
+  return new Promise(resolve => {
+    let interval: ReturnType<typeof setInterval>;
+
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin || !event.data) return;
+
+      let { code, state } = event.data;
+      if (!code || !state) return;
+
+      cleanup();
+      resolve({ code, state });
+    }
+
+    function cleanup() {
+      window.removeEventListener('message', onMessage);
+      clearInterval(interval);
+    }
+
+    window.addEventListener('message', onMessage);
+
+    interval = setInterval(() => {
+      if (popup.closed) {
+        cleanup();
+        resolve({ closed: true });
+      }
+    }, 10);
+  });
+}
+
+export class SessionState {
+  state: 'checking' | 'logged-out' | 'logging-in' | 'logged-in' | 'logging-out' = $state('checking');
+  currentUser: AuthenticatedUser | null = $state(null);
+
+  // TODO: implement `ownedCrates` (loaded from the `/api/v1/me` response)
+  // TODO: implement sudo mode (`sudoEnabledUntil`, `isSudoEnabled`, `setSudo()`)
+  //   Sudo mode enables admin actions for a limited duration. The expiry
+  //   timestamp is persisted in localStorage under the 'sudo' key so it
+  //   survives page reloads. On user load, the stored expiry is checked
+  //   and sudo mode is restored if still valid.
+  // TODO: implement saved transition (redirect to originally requested page after login)
+  // TODO: integrate with Sentry (`sentry.setUser({ id })` after loading user)
+
+  #client: ApiClient;
+  #notifications?: NotificationsContext;
+
+  constructor(client: ApiClient, userPromise: Promise<AuthenticatedUser | null>, notifications?: NotificationsContext) {
+    this.#client = client;
+    this.#notifications = notifications;
+
+    userPromise.then(user => {
+      this.state = user ? 'logged-in' : 'logged-out';
+      this.currentUser = user;
+    });
+  }
+
+  /**
+   * Opens a popup window and initiates the GitHub OAuth flow.
+   *
+   * The popup navigates to `/github-auth-loading.html`, which fetches the
+   * OAuth URL from `/api/private/session/begin` and redirects to GitHub.
+   *
+   * Example URL:
+   * https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg
+   *
+   * Once the user has allowed the OAuth flow, GitHub redirects back to
+   * this application, and the popup sends a postMessage with the OAuth
+   * callback parameters.
+   *
+   * Using a same-origin loading page avoids the opaque origin issue that
+   * occurs with `document.write()` on a blank popup, which causes GitHub
+   * to reject the OAuth POST with HTTP 422.
+   *
+   * @see https://developer.github.com/v3/oauth/#redirect-users-to-request-github-access
+   * @see https://github.com/rust-lang/crates.io/discussions/4320
+   */
+  async login(): Promise<void> {
+    let popup = window.open('/github-auth-loading.html', '_blank', POPUP_FEATURES);
+    if (!popup) {
+      return;
+    }
+
+    this.state = 'logging-in';
+
+    let result = await waitForOAuthCallback(popup);
+    if ('closed' in result) {
+      this.#notifications?.warning('Login was canceled because the popup window was closed.');
+      this.state = 'logged-out';
+      return;
+    }
+
+    popup.close();
+
+    let { code, state } = result;
+    let { data, error } = await this.#client.GET('/api/private/session/authorize', {
+      params: { query: { code, state } },
+    });
+
+    if (!data) {
+      let detail = (error as unknown as { errors?: { detail?: string }[] })?.errors?.[0]?.detail;
+      this.#notifications?.error(detail ? `Failed to log in: ${detail}` : 'Failed to log in');
+      this.state = 'logged-out';
+      return;
+    }
+
+    localStorage.setItem(LOGIN_KEY, '1');
+
+    let user = await loadUser(this.#client);
+    this.currentUser = user;
+    this.state = user ? 'logged-in' : 'logged-out';
+
+    // TODO: perform the originally saved transition, if it exists
+  }
+
+  async logout(): Promise<void> {
+    this.state = 'logging-out';
+
+    try {
+      await this.#client.DELETE('/api/private/session');
+    } finally {
+      localStorage.removeItem(LOGIN_KEY);
+
+      // Full page navigation to ensure all in-memory state is cleared on logout.
+      window.location.assign(resolve('/'));
+    }
+  }
+}
+
+export const [getSession, setSession] = createContext<SessionState>();

--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { navigating, page } from '$app/state';
+  import { createClient } from '@crates-io/api-client';
 
   import { ColorSchemeState, setColorScheme } from '$lib/color-scheme.svelte';
   import Footer from '$lib/components/Footer.svelte';
@@ -11,10 +12,11 @@
   import { ProgressState, setProgressContext } from '$lib/progress.svelte';
   import { SearchFormContext, setSearchFormContext } from '$lib/search-form.svelte';
   import { setTooltipContext } from '$lib/tooltip.svelte';
+  import { SessionState, setSession } from '$lib/utils/session.svelte';
 
   import '$lib/css/global.css';
 
-  let { children } = $props();
+  let { children, data } = $props();
   let propsId = $props.id();
 
   let isIndex = $derived(page.route.id === '/');
@@ -43,8 +45,9 @@
   let notifications = new NotificationsState();
   setNotifications(notifications);
 
-  // TODO: fetch current user
-  let currentUser = null;
+  // svelte-ignore state_referenced_locally
+  let sessionState = new SessionState(createClient({ fetch }), data.userPromise, notifications);
+  setSession(sessionState);
 </script>
 
 <svelte:head>
@@ -59,7 +62,7 @@
 <NotificationContainer position="top-right" />
 <TooltipContainer />
 
-<Header hero={isIndex} {currentUser} />
+<Header hero={isIndex} />
 
 <main class="main">
   <div class="inner-main width-limit">

--- a/svelte/src/routes/+layout.ts
+++ b/svelte/src/routes/+layout.ts
@@ -1,9 +1,15 @@
+import { createClient } from '@crates-io/api-client';
+
 import { loadPlaygroundCrates } from '$lib/utils/playground';
+import { loadUser } from '$lib/utils/session.svelte';
 
 export const ssr = false;
 
 export async function load({ fetch }) {
+  let client = createClient({ fetch });
+
   return {
     playgroundCratesPromise: loadPlaygroundCrates(fetch),
+    userPromise: loadUser(client),
   };
 }

--- a/svelte/static/github-auth-loading.html
+++ b/svelte/static/github-auth-loading.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>crates.io - Redirecting to GitHub</title>
+</head>
+<body>
+  <p>Please wait while we redirect you to GitHub...</p>
+  <script>
+    fetch('/api/private/session/begin')
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then(data => {
+        window.location.href = data.url;
+      })
+      .catch(() => {
+        document.body.textContent = 'Failed to start login. Please close this window and try again.';
+      });
+  </script>
+</body>
+</html>

--- a/svelte/static/github-redirect.html
+++ b/svelte/static/github-redirect.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>crates.io OAuth Redirect</title>
+  <script>
+    var params = new URLSearchParams(location.search);
+    var code = params.get('code');
+    var state = params.get('state');
+
+    if (window.opener) {
+      window.opener.postMessage({ code: code, state: state }, window.location.origin);
+    }
+  </script>
+</head>
+</html>


### PR DESCRIPTION
This ports the Ember `session` service to Svelte 5 using `createContext` for dependency injection and `$state` runes for reactive state tracking.

The OAuth flow opens a popup to `github-auth-loading.html`, which fetches the authorization URL from the backend and redirects to GitHub. After authorization, `github-redirect.html` posts the callback params back to the opener via `postMessage`.

`SessionState` is initialized in the root layout with a non-blocking user load, and `Header` now reads session state from context instead of accepting a `currentUser` prop.

I've temporarily deployed this to our staging server to test it, and everything seems to be working as intended. The playwright tests regarding login and logout are now also passing without any changes when run against the Svelte app.

### Related

- https://github.com/rust-lang/crates.io/issues/12515