### PR TITLE
e2e: Add missing `msw` fixture in `crate-dependencies` test

### DIFF
--- a/e2e/acceptance/crate-dependencies.spec.ts
+++ b/e2e/acceptance/crate-dependencies.spec.ts
@@ -30,7 +30,9 @@ test.describe('Acceptance | crate dependencies page', { tag: '@acceptance' }, ()
     await expect(page.locator('[data-test-dev-dependencies] li')).toHaveCount(0);
   });
 
-  test('shows an error page if crate not found', async ({ page }) => {
+  test('shows an error page if crate not found', async ({ page, msw }) => {
+    void msw;
+
     await page.goto('/crates/foo/1.0.0/dependencies');
     await expect(page).toHaveURL('/crates/foo/1.0.0/dependencies');
     await expect(page.locator('[data-test-404-page]')).toBeVisible();


### PR DESCRIPTION
Without explicitly mentioning this fixture the request will go to the actual backend, not MSW. This is unintentional, so instead we add `msw` to the fixtures object and "use" it via `void msw` to silence the unused argument warnings.