### PR TITLE
svelte: Adjust `LoadingSpinner` screen reader fallback

### DIFF
--- a/svelte/src/lib/components/LoadingSpinner.svelte
+++ b/svelte/src/lib/components/LoadingSpinner.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <div class={['spinner', theme, className]} {...restProps}>
-  <span class="sr-only">Loading...</span>
+  <span class="sr-only">Loading…</span>
 </div>
 
 <style>


### PR DESCRIPTION
This matches the Ember.js implementation.
### Related

- https://github.com/rust-lang/crates.io/issues/12515