### PR TITLE
svelte: Implement `FollowButton` component

### DIFF
--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -4,8 +4,10 @@
   import { resolve } from '$app/paths';
 
   import TrashIcon from '$lib/assets/trash.svg?component';
+  import FollowButton from '$lib/components/FollowButton.svelte';
   import * as NavTabs from '$lib/components/nav-tabs';
   import Tooltip from '$lib/components/Tooltip.svelte';
+  import { getSession } from '$lib/utils/session.svelte';
 
   type Crate = components['schemas']['Crate'];
   type Version = components['schemas']['Version'];
@@ -33,6 +35,8 @@
 
   let { crate, version, versionNum: version_num, keywords = [] }: Props = $props();
   let crate_id = $derived(crate.id);
+
+  let session = getSession();
 
   // TODO: implement isOwner check using session service
   let isOwner = $derived(false);
@@ -95,12 +99,11 @@
     </ul>
   {/if}
 
-  <!-- TODO: Add FollowButton component when session service is implemented -->
-  <!-- {#if session.currentUser}
+  {#if session.currentUser}
     <div class="follow-button">
-      <FollowButton {crate} />
+      <FollowButton crateName={crate.name} />
     </div>
-  {/if} -->
+  {/if}
 </div>
 
 <NavTabs.Root aria-label="{crate.name} crate subpages" style="margin-bottom: var(--space-s)">

--- a/svelte/src/lib/components/FollowButton.svelte
+++ b/svelte/src/lib/components/FollowButton.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { createClient } from '@crates-io/api-client';
+
+  import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+  import { getNotifications } from '$lib/notifications.svelte';
+
+  interface Props {
+    /** The name of the crate to follow/unfollow. */
+    crateName: string;
+  }
+
+  let { crateName }: Props = $props();
+
+  let notifications = getNotifications();
+  let client = createClient({ fetch });
+
+  let following = $state(false);
+  let isLoadingState = $state(true);
+  let isToggling = $state(false);
+  let loadError = $state(false);
+
+  let isLoading = $derived(isLoadingState || isToggling);
+  let isDisabled = $derived(isLoading || loadError);
+
+  $effect(() => {
+    loadFollowState(crateName);
+  });
+
+  async function loadFollowState(name: string) {
+    isLoadingState = true;
+    loadError = false;
+
+    try {
+      let result = await client.GET('/api/v1/crates/{name}/following', {
+        params: { path: { name } },
+      });
+
+      if (!result.response.ok) {
+        throw new Error(`Failed to load follow state: ${result.response.status}`);
+      }
+
+      following = result.data!.following;
+    } catch {
+      loadError = true;
+      notifications.error(
+        `Something went wrong while trying to figure out if you are already following the ${name} crate. Please try again later!`,
+      );
+    } finally {
+      isLoadingState = false;
+    }
+  }
+
+  async function toggleFollow() {
+    isToggling = true;
+
+    try {
+      let options = { params: { path: { name: crateName } } };
+
+      let result = following
+        ? await client.DELETE('/api/v1/crates/{name}/follow', options)
+        : await client.PUT('/api/v1/crates/{name}/follow', options);
+
+      if (!result.response.ok) {
+        throw new Error(`Failed to ${following ? 'unfollow' : 'follow'} crate: ${result.response.status}`);
+      }
+
+      following = !following;
+    } catch {
+      notifications.error(
+        `Something went wrong when ${following ? 'unfollowing' : 'following'} the ${crateName} crate. Please try again later!`,
+      );
+    } finally {
+      isToggling = false;
+    }
+  }
+</script>
+
+<button
+  type="button"
+  disabled={isDisabled}
+  data-test-follow-button
+  class="follow-button button button--tan"
+  onclick={toggleFollow}
+>
+  {#if isLoading}
+    <LoadingSpinner theme="light" data-test-spinner />
+  {:else if following}
+    Unfollow
+  {:else}
+    Follow
+  {/if}
+</button>
+
+<style>
+  .follow-button {
+    height: 48px;
+    width: 150px;
+    justify-content: center;
+  }
+</style>


### PR DESCRIPTION
This ports the `FollowButton` component from the Ember.js app to the Svelte app and integrates it into the `CrateHeader` component.

This makes `TEST_APP=svelte pnpm e2e e2e/acceptance/crate-following.spec.ts` pass now :)

### Related

- https://github.com/rust-lang/crates.io/issues/12515