### PR TITLE
e2e: Merge duplicate `test.describe()` blocks

### DIFF
--- a/e2e/acceptance/invites.spec.ts
+++ b/e2e/acceptance/invites.spec.ts
@@ -2,15 +2,6 @@ import { expect, test } from '@/e2e/helper';
 import { http, HttpResponse } from 'msw';
 
 test.describe('Acceptance | /me/pending-invites', { tag: '@acceptance' }, () => {
-  test('shows "page requires authentication" error when not logged in', async ({ page }) => {
-    await page.goto('/me/pending-invites');
-    await expect(page).toHaveURL('/me/pending-invites');
-    await expect(page.locator('[data-test-title]')).toHaveText('This page requires authentication');
-    await expect(page.locator('[data-test-login]')).toBeVisible();
-  });
-});
-
-test.describe('Acceptance | /me/pending-invites', { tag: '@acceptance' }, () => {
   async function prepare(msw) {
     let inviter = await msw.db.user.create({ name: 'janed' });
     let inviter2 = await msw.db.user.create({ name: 'wycats' });
@@ -39,6 +30,13 @@ test.describe('Acceptance | /me/pending-invites', { tag: '@acceptance' }, () => 
 
     return { nanomsg, user };
   }
+
+  test('shows "page requires authentication" error when not logged in', async ({ page }) => {
+    await page.goto('/me/pending-invites');
+    await expect(page).toHaveURL('/me/pending-invites');
+    await expect(page.locator('[data-test-title]')).toHaveText('This page requires authentication');
+    await expect(page.locator('[data-test-login]')).toBeVisible();
+  });
 
   test('list all pending crate owner invites', async ({ page, msw }) => {
     await prepare(msw);

--- a/e2e/routes/settings/tokens/new.spec.ts
+++ b/e2e/routes/settings/tokens/new.spec.ts
@@ -364,9 +364,7 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     await expect(page.locator('[data-test-api-token="1"] [data-test-crate-scopes]')).toHaveCount(0);
     await expect(page.locator('[data-test-api-token="1"] [data-test-expired-at]')).toHaveCount(0);
   });
-});
 
-test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
   test('access is blocked if unauthenticated', async ({ page }) => {
     await page.goto('/settings/tokens/new');
     await expect(page).toHaveURL('/settings/tokens/new');


### PR DESCRIPTION
These were from a time when we were using `beforeEach()` for authentication, but since we moved towards explicit `prepare()` calls, this split is no longer needed.