### PR TITLE
svelte: Implement `/install` redirect

### DIFF
--- a/svelte/src/routes/install/+page.svelte
+++ b/svelte/src/routes/install/+page.svelte
@@ -1,2 +1,0 @@
-<h1>Install</h1>
-<p>Stub route for /install</p>

--- a/svelte/src/routes/install/+page.ts
+++ b/svelte/src/routes/install/+page.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+  redirect(301, 'https://doc.rust-lang.org/cargo/getting-started/installation.html');
+}


### PR DESCRIPTION
This redirects to the Cargo installation guide and replaces the stub page with a load function that performs a permanent redirect to match the Ember.js app behavior.

### Related

- https://github.com/rust-lang/crates.io/issues/12515