### PR TITLE
OpenAPI: Add `request_body` to `update_user` annotation

### DIFF
--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -4015,7 +4015,16 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": {
+                    user: {
+                        email?: string | null;
+                        publish_notifications?: boolean | null;
+                    };
+                };
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -16,12 +16,13 @@ use secrecy::ExposeSecret;
 use serde::Deserialize;
 use tracing::warn;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct UserUpdate {
+    #[schema(inline)]
     user: User,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct User {
     email: Option<String>,
     publish_notifications: Option<bool>,
@@ -38,6 +39,7 @@ pub struct User {
     params(
         ("user" = i32, Path, description = "ID of the user"),
     ),
+    request_body = inline(UserUpdate),
     security(
         ("api_token" = []),
         ("cookie" = []),

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -5064,6 +5064,38 @@ expression: response.json()
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "user": {
+                    "properties": {
+                      "email": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "publish_notifications": {
+                        "type": [
+                          "boolean",
+                          "null"
+                        ]
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "user"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {


### PR DESCRIPTION
This was missing from our OpenAPI description and was preventing us from using this endpoint in our generated API client.