### PR TITLE
svelte: Simplify `SessionState` class

### DIFF
--- a/svelte/src/lib/storybook/SessionDecorator.svelte
+++ b/svelte/src/lib/storybook/SessionDecorator.svelte
@@ -8,10 +8,11 @@
 
   let { children, user }: { children: Snippet; user?: AuthenticatedUser } = $props();
 
-  // svelte-ignore state_referenced_locally
-  let userPromise = Promise.resolve(user ?? null);
-  let session = new SessionState(createClient({ fetch }), userPromise);
+  let session = new SessionState(createClient({ fetch }));
   setSession(session);
+
+  // svelte-ignore state_referenced_locally
+  session.setUser(user ?? null);
 </script>
 
 {@render children()}

--- a/svelte/src/lib/utils/session.svelte.ts
+++ b/svelte/src/lib/utils/session.svelte.ts
@@ -96,11 +96,9 @@ export class SessionState {
   #client: ApiClient;
   #notifications?: NotificationsContext;
 
-  constructor(client: ApiClient, userPromise: Promise<AuthenticatedUser | null>, notifications?: NotificationsContext) {
+  constructor(client: ApiClient, notifications?: NotificationsContext) {
     this.#client = client;
     this.#notifications = notifications;
-
-    userPromise.then(user => this.setUser(user));
   }
 
   setUser(user: AuthenticatedUser | null): void {

--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -45,9 +45,11 @@
   let notifications = new NotificationsState();
   setNotifications(notifications);
 
-  // svelte-ignore state_referenced_locally
-  let sessionState = new SessionState(createClient({ fetch }), data.userPromise, notifications);
+  let sessionState = new SessionState(createClient({ fetch }), notifications);
   setSession(sessionState);
+
+  // svelte-ignore state_referenced_locally
+  data.userPromise.then(user => sessionState.setUser(user));
 </script>
 
 <svelte:head>


### PR DESCRIPTION
Instead of passing a `userPromise` into the constructor we now provide a synchronous `setUser()` fn and await the promise outside of the state class. This will simplify further work on gated auth-only routes.

### Related

- https://github.com/rust-lang/crates.io/issues/12515