### PR TITLE
svelte: Dynamically import `$app/paths` in `init()` hook

### DIFF
--- a/svelte/src/hooks.client.ts
+++ b/svelte/src/hooks.client.ts
@@ -1,5 +1,3 @@
-import { asset } from '$app/paths';
-
 export async function init() {
   if (import.meta.env.VITE_MSW_ENABLED) {
     let { http, passthrough } = await import('msw');
@@ -12,6 +10,11 @@ export async function init() {
       http.get('https://:avatars.githubusercontent.com/u/:id', passthrough),
       http.get('https://code.cdn.mozilla.net/fonts/*', passthrough),
     );
+
+    // We need to dynamically import `$app/paths` here to avoid a race condition during app startup,
+    // resulting in a "ReferenceError: __SVELTEKIT_PAYLOAD__ is not defined" error.
+    let { asset } = await import('$app/paths');
+
     await worker.start({
       serviceWorker: { url: asset('/mockServiceWorker.js') },
       onUnhandledRequest(request, print) {


### PR DESCRIPTION
As the code comment explains, we've been running into "ReferenceError: \_\_SVELTEKIT_PAYLOAD__ is not defined" errors ever since we've introduced the `init()` hook in 906c8d9. I've been able to somewhat reliably reproduce this by disabling the browser cache and constantly reloading the app. Before 906c8d9, this worked fine. After 906c8d9, in most cases the error was thrown causing an empty page to be shown. By using a dynamic import we can apparently avoid the race condition, or at least limit it to the codepath that actually uses MSW.

### Related

- https://github.com/rust-lang/crates.io/issues/12515