### PR TITLE
Disable default features of `oauth2` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,7 +3397,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4302,7 +4301,6 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "rand 0.8.5",
- "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -5401,7 +5399,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -7294,15 +7291,6 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ minijinja = { version = "=2.15.1", features = ["loader"] }
 mockall = "=0.14.0"
 moka = { version = "=0.12.13", default-features = false, features = ["future"] }
 native-tls = "=0.2.15"
-oauth2 = "=5.0.0"
+oauth2 = { version = "=5.0.0", default-features = false }
 object_store = { version = "=0.13.1", features = ["aws"] }
 p256 = "=0.13.2"
 parking_lot = "=0.12.5"

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -6,6 +6,7 @@ use crate::models::{NewEmail, NewOauthGithub, NewUser, User};
 use crate::schema::users;
 use crate::util::diesel::is_read_only_error;
 use crate::util::errors::{AppResult, bad_request, server_error};
+use crate::util::oauth::ReqwestClient;
 use crate::views::EncodableMe;
 use axum::Json;
 use axum::extract::{FromRequestParts, Query};
@@ -104,9 +105,11 @@ pub async fn authorize_session(
     }
 
     // Fetch the access token from GitHub using the code we just got
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .build()?;
+    let client = ReqwestClient(
+        reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?,
+    );
 
     let token = app
         .github_oauth

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,7 @@ pub mod diesel;
 pub mod errors;
 pub mod gh_token_encryption;
 mod io_util;
+pub mod oauth;
 mod request_helpers;
 pub mod string_excl_null;
 pub mod tracing;

--- a/src/util/oauth.rs
+++ b/src/util/oauth.rs
@@ -1,0 +1,35 @@
+use std::future::Future;
+use std::pin::Pin;
+
+/// Bridges `reqwest::Client` with `oauth2::AsyncHttpClient` so that
+/// oauth2 can be used without pulling in its default reqwest feature.
+pub struct ReqwestClient(pub reqwest::Client);
+
+impl<'c> oauth2::AsyncHttpClient<'c> for ReqwestClient {
+    type Error = oauth2::HttpClientError<reqwest::Error>;
+
+    type Future =
+        Pin<Box<dyn Future<Output = Result<oauth2::HttpResponse, Self::Error>> + Send + Sync + 'c>>;
+
+    fn call(&'c self, request: oauth2::HttpRequest) -> Self::Future {
+        Box::pin(async move {
+            let response = self
+                .0
+                .execute(request.try_into().map_err(Box::new)?)
+                .await
+                .map_err(Box::new)?;
+
+            let mut builder = http::Response::builder()
+                .status(response.status())
+                .version(response.version());
+
+            for (name, value) in response.headers().iter() {
+                builder = builder.header(name, value);
+            }
+
+            builder
+                .body(response.bytes().await.map_err(Box::new)?.to_vec())
+                .map_err(oauth2::HttpClientError::Http)
+        })
+    }
+}


### PR DESCRIPTION
The `oauth2` crate's built-in `AsyncHttpClient` impl for `reqwest::Client` is gated behind the `reqwest` feature flag, which pins oauth2 to a specific reqwest version. Disabling default features and providing our own `ReqwestClient` wrapper decouples us from this constraint, unblocking [future reqwest upgrades (e.g. 0.13)](https://github.com/rust-lang/crates.io/pull/12639) before oauth2 adds native support.

This also removes the redundant transitive `reqwest` and `webpki-roots` dependencies that oauth2 pulled in by default.