### PR TITLE
Add `Artificial intelligence` category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -88,6 +88,14 @@ Rust. Includes HTTP API wrappers as well. Non-idiomatic or unsafe
 bindings can be found in External FFI bindings.
 """
 
+[artificial-intelligence]
+name = "Artificial intelligence"
+description = """
+Crates for machine learning, deep learning, large language models,
+AI agents, and related tooling. Crates focused specifically on
+computer vision belong in the Computer vision category.
+"""
+
 [asynchronous]
 name = "Asynchronous"
 description = """
@@ -507,8 +515,8 @@ Rust.
 [science]
 name = "Science"
 description = """
-Crates related to solving problems involving physics, chemistry, 
-biology, machine learning, geoscience, and other scientific fields.
+Crates related to solving problems involving physics, chemistry,
+biology, geoscience, and other scientific fields.
 """
 
 [science.categories.computational-chemistry]


### PR DESCRIPTION
This adds a top-level category for AI-related crates covering machine learning, deep learning, large language models, AI agents, and related tooling. The PR also removes "machine learning" from the `Science` category description since it is now covered by the dedicated category.

Closes https://github.com/rust-lang/crates.io/pull/12928. Resolves https://github.com/rust-lang/crates.io/discussions/12929.