### PR TITLE
playwright: Automatically use the `msw` fixture

### DIFF
--- a/e2e/acceptance/crate-dependencies.spec.ts
+++ b/e2e/acceptance/crate-dependencies.spec.ts
@@ -30,9 +30,7 @@ test.describe('Acceptance | crate dependencies page', { tag: '@acceptance' }, ()
     await expect(page.locator('[data-test-dev-dependencies] li')).toHaveCount(0);
   });
 
-  test('shows an error page if crate not found', async ({ page, msw }) => {
-    void msw;
-
+  test('shows an error page if crate not found', async ({ page }) => {
     await page.goto('/crates/foo/1.0.0/dependencies');
     await expect(page).toHaveURL('/crates/foo/1.0.0/dependencies');
     await expect(page.locator('[data-test-404-page]')).toBeVisible();

--- a/e2e/acceptance/token-invites.spec.ts
+++ b/e2e/acceptance/token-invites.spec.ts
@@ -19,9 +19,7 @@ test.describe('Acceptance | /accept-invite/:token', { tag: '@acceptance' }, () =
   test('shows error for unknown token', async ({ page }) => {
     await page.goto('/accept-invite/unknown');
     await expect(page).toHaveURL('/accept-invite/unknown');
-    await expect(page.locator('[data-test-error-message]')).toHaveText(
-      'You may want to visit crates.io/me/pending-invites to try again.',
-    );
+    await expect(page.locator('[data-test-error-message]')).toHaveText('Not Found');
   });
 
   test('shows error for expired token', async ({ page, msw }) => {

--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -57,17 +57,20 @@ export const test = base.extend<AppOptions & AppFixtures>({
   //
   // We are explicitly not using the `createWorkerFixture()`function, because
   // uses `auto: true`, and we want to be explicit about our usage of the fixture.
-  msw: async ({ page }, use) => {
-    const worker = await createWorker(page, handlers);
-    const authenticateAs = async function (user) {
-      await db.mswSession.create({ user });
-      await page.addInitScript("globalThis.localStorage.setItem('isLoggedIn', '1')");
-    };
+  msw: [
+    async ({ page }, use) => {
+      const worker = await createWorker(page, handlers);
+      const authenticateAs = async function (user) {
+        await db.mswSession.create({ user });
+        await page.addInitScript("globalThis.localStorage.setItem('isLoggedIn', '1')");
+      };
 
-    await use({ worker, db, authenticateAs });
-    await db.reset();
-    worker.resetCookieStore();
-  },
+      await use({ worker, db, authenticateAs });
+      await db.reset();
+      worker.resetCookieStore();
+    },
+    { auto: true, scope: 'test' },
+  ],
   ember: [
     async ({ page, emberOptions }, use) => {
       let ember = new EmberPage(page);


### PR DESCRIPTION
Apparently we have a number of tests where the `msw` fixture was not explicitly used, leading to those tests performing actual network requests to the development server (and potentially proxying to the production server). This commit changes the Playwright setup to automatically use the `msw` fixture for all tests to prevent any unplanned network requests from being captured.

The `token-invites` test suite had to be fixed to make this change work. It previously did not hit the MSW setup and resulted in an non-JSON 404 response, causing the page to display the fallback text. Now that the test uses the MSW setup, we receive a "Not Found" error from the backend (like in production) and display that error message instead. This is obviously not a great error message, but it reflects the current situation that is in production. Fixing the error message seems out of scope for the `msw` fixture change.