### PR TITLE
svelte: Use `initialPromise` to await session in settings layout

### DIFF
--- a/svelte/src/lib/utils/session.svelte.ts
+++ b/svelte/src/lib/utils/session.svelte.ts
@@ -84,6 +84,14 @@ export class SessionState {
   state: 'checking' | 'logged-out' | 'logging-in' | 'logged-in' | 'logging-out' = $state('checking');
   currentUser: AuthenticatedUser | null = $state(null);
 
+  /**
+   * Resolves once the initial user authentication check completes
+   * and `currentUser` has been set via `setUser()`. Layouts that
+   * require an authenticated user can `{#await}` this to avoid
+   * rendering before `currentUser` is available.
+   */
+  initialPromise: Promise<void> | null = null;
+
   // TODO: implement `ownedCrates` (loaded from the `/api/v1/me` response)
   // TODO: implement sudo mode (`sudoEnabledUntil`, `isSudoEnabled`, `setSudo()`)
   //   Sudo mode enables admin actions for a limited duration. The expiry

--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -49,7 +49,7 @@
   setSession(sessionState);
 
   // svelte-ignore state_referenced_locally
-  data.userPromise.then(user => sessionState.setUser(user));
+  sessionState.initialPromise = data.userPromise.then(user => sessionState.setUser(user));
 </script>
 
 <svelte:head>

--- a/svelte/src/routes/settings/+layout.svelte
+++ b/svelte/src/routes/settings/+layout.svelte
@@ -1,18 +1,11 @@
 <script lang="ts">
   import { getSession } from '$lib/utils/session.svelte';
 
-  let { children, data } = $props();
+  let { children } = $props();
 
   let session = getSession();
-
-  // The root layout's `userPromise.then()` sets the user via a microtask,
-  // which means `session.currentUser` is still `null` during the initial
-  // synchronous render. Since the settings `+layout.ts` already awaited
-  // the user, we can set it synchronously here to avoid a render flash
-  // where child components briefly see `currentUser: null`.
-  //
-  // svelte-ignore state_referenced_locally
-  session.setUser(data.user);
 </script>
 
-{@render children()}
+{#await session.initialPromise then}
+  {@render children()}
+{/await}

--- a/svelte/src/routes/settings/+layout.ts
+++ b/svelte/src/routes/settings/+layout.ts
@@ -7,6 +7,4 @@ export async function load({ parent }) {
   if (!user) {
     error(401, { message: 'This page requires authentication', loginNeeded: true });
   }
-
-  return { user };
 }


### PR DESCRIPTION
Add `initialPromise` to `SessionState` so layouts that require an authenticated user can `{#await}` it instead of duplicating the `setUser()` call synchronously.

This works better than the previous approach because when the user navigates from another page to the settings page, the user in the session state would've previously been reset to what was received from the API. Now we have removed the reassignment, which means that any changes to user in the session state are preserved (e.g. `publish_notifications` flag).

### Related

- https://github.com/rust-lang/crates.io/issues/12515