### PR TITLE
svelte: Implement composable page title via context

### DIFF
--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -63,10 +63,6 @@
   }
 </script>
 
-<svelte:head>
-  <title>{crate.name} - crates.io: Rust Package Registry</title>
-</svelte:head>
-
 <CrateHeader {crate} {version} versionNum={requestedVersion} {keywords} />
 
 <div class="crate-info">

--- a/svelte/src/lib/components/PageTitle.svelte
+++ b/svelte/src/lib/components/PageTitle.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { getPageTitle } from '$lib/page-title.svelte';
+
+  let { title }: { title: string } = $props();
+
+  let pageTitle = getPageTitle();
+
+  $effect(() => {
+    return pageTitle.push(title);
+  });
+</script>

--- a/svelte/src/lib/page-title.svelte.ts
+++ b/svelte/src/lib/page-title.svelte.ts
@@ -1,0 +1,60 @@
+import { createContext, untrack } from 'svelte';
+
+const BASE_TITLE = 'crates.io: Rust Package Registry';
+const SEPARATOR = ' - ';
+
+/**
+ * Wrapper object so cleanup can use object identity to remove the
+ * correct token, even when multiple segments have the same string value.
+ */
+interface TitleToken {
+  title: string;
+}
+
+/**
+ * Manages a composable stack of page title segments.
+ *
+ * Title segments are pushed by nested components (layouts, pages) and
+ * composed into a single document title. The most recently pushed
+ * segment appears first, followed by parent segments, followed by
+ * the base title.
+ *
+ * Example: pushing "serde" then "Versions" produces
+ * "Versions - serde - crates.io: Rust Package Registry"
+ */
+export class PageTitleState {
+  /**
+   * Stack of active title segments, ordered from outermost (layout) to
+   * innermost (page). Uses `$state.raw` instead of `$state` so that
+   * token objects are not wrapped in proxies, which would break the
+   * identity comparison in the cleanup function returned by {@link push}.
+   */
+  #tokens = $state.raw<TitleToken[]>([]);
+
+  /** The composed document title string. */
+  get title(): string {
+    if (this.#tokens.length === 0) return BASE_TITLE;
+
+    let segments = this.#tokens.map(t => t.title).reverse();
+    return [...segments, BASE_TITLE].join(SEPARATOR);
+  }
+
+  /**
+   * Pushes a title segment onto the stack.
+   *
+   * Returns a cleanup function that removes the segment. This is
+   * designed to be used as the return value of a `$effect()` callback,
+   * so the segment is automatically removed when the component unmounts
+   * or the effect re-runs with a new value.
+   */
+  push(title: string): () => void {
+    let token: TitleToken = { title };
+    this.#tokens = [...untrack(() => this.#tokens), token];
+
+    return () => {
+      this.#tokens = untrack(() => this.#tokens).filter(t => t !== token);
+    };
+  }
+}
+
+export const [getPageTitle, setPageTitle] = createContext<PageTitleState>();

--- a/svelte/src/lib/page-title.test.ts
+++ b/svelte/src/lib/page-title.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { PageTitleState } from './page-title.svelte';
+
+describe('PageTitleState', () => {
+  it('returns base title when no segments are pushed', () => {
+    let state = new PageTitleState();
+    expect(state.title).toBe('crates.io: Rust Package Registry');
+  });
+
+  it('composes a single segment with the base title', () => {
+    let state = new PageTitleState();
+    state.push('Crates');
+    expect(state.title).toBe('Crates - crates.io: Rust Package Registry');
+  });
+
+  it('composes multiple segments in reverse order (deepest first)', () => {
+    let state = new PageTitleState();
+    state.push('serde');
+    state.push('Versions');
+    expect(state.title).toBe('Versions - serde - crates.io: Rust Package Registry');
+  });
+
+  it('removes segment when cleanup function is called', () => {
+    let state = new PageTitleState();
+    let cleanup = state.push('Crates');
+    expect(state.title).toBe('Crates - crates.io: Rust Package Registry');
+
+    cleanup();
+    expect(state.title).toBe('crates.io: Rust Package Registry');
+  });
+
+  it('removes only the specific token when cleanup is called with duplicate titles', () => {
+    let state = new PageTitleState();
+    let cleanup1 = state.push('Same');
+    state.push('Same');
+    expect(state.title).toBe('Same - Same - crates.io: Rust Package Registry');
+
+    cleanup1();
+    expect(state.title).toBe('Same - crates.io: Rust Package Registry');
+  });
+
+  it('handles push and cleanup in nested layout/page order', () => {
+    let state = new PageTitleState();
+
+    // Layout mounts and pushes "serde"
+    let cleanupLayout = state.push('serde');
+    expect(state.title).toBe('serde - crates.io: Rust Package Registry');
+
+    // Page mounts and pushes "Versions"
+    let cleanupPage = state.push('Versions');
+    expect(state.title).toBe('Versions - serde - crates.io: Rust Package Registry');
+
+    // Page unmounts
+    cleanupPage();
+    expect(state.title).toBe('serde - crates.io: Rust Package Registry');
+
+    // Layout unmounts
+    cleanupLayout();
+    expect(state.title).toBe('crates.io: Rust Package Registry');
+  });
+
+  it('handles page navigation (old page cleanup, new page push)', () => {
+    let state = new PageTitleState();
+
+    // First page
+    let cleanup1 = state.push('Crates');
+    expect(state.title).toBe('Crates - crates.io: Rust Package Registry');
+
+    // Navigate: old page unmounts, new page mounts
+    cleanup1();
+    state.push('Categories');
+    expect(state.title).toBe('Categories - crates.io: Rust Package Registry');
+  });
+
+  it('handles three levels of nesting', () => {
+    let state = new PageTitleState();
+    state.push('Settings');
+    state.push('Tokens');
+    state.push('New');
+    expect(state.title).toBe('New - Tokens - Settings - crates.io: Rust Package Registry');
+  });
+});

--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
   import ProgressBar from '$lib/components/ProgressBar.svelte';
   import TooltipContainer from '$lib/components/TooltipContainer.svelte';
   import { NotificationsState, setNotifications } from '$lib/notifications.svelte';
+  import { PageTitleState, setPageTitle } from '$lib/page-title.svelte';
   import { ProgressState, setProgressContext } from '$lib/progress.svelte';
   import { SearchFormContext, setSearchFormContext } from '$lib/search-form.svelte';
   import { setTooltipContext } from '$lib/tooltip.svelte';
@@ -27,6 +28,9 @@
   $effect(() => {
     document.documentElement.dataset.colorScheme = colorScheme.resolvedScheme;
   });
+
+  let pageTitle = new PageTitleState();
+  setPageTitle(pageTitle);
 
   let searchFormContext = new SearchFormContext();
   setSearchFormContext(searchFormContext);
@@ -53,7 +57,7 @@
 </script>
 
 <svelte:head>
-  <title>crates.io: Rust Package Registry</title>
+  <title>{pageTitle.title}</title>
 </svelte:head>
 
 {#if !__TEST__}

--- a/svelte/src/routes/categories/+page.svelte
+++ b/svelte/src/routes/categories/+page.svelte
@@ -2,6 +2,7 @@
   import { resolve } from '$app/paths';
 
   import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageTitle from '$lib/components/PageTitle.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import ResultsCount from '$lib/components/ResultsCount.svelte';
   import * as SortDropdown from '$lib/components/sort-dropdown';
@@ -13,9 +14,7 @@
   let currentSortBy = $derived(data.sort === 'crates' ? '# Crates' : 'Alphabetical');
 </script>
 
-<svelte:head>
-  <title>Categories - crates.io</title>
-</svelte:head>
+<PageTitle title="Categories" />
 
 <PageHeader title="All Categories" />
 

--- a/svelte/src/routes/categories/[category_id]/+page.svelte
+++ b/svelte/src/routes/categories/[category_id]/+page.svelte
@@ -4,6 +4,7 @@
 
   import CrateList from '$lib/components/CrateList.svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageTitle from '$lib/components/PageTitle.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import ResultsCount from '$lib/components/ResultsCount.svelte';
   import * as SortDropdown from '$lib/components/sort-dropdown';
@@ -42,9 +43,7 @@
   });
 </script>
 
-<svelte:head>
-  <title>{data.category.category} - Categories - crates.io</title>
-</svelte:head>
+<PageTitle title="{data.category.category} - Categories" />
 
 <PageHeader>
   <h1 class="heading">

--- a/svelte/src/routes/category_slugs/+page.svelte
+++ b/svelte/src/routes/category_slugs/+page.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageTitle from '$lib/components/PageTitle.svelte';
 
   let { data } = $props();
 </script>
 
-<svelte:head>
-  <title>Category Slugs - crates.io</title>
-</svelte:head>
+<PageTitle title="Category Slugs" />
 
 <PageHeader title="All Valid Category Slugs" />
 

--- a/svelte/src/routes/crates/+page.svelte
+++ b/svelte/src/routes/crates/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import CrateList from '$lib/components/CrateList.svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageTitle from '$lib/components/PageTitle.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import ResultsCount from '$lib/components/ResultsCount.svelte';
   import * as SortDropdown from '$lib/components/sort-dropdown';
@@ -23,9 +24,7 @@
   });
 </script>
 
-<svelte:head>
-  <title>Crates - crates.io</title>
-</svelte:head>
+<PageTitle title="Crates" />
 
 <PageHeader title="All Crates" {suffix} />
 

--- a/svelte/src/routes/crates/[crate_id]/+layout.svelte
+++ b/svelte/src/routes/crates/[crate_id]/+layout.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import PageTitle from '$lib/components/PageTitle.svelte';
+
   let { data, children } = $props();
 </script>
 
@@ -7,5 +9,7 @@
     <meta name="description" content={data.crate.description} />
   {/if}
 </svelte:head>
+
+<PageTitle title={data.crate.name} />
 
 {@render children()}

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.svelte
@@ -10,10 +10,6 @@
   let descriptions = $derived(data.descriptionMap);
 </script>
 
-<svelte:head>
-  <title>{data.crate.name} - crates.io: Rust Package Registry</title>
-</svelte:head>
-
 <CrateHeader crate={data.crate} version={data.version} versionNum={data.version.num} />
 
 <h2 class="heading">Dependencies</h2>

--- a/svelte/src/routes/crates/[crate_id]/versions/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/versions/+page.svelte
@@ -65,10 +65,6 @@
   }
 </script>
 
-<svelte:head>
-  <title>{data.crate.name} - Versions - crates.io</title>
-</svelte:head>
-
 <CrateHeader crate={data.crate} />
 
 <div class="results-meta">

--- a/svelte/src/routes/keywords/+page.svelte
+++ b/svelte/src/routes/keywords/+page.svelte
@@ -2,6 +2,7 @@
   import { resolve } from '$app/paths';
 
   import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageTitle from '$lib/components/PageTitle.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import ResultsCount from '$lib/components/ResultsCount.svelte';
   import * as SortDropdown from '$lib/components/sort-dropdown';
@@ -13,9 +14,7 @@
   let currentSortBy = $derived(data.sort === 'crates' ? '# Crates' : 'Alphabetical');
 </script>
 
-<svelte:head>
-  <title>Keywords - crates.io</title>
-</svelte:head>
+<PageTitle title="Keywords" />
 
 <PageHeader title="All Keywords" />
 

--- a/svelte/src/routes/keywords/[keyword_id]/+page.svelte
+++ b/svelte/src/routes/keywords/[keyword_id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import CrateList from '$lib/components/CrateList.svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageTitle from '$lib/components/PageTitle.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import ResultsCount from '$lib/components/ResultsCount.svelte';
   import * as SortDropdown from '$lib/components/sort-dropdown';
@@ -28,9 +29,7 @@
   });
 </script>
 
-<svelte:head>
-  <title>{data.keyword} - Keywords - crates.io</title>
-</svelte:head>
+<PageTitle title="{data.keyword} - Keywords" />
 
 <PageHeader title="All Crates" suffix="for keyword '{data.keyword}'" />
 

--- a/svelte/src/routes/search/+page.svelte
+++ b/svelte/src/routes/search/+page.svelte
@@ -5,6 +5,7 @@
   import Alert from '$lib/components/Alert.svelte';
   import CrateList from '$lib/components/CrateList.svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageTitle from '$lib/components/PageTitle.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import ResultsCount from '$lib/components/ResultsCount.svelte';
   import * as SortDropdown from '$lib/components/sort-dropdown';
@@ -43,12 +44,10 @@
     }
   });
 
-  let pageTitle = $derived('Search Results' + (data.q ? ` for '${data.q}'` : ''));
+  let searchTitle = $derived('Search Results' + (data.q ? ` for '${data.q}'` : ''));
 </script>
 
-<svelte:head>
-  <title>{pageTitle} - crates.io</title>
-</svelte:head>
+<PageTitle title={searchTitle} />
 
 <PageHeader title="Search Results" suffix={data.q ? `for '${data.q}'` : undefined} data-test-header />
 

--- a/svelte/src/routes/settings/profile/+page.svelte
+++ b/svelte/src/routes/settings/profile/+page.svelte
@@ -4,6 +4,7 @@
   import EmailInput from '$lib/components/EmailInput.svelte';
   import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageTitle from '$lib/components/PageTitle.svelte';
   import SettingsPage from '$lib/components/SettingsPage.svelte';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import { getNotifications } from '$lib/notifications.svelte';
@@ -38,9 +39,7 @@
   }
 </script>
 
-<svelte:head>
-  <title>Account Settings | crates.io: Rust Package Registry</title>
-</svelte:head>
+<PageTitle title="Settings" />
 
 <PageHeader title="Account Settings" />
 

--- a/svelte/src/routes/settings/tokens/+page.svelte
+++ b/svelte/src/routes/settings/tokens/+page.svelte
@@ -12,6 +12,7 @@
   import CopyButton from '$lib/components/CopyButton.svelte';
   import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageTitle from '$lib/components/PageTitle.svelte';
   import PatternDescription from '$lib/components/PatternDescription.svelte';
   import SettingsPage from '$lib/components/SettingsPage.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
@@ -81,9 +82,7 @@
   }
 </script>
 
-<svelte:head>
-  <title>API Tokens | crates.io: Rust Package Registry</title>
-</svelte:head>
+<PageTitle title="Settings" />
 
 <PageHeader title="Account Settings" />
 

--- a/svelte/src/routes/settings/tokens/new/+page.svelte
+++ b/svelte/src/routes/settings/tokens/new/+page.svelte
@@ -7,6 +7,7 @@
   import TrashIcon from '$lib/assets/trash.svg?component';
   import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
   import PageHeader from '$lib/components/PageHeader.svelte';
+  import PageTitle from '$lib/components/PageTitle.svelte';
   import PatternDescription from '$lib/components/PatternDescription.svelte';
   import SettingsPage from '$lib/components/SettingsPage.svelte';
   import { getNotifications } from '$lib/notifications.svelte';
@@ -173,9 +174,7 @@
   }
 </script>
 
-<svelte:head>
-  <title>New API Token | crates.io: Rust Package Registry</title>
-</svelte:head>
+<PageTitle title="Settings" />
 
 <PageHeader title="Account Settings" />
 

--- a/svelte/src/routes/teams/[team_id]/+page.svelte
+++ b/svelte/src/routes/teams/[team_id]/+page.svelte
@@ -26,10 +26,6 @@
   });
 </script>
 
-<svelte:head>
-  <title>{orgName}/{data.team.name} - crates.io</title>
-</svelte:head>
-
 <PageHeader style="display: flex; align-items: center;" data-test-heading>
   <UserAvatar
     user={{ ...data.team, kind: 'team' }}

--- a/svelte/src/routes/users/[user_id]/+page.svelte
+++ b/svelte/src/routes/users/[user_id]/+page.svelte
@@ -23,10 +23,6 @@
   });
 </script>
 
-<svelte:head>
-  <title>{data.user.login} - crates.io</title>
-</svelte:head>
-
 <PageHeader style="display: flex; align-items: center; gap: var(--space-xs);" data-test-heading>
   <UserAvatar user={{ ...data.user, kind: 'user' }} size="medium" data-test-avatar />
   <h1 data-test-username>{data.user.login}</h1>


### PR DESCRIPTION
Replace per-page `<svelte:head><title>` blocks with a centralized `PageTitleState` context and `<PageTitle>` component. A single `<svelte:head>` in the root layout reactively renders the composed title. Pages and layouts push title segments onto a stack, and cleanup is handled automatically via `$effect` return values.

The crate layout pushes the crate name, so child pages like versions and dependencies compose with it automatically.

This roughly matches the `ember-page-title` behavior.

### Related

- https://github.com/rust-lang/crates.io/issues/12515