### PR TITLE
svelte: Fix whitespace issues in token scope lists

### DIFF
--- a/svelte/src/routes/settings/tokens/+page.svelte
+++ b/svelte/src/routes/settings/tokens/+page.svelte
@@ -130,20 +130,32 @@
               {#if token.endpoint_scopes}
                 <div class="endpoint-scopes" data-test-endpoint-scopes>
                   Scopes:
-                  {#each formatScopes(token.endpoint_scopes) as part, i (i)}{#if part.type === 'element'}<strong
-                        >{part.value}<Tooltip text={scopeDescription(part.value)} /></strong
-                      >{:else}{part.value}{/if}{/each}
+                  {#each formatScopes(token.endpoint_scopes) as part, i (i)}
+                    {#if part.type === 'element'}
+                      <strong>
+                        <Tooltip text={scopeDescription(part.value)} />
+                        {part.value}
+                      </strong>
+                    {:else}
+                      {part.value}
+                    {/if}
+                  {/each}
                 </div>
               {/if}
 
               {#if token.crate_scopes}
                 <div class="crate-scopes" data-test-crate-scopes>
                   Crates:
-                  {#each formatScopes(token.crate_scopes) as part, i (i)}{#if part.type === 'element'}<strong
-                        >{part.value}<Tooltip>
-                          <PatternDescription pattern={part.value} />
-                        </Tooltip></strong
-                      >{:else}{part.value}{/if}{/each}
+                  {#each formatScopes(token.crate_scopes) as part, i (i)}
+                    {#if part.type === 'element'}
+                      <strong>
+                        <Tooltip><PatternDescription pattern={part.value} /></Tooltip>
+                        {part.value}
+                      </strong>
+                    {:else}
+                      {part.value}
+                    {/if}
+                  {/each}
                 </div>
               {/if}
             </div>


### PR DESCRIPTION
Rendering the `Tooltip` component *after* the `part.value` caused there to be an HTML comment DOM node, which resulted in whitespace between the value and the comma. By moving the tooltip invocation in front of the value we fix the problem.

**Before:**

<img width="379" height="206" alt="Bildschirmfoto 2026-03-04 um 10 32 46" src="https://github.com/user-attachments/assets/10ce1d82-b903-40ee-9580-2d3e35a6e35f" />


**After:**

<img width="381" height="204" alt="Bildschirmfoto 2026-03-04 um 10 32 09" src="https://github.com/user-attachments/assets/1ed71122-059c-471d-a81a-d06e49d26122" />

### Related

- https://github.com/rust-lang/crates.io/issues/12515
