### PR TITLE
svelte: Remove unused `docs/+page.svelte` file

### DIFF
--- a/svelte/src/routes/docs/+page.svelte
+++ b/svelte/src/routes/docs/+page.svelte
@@ -1,2 +1,0 @@
-<h1>Documentation</h1>
-<p>Stub route for /docs</p>


### PR DESCRIPTION
In the Ember.js app, this page is just empty. By removing this file we show a "Not Found" error page in the Svelte app instead. While this is not the same behavior as the Ember.js app, it is strictly better and there is no shared Playwright test for this specific URL anyway 😅 

### Related

- https://github.com/rust-lang/crates.io/issues/12515