### PR TITLE
svelte: Remove unused `settings/+page.svelte` file

### DIFF
--- a/svelte/src/routes/settings/+page.svelte
+++ b/svelte/src/routes/settings/+page.svelte
@@ -1,2 +1,0 @@
-<h1>Settings</h1>
-<p>Stub route for /settings</p>


### PR DESCRIPTION
This page redirects to `/settings/profile` so there is no reason to keep the template file around.

### Related

- https://github.com/rust-lang/crates.io/issues/12515