### PR TITLE
Fix URL in error message for rate limits

### DIFF
--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -56,7 +56,7 @@ impl AppError for TooManyRequests {
         let retry_after = self.retry_after.format(HTTP_DATE_FORMAT);
 
         let detail = format!(
-            "{}. Please try again after {retry_after} and see https://crates.io/rate-limits for more details.",
+            "{}. Please try again after {retry_after} and see https://crates.io/docs/rate-limits for more details.",
             self.action.error_message()
         );
         let mut response = json_error(&detail, StatusCode::TOO_MANY_REQUESTS);


### PR DESCRIPTION
When publishing too many crates at once, the error message contains a broken link.