### PR TITLE
OpenAPI: Fix missing pagination params for `list_reverse_dependencies`

### DIFF
--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -2704,7 +2704,27 @@ export interface operations {
     };
     list_reverse_dependencies: {
         parameters: {
-            query?: never;
+            query?: {
+                /**
+                 * @description The page number to request.
+                 *
+                 *     This parameter is mutually exclusive with `seek` and not supported for
+                 *     all requests.
+                 */
+                page?: number;
+                /** @description The number of items to request per page. */
+                per_page?: number;
+                /**
+                 * @description The seek key to request.
+                 *
+                 *     This parameter is mutually exclusive with `page` and not supported for
+                 *     all requests.
+                 *
+                 *     The seek key can usually be found in the `meta.next_page` field of
+                 *     paginated responses.
+                 */
+                seek?: string;
+            };
             header?: never;
             path: {
                 /** @description Name of the crate */

--- a/src/controllers/krate/rev_deps.rs
+++ b/src/controllers/krate/rev_deps.rs
@@ -1,5 +1,5 @@
 use crate::app::AppState;
-use crate::controllers::helpers::pagination::PaginationOptions;
+use crate::controllers::helpers::pagination::{PaginationOptions, PaginationQueryParams};
 use crate::controllers::krate::CratePath;
 use crate::models::{CrateName, User, Version, VersionOwnerAction};
 use crate::util::errors::AppResult;
@@ -33,7 +33,7 @@ pub struct RevDepsMeta {
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/reverse_dependencies",
-    params(CratePath),
+    params(CratePath, PaginationQueryParams),
     tag = "crates",
     responses((status = 200, description = "Successful Response", body = inline(RevDepsResponse))),
 )]

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -2827,6 +2827,37 @@ expression: response.json()
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "The page number to request.\n\nThis parameter is mutually exclusive with `seek` and not supported for\nall requests.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to request per page.",
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The seek key to request.\n\nThis parameter is mutually exclusive with `page` and not supported for\nall requests.\n\nThe seek key can usually be found in the `meta.next_page` field of\npaginated responses.",
+            "in": "query",
+            "name": "seek",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
The `PaginationQueryParams` params were unintentionally missing from the utoipa annotations. This PR fixes the problem, updates the corresponding test snapshot, and regenerates the API client library.