### PR TITLE
OpenAPI: Add missing `#[schema(as = ...)]` annotations to remove `Encodable` prefix from schema names

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -143,6 +143,7 @@ pub struct InvitationResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, utoipa::ToSchema)]
+#[schema(as = Dependency)]
 pub struct EncodableDependency {
     /// An opaque identifier for the dependency.
     #[schema(example = 169)]
@@ -638,6 +639,7 @@ impl From<Team> for EncodableTeam {
 }
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]
+#[schema(as = ApiTokenWithToken)]
 pub struct EncodableApiTokenWithToken {
     #[serde(flatten)]
     pub token: ApiToken,

--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -1025,6 +1025,15 @@ export interface components {
              */
             name: string;
         };
+        ApiTokenWithToken: components["schemas"]["ApiToken"] & {
+            /**
+             * @description The plaintext API token.
+             *
+             *     Only available when the token is created.
+             * @example a1b2c3d4e5f6g7h8i9j0
+             */
+            token: string;
+        };
         AuthenticatedUser: {
             /**
              * @description The user's avatar URL, if set.
@@ -1317,16 +1326,7 @@ export interface components {
              */
             inviter_id: number;
         };
-        EncodableApiTokenWithToken: components["schemas"]["ApiToken"] & {
-            /**
-             * @description The plaintext API token.
-             *
-             *     Only available when the token is created.
-             * @example a1b2c3d4e5f6g7h8i9j0
-             */
-            token: string;
-        };
-        EncodableDependency: {
+        Dependency: {
             /**
              * @description The name of the crate this dependency points to.
              * @example serde
@@ -2742,7 +2742,7 @@ export interface operations {
                 content: {
                     "application/json": {
                         /** @description The list of reverse dependencies of the crate. */
-                        dependencies: components["schemas"]["EncodableDependency"][];
+                        dependencies: components["schemas"]["Dependency"][];
                         meta: {
                             /**
                              * Format: int64
@@ -2950,7 +2950,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        dependencies: components["schemas"]["EncodableDependency"][];
+                        dependencies: components["schemas"]["Dependency"][];
                     };
                 };
             };
@@ -3469,7 +3469,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        api_token: components["schemas"]["EncodableApiTokenWithToken"];
+                        api_token: components["schemas"]["ApiTokenWithToken"];
                     };
                 };
             };

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -77,6 +77,26 @@ expression: response.json()
         ],
         "type": "object"
       },
+      "ApiTokenWithToken": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApiToken"
+          },
+          {
+            "properties": {
+              "token": {
+                "description": "The plaintext API token.\n\nOnly available when the token is created.",
+                "example": "a1b2c3d4e5f6g7h8i9j0",
+                "type": "string"
+              }
+            },
+            "required": [
+              "token"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "AuthenticatedUser": {
         "properties": {
           "avatar": {
@@ -502,27 +522,7 @@ expression: response.json()
         ],
         "type": "object"
       },
-      "EncodableApiTokenWithToken": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ApiToken"
-          },
-          {
-            "properties": {
-              "token": {
-                "description": "The plaintext API token.\n\nOnly available when the token is created.",
-                "example": "a1b2c3d4e5f6g7h8i9j0",
-                "type": "string"
-              }
-            },
-            "required": [
-              "token"
-            ],
-            "type": "object"
-          }
-        ]
-      },
-      "EncodableDependency": {
+      "Dependency": {
         "properties": {
           "crate_id": {
             "description": "The name of the crate this dependency points to.",
@@ -2869,7 +2869,7 @@ expression: response.json()
                     "dependencies": {
                       "description": "The list of reverse dependencies of the crate.",
                       "items": {
-                        "$ref": "#/components/schemas/EncodableDependency"
+                        "$ref": "#/components/schemas/Dependency"
                       },
                       "type": "array"
                     },
@@ -3224,7 +3224,7 @@ expression: response.json()
                   "properties": {
                     "dependencies": {
                       "items": {
-                        "$ref": "#/components/schemas/EncodableDependency"
+                        "$ref": "#/components/schemas/Dependency"
                       },
                       "type": "array"
                     }
@@ -4110,7 +4110,7 @@ expression: response.json()
                 "schema": {
                   "properties": {
                     "api_token": {
-                      "$ref": "#/components/schemas/EncodableApiTokenWithToken"
+                      "$ref": "#/components/schemas/ApiTokenWithToken"
                     }
                   },
                   "required": [

--- a/svelte/src/lib/components/dependency-list/Row.stories.svelte
+++ b/svelte/src/lib/components/dependency-list/Row.stories.svelte
@@ -5,7 +5,7 @@
 
   import Row from './Row.svelte';
 
-  type Dependency = components['schemas']['EncodableDependency'];
+  type Dependency = components['schemas']['Dependency'];
 
   const { Story } = defineMeta({
     title: 'dependency-list/Row',

--- a/svelte/src/lib/components/dependency-list/Row.svelte
+++ b/svelte/src/lib/components/dependency-list/Row.svelte
@@ -8,7 +8,7 @@
   import Placeholder from '$lib/components/Placeholder.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
 
-  type Dependency = components['schemas']['EncodableDependency'];
+  type Dependency = components['schemas']['Dependency'];
 
   interface Props {
     dependency: Dependency;


### PR DESCRIPTION
The `Encodable` prefix is an implementation detail of the crates.io codebase, but should not be used in external documentation like the OpenAPI description.