### PR TITLE
msw: Add `GET /api/v1/crates/:name/owners` handler

### DIFF
--- a/packages/crates-io-msw/handlers/crates.js
+++ b/packages/crates-io-msw/handlers/crates.js
@@ -4,6 +4,7 @@ import downloads from './crates/downloads.js';
 import followCrate from './crates/follow.js';
 import following from './crates/following.js';
 import getCrate from './crates/get.js';
+import listOwners from './crates/list-owners.js';
 import listCrates from './crates/list.js';
 import patchCrate from './crates/patch.js';
 import removeOwners from './crates/remove-owners.js';
@@ -21,6 +22,7 @@ export default [
   followCrate,
   unfollowCrate,
   addOwners,
+  listOwners,
   removeOwners,
   userOwners,
   teamOwners,

--- a/packages/crates-io-msw/handlers/crates/list-owners.js
+++ b/packages/crates-io-msw/handlers/crates/list-owners.js
@@ -1,0 +1,38 @@
+import { http, HttpResponse } from 'msw';
+
+import { db } from '../../index.js';
+import { notFound } from '../../utils/handlers.js';
+
+export default http.get('/api/v1/crates/:name/owners', async ({ params }) => {
+  let crate = db.crate.findFirst(q => q.where({ name: params.name }));
+  if (!crate) {
+    return notFound();
+  }
+
+  let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.crate.id === crate.id));
+
+  let users = [
+    ...ownerships
+      .filter(o => o.user)
+      .map(o => ({
+        id: o.user.id,
+        login: o.user.login,
+        kind: 'user',
+        url: `https://github.com/${o.user.login}`,
+        name: o.user.name,
+        avatar: o.user.avatar,
+      })),
+    ...ownerships
+      .filter(o => o.team)
+      .map(o => ({
+        id: o.team.id,
+        login: o.team.login,
+        kind: 'team',
+        url: o.team.url,
+        name: o.team.name,
+        avatar: o.team.avatar,
+      })),
+  ];
+
+  return HttpResponse.json({ users });
+});

--- a/packages/crates-io-msw/handlers/crates/list-owners.test.js
+++ b/packages/crates-io-msw/handlers/crates/list-owners.test.js
@@ -1,0 +1,108 @@
+import { expect, test } from 'vitest';
+
+import { db } from '../../index.js';
+
+test('returns 404 for unknown crates', async function () {
+  let response = await fetch('/api/v1/crates/foo/owners');
+  expect(response.status).toBe(404);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Not Found",
+        },
+      ],
+    }
+  `);
+});
+
+test('empty case', async function () {
+  await db.crate.create({ name: 'rand' });
+
+  let response = await fetch('/api/v1/crates/rand/owners');
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "users": [],
+    }
+  `);
+});
+
+test('returns user owners', async function () {
+  let user = await db.user.create({ name: 'John Doe' });
+  let crate = await db.crate.create({ name: 'rand' });
+  await db.crateOwnership.create({ crate, user });
+
+  let response = await fetch('/api/v1/crates/rand/owners');
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "users": [
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 1,
+          "kind": "user",
+          "login": "john-doe",
+          "name": "John Doe",
+          "url": "https://github.com/john-doe",
+        },
+      ],
+    }
+  `);
+});
+
+test('returns team owners', async function () {
+  let team = await db.team.create({ name: 'maintainers' });
+  let crate = await db.crate.create({ name: 'rand' });
+  await db.crateOwnership.create({ crate, team });
+
+  let response = await fetch('/api/v1/crates/rand/owners');
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "users": [
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 1,
+          "kind": "team",
+          "login": "github:rust-lang:maintainers",
+          "name": "maintainers",
+          "url": "https://github.com/rust-lang",
+        },
+      ],
+    }
+  `);
+});
+
+test('returns user owners before team owners', async function () {
+  let user = await db.user.create({ name: 'John Doe' });
+  let team = await db.team.create({ name: 'maintainers' });
+  let crate = await db.crate.create({ name: 'rand' });
+  await db.crateOwnership.create({ crate, user });
+  await db.crateOwnership.create({ crate, team });
+
+  let response = await fetch('/api/v1/crates/rand/owners');
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "users": [
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 1,
+          "kind": "user",
+          "login": "john-doe",
+          "name": "John Doe",
+          "url": "https://github.com/john-doe",
+        },
+        {
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "id": 1,
+          "kind": "team",
+          "login": "github:rust-lang:maintainers",
+          "name": "maintainers",
+          "url": "https://github.com/rust-lang",
+        },
+      ],
+    }
+  `);
+});


### PR DESCRIPTION
The Svelte layout loads owners via the combined `/owners` endpoint, but MSW only had handlers for the `owner_user` and `owner_team` endpoints. Without this handler, the request fell through to the generic version handler which interpreted `owners` as a version number 😅 