### PR TITLE
msw: Fix playground handler response shape

### DIFF
--- a/packages/crates-io-msw/handlers/playground.js
+++ b/packages/crates-io-msw/handlers/playground.js
@@ -1,3 +1,3 @@
 import { http, HttpResponse } from 'msw';
 
-export default [http.get('https://play.rust-lang.org/meta/crates', () => HttpResponse.json([]))];
+export default [http.get('https://play.rust-lang.org/meta/crates', () => HttpResponse.json({ crates: [] }))];

--- a/packages/crates-io-msw/handlers/playground.test.js
+++ b/packages/crates-io-msw/handlers/playground.test.js
@@ -3,5 +3,9 @@ import { expect, test } from 'vitest';
 test('returns 200 OK and an empty array', async function () {
   let response = await fetch('https://play.rust-lang.org/meta/crates');
   expect(response.status).toBe(200);
-  expect(await response.json()).toMatchInlineSnapshot(`[]`);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "crates": [],
+    }
+  `);
 });


### PR DESCRIPTION
The handler returned `[]` instead of `{ crates: [] }`, causing `loadPlaygroundCrates()` in the Svelte app to resolve with `undefined` and crash the `CrateSidebar` component 🙈 