### PR TITLE
svelte: Use composite key in `OwnersList` `{#each}` block

### DIFF
--- a/svelte/src/lib/components/OwnersList.svelte
+++ b/svelte/src/lib/components/OwnersList.svelte
@@ -32,7 +32,7 @@
   class:detailed={showDetailedList}
   data-test-owners={showDetailedList ? 'detailed' : 'basic'}
 >
-  {#each owners as owner (owner.id)}
+  {#each owners as owner (`${owner.kind}:${owner.id}`)}
     {@const isTeam = owner.kind === 'team'}
     {@const href = isTeam
       ? resolve('/teams/[team_id]', { team_id: owner.login })


### PR DESCRIPTION
Use `${owner.kind}:${owner.id}` instead of `owner.id` as the key, since users and teams can share the same numeric ID, which would cause a conflict and throw an error.

### Related

- https://github.com/rust-lang/crates.io/issues/12515