### PR TITLE
Add static `og:title` and `og:description` meta tags

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -23,6 +23,8 @@
 
     <meta name="google" content="notranslate" />
 
+    <meta property="og:title" content="crates.io: Rust Package Registry">
+    <meta property="og:description" content="crates.io serves as a central registry for sharing crates, which are packages or libraries written in Rust that you can use to enhance your projects">
     <meta property="og:image" content="{{og_image_url}}">
     <meta name="twitter:card" content="summary_large_image">
 


### PR DESCRIPTION
Open Graph description and title should fix the issue of not dismissible preview.

Closes Issue: #11541 