### PR TITLE
svelte: Redirect `/crates/[id]/owners` to `/crates/[id]/settings`

### DIFF
--- a/svelte/src/routes/crates/[crate_id]/owners/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/owners/+page.svelte
@@ -1,6 +1,0 @@
-<script lang="ts">
-  let { data } = $props();
-</script>
-
-<h1>Owners: {data.crate_id}</h1>
-<p>Stub route for /crates/:crate_id/owners</p>

--- a/svelte/src/routes/crates/[crate_id]/owners/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/owners/+page.ts
@@ -1,3 +1,6 @@
+import { resolve } from '$app/paths';
+import { redirect } from '@sveltejs/kit';
+
 export function load({ params }) {
-  return { crate_id: params.crate_id };
+  redirect(308, resolve('/crates/[crate_id]/settings', { crate_id: params.crate_id }));
 }


### PR DESCRIPTION
see https://github.com/rust-lang/crates.io/blob/4c3318bc17c2b0ac09622aa4f7f8de21a6af1c27/app/routes/crate/owners.js :)

### Related

- https://github.com/rust-lang/crates.io/issues/12515