### PR TITLE
svelte: Wire up `isOwner` check in `CrateHeader` component

### DIFF
--- a/svelte/src/lib/components/CrateHeader.stories.svelte
+++ b/svelte/src/lib/components/CrateHeader.stories.svelte
@@ -3,6 +3,7 @@
 
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
+  import SessionDecorator from '$lib/storybook/SessionDecorator.svelte';
   import CrateHeader from './CrateHeader.svelte';
 
   const { Story } = defineMeta({
@@ -11,9 +12,35 @@
     tags: ['autodocs'],
   });
 
+  type AuthenticatedUser = components['schemas']['AuthenticatedUser'];
   type Crate = components['schemas']['Crate'];
+  type Owner = components['schemas']['Owner'];
   type Version = components['schemas']['Version'];
   type Keyword = components['schemas']['Keyword'];
+
+  const ownerUser: AuthenticatedUser = {
+    id: 42,
+    login: 'johndoe',
+    name: 'John Doe',
+    avatar: 'https://avatars.githubusercontent.com/u/1234567?v=4',
+    email: 'john@example.com',
+    email_verified: true,
+    email_verification_sent: true,
+    is_admin: false,
+    publish_notifications: true,
+    url: 'https://github.com/johndoe',
+  };
+
+  const owners: Owner[] = [
+    {
+      id: 42,
+      login: 'johndoe',
+      kind: 'user',
+      url: 'https://github.com/johndoe',
+      name: 'John Doe',
+      avatar: 'https://avatars.githubusercontent.com/u/1234567?v=4',
+    },
+  ];
 
   const baseCrate: Crate = {
     id: 'serde',
@@ -152,3 +179,15 @@
     versionNum: '1.0.215',
   }}
 />
+
+<Story name="Crate Owner" asChild>
+  <SessionDecorator user={ownerUser}>
+    <CrateHeader
+      crate={baseCrate}
+      version={baseVersion}
+      versionNum="1.0.215"
+      keywords={sampleKeywords}
+      ownersPromise={Promise.resolve(owners)}
+    />
+  </SessionDecorator>
+</Story>

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -12,6 +12,7 @@
   type Crate = components['schemas']['Crate'];
   type Version = components['schemas']['Version'];
   type Keyword = components['schemas']['Keyword'];
+  type Owner = components['schemas']['Owner'];
 
   interface Props {
     /** The crate to display in the header. */
@@ -31,15 +32,15 @@
 
     /** The keywords associated with this crate. */
     keywords?: Keyword[];
+
+    /** The owners of this crate, used to determine if the Settings tab should be shown. */
+    ownersPromise?: Promise<Owner[]>;
   }
 
-  let { crate, version, versionNum: version_num, keywords = [] }: Props = $props();
+  let { crate, version, versionNum: version_num, keywords = [], ownersPromise }: Props = $props();
   let crate_id = $derived(crate.id);
 
   let session = getSession();
-
-  // TODO: implement isOwner check using session service
-  let isOwner = $derived(false);
 
   let readmeHref = $derived(
     version_num
@@ -115,9 +116,11 @@
   <NavTabs.Tab href={depsHref} data-test-deps-tab>Dependencies</NavTabs.Tab>
   <NavTabs.Tab href={revDepsHref} data-test-rev-deps-tab>Dependents</NavTabs.Tab>
   <NavTabs.Tab href={securityHref} data-test-security-tab>Security</NavTabs.Tab>
-  {#if isOwner}
-    <NavTabs.Tab href={settingsHref} data-test-settings-tab>Settings</NavTabs.Tab>
-  {/if}
+  {#await ownersPromise then owners}
+    {#if owners?.some(o => o.kind === 'user' && o.id === session.currentUser?.id)}
+      <NavTabs.Tab href={settingsHref} data-test-settings-tab>Settings</NavTabs.Tab>
+    {/if}
+  {/await}
 </NavTabs.Root>
 
 <style>

--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -63,7 +63,7 @@
   }
 </script>
 
-<CrateHeader {crate} {version} versionNum={requestedVersion} {keywords} />
+<CrateHeader {crate} {version} versionNum={requestedVersion} {keywords} {ownersPromise} />
 
 <div class="crate-info">
   <div class="docs" data-test-docs>

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.svelte
@@ -10,7 +10,12 @@
   let descriptions = $derived(data.descriptionMap);
 </script>
 
-<CrateHeader crate={data.crate} version={data.version} versionNum={data.version.num} />
+<CrateHeader
+  crate={data.crate}
+  version={data.version}
+  versionNum={data.version.num}
+  ownersPromise={data.ownersPromise}
+/>
 
 <h2 class="heading">Dependencies</h2>
 {#if normal.length > 0}

--- a/svelte/src/routes/crates/[crate_id]/reverse_dependencies/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/reverse_dependencies/+page.svelte
@@ -10,7 +10,7 @@
   let pagination = $derived(calculatePagination(data.page, data.perPage, data.total));
 </script>
 
-<CrateHeader crate={data.crate} />
+<CrateHeader crate={data.crate} ownersPromise={data.ownersPromise} />
 
 {#if data.total > 0}
   <div class="results-meta">

--- a/svelte/src/routes/crates/[crate_id]/versions/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/versions/+page.svelte
@@ -65,7 +65,7 @@
   }
 </script>
 
-<CrateHeader crate={data.crate} />
+<CrateHeader crate={data.crate} ownersPromise={data.ownersPromise} />
 
 <div class="results-meta">
   <span class="page-description text--small" data-test-page-description>


### PR DESCRIPTION
This replaces the hardcoded `isOwner = false` with an `{#await}` block that resolves `ownersPromise` and compares the current user against the crate owners. This matches how the Ember.js implementation works.

### Related

- https://github.com/rust-lang/crates.io/issues/12515