### PR TITLE
ISSUE_TEMPLATE/config.yml: update feature request link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Feature request
     about: Suggest an idea for this project
-    url: https://github.com/rust-lang/crates.io/discussions/new
+    url: https://github.com/rust-lang/crates.io/discussions/new?category=feature-requests


### PR DESCRIPTION
Going to `https://github.com/rust-lang/crates.io/discussions/new` redirects to `https://github.com/rust-lang/crates.io/discussions/new/choose` but with a banner at the top saying "Sorry, we didn't recognize that category! Please choose one of the following valid categories."

Add the missing `category=feature-requests` parameter to bring up the feature request category.