### PR TITLE
Check GitHub API proactively for renamed or deleted users

### DIFF
--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -142,6 +142,9 @@ pub struct OauthGithub {
     pub avatar: Option<String>,
     /// In the process of being migrated from `users.gh_encrypted_token`.
     pub encrypted_token: Vec<u8>,
+    /// The last time we verified with GitHub what the GitHub username for this user was, and
+    /// whether the account was valid
+    pub last_sync: DateTime<Utc>,
     /// In the process of being migrated from `users.gh_login`.
     pub login: String,
     /// Foreign key to the `users` table.
@@ -193,6 +196,7 @@ impl NewOauthGithub<'_> {
                 oauth_github::encrypted_token.eq(excluded(oauth_github::encrypted_token)),
                 oauth_github::login.eq(excluded(oauth_github::login)),
                 oauth_github::avatar.eq(excluded(oauth_github::avatar)),
+                oauth_github::last_sync.eq(Utc::now()),
             ))
             .get_result(&mut conn)
             .await

--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -676,6 +676,8 @@ diesel::table! {
         avatar -> Nullable<Varchar>,
         /// Encrypted GitHub access token
         encrypted_token -> Bytea,
+        /// The last time we verified with GitHub what the GitHub username for this user was, and whether the account was valid
+        last_sync -> Timestamptz,
         /// GitHub username
         login -> Varchar,
         /// Crates.io user ID foreign key

--- a/crates/crates_io_database_dump/src/dump-db.toml
+++ b/crates/crates_io_database_dump/src/dump-db.toml
@@ -170,6 +170,7 @@ account_id = "private"
 encrypted_token = "private"
 login = "private"
 avatar = "private"
+last_sync = "private"
 [oauth_github.column_defaults]
 encrypted_token = "''"
 

--- a/crates/crates_io_github/examples/test_github_client.rs
+++ b/crates/crates_io_github/examples/test_github_client.rs
@@ -17,6 +17,9 @@ enum Request {
         #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
         access_token: SecretString,
     },
+    GetUserById {
+        account_id: i64,
+    },
     OrgByName {
         org_name: String,
         #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
@@ -66,6 +69,10 @@ async fn main() -> Result<()> {
         Request::GetUser { name, access_token } => {
             let access_token = AccessToken::new(access_token.expose_secret().into());
             let response = github_client.get_user(&name, &access_token).await?;
+            println!("{response:#?}");
+        }
+        Request::GetUserById { account_id } => {
+            let response = github_client.get_user_by_id(account_id).await?;
             println!("{response:#?}");
         }
         Request::OrgByName {

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -26,6 +26,7 @@ type Result<T> = std::result::Result<T, GitHubError>;
 pub trait GitHubClient: Send + Sync {
     async fn current_user(&self, auth: &AccessToken) -> Result<GitHubUser>;
     async fn get_user(&self, name: &str, auth: &AccessToken) -> Result<GitHubUser>;
+    async fn get_user_by_id(&self, account_id: i64) -> Result<GitHubUser>;
     async fn org_by_name(&self, org_name: &str, auth: &AccessToken) -> Result<GitHubOrganization>;
     async fn team_by_name(
         &self,
@@ -211,6 +212,11 @@ impl GitHubClient for RealGitHubClient {
     async fn get_user(&self, name: &str, auth: &AccessToken) -> Result<GitHubUser> {
         let url = format!("/users/{name}");
         self.request(&url, auth).await
+    }
+
+    async fn get_user_by_id(&self, account_id: i64) -> Result<GitHubUser> {
+        let url = format!("/user/{account_id}");
+        self._request(&url, std::convert::identity).await
     }
 
     async fn org_by_name(&self, org_name: &str, auth: &AccessToken) -> Result<GitHubOrganization> {

--- a/migrations/2026-05-05-180007-0000_add_last_sync_to_oauth_github/down.sql
+++ b/migrations/2026-05-05-180007-0000_add_last_sync_to_oauth_github/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS oauth_github
+DROP COLUMN last_sync;

--- a/migrations/2026-05-05-180007-0000_add_last_sync_to_oauth_github/up.sql
+++ b/migrations/2026-05-05-180007-0000_add_last_sync_to_oauth_github/up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE IF EXISTS oauth_github
+-- Set existing rows' last sync value to 1970
+ADD COLUMN last_sync timestamptz NOT NULL DEFAULT to_timestamp(0),
+-- Set new rows' last sync value to the current time going forward, because creating a new
+-- crates.io account fetches the user info from GitHub
+ALTER COLUMN last_sync SET DEFAULT now();
+
+comment on column oauth_github.last_sync is 'The last time we verified with GitHub what the GitHub username for this user was, and whether the account was valid';

--- a/migrations/2026-05-05-180007-0000_add_last_sync_to_oauth_github/up.sql
+++ b/migrations/2026-05-05-180007-0000_add_last_sync_to_oauth_github/up.sql
@@ -1,8 +1,8 @@
+-- safety-assured:start
+-- Adding a column with a constant value default is safe because we're using Postgres > 11.
 ALTER TABLE IF EXISTS oauth_github
--- Set existing rows' last sync value to 1970
-ADD COLUMN last_sync timestamptz NOT NULL DEFAULT to_timestamp(0),
--- Set new rows' last sync value to the current time going forward, because creating a new
--- crates.io account fetches the user info from GitHub
-ALTER COLUMN last_sync SET DEFAULT now();
+-- Set existing rows' last sync value to 1970.
+ADD COLUMN last_sync timestamptz NOT NULL DEFAULT to_timestamp(0);
+-- safety-assured:end
 
 comment on column oauth_github.last_sync is 'The last time we verified with GitHub what the GitHub username for this user was, and whether the account was valid';

--- a/migrations/2026-05-05-180007-0000_add_last_sync_to_oauth_github/up.sql
+++ b/migrations/2026-05-05-180007-0000_add_last_sync_to_oauth_github/up.sql
@@ -1,8 +1,5 @@
--- safety-assured:start
--- Adding a column with a constant value default is safe because we're using Postgres > 11.
-ALTER TABLE IF EXISTS oauth_github
--- Set existing rows' last sync value to 1970.
-ADD COLUMN last_sync timestamptz NOT NULL DEFAULT to_timestamp(0);
--- safety-assured:end
+ALTER TABLE oauth_github
+    -- Set existing rows' last sync value to 1970.
+    ADD COLUMN last_sync timestamptz NOT NULL DEFAULT 'epoch';
 
 comment on column oauth_github.last_sync is 'The last time we verified with GitHub what the GitHub username for this user was, and whether the account was valid';

--- a/src/bin/crates-admin/enqueue_job.rs
+++ b/src/bin/crates-admin/enqueue_job.rs
@@ -190,23 +190,16 @@ pub async fn run(command: Command) -> Result<()> {
                 .await?;
 
             for oauth_github in oldest_oauth_github_records {
-                let user_id = oauth_github.user_id;
-                let github_id = oauth_github.account_id;
-                let old_username = oauth_github.login.clone();
-
                 let job = jobs::UpdateUserFromGithub {
                     dry_run,
                     account_id: oauth_github.account_id,
                 };
 
-                // Don't stop the whole batch if one user update errors, but do log the error
+                // Don't stop the whole batch if one enqueue errors, but do log the error
                 if let Err(e) = job.enqueue(&conn).await {
                     error!(
-                        error = %e,
-                        user_id,
-                        github_id,
-                        old_username,
-                        "Error running UpdateUserFromGithub"
+                        "Error enqueueing UpdateUserFromGithub for user_id {}, github_id {}, old username `{}`: {e}",
+                        oauth_github.user_id, oauth_github.account_id, oauth_github.login,
                     );
                 }
             }

--- a/src/bin/crates-admin/enqueue_job.rs
+++ b/src/bin/crates-admin/enqueue_job.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use chrono::NaiveDate;
 use crates_io::db;
-use crates_io::schema::{background_jobs, crates};
+use crates_io::models::OauthGithub;
+use crates_io::schema::{background_jobs, crates, oauth_github};
 use crates_io::worker::jobs;
 use crates_io_worker::BackgroundJob;
 use diesel::dsl::exists;
@@ -56,6 +57,14 @@ pub enum Command {
     SyncUpdatesFeed,
     TrustpubCleanup,
     UpdateDownloads,
+    /// Sync the oldest batch of users with GitHub
+    UpdateUserBatch {
+        #[arg(long = "dry-run")]
+        dry_run: bool,
+
+        #[arg(long = "batch-size", default_value = "100")]
+        batch_size: usize,
+    },
 }
 
 pub async fn run(command: Command) -> Result<()> {
@@ -167,6 +176,36 @@ pub async fn run(command: Command) -> Result<()> {
                 );
             } else {
                 jobs::UpdateDownloads.enqueue(&conn).await?;
+            }
+        }
+
+        Command::UpdateUserBatch {
+            dry_run,
+            batch_size,
+        } => {
+            let oldest_oauth_github_records = oauth_github::table
+                .order(oauth_github::last_sync.asc())
+                .limit(batch_size as i64)
+                .load::<OauthGithub>(&mut conn)
+                .await?;
+
+            for oauth_github in oldest_oauth_github_records {
+                let user_id = oauth_github.user_id;
+                let github_id = oauth_github.account_id;
+                let old_username = oauth_github.login.clone();
+
+                let job = jobs::UpdateUserFromGithub::new(dry_run, oauth_github);
+
+                // Don't stop the whole batch if one user update errors, but do log the error
+                if let Err(e) = job.enqueue(&conn).await {
+                    error!(
+                        error = %e,
+                        user_id,
+                        github_id,
+                        old_username,
+                        "Error running UpdateUserFromGithub"
+                    );
+                }
             }
         }
     };

--- a/src/bin/crates-admin/enqueue_job.rs
+++ b/src/bin/crates-admin/enqueue_job.rs
@@ -194,7 +194,10 @@ pub async fn run(command: Command) -> Result<()> {
                 let github_id = oauth_github.account_id;
                 let old_username = oauth_github.login.clone();
 
-                let job = jobs::UpdateUserFromGithub::new(dry_run, oauth_github);
+                let job = jobs::UpdateUserFromGithub {
+                    dry_run,
+                    account_id: oauth_github.account_id,
+                };
 
                 // Don't stop the whole batch if one user update errors, but do log the error
                 if let Err(e) = job.enqueue(&conn).await {

--- a/src/tests/util/github.rs
+++ b/src/tests/util/github.rs
@@ -53,6 +53,9 @@ impl MockData {
         mock.expect_current_user()
             .returning(|_auth| self.current_user());
 
+        mock.expect_get_user_by_id()
+            .returning(|account_id| self.get_user_by_id(account_id));
+
         mock.expect_org_by_name()
             .returning(|org_name, _auth| self.org_by_name(org_name));
 
@@ -72,6 +75,21 @@ impl MockData {
 
     fn current_user(&self) -> Result<GitHubUser, GitHubError> {
         let user = &self.users[0];
+        Ok(GitHubUser {
+            id: user.id,
+            login: user.login.into(),
+            name: Some(user.name.into()),
+            email: Some(user.email.into()),
+            avatar_url: Some(format!("https://avatars.example.com/{}", user.id)),
+        })
+    }
+
+    fn get_user_by_id(&self, account_id: i64) -> Result<GitHubUser, GitHubError> {
+        let user = self
+            .users
+            .iter()
+            .find(|user| user.id as i64 == account_id)
+            .ok_or_else(not_found)?;
         Ok(GitHubUser {
             id: user.id,
             login: user.login.into(),

--- a/src/tests/worker/mod.rs
+++ b/src/tests/worker/mod.rs
@@ -9,3 +9,4 @@ mod squash_index;
 mod sync_admins;
 mod trustpub;
 mod update_default_version;
+mod update_user_from_github;

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -67,7 +67,10 @@ impl UpdateTest {
             .unwrap();
         let last_sync_before_update = oauth_github_before_update.last_sync;
 
-        let job = jobs::UpdateUserFromGithub::new(dry_run, oauth_github_before_update);
+        let job = jobs::UpdateUserFromGithub {
+            dry_run,
+            account_id: oauth_github_before_update.account_id,
+        };
         job.enqueue(&conn).await.unwrap();
         let _ = app.try_run_pending_background_jobs().await;
 

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -24,8 +24,7 @@ struct UpdateTest {
     dry_run: bool,
     existing_github_id: i64,
     existing_username: &'static str,
-    github_current_user_response: Result<GitHubUser, GitHubError>,
-    github_user_by_id_response: Result<GitHubUser, GitHubError>,
+    github_mock: MockGitHubClient,
     expected_username: &'static str,
     expected_last_sync_updated: bool,
 }
@@ -36,19 +35,10 @@ impl UpdateTest {
             dry_run,
             existing_github_id,
             existing_username,
-            github_current_user_response,
-            github_user_by_id_response,
+            github_mock,
             expected_username,
             expected_last_sync_updated,
         } = self;
-
-        let mut github_mock = MockGitHubClient::new();
-        github_mock
-            .expect_current_user()
-            .return_once(|_| github_current_user_response);
-        github_mock
-            .expect_get_user_by_id()
-            .return_once(|_| github_user_by_id_response);
 
         let (app, _) = TestApp::full().with_github(github_mock).empty().await;
         let emails = &app.as_inner().emails;
@@ -111,14 +101,17 @@ fn github_user(id: i64, username: &str) -> GitHubUser {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn no_updates_needed() {
+    let mut github_mock = MockGitHubClient::new();
+    // What we have and what GitHub has agree
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Ok(github_user(GITHUB_ID, EXISTING_LOGIN)));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
-        // What we have and what github has agree
         existing_username: EXISTING_LOGIN,
-        github_current_user_response: Ok(github_user(GITHUB_ID, EXISTING_LOGIN)),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
+        github_mock,
         expected_username: EXISTING_LOGIN,
         // but still update last sync
         expected_last_sync_updated: true,
@@ -129,13 +122,16 @@ async fn no_updates_needed() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn yes_updates_needed() {
+    let mut github_mock = MockGitHubClient::new();
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Ok(github_user(GITHUB_ID, "my-new-username")));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        github_current_user_response: Ok(github_user(GITHUB_ID, "my-new-username")),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
+        github_mock,
         expected_username: "my-new-username",
         expected_last_sync_updated: true,
     }
@@ -145,14 +141,17 @@ async fn yes_updates_needed() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_deleted() {
+    let mut github_mock = MockGitHubClient::new();
+    // If GitHub returns 404, this user has deleted their account.
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        // If GitHub returns 404, this user has deleted their account.
-        github_current_user_response: Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
+        github_mock,
         expected_username: "ghost_1",
         expected_last_sync_updated: true,
     }
@@ -162,15 +161,18 @@ async fn github_deleted() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn still_deleted() {
+    let mut github_mock = MockGitHubClient::new();
+    // GitHub still returns 404, they're still deleted
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         // We marked this user as deleted previously
         existing_username: "ghost_1",
-        // GitHub still returns 404, they're still deleted
-        github_current_user_response: Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
+        github_mock,
         expected_username: "ghost_1",
         expected_last_sync_updated: true,
     }
@@ -180,16 +182,21 @@ async fn still_deleted() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_unauthorized_fallback_success_no_update() {
+    let mut github_mock = MockGitHubClient::new();
+    // This could mean the user's oauth token has been revoked or similar
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Err(GitHubError::Unauthorized(anyhow::anyhow!("Not allowed"))));
+    // Falling back to anonymous get_user_by_id shows no rename needed
+    github_mock
+        .expect_get_user_by_id()
+        .return_once(|_| Ok(github_user(GITHUB_ID, EXISTING_LOGIN)));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        // This could mean the user's oauth token has been revoked or similar
-        github_current_user_response: Err(GitHubError::Unauthorized(anyhow::anyhow!(
-            "Not allowed"
-        ))),
-        // Falling back to anonymous get_user_by_id shows no rename needed
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, EXISTING_LOGIN)),
+        github_mock,
         expected_username: EXISTING_LOGIN,
         expected_last_sync_updated: true,
     }
@@ -199,16 +206,17 @@ async fn github_unauthorized_fallback_success_no_update() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_unauthorized_enterprise_user() {
+    let mut github_mock = MockGitHubClient::new();
+    // This could mean the user's oauth token has been revoked or similar
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Err(GitHubError::Unauthorized(anyhow::anyhow!("Not allowed"))));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: "asmith_microsoft",
-        // This could mean the user's oauth token has been revoked or similar
-        github_current_user_response: Err(GitHubError::Unauthorized(anyhow::anyhow!(
-            "Not allowed"
-        ))),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
+        github_mock,
         expected_username: "asmith_microsoft",
         expected_last_sync_updated: true,
     }
@@ -218,16 +226,21 @@ async fn github_unauthorized_enterprise_user() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_unauthorized_fallback_success_yes_update() {
+    let mut github_mock = MockGitHubClient::new();
+    // This could mean the user's oauth token has been revoked or similar
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Err(GitHubError::Unauthorized(anyhow::anyhow!("Not allowed"))));
+    // Falling back to anonymous get_user_by_id shows yes rename needed
+    github_mock
+        .expect_get_user_by_id()
+        .return_once(|_| Ok(github_user(GITHUB_ID, "updated-username")));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        // This could mean the user's oauth token has been revoked or similar
-        github_current_user_response: Err(GitHubError::Unauthorized(anyhow::anyhow!(
-            "Not allowed"
-        ))),
-        // Falling back to anonymous get_user_by_id shows yes rename needed
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "updated-username")),
+        github_mock,
         expected_username: "updated-username",
         expected_last_sync_updated: true,
     }
@@ -237,16 +250,21 @@ async fn github_unauthorized_fallback_success_yes_update() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_unauthorized_fallback_not_found_deleted() {
+    let mut github_mock = MockGitHubClient::new();
+    // This could mean the user's oauth token has been revoked or similar
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Err(GitHubError::Unauthorized(anyhow::anyhow!("Not allowed"))));
+    // Falling back to anonymous get_user_by_id shows the user has been deleted
+    github_mock
+        .expect_get_user_by_id()
+        .return_once(|_| Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        // This could mean the user's oauth token has been revoked or similar
-        github_current_user_response: Err(GitHubError::Unauthorized(anyhow::anyhow!(
-            "Not allowed"
-        ))),
-        // Falling back to anonymous get_user_by_id shows the user has been deleted
-        github_user_by_id_response: Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))),
+        github_mock,
         expected_username: "ghost_1",
         expected_last_sync_updated: true,
     }
@@ -256,18 +274,21 @@ async fn github_unauthorized_fallback_not_found_deleted() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_unauthorized_fallback_other_error_no_update() {
+    let mut github_mock = MockGitHubClient::new();
+    // This could mean the user's oauth token has been revoked or similar
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Err(GitHubError::Unauthorized(anyhow::anyhow!("Not allowed"))));
+    // Falling back to anonymous get_user_by_id fails too; try again later
+    github_mock
+        .expect_get_user_by_id()
+        .return_once(|_| Err(GitHubError::Other(anyhow::anyhow!("Over your rate limit"))));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        // This could mean the user's oauth token has been revoked or similar
-        github_current_user_response: Err(GitHubError::Unauthorized(anyhow::anyhow!(
-            "Not allowed"
-        ))),
-        // Falling back to anonymous get_user_by_id fails too; try again later
-        github_user_by_id_response: Err(GitHubError::Other(anyhow::anyhow!(
-            "Over your rate limit"
-        ))),
+        github_mock,
         expected_username: EXISTING_LOGIN,
         expected_last_sync_updated: false,
     }
@@ -277,14 +298,21 @@ async fn github_unauthorized_fallback_other_error_no_update() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_forbidden_fallback_success_yes_update() {
+    let mut github_mock = MockGitHubClient::new();
+    // This could mean the user's oauth token needs to be refreshed or similar
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Err(GitHubError::Forbidden(anyhow::anyhow!("Not allowed"))));
+    // Falling back to anonymous get_user_by_id shows yes rename needed
+    github_mock
+        .expect_get_user_by_id()
+        .return_once(|_| Ok(github_user(GITHUB_ID, "updated-username")));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        // This could mean the user's oauth token needs to be refreshed or similar
-        github_current_user_response: Err(GitHubError::Forbidden(anyhow::anyhow!("Not allowed"))),
-        // Falling back to anonymous get_user_by_id shows yes rename needed
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "updated-username")),
+        github_mock,
         expected_username: "updated-username",
         expected_last_sync_updated: true,
     }
@@ -294,17 +322,18 @@ async fn github_forbidden_fallback_success_yes_update() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_unavailable() {
+    let mut github_mock = MockGitHubClient::new();
+    // If GitHub returns some error we haven't accounted for, we can't know anything about
+    // this user. Try again later.
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Err(GitHubError::Other(anyhow::anyhow!("9% uptime is one nine"))));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        // If GitHub returns some error we haven't accounted for, we can't know anything about
-        // this user. Try again later.
-        github_current_user_response: Err(GitHubError::Other(anyhow::anyhow!(
-            "9% uptime is one nine"
-        ))),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
+        github_mock,
         expected_username: EXISTING_LOGIN,
         expected_last_sync_updated: false,
     }
@@ -314,15 +343,18 @@ async fn github_unavailable() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn undeleted() {
+    let mut github_mock = MockGitHubClient::new();
+    // Not sure how often this happens, but if we marked an account as ghost but we get a
+    // valid user again, we should update their username
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Ok(github_user(GITHUB_ID, "my-new-username")));
+
     UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: "ghost_1",
-        // Not sure how often this happens, but if we marked an account as ghost but we get a
-        // valid user again, we should update their username
-        github_current_user_response: Ok(github_user(GITHUB_ID, "my-new-username")),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
+        github_mock,
         expected_username: "my-new-username",
         expected_last_sync_updated: true,
     }
@@ -332,13 +364,16 @@ async fn undeleted() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn dry_run_mode_doesnt_update() {
+    let mut github_mock = MockGitHubClient::new();
+    github_mock
+        .expect_current_user()
+        .return_once(|_| Ok(github_user(GITHUB_ID, "my-new-username")));
+
     UpdateTest {
         dry_run: true,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        github_current_user_response: Ok(github_user(GITHUB_ID, "my-new-username")),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
+        github_mock,
         expected_username: EXISTING_LOGIN,
         expected_last_sync_updated: false,
     }

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -78,12 +78,15 @@ impl UpdateTest {
         let user_after_update = User::find(&conn, u.id).await.unwrap();
         assert_eq!(user_after_update.gh_login, expected_username);
 
-        // Drain the failed job so the `TestAppInner::drop` empty-queue
-        // post-condition is satisfied.
-        diesel::delete(background_jobs::table)
-            .execute(&mut conn)
-            .await
-            .unwrap();
+        if job_result.is_err() {
+            // The worker leaves failed rows in `background_jobs` so they can
+            // be retried; clean it up so `TestAppInner::drop`'s empty-queue
+            // post-condition is satisfied.
+            diesel::delete(background_jobs::table)
+                .execute(&mut conn)
+                .await
+                .unwrap();
+        }
 
         job_result
     }

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -24,7 +24,8 @@ struct UpdateTest {
     dry_run: bool,
     existing_github_id: i64,
     existing_username: &'static str,
-    github_response: Result<GitHubUser, GitHubError>,
+    github_current_user_response: Result<GitHubUser, GitHubError>,
+    github_user_by_id_response: Result<GitHubUser, GitHubError>,
     expected_username: &'static str,
     expected_last_sync_updated: bool,
 }
@@ -35,7 +36,8 @@ impl UpdateTest {
             dry_run,
             existing_github_id,
             existing_username,
-            github_response,
+            github_current_user_response,
+            github_user_by_id_response,
             expected_username,
             expected_last_sync_updated,
         } = self;
@@ -43,7 +45,10 @@ impl UpdateTest {
         let mut github_mock = MockGitHubClient::new();
         github_mock
             .expect_current_user()
-            .return_once(|_| github_response);
+            .return_once(|_| github_current_user_response);
+        github_mock
+            .expect_get_user_by_id()
+            .return_once(|_| github_user_by_id_response);
 
         let (app, _) = TestApp::full().with_github(github_mock).empty().await;
         let emails = &app.as_inner().emails;
@@ -108,7 +113,9 @@ async fn no_updates_needed() {
         existing_github_id: GITHUB_ID,
         // What we have and what github has agree
         existing_username: EXISTING_LOGIN,
-        github_response: Ok(github_user(GITHUB_ID, EXISTING_LOGIN)),
+        github_current_user_response: Ok(github_user(GITHUB_ID, EXISTING_LOGIN)),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
         expected_username: EXISTING_LOGIN,
         // but still update last sync
         expected_last_sync_updated: true,
@@ -123,7 +130,9 @@ async fn yes_updates_needed() {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        github_response: Ok(github_user(GITHUB_ID, "my-new-username")),
+        github_current_user_response: Ok(github_user(GITHUB_ID, "my-new-username")),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
         expected_username: "my-new-username",
         expected_last_sync_updated: true,
     }
@@ -140,7 +149,11 @@ async fn negative_github_id() {
         existing_github_id: -1,
         existing_username: EXISTING_LOGIN,
         // We shouldn't even contact GitHub in this case, so error in case we do
-        github_response: Err(GitHubError::Other(anyhow::anyhow!("Shouldn't be called"))),
+        github_current_user_response: Err(GitHubError::Other(anyhow::anyhow!(
+            "current_user shouldn't be called"
+        ))),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
         expected_username: "ghost_1",
         expected_last_sync_updated: true,
     }
@@ -156,7 +169,11 @@ async fn zero_github_id() {
         existing_github_id: 0,
         existing_username: EXISTING_LOGIN,
         // We shouldn't even contact GitHub in this case, so error in case we do
-        github_response: Err(GitHubError::Other(anyhow::anyhow!("Shouldn't be called"))),
+        github_current_user_response: Err(GitHubError::Other(anyhow::anyhow!(
+            "current_user shouldn't be called"
+        ))),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
         expected_username: "ghost_1",
         expected_last_sync_updated: true,
     }
@@ -174,7 +191,11 @@ async fn negative_github_id_with_ghost_username() {
         // We've already set this username to ghost, but set it and update `last_sync` anyway
         existing_username: "ghost_1",
         // We shouldn't even contact GitHub in this case, so error in case we do
-        github_response: Err(GitHubError::Other(anyhow::anyhow!("Shouldn't be called"))),
+        github_current_user_response: Err(GitHubError::Other(anyhow::anyhow!(
+            "Shouldn't be called"
+        ))),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
         expected_username: "ghost_1",
         expected_last_sync_updated: true,
     }
@@ -189,7 +210,9 @@ async fn github_deleted() {
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
         // If GitHub returns 404, this user has deleted their account.
-        github_response: Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))),
+        github_current_user_response: Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
         expected_username: "ghost_1",
         expected_last_sync_updated: true,
     }
@@ -205,8 +228,124 @@ async fn still_deleted() {
         // We marked this user as deleted previously
         existing_username: "ghost_1",
         // GitHub still returns 404, they're still deleted
-        github_response: Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))),
+        github_current_user_response: Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
         expected_username: "ghost_1",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn github_unauthorized_fallback_success_no_update() {
+    UpdateTest {
+        dry_run: false,
+        existing_github_id: GITHUB_ID,
+        existing_username: EXISTING_LOGIN,
+        // This could mean the user's oauth token has been revoked or similar
+        github_current_user_response: Err(GitHubError::Unauthorized(anyhow::anyhow!(
+            "Not allowed"
+        ))),
+        // Falling back to anonymous get_user_by_id shows no rename needed
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, EXISTING_LOGIN)),
+        expected_username: EXISTING_LOGIN,
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn github_unauthorized_enterprise_user() {
+    UpdateTest {
+        dry_run: false,
+        existing_github_id: GITHUB_ID,
+        existing_username: "asmith_microsoft",
+        // This could mean the user's oauth token has been revoked or similar
+        github_current_user_response: Err(GitHubError::Unauthorized(anyhow::anyhow!(
+            "Not allowed"
+        ))),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
+        expected_username: "asmith_microsoft",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn github_unauthorized_fallback_success_yes_update() {
+    UpdateTest {
+        dry_run: false,
+        existing_github_id: GITHUB_ID,
+        existing_username: EXISTING_LOGIN,
+        // This could mean the user's oauth token has been revoked or similar
+        github_current_user_response: Err(GitHubError::Unauthorized(anyhow::anyhow!(
+            "Not allowed"
+        ))),
+        // Falling back to anonymous get_user_by_id shows yes rename needed
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "updated-username")),
+        expected_username: "updated-username",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn github_unauthorized_fallback_not_found_deleted() {
+    UpdateTest {
+        dry_run: false,
+        existing_github_id: GITHUB_ID,
+        existing_username: EXISTING_LOGIN,
+        // This could mean the user's oauth token has been revoked or similar
+        github_current_user_response: Err(GitHubError::Unauthorized(anyhow::anyhow!(
+            "Not allowed"
+        ))),
+        // Falling back to anonymous get_user_by_id shows the user has been deleted
+        github_user_by_id_response: Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))),
+        expected_username: "ghost_1",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn github_unauthorized_fallback_other_error_no_update() {
+    UpdateTest {
+        dry_run: false,
+        existing_github_id: GITHUB_ID,
+        existing_username: EXISTING_LOGIN,
+        // This could mean the user's oauth token has been revoked or similar
+        github_current_user_response: Err(GitHubError::Unauthorized(anyhow::anyhow!(
+            "Not allowed"
+        ))),
+        // Falling back to anonymous get_user_by_id fails too; try again later
+        github_user_by_id_response: Err(GitHubError::Other(anyhow::anyhow!(
+            "Over your rate limit"
+        ))),
+        expected_username: EXISTING_LOGIN,
+        expected_last_sync_updated: false,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn github_forbidden_fallback_success_yes_update() {
+    UpdateTest {
+        dry_run: false,
+        existing_github_id: GITHUB_ID,
+        existing_username: EXISTING_LOGIN,
+        // This could mean the user's oauth token needs to be refreshed or similar
+        github_current_user_response: Err(GitHubError::Forbidden(anyhow::anyhow!("Not allowed"))),
+        // Falling back to anonymous get_user_by_id shows yes rename needed
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "updated-username")),
+        expected_username: "updated-username",
         expected_last_sync_updated: true,
     }
     .run()
@@ -221,7 +360,11 @@ async fn github_unavailable() {
         existing_username: EXISTING_LOGIN,
         // If GitHub returns some error we haven't accounted for, we can't know anything about
         // this user. Try again later.
-        github_response: Err(GitHubError::Other(anyhow::anyhow!("9% uptime is one nine"))),
+        github_current_user_response: Err(GitHubError::Other(anyhow::anyhow!(
+            "9% uptime is one nine"
+        ))),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
         expected_username: EXISTING_LOGIN,
         expected_last_sync_updated: false,
     }
@@ -237,7 +380,9 @@ async fn undeleted() {
         existing_username: "ghost_1",
         // Not sure how often this happens, but if we marked an account as ghost but we get a
         // valid user again, we should update their username
-        github_response: Ok(github_user(GITHUB_ID, "my-new-username")),
+        github_current_user_response: Ok(github_user(GITHUB_ID, "my-new-username")),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
         expected_username: "my-new-username",
         expected_last_sync_updated: true,
     }
@@ -251,7 +396,9 @@ async fn dry_run_mode_doesnt_update() {
         dry_run: true,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
-        github_response: Ok(github_user(GITHUB_ID, "my-new-username")),
+        github_current_user_response: Ok(github_user(GITHUB_ID, "my-new-username")),
+        // Shouldn't be called in this test
+        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
         expected_username: EXISTING_LOGIN,
         expected_last_sync_updated: false,
     }

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -1,0 +1,235 @@
+use crate::util::TestApp;
+use crates_io::{
+    controllers::session,
+    models::{OauthGithub, User},
+    schema::{background_jobs, oauth_github},
+    util::gh_token_encryption::GitHubTokenEncryption,
+    worker::jobs,
+};
+use crates_io_github::{GitHubError, GitHubUser, MockGitHubClient};
+use crates_io_worker::BackgroundJob;
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use std::sync::LazyLock;
+
+const GITHUB_ID: i64 = 456789;
+const EXISTING_LOGIN: &str = "my-login";
+static ENCRYPTED_TOKEN: LazyLock<Vec<u8>> = LazyLock::new(|| {
+    GitHubTokenEncryption::for_testing()
+        .encrypt("some random token")
+        .unwrap()
+});
+
+struct UpdateTest {
+    existing_github_id: i64,
+    existing_username: &'static str,
+    github_response: Result<GitHubUser, GitHubError>,
+    expected_username: &'static str,
+    expected_last_sync_updated: bool,
+}
+
+impl UpdateTest {
+    async fn run(self) {
+        let Self {
+            existing_github_id,
+            existing_username,
+            github_response,
+            expected_username,
+            expected_last_sync_updated,
+        } = self;
+
+        let mut github_mock = MockGitHubClient::new();
+        github_mock
+            .expect_current_user()
+            .return_once(|_| github_response);
+
+        let (app, _) = TestApp::full().with_github(github_mock).empty().await;
+        let emails = &app.as_inner().emails;
+        let mut conn = app.db_conn().await;
+
+        let original_gh_user = github_user(existing_github_id, existing_username);
+        let u =
+            session::save_user_to_database(&original_gh_user, &ENCRYPTED_TOKEN, emails, &mut conn)
+                .await
+                .unwrap();
+
+        let oauth_github_before_update = oauth_github::table
+            .filter(oauth_github::user_id.eq(u.id))
+            .first::<OauthGithub>(&mut conn)
+            .await
+            .unwrap();
+        let last_sync_before_update = oauth_github_before_update.last_sync;
+
+        let job = jobs::UpdateUserFromGithub::new(oauth_github_before_update);
+        job.enqueue(&conn).await.unwrap();
+        let _ = app.try_run_pending_background_jobs().await;
+
+        let oauth_github_after_update = oauth_github::table
+            .filter(oauth_github::user_id.eq(u.id))
+            .first::<OauthGithub>(&mut conn)
+            .await
+            .unwrap();
+        assert_eq!(expected_username, oauth_github_after_update.login);
+        if expected_last_sync_updated {
+            assert_ne!(last_sync_before_update, oauth_github_after_update.last_sync);
+        } else {
+            assert_eq!(last_sync_before_update, oauth_github_after_update.last_sync);
+        }
+
+        // For now, we want to update the `User` record too
+        let user_after_update = User::find(&conn, u.id).await.unwrap();
+        assert_eq!(expected_username, user_after_update.gh_login);
+
+        // Drain the failed job so the `TestAppInner::drop` empty-queue
+        // post-condition is satisfied.
+        diesel::delete(background_jobs::table)
+            .execute(&mut conn)
+            .await
+            .unwrap();
+    }
+}
+
+fn github_user(id: i64, username: &str) -> GitHubUser {
+    GitHubUser {
+        login: username.into(),
+        id: id as i32,
+        avatar_url: None,
+        email: None,
+        name: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn no_updates_needed() {
+    UpdateTest {
+        existing_github_id: GITHUB_ID,
+        // What we have and what github has agree
+        existing_username: EXISTING_LOGIN,
+        github_response: Ok(github_user(GITHUB_ID, EXISTING_LOGIN)),
+        expected_username: EXISTING_LOGIN,
+        // but still update last sync
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn yes_updates_needed() {
+    UpdateTest {
+        existing_github_id: GITHUB_ID,
+        existing_username: EXISTING_LOGIN,
+        github_response: Ok(github_user(GITHUB_ID, "my-new-username")),
+        expected_username: "my-new-username",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn negative_github_id() {
+    UpdateTest {
+        // The GitHub ID in our database is -1 because at some point we learned the GitHub user
+        // was no longer valid
+        existing_github_id: -1,
+        existing_username: EXISTING_LOGIN,
+        // We shouldn't even contact GitHub in this case, so error in case we do
+        github_response: Err(GitHubError::Other(anyhow::anyhow!("Shouldn't be called"))),
+        expected_username: "ghost_1",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zero_github_id() {
+    UpdateTest {
+        // Check that we're also treating 0 as invalid
+        existing_github_id: 0,
+        existing_username: EXISTING_LOGIN,
+        // We shouldn't even contact GitHub in this case, so error in case we do
+        github_response: Err(GitHubError::Other(anyhow::anyhow!("Shouldn't be called"))),
+        expected_username: "ghost_1",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn negative_github_id_with_ghost_username() {
+    UpdateTest {
+        // The GitHub ID in our database is negative because at some point we learned the GitHub
+        // user was no longer valid
+        existing_github_id: -9000,
+        // We've already set this username to ghost, but set it and update `last_sync` anyway
+        existing_username: "ghost_1",
+        // We shouldn't even contact GitHub in this case, so error in case we do
+        github_response: Err(GitHubError::Other(anyhow::anyhow!("Shouldn't be called"))),
+        expected_username: "ghost_1",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn github_deleted() {
+    UpdateTest {
+        existing_github_id: GITHUB_ID,
+        existing_username: EXISTING_LOGIN,
+        // If GitHub returns 404, this user has deleted their account.
+        github_response: Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))),
+        expected_username: "ghost_1",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn still_deleted() {
+    UpdateTest {
+        existing_github_id: GITHUB_ID,
+        // We marked this user as deleted previously
+        existing_username: "ghost_1",
+        // GitHub still returns 404, they're still deleted
+        github_response: Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))),
+        expected_username: "ghost_1",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn github_unavailable() {
+    UpdateTest {
+        existing_github_id: GITHUB_ID,
+        existing_username: EXISTING_LOGIN,
+        // If GitHub returns some error we haven't accounted for, we can't know anything about
+        // this user. Try again later.
+        github_response: Err(GitHubError::Other(anyhow::anyhow!("9% uptime is one nine"))),
+        expected_username: EXISTING_LOGIN,
+        expected_last_sync_updated: false,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn undeleted() {
+    UpdateTest {
+        existing_github_id: GITHUB_ID,
+        existing_username: "ghost_1",
+        // Not sure how often this happens, but if we marked an account as ghost but we get a
+        // valid user again, we should update their username
+        github_response: Ok(github_user(GITHUB_ID, "my-new-username")),
+        expected_username: "my-new-username",
+        expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -70,16 +70,16 @@ impl UpdateTest {
             .first::<OauthGithub>(&mut conn)
             .await
             .unwrap();
-        assert_eq!(expected_username, oauth_github_after_update.login);
+        assert_eq!(oauth_github_after_update.login, expected_username);
         if expected_last_sync_updated {
-            assert_ne!(last_sync_before_update, oauth_github_after_update.last_sync);
+            assert_ne!(oauth_github_after_update.last_sync, last_sync_before_update);
         } else {
-            assert_eq!(last_sync_before_update, oauth_github_after_update.last_sync);
+            assert_eq!(oauth_github_after_update.last_sync, last_sync_before_update);
         }
 
         // For now, we want to update the `User` record too
         let user_after_update = User::find(&conn, u.id).await.unwrap();
-        assert_eq!(expected_username, user_after_update.gh_login);
+        assert_eq!(user_after_update.gh_login, expected_username);
 
         // Drain the failed job so the `TestAppInner::drop` empty-queue
         // post-condition is satisfied.

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -23,8 +23,7 @@ static ENCRYPTED_TOKEN: LazyLock<Vec<u8>> = LazyLock::new(|| {
 
 struct UpdateTest {
     dry_run: bool,
-    existing_github_id: i64,
-    existing_username: &'static str,
+    existing_gh_user: GitHubUser,
     github_mock: MockGitHubClient,
     expected_username: &'static str,
     expected_last_sync_updated: bool,
@@ -34,8 +33,7 @@ impl UpdateTest {
     async fn run(self) -> anyhow::Result<()> {
         let Self {
             dry_run,
-            existing_github_id,
-            existing_username,
+            existing_gh_user,
             github_mock,
             expected_username,
             expected_last_sync_updated,
@@ -45,9 +43,8 @@ impl UpdateTest {
         let emails = &app.as_inner().emails;
         let mut conn = app.db_conn().await;
 
-        let original_gh_user = github_user(existing_github_id, existing_username);
         let u =
-            session::save_user_to_database(&original_gh_user, &ENCRYPTED_TOKEN, emails, &mut conn)
+            session::save_user_to_database(&existing_gh_user, &ENCRYPTED_TOKEN, emails, &mut conn)
                 .await
                 .unwrap();
 
@@ -112,8 +109,7 @@ async fn no_updates_needed() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: EXISTING_LOGIN,
+        existing_gh_user: github_user(GITHUB_ID, EXISTING_LOGIN),
         github_mock,
         expected_username: EXISTING_LOGIN,
         // but still update last sync
@@ -134,8 +130,7 @@ async fn yes_updates_needed() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: EXISTING_LOGIN,
+        existing_gh_user: github_user(GITHUB_ID, EXISTING_LOGIN),
         github_mock,
         expected_username: "my-new-username",
         expected_last_sync_updated: true,
@@ -156,8 +151,7 @@ async fn github_deleted() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: EXISTING_LOGIN,
+        existing_gh_user: github_user(GITHUB_ID, EXISTING_LOGIN),
         github_mock,
         expected_username: "ghost_1",
         expected_last_sync_updated: true,
@@ -178,9 +172,8 @@ async fn still_deleted() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
         // We marked this user as deleted previously
-        existing_username: "ghost_1",
+        existing_gh_user: github_user(GITHUB_ID, "ghost_1"),
         github_mock,
         expected_username: "ghost_1",
         expected_last_sync_updated: true,
@@ -205,8 +198,7 @@ async fn github_unauthorized_fallback_success_no_update() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: EXISTING_LOGIN,
+        existing_gh_user: github_user(GITHUB_ID, EXISTING_LOGIN),
         github_mock,
         expected_username: EXISTING_LOGIN,
         expected_last_sync_updated: true,
@@ -227,8 +219,7 @@ async fn github_unauthorized_enterprise_user() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: "asmith_microsoft",
+        existing_gh_user: github_user(GITHUB_ID, "asmith_microsoft"),
         github_mock,
         expected_username: "asmith_microsoft",
         expected_last_sync_updated: true,
@@ -253,8 +244,7 @@ async fn github_unauthorized_fallback_success_yes_update() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: EXISTING_LOGIN,
+        existing_gh_user: github_user(GITHUB_ID, EXISTING_LOGIN),
         github_mock,
         expected_username: "updated-username",
         expected_last_sync_updated: true,
@@ -279,8 +269,7 @@ async fn github_unauthorized_fallback_not_found_deleted() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: EXISTING_LOGIN,
+        existing_gh_user: github_user(GITHUB_ID, EXISTING_LOGIN),
         github_mock,
         expected_username: "ghost_1",
         expected_last_sync_updated: true,
@@ -305,8 +294,7 @@ async fn github_unauthorized_fallback_other_error_no_update() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: EXISTING_LOGIN,
+        existing_gh_user: github_user(GITHUB_ID, EXISTING_LOGIN),
         github_mock,
         expected_username: EXISTING_LOGIN,
         expected_last_sync_updated: false,
@@ -331,8 +319,7 @@ async fn github_forbidden_fallback_success_yes_update() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: EXISTING_LOGIN,
+        existing_gh_user: github_user(GITHUB_ID, EXISTING_LOGIN),
         github_mock,
         expected_username: "updated-username",
         expected_last_sync_updated: true,
@@ -354,8 +341,7 @@ async fn github_unavailable() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: EXISTING_LOGIN,
+        existing_gh_user: github_user(GITHUB_ID, EXISTING_LOGIN),
         github_mock,
         expected_username: EXISTING_LOGIN,
         expected_last_sync_updated: false,
@@ -377,8 +363,7 @@ async fn undeleted() {
 
     let result = UpdateTest {
         dry_run: false,
-        existing_github_id: GITHUB_ID,
-        existing_username: "ghost_1",
+        existing_gh_user: github_user(GITHUB_ID, "ghost_1"),
         github_mock,
         expected_username: "my-new-username",
         expected_last_sync_updated: true,
@@ -398,8 +383,7 @@ async fn dry_run_mode_doesnt_update() {
 
     let result = UpdateTest {
         dry_run: true,
-        existing_github_id: GITHUB_ID,
-        existing_username: EXISTING_LOGIN,
+        existing_gh_user: github_user(GITHUB_ID, EXISTING_LOGIN),
         github_mock,
         expected_username: EXISTING_LOGIN,
         expected_last_sync_updated: false,

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -21,6 +21,7 @@ static ENCRYPTED_TOKEN: LazyLock<Vec<u8>> = LazyLock::new(|| {
 });
 
 struct UpdateTest {
+    dry_run: bool,
     existing_github_id: i64,
     existing_username: &'static str,
     github_response: Result<GitHubUser, GitHubError>,
@@ -31,6 +32,7 @@ struct UpdateTest {
 impl UpdateTest {
     async fn run(self) {
         let Self {
+            dry_run,
             existing_github_id,
             existing_username,
             github_response,
@@ -60,7 +62,7 @@ impl UpdateTest {
             .unwrap();
         let last_sync_before_update = oauth_github_before_update.last_sync;
 
-        let job = jobs::UpdateUserFromGithub::new(oauth_github_before_update);
+        let job = jobs::UpdateUserFromGithub::new(dry_run, oauth_github_before_update);
         job.enqueue(&conn).await.unwrap();
         let _ = app.try_run_pending_background_jobs().await;
 
@@ -102,6 +104,7 @@ fn github_user(id: i64, username: &str) -> GitHubUser {
 #[tokio::test(flavor = "multi_thread")]
 async fn no_updates_needed() {
     UpdateTest {
+        dry_run: false,
         existing_github_id: GITHUB_ID,
         // What we have and what github has agree
         existing_username: EXISTING_LOGIN,
@@ -117,6 +120,7 @@ async fn no_updates_needed() {
 #[tokio::test(flavor = "multi_thread")]
 async fn yes_updates_needed() {
     UpdateTest {
+        dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
         github_response: Ok(github_user(GITHUB_ID, "my-new-username")),
@@ -130,6 +134,7 @@ async fn yes_updates_needed() {
 #[tokio::test(flavor = "multi_thread")]
 async fn negative_github_id() {
     UpdateTest {
+        dry_run: false,
         // The GitHub ID in our database is -1 because at some point we learned the GitHub user
         // was no longer valid
         existing_github_id: -1,
@@ -146,6 +151,7 @@ async fn negative_github_id() {
 #[tokio::test(flavor = "multi_thread")]
 async fn zero_github_id() {
     UpdateTest {
+        dry_run: false,
         // Check that we're also treating 0 as invalid
         existing_github_id: 0,
         existing_username: EXISTING_LOGIN,
@@ -161,6 +167,7 @@ async fn zero_github_id() {
 #[tokio::test(flavor = "multi_thread")]
 async fn negative_github_id_with_ghost_username() {
     UpdateTest {
+        dry_run: false,
         // The GitHub ID in our database is negative because at some point we learned the GitHub
         // user was no longer valid
         existing_github_id: -9000,
@@ -178,6 +185,7 @@ async fn negative_github_id_with_ghost_username() {
 #[tokio::test(flavor = "multi_thread")]
 async fn github_deleted() {
     UpdateTest {
+        dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
         // If GitHub returns 404, this user has deleted their account.
@@ -192,6 +200,7 @@ async fn github_deleted() {
 #[tokio::test(flavor = "multi_thread")]
 async fn still_deleted() {
     UpdateTest {
+        dry_run: false,
         existing_github_id: GITHUB_ID,
         // We marked this user as deleted previously
         existing_username: "ghost_1",
@@ -207,6 +216,7 @@ async fn still_deleted() {
 #[tokio::test(flavor = "multi_thread")]
 async fn github_unavailable() {
     UpdateTest {
+        dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
         // If GitHub returns some error we haven't accounted for, we can't know anything about
@@ -222,6 +232,7 @@ async fn github_unavailable() {
 #[tokio::test(flavor = "multi_thread")]
 async fn undeleted() {
     UpdateTest {
+        dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: "ghost_1",
         // Not sure how often this happens, but if we marked an account as ghost but we get a
@@ -229,6 +240,20 @@ async fn undeleted() {
         github_response: Ok(github_user(GITHUB_ID, "my-new-username")),
         expected_username: "my-new-username",
         expected_last_sync_updated: true,
+    }
+    .run()
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dry_run_mode_doesnt_update() {
+    UpdateTest {
+        dry_run: true,
+        existing_github_id: GITHUB_ID,
+        existing_username: EXISTING_LOGIN,
+        github_response: Ok(github_user(GITHUB_ID, "my-new-username")),
+        expected_username: EXISTING_LOGIN,
+        expected_last_sync_updated: false,
     }
     .run()
     .await;

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -144,69 +144,6 @@ async fn yes_updates_needed() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn negative_github_id() {
-    UpdateTest {
-        dry_run: false,
-        // The GitHub ID in our database is -1 because at some point we learned the GitHub user
-        // was no longer valid
-        existing_github_id: -1,
-        existing_username: EXISTING_LOGIN,
-        // We shouldn't even contact GitHub in this case, so error in case we do
-        github_current_user_response: Err(GitHubError::Other(anyhow::anyhow!(
-            "current_user shouldn't be called"
-        ))),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
-        expected_username: "ghost_1",
-        expected_last_sync_updated: true,
-    }
-    .run()
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn zero_github_id() {
-    UpdateTest {
-        dry_run: false,
-        // Check that we're also treating 0 as invalid
-        existing_github_id: 0,
-        existing_username: EXISTING_LOGIN,
-        // We shouldn't even contact GitHub in this case, so error in case we do
-        github_current_user_response: Err(GitHubError::Other(anyhow::anyhow!(
-            "current_user shouldn't be called"
-        ))),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
-        expected_username: "ghost_1",
-        expected_last_sync_updated: true,
-    }
-    .run()
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn negative_github_id_with_ghost_username() {
-    UpdateTest {
-        dry_run: false,
-        // The GitHub ID in our database is negative because at some point we learned the GitHub
-        // user was no longer valid
-        existing_github_id: -9000,
-        // We've already set this username to ghost, but set it and update `last_sync` anyway
-        existing_username: "ghost_1",
-        // We shouldn't even contact GitHub in this case, so error in case we do
-        github_current_user_response: Err(GitHubError::Other(anyhow::anyhow!(
-            "Shouldn't be called"
-        ))),
-        // Shouldn't be called in this test
-        github_user_by_id_response: Ok(github_user(GITHUB_ID, "wrong-user-info")),
-        expected_username: "ghost_1",
-        expected_last_sync_updated: true,
-    }
-    .run()
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn github_deleted() {
     UpdateTest {
         dry_run: false,

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -1,4 +1,5 @@
 use crate::util::TestApp;
+use claims::{assert_err, assert_ok};
 use crates_io::{
     controllers::session,
     models::{OauthGithub, User},
@@ -30,7 +31,7 @@ struct UpdateTest {
 }
 
 impl UpdateTest {
-    async fn run(self) {
+    async fn run(self) -> anyhow::Result<()> {
         let Self {
             dry_run,
             existing_github_id,
@@ -62,7 +63,7 @@ impl UpdateTest {
             account_id: oauth_github_before_update.account_id,
         };
         job.enqueue(&conn).await.unwrap();
-        let _ = app.try_run_pending_background_jobs().await;
+        let job_result = app.try_run_pending_background_jobs().await;
 
         let oauth_github_after_update = oauth_github::table
             .filter(oauth_github::user_id.eq(u.id))
@@ -86,6 +87,8 @@ impl UpdateTest {
             .execute(&mut conn)
             .await
             .unwrap();
+
+        job_result
     }
 }
 
@@ -107,7 +110,7 @@ async fn no_updates_needed() {
         .expect_current_user()
         .return_once(|_| Ok(github_user(GITHUB_ID, EXISTING_LOGIN)));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
@@ -118,6 +121,8 @@ async fn no_updates_needed() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -127,7 +132,7 @@ async fn yes_updates_needed() {
         .expect_current_user()
         .return_once(|_| Ok(github_user(GITHUB_ID, "my-new-username")));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
@@ -137,6 +142,8 @@ async fn yes_updates_needed() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -147,7 +154,7 @@ async fn github_deleted() {
         .expect_current_user()
         .return_once(|_| Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
@@ -157,6 +164,8 @@ async fn github_deleted() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -167,7 +176,7 @@ async fn still_deleted() {
         .expect_current_user()
         .return_once(|_| Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         // We marked this user as deleted previously
@@ -178,6 +187,8 @@ async fn still_deleted() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -192,7 +203,7 @@ async fn github_unauthorized_fallback_success_no_update() {
         .expect_get_user_by_id()
         .return_once(|_| Ok(github_user(GITHUB_ID, EXISTING_LOGIN)));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
@@ -202,6 +213,8 @@ async fn github_unauthorized_fallback_success_no_update() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -212,7 +225,7 @@ async fn github_unauthorized_enterprise_user() {
         .expect_current_user()
         .return_once(|_| Err(GitHubError::Unauthorized(anyhow::anyhow!("Not allowed"))));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: "asmith_microsoft",
@@ -222,6 +235,8 @@ async fn github_unauthorized_enterprise_user() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -236,7 +251,7 @@ async fn github_unauthorized_fallback_success_yes_update() {
         .expect_get_user_by_id()
         .return_once(|_| Ok(github_user(GITHUB_ID, "updated-username")));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
@@ -246,6 +261,8 @@ async fn github_unauthorized_fallback_success_yes_update() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -260,7 +277,7 @@ async fn github_unauthorized_fallback_not_found_deleted() {
         .expect_get_user_by_id()
         .return_once(|_| Err(GitHubError::NotFound(anyhow::anyhow!("404 Not Found"))));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
@@ -270,6 +287,8 @@ async fn github_unauthorized_fallback_not_found_deleted() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -284,7 +303,7 @@ async fn github_unauthorized_fallback_other_error_no_update() {
         .expect_get_user_by_id()
         .return_once(|_| Err(GitHubError::Other(anyhow::anyhow!("Over your rate limit"))));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
@@ -294,6 +313,8 @@ async fn github_unauthorized_fallback_other_error_no_update() {
     }
     .run()
     .await;
+
+    assert_err!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -308,7 +329,7 @@ async fn github_forbidden_fallback_success_yes_update() {
         .expect_get_user_by_id()
         .return_once(|_| Ok(github_user(GITHUB_ID, "updated-username")));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
@@ -318,6 +339,8 @@ async fn github_forbidden_fallback_success_yes_update() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -329,7 +352,7 @@ async fn github_unavailable() {
         .expect_current_user()
         .return_once(|_| Err(GitHubError::Other(anyhow::anyhow!("9% uptime is one nine"))));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
@@ -339,6 +362,8 @@ async fn github_unavailable() {
     }
     .run()
     .await;
+
+    assert_err!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -350,7 +375,7 @@ async fn undeleted() {
         .expect_current_user()
         .return_once(|_| Ok(github_user(GITHUB_ID, "my-new-username")));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: false,
         existing_github_id: GITHUB_ID,
         existing_username: "ghost_1",
@@ -360,6 +385,8 @@ async fn undeleted() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -369,7 +396,7 @@ async fn dry_run_mode_doesnt_update() {
         .expect_current_user()
         .return_once(|_| Ok(github_user(GITHUB_ID, "my-new-username")));
 
-    UpdateTest {
+    let result = UpdateTest {
         dry_run: true,
         existing_github_id: GITHUB_ID,
         existing_username: EXISTING_LOGIN,
@@ -379,4 +406,6 @@ async fn dry_run_mode_doesnt_update() {
     }
     .run()
     .await;
+
+    assert_ok!(result);
 }

--- a/src/worker/jobs/mod.rs
+++ b/src/worker/jobs/mod.rs
@@ -18,6 +18,7 @@ mod sync_admins;
 pub mod trustpub;
 mod typosquat;
 mod update_default_version;
+mod update_user_from_github;
 
 pub use self::analyze_crate_file::AnalyzeCrateFile;
 pub use self::archive_version_downloads::ArchiveVersionDownloads;
@@ -42,3 +43,4 @@ pub use self::send_publish_notifications::SendPublishNotificationsJob;
 pub use self::sync_admins::SyncAdmins;
 pub use self::typosquat::CheckTyposquat;
 pub use self::update_default_version::UpdateDefaultVersion;
+pub use self::update_user_from_github::UpdateUserFromGithub;

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -41,21 +41,20 @@ impl BackgroundJob for UpdateUserFromGithub {
             .await?;
 
         info!(
-            dry_run = self.dry_run,
-            user_id = oauth_github.user_id,
-            github_id = self.account_id,
-            old_username = oauth_github.login,
-            "Starting UpdateUserFromGithub"
+            "Starting UpdateUserFromGithub ({}): user_id {}, github_id {}, old username {}",
+            if self.dry_run { "DRY RUN" } else { "FOR REAL" },
+            oauth_github.user_id,
+            self.account_id,
+            oauth_github.login,
         );
 
         let github_user = self.refresh_user(&ctx, &oauth_github).await?;
 
         if self.dry_run {
             info!(
-                user_id = oauth_github.user_id,
-                old_username = oauth_github.login,
-                new_username = github_user.login,
-                "Dry run UpdateUserFromGithub proposed update"
+                "Dry run UpdateUserFromGithub proposed update for crates.io user {} \
+                from username `{}` to username `{}`",
+                oauth_github.user_id, oauth_github.login, github_user.login,
             );
         } else {
             self.apply_update(&oauth_github, &github_user, &mut conn)

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -1,0 +1,50 @@
+use crate::worker::Environment;
+use crates_io_github::GitHubUser;
+use crates_io_worker::BackgroundJob;
+use diesel_async::AsyncPgConnection;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Serialize, Deserialize)]
+pub struct UpdateUserFromGithub {
+    /// Crates.io user ID
+    user_id: i32,
+    /// GitHub ID
+    account_id: i32,
+    /// Encrypted GitHub token
+    encrypted_token: Vec<u8>,
+}
+
+impl BackgroundJob for UpdateUserFromGithub {
+    const JOB_NAME: &'static str = "update_user_from_github";
+    const DEDUPLICATED: bool = true;
+
+    type Context = Arc<Environment>;
+
+    /// For the specified user, query the GitHub API for the user's current information to see if
+    /// their account has been deleted or renamed. Update the `users` and `oauth_github` tables,
+    /// saving the current time in `last_sync` even if the user information hasn't changed.
+    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+        let mut conn = ctx.deadpool.get().await?;
+
+        let github_user = self.refresh_user(&ctx).await?;
+
+        self.apply_update(&github_user, &mut conn).await;
+
+        Ok(())
+    }
+}
+
+impl UpdateUserFromGithub {
+    /// Given the current environment's context, request information from GitHub using the user's
+    /// API token.
+    async fn refresh_user(&self, _ctx: &Arc<Environment>) -> anyhow::Result<GitHubUser> {
+        todo!();
+    }
+
+    /// Given the information from GitHub about the current user, make the appropriate changes to
+    /// the `users` and `oauth_github` tables.
+    async fn apply_update(&self, _github_user: &GitHubUser, _conn: &mut AsyncPgConnection) {
+        todo!();
+    }
+}

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -16,15 +16,9 @@ use tracing::{error, info};
 pub struct UpdateUserFromGithub {
     /// Dry run will fetch updates from GitHub and log what it would change, but does not actually
     /// update the database.
-    dry_run: bool,
-    /// Crates.io user ID
-    user_id: i32,
+    pub dry_run: bool,
     /// GitHub ID
-    account_id: i64,
-    /// Encrypted GitHub token
-    encrypted_token: Vec<u8>,
-    /// Username currently in the database
-    old_username: String,
+    pub account_id: i64,
 }
 
 impl BackgroundJob for UpdateUserFromGithub {
@@ -37,27 +31,35 @@ impl BackgroundJob for UpdateUserFromGithub {
     /// their account has been deleted or renamed. Update the `users` and `oauth_github` tables,
     /// saving the current time in `last_sync` even if the user information hasn't changed.
     async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+        let mut conn = ctx.deadpool.get().await?;
+
+        // If no oauth_github info with this account id is found, then the record has been deleted
+        // since this job was enqueued. Stop and exit with success so we don't retry the job.
+        let oauth_github = oauth_github::table
+            .filter(oauth_github::account_id.eq(self.account_id))
+            .first::<OauthGithub>(&mut conn)
+            .await?;
+
         info!(
             dry_run = self.dry_run,
-            user_id = self.user_id,
+            user_id = oauth_github.user_id,
             github_id = self.account_id,
-            old_username = self.old_username,
+            old_username = oauth_github.login,
             "Starting UpdateUserFromGithub"
         );
 
-        let mut conn = ctx.deadpool.get().await?;
-
-        let github_user = self.refresh_user(&ctx).await?;
+        let github_user = self.refresh_user(&ctx, &oauth_github).await?;
 
         if self.dry_run {
             info!(
-                user_id = self.user_id,
-                old_username = self.old_username,
+                user_id = oauth_github.user_id,
+                old_username = oauth_github.login,
                 new_username = github_user.login,
                 "Dry run UpdateUserFromGithub proposed update"
             );
         } else {
-            self.apply_update(&github_user, &mut conn).await;
+            self.apply_update(&oauth_github, &github_user, &mut conn)
+                .await;
         }
 
         Ok(())
@@ -65,43 +67,29 @@ impl BackgroundJob for UpdateUserFromGithub {
 }
 
 impl UpdateUserFromGithub {
-    pub fn new(dry_run: bool, oauth_github: OauthGithub) -> Self {
-        let OauthGithub {
-            user_id,
-            account_id,
-            encrypted_token,
-            login,
-            ..
-        } = oauth_github;
-
-        Self {
-            dry_run,
-            user_id,
-            account_id,
-            encrypted_token,
-            old_username: login,
-        }
-    }
-
     /// Given the current environment's context, request information from GitHub using the user's
     /// API token.
-    async fn refresh_user(&self, ctx: &Arc<Environment>) -> anyhow::Result<GitHubUser> {
+    async fn refresh_user(
+        &self,
+        ctx: &Arc<Environment>,
+        oauth_github: &OauthGithub,
+    ) -> anyhow::Result<GitHubUser> {
         // if the user's gh_id isn't positive, we don't even need to ask github about this,
         // we know this user is invalid. Just make sure their username is the ghost username.
         if self.account_id < 1 {
-            Ok(self.ghost_user())
+            Ok(self.ghost_user(oauth_github.user_id))
         } else {
             let github = ctx.github.as_ref();
             let token = ctx
                 .config
                 .gh_token_encryption
-                .decrypt(&self.encrypted_token)?;
+                .decrypt(&oauth_github.encrypted_token)?;
 
             match github.current_user(&token).await {
                 Ok(github_user) => Ok(github_user),
                 // If the user is not found, the account has been deleted. Update to the ghost
                 // username.
-                Err(GitHubError::NotFound(_)) => Ok(self.ghost_user()),
+                Err(GitHubError::NotFound(_)) => Ok(self.ghost_user(oauth_github.user_id)),
                 // Unauthorized/forbidden could mean:
                 //
                 // - the token we have for this user is out-of-date
@@ -113,10 +101,10 @@ impl UpdateUserFromGithub {
                 // enterprise to see any information on enterprise managed users.
                 Err(GitHubError::Unauthorized(_)) | Err(GitHubError::Forbidden(_)) => {
                     // Enterprise managed users are the only ones that should contain underscores.
-                    if self.old_username.contains('_') {
+                    if oauth_github.login.contains('_') {
                         // We can't get updated info, so keep what we have.
                         Ok(GitHubUser {
-                            login: self.old_username.clone(),
+                            login: oauth_github.login.clone(),
                             id: self.account_id as i32,
                             // The other fields are not used in `apply_update`.
                             avatar_url: Default::default(),
@@ -126,7 +114,9 @@ impl UpdateUserFromGithub {
                     } else {
                         match github.get_user_by_id(self.account_id).await {
                             Ok(github_user) => Ok(github_user),
-                            Err(GitHubError::NotFound(_)) => Ok(self.ghost_user()),
+                            Err(GitHubError::NotFound(_)) => {
+                                Ok(self.ghost_user(oauth_github.user_id))
+                            }
                             // Not sure how we could get Unauthorized/Forbidden for an anonymous
                             // API request. We could get rate limited though; if that's the case,
                             // stop and try this user again later.
@@ -143,7 +133,12 @@ impl UpdateUserFromGithub {
 
     /// Given the information from GitHub about the current user, make the appropriate changes to
     /// the `users` and `oauth_github` tables.
-    async fn apply_update(&self, github_user: &GitHubUser, conn: &mut AsyncPgConnection) {
+    async fn apply_update(
+        &self,
+        oauth_github: &OauthGithub,
+        github_user: &GitHubUser,
+        conn: &mut AsyncPgConnection,
+    ) {
         // Use a transaction so that we either update both or neither the `users` record and the
         // corresponding `oauth_github` record. If neither are updated, log and continue to the
         // next user rather than stopping-- hopefully we'll get that user updated next time.
@@ -152,9 +147,9 @@ impl UpdateUserFromGithub {
                 // This will be removed when we no longer sync crates.io usernames with GitHub.
                 // (The transaction can be removed when this is removed as well)
                 // It's only needed if there's a change in username.
-                if self.old_username != github_user.login {
+                if oauth_github.login != github_user.login {
                     diesel::update(users::table)
-                        .filter(users::id.eq(self.user_id))
+                        .filter(users::id.eq(oauth_github.user_id))
                         .set(users::gh_login.eq(&github_user.login))
                         .execute(conn)
                         .await?;
@@ -163,7 +158,7 @@ impl UpdateUserFromGithub {
                 // This update is needed even if there's no change in username to set the
                 // `last_sync` time to `now`.
                 diesel::update(oauth_github::table)
-                    .filter(oauth_github::user_id.eq(self.user_id))
+                    .filter(oauth_github::account_id.eq(self.account_id))
                     .set((
                         oauth_github::login.eq(&github_user.login),
                         oauth_github::last_sync.eq(Utc::now()),
@@ -179,19 +174,19 @@ impl UpdateUserFromGithub {
             // Better luck next time.
             error!(
                 "Could not update user ID {} from username {} to username {}: {e}",
-                self.user_id, self.old_username, github_user.login,
+                oauth_github.user_id, oauth_github.login, github_user.login,
             );
         }
     }
 
     /// If this user has been deleted, ensure their username has been changed to
     /// `ghost_{crates.io id}` to ensure uniqueness by creating a `GitHubUser` by hand.
-    fn ghost_user(&self) -> GitHubUser {
+    fn ghost_user(&self, user_id: i32) -> GitHubUser {
         GitHubUser {
             avatar_url: None,
             email: None,
             id: self.account_id as i32,
-            login: format!("ghost_{}", self.user_id),
+            login: format!("ghost_{}", user_id),
             name: None,
         }
     }

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -24,6 +24,8 @@ pub struct UpdateUserFromGithub {
 impl BackgroundJob for UpdateUserFromGithub {
     const JOB_NAME: &'static str = "update_user_from_github";
     const DEDUPLICATED: bool = true;
+    // These jobs aren't urgent and shouldn't page anyone if they take a long time.
+    const PRIORITY: i16 = -15;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -74,60 +74,52 @@ impl UpdateUserFromGithub {
         ctx: &Arc<Environment>,
         oauth_github: &OauthGithub,
     ) -> anyhow::Result<GitHubUser> {
-        // if the user's gh_id isn't positive, we don't even need to ask github about this,
-        // we know this user is invalid. Just make sure their username is the ghost username.
-        if self.account_id < 1 {
-            Ok(self.ghost_user(oauth_github.user_id))
-        } else {
-            let github = ctx.github.as_ref();
-            let token = ctx
-                .config
-                .gh_token_encryption
-                .decrypt(&oauth_github.encrypted_token)?;
+        let github = ctx.github.as_ref();
+        let token = ctx
+            .config
+            .gh_token_encryption
+            .decrypt(&oauth_github.encrypted_token)?;
 
-            match github.current_user(&token).await {
-                Ok(github_user) => Ok(github_user),
-                // If the user is not found, the account has been deleted. Update to the ghost
-                // username.
-                Err(GitHubError::NotFound(_)) => Ok(self.ghost_user(oauth_github.user_id)),
-                // Unauthorized/forbidden could mean:
-                //
-                // - the token we have for this user is out-of-date
-                // - the user has revoked crates.io's oauth access
-                //
-                // In those cases, try to request the user's info via an unauthenticated GitHub
-                // API request, unless they are a GitHub Enterprise Managed User as indicated by an
-                // underscore in their username because we have to be authorized by the managing
-                // enterprise to see any information on enterprise managed users.
-                Err(GitHubError::Unauthorized(_)) | Err(GitHubError::Forbidden(_)) => {
-                    // Enterprise managed users are the only ones that should contain underscores.
-                    if oauth_github.login.contains('_') {
-                        // We can't get updated info, so keep what we have.
-                        Ok(GitHubUser {
-                            login: oauth_github.login.clone(),
-                            id: self.account_id as i32,
-                            // The other fields are not used in `apply_update`.
-                            avatar_url: Default::default(),
-                            email: Default::default(),
-                            name: Default::default(),
-                        })
-                    } else {
-                        match github.get_user_by_id(self.account_id).await {
-                            Ok(github_user) => Ok(github_user),
-                            Err(GitHubError::NotFound(_)) => {
-                                Ok(self.ghost_user(oauth_github.user_id))
-                            }
-                            // Not sure how we could get Unauthorized/Forbidden for an anonymous
-                            // API request. We could get rate limited though; if that's the case,
-                            // stop and try this user again later.
-                            Err(e) => Err(e.into()),
-                        }
+        match github.current_user(&token).await {
+            Ok(github_user) => Ok(github_user),
+            // If the user is not found, the account has been deleted. Update to the ghost
+            // username.
+            Err(GitHubError::NotFound(_)) => Ok(self.ghost_user(oauth_github.user_id)),
+            // Unauthorized/forbidden could mean:
+            //
+            // - the token we have for this user is out-of-date
+            // - the user has revoked crates.io's oauth access
+            //
+            // In those cases, try to request the user's info via an unauthenticated GitHub
+            // API request, unless they are a GitHub Enterprise Managed User as indicated by an
+            // underscore in their username because we have to be authorized by the managing
+            // enterprise to see any information on enterprise managed users.
+            Err(GitHubError::Unauthorized(_)) | Err(GitHubError::Forbidden(_)) => {
+                // Enterprise managed users are the only ones that should contain underscores.
+                if oauth_github.login.contains('_') {
+                    // We can't get updated info, so keep what we have.
+                    Ok(GitHubUser {
+                        login: oauth_github.login.clone(),
+                        id: self.account_id as i32,
+                        // The other fields are not used in `apply_update`.
+                        avatar_url: Default::default(),
+                        email: Default::default(),
+                        name: Default::default(),
+                    })
+                } else {
+                    match github.get_user_by_id(self.account_id).await {
+                        Ok(github_user) => Ok(github_user),
+                        Err(GitHubError::NotFound(_)) => Ok(self.ghost_user(oauth_github.user_id)),
+                        // Not sure how we could get Unauthorized/Forbidden for an anonymous
+                        // API request. We could get rate limited though; if that's the case,
+                        // stop and try this user again later.
+                        Err(e) => Err(e.into()),
                     }
                 }
-                // If we get another sort of error, it may be transient; stop and try this user
-                // again later.
-                Err(e @ GitHubError::Other(_)) => Err(e.into()),
             }
+            // If we get another sort of error, it may be transient; stop and try this user
+            // again later.
+            Err(e @ GitHubError::Other(_)) => Err(e.into()),
         }
     }
 

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -151,12 +151,17 @@ impl UpdateUserFromGithub {
             .transaction(async |conn| {
                 // This will be removed when we no longer sync crates.io usernames with GitHub.
                 // (The transaction can be removed when this is removed as well)
-                diesel::update(users::table)
-                    .filter(users::id.eq(self.user_id))
-                    .set(users::gh_login.eq(&github_user.login))
-                    .execute(conn)
-                    .await?;
+                // It's only needed if there's a change in username.
+                if self.old_username != github_user.login {
+                    diesel::update(users::table)
+                        .filter(users::id.eq(self.user_id))
+                        .set(users::gh_login.eq(&github_user.login))
+                        .execute(conn)
+                        .await?;
+                }
 
+                // This update is needed even if there's no change in username to set the
+                // `last_sync` time to `now`.
                 diesel::update(oauth_github::table)
                     .filter(oauth_github::user_id.eq(self.user_id))
                     .set((

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -1,18 +1,27 @@
-use crate::worker::Environment;
-use crates_io_github::GitHubUser;
+use crate::{
+    models::OauthGithub,
+    schema::{oauth_github, users},
+    worker::Environment,
+};
+use chrono::Utc;
+use crates_io_github::{GitHubError, GitHubUser};
 use crates_io_worker::BackgroundJob;
-use diesel_async::AsyncPgConnection;
+use diesel::prelude::*;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::error;
 
 #[derive(Serialize, Deserialize)]
 pub struct UpdateUserFromGithub {
     /// Crates.io user ID
     user_id: i32,
     /// GitHub ID
-    account_id: i32,
+    account_id: i64,
     /// Encrypted GitHub token
     encrypted_token: Vec<u8>,
+    /// Username currently in the database
+    old_username: String,
 }
 
 impl BackgroundJob for UpdateUserFromGithub {
@@ -36,15 +45,102 @@ impl BackgroundJob for UpdateUserFromGithub {
 }
 
 impl UpdateUserFromGithub {
+    pub fn new(oauth_github: OauthGithub) -> Self {
+        let OauthGithub {
+            user_id,
+            account_id,
+            encrypted_token,
+            login,
+            ..
+        } = oauth_github;
+
+        Self {
+            user_id,
+            account_id,
+            encrypted_token,
+            old_username: login,
+        }
+    }
+
     /// Given the current environment's context, request information from GitHub using the user's
     /// API token.
-    async fn refresh_user(&self, _ctx: &Arc<Environment>) -> anyhow::Result<GitHubUser> {
-        todo!();
+    async fn refresh_user(&self, ctx: &Arc<Environment>) -> anyhow::Result<GitHubUser> {
+        // if the user's gh_id isn't positive, we don't even need to ask github about this,
+        // we know this user is invalid. Just make sure their username is the ghost username.
+        if self.account_id < 1 {
+            Ok(self.ghost_user())
+        } else {
+            let github = ctx.github.as_ref();
+            let token = ctx
+                .config
+                .gh_token_encryption
+                .decrypt(&self.encrypted_token)?;
+
+            match github.current_user(&token).await {
+                Ok(github_user) => Ok(github_user),
+                // If the user is not found, the account has been deleted. Update to the ghost
+                // username.
+                Err(GitHubError::NotFound(_)) => Ok(self.ghost_user()),
+                // Does unauthorized/forbidden mean the user has been deleted?
+                // Or does it mean the user removed crates.io's authorization?
+                // Or that the token we have for the user is bad?
+                Err(GitHubError::Unauthorized(_)) | Err(GitHubError::Forbidden(_)) => {
+                    Ok(self.ghost_user())
+                }
+                // If we get another sort of error, it may be transient; stop and try this user
+                // again later.
+                Err(e @ GitHubError::Other(_)) => Err(e.into()),
+            }
+        }
     }
 
     /// Given the information from GitHub about the current user, make the appropriate changes to
     /// the `users` and `oauth_github` tables.
-    async fn apply_update(&self, _github_user: &GitHubUser, _conn: &mut AsyncPgConnection) {
-        todo!();
+    async fn apply_update(&self, github_user: &GitHubUser, conn: &mut AsyncPgConnection) {
+        // Use a transaction so that we either update both or neither the `users` record and the
+        // corresponding `oauth_github` record. If neither are updated, log and continue to the
+        // next user rather than stopping-- hopefully we'll get that user updated next time.
+        if let Err(e) = conn
+            .transaction(async |conn| {
+                // This will be removed when we no longer sync crates.io usernames with GitHub.
+                // (The transaction can be removed when this is removed as well)
+                diesel::update(users::table)
+                    .filter(users::id.eq(self.user_id))
+                    .set(users::gh_login.eq(&github_user.login))
+                    .execute(conn)
+                    .await?;
+
+                diesel::update(oauth_github::table)
+                    .filter(oauth_github::user_id.eq(self.user_id))
+                    .set((
+                        oauth_github::login.eq(&github_user.login),
+                        oauth_github::last_sync.eq(Utc::now()),
+                    ))
+                    .execute(conn)
+                    .await?;
+
+                Ok::<(), diesel::result::Error>(())
+            })
+            .await
+        {
+            // Database update failed; it's ok to not update this user this round.
+            // Better luck next time.
+            error!(
+                "Could not update user ID {} from username {} to username {}: {e}",
+                self.user_id, self.old_username, github_user.login,
+            );
+        }
+    }
+
+    /// If this user has been deleted, ensure their username has been changed to
+    /// `ghost_{crates.io id}` to ensure uniqueness by creating a `GitHubUser` by hand.
+    fn ghost_user(&self) -> GitHubUser {
+        GitHubUser {
+            avatar_url: None,
+            email: None,
+            id: self.account_id as i32,
+            login: format!("ghost_{}", self.user_id),
+            name: None,
+        }
     }
 }

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -102,11 +102,37 @@ impl UpdateUserFromGithub {
                 // If the user is not found, the account has been deleted. Update to the ghost
                 // username.
                 Err(GitHubError::NotFound(_)) => Ok(self.ghost_user()),
-                // Does unauthorized/forbidden mean the user has been deleted?
-                // Or does it mean the user removed crates.io's authorization?
-                // Or that the token we have for the user is bad?
+                // Unauthorized/forbidden could mean:
+                //
+                // - the token we have for this user is out-of-date
+                // - the user has revoked crates.io's oauth access
+                //
+                // In those cases, try to request the user's info via an unauthenticated GitHub
+                // API request, unless they are a GitHub Enterprise Managed User as indicated by an
+                // underscore in their username because we have to be authorized by the managing
+                // enterprise to see any information on enterprise managed users.
                 Err(GitHubError::Unauthorized(_)) | Err(GitHubError::Forbidden(_)) => {
-                    Ok(self.ghost_user())
+                    // Enterprise managed users are the only ones that should contain underscores.
+                    if self.old_username.contains('_') {
+                        // We can't get updated info, so keep what we have.
+                        Ok(GitHubUser {
+                            login: self.old_username.clone(),
+                            id: self.account_id as i32,
+                            // The other fields are not used in `apply_update`.
+                            avatar_url: Default::default(),
+                            email: Default::default(),
+                            name: Default::default(),
+                        })
+                    } else {
+                        match github.get_user_by_id(self.account_id).await {
+                            Ok(github_user) => Ok(github_user),
+                            Err(GitHubError::NotFound(_)) => Ok(self.ghost_user()),
+                            // Not sure how we could get Unauthorized/Forbidden for an anonymous
+                            // API request. We could get rate limited though; if that's the case,
+                            // stop and try this user again later.
+                            Err(e) => Err(e.into()),
+                        }
+                    }
                 }
                 // If we get another sort of error, it may be transient; stop and try this user
                 // again later.

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -10,10 +10,13 @@ use diesel::prelude::*;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::error;
+use tracing::{error, info};
 
 #[derive(Serialize, Deserialize)]
 pub struct UpdateUserFromGithub {
+    /// Dry run will fetch updates from GitHub and log what it would change, but does not actually
+    /// update the database.
+    dry_run: bool,
     /// Crates.io user ID
     user_id: i32,
     /// GitHub ID
@@ -34,18 +37,35 @@ impl BackgroundJob for UpdateUserFromGithub {
     /// their account has been deleted or renamed. Update the `users` and `oauth_github` tables,
     /// saving the current time in `last_sync` even if the user information hasn't changed.
     async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+        info!(
+            dry_run = self.dry_run,
+            user_id = self.user_id,
+            github_id = self.account_id,
+            old_username = self.old_username,
+            "Starting UpdateUserFromGithub"
+        );
+
         let mut conn = ctx.deadpool.get().await?;
 
         let github_user = self.refresh_user(&ctx).await?;
 
-        self.apply_update(&github_user, &mut conn).await;
+        if self.dry_run {
+            info!(
+                user_id = self.user_id,
+                old_username = self.old_username,
+                new_username = github_user.login,
+                "Dry run UpdateUserFromGithub proposed update"
+            );
+        } else {
+            self.apply_update(&github_user, &mut conn).await;
+        }
 
         Ok(())
     }
 }
 
 impl UpdateUserFromGithub {
-    pub fn new(oauth_github: OauthGithub) -> Self {
+    pub fn new(dry_run: bool, oauth_github: OauthGithub) -> Self {
         let OauthGithub {
             user_id,
             account_id,
@@ -55,6 +75,7 @@ impl UpdateUserFromGithub {
         } = oauth_github;
 
         Self {
+            dry_run,
             user_id,
             account_id,
             encrypted_token,

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -43,6 +43,7 @@ impl RunnerExt for Runner<Arc<Environment>> {
             .register_job_type::<jobs::SyncToSparseIndex>()
             .register_job_type::<jobs::UpdateDownloads>()
             .register_job_type::<jobs::UpdateDefaultVersion>()
+            .register_job_type::<jobs::UpdateUserFromGithub>()
             .register_job_type::<jobs::SendTokenExpiryNotifications>()
             .register_job_type::<jobs::SendPublishNotificationsJob>()
             .register_job_type::<jobs::rss::SyncCrateFeed>()


### PR DESCRIPTION
Also to hopefully get the database to a state where `users.gh_login` is unique.

# Rates

The part that I haven't decided/completed yet is how often to run the `UpdateFromGithub` job and at what pace. Currently, the job must be enqueued completely manually and it does a batch of 100 crates.io users then stops at a pace under the GitHub API rate limits.

We definitely need to run the job against all users once before thinking about implementing https://github.com/rust-lang/rfcs/pull/3946, so that 1. we start all accounts off with their current GitHub username as their crates.io username and 2. the crates.io username based on the GitHub username can be unique.

What I'm imagining is that once we decide to implement the part of https://github.com/rust-lang/rfcs/pull/3946 that stops updating your crates.io username in sync with your GitHub username, then the `UpdateFromGithub` job will only update `oauth_github.login` and not `users.gh_login` (or whatever that column ends up getting renamed to when it becomes the crates.io username).

Reasons to be cautious about how often and how fast this job runs:

- I don't know how the queries and updates to our database will affect database load in production. I hope I've written this in such a way as to not be noticeable, but I could be wrong! If i'm wrong, are there better ways to write the queries? Or will we need to schedule this task to run during times that our traffic is lower?
- We haven't been doing these proactive updates, so there isn't a huge reason to rush into doing them as fast as possible.

Reasons to turn this on to run all the time as fast as possible:

- To get the best mitigation of such long-standing issues as:
  - https://github.com/rust-lang/crates.io/issues/1585
  - https://github.com/rust-lang/crates.io/issues/1584
- We're confident it doesn't affect performance or cause issues (once we've established that confidence however we need to)

And of course there are places between "as slow as possible" and "as fast as possible" that we could land; I'm interested to get peoples' thoughts on the tradeoffs.

# User IDs

@LawnGnome You mentioned the other day something about the crates.io user account ID being PII that we should be cautious about using, mostly because archives exist. I'm interested in your thoughts about using `ghost_{user id}` as the crates.io username for deleted GitHub accounts. I think this is fine, and here's why:

- Our API responses to `https://crates.io/api/v1/users/{username}` include the user's crates.io ID; it's not secret information
- I think the information that could be gleaned from using the user ID  in conjunction with an archive is that crates.io says there's an account `ghost_123` that owns crate `foo`; the archive can tell us through user ID association that this user previously had the username `LawnGnome`, and perhaps this person deleted their GitHub account because they didn't want people to know they published crate `foo`. I don't think this is actually a reason not to use user IDs in this way because:
  - The archive may go back to a point in time where you could see the owner of `foo` was `LawnGnome` anyway
  - Users can request that crates.io delete all data we have associated with them, including their user record and sometimes including their crate, which we're likely to grant if the reason is to remove PII the user doesn't want to be exposed
  
Am I missing a way the user ID could be used that would make `ghost_{user id}` a bad idea?

# Other

Any other concerns I haven't addressed?