### PR TITLE
simplify docs.rs build-status request to safe a redirect

### DIFF
--- a/app/models/version.js
+++ b/app/models/version.js
@@ -192,7 +192,7 @@ export default class Version extends Model {
   });
 
   loadDocsStatusTask = task(async () => {
-    return await ajax(`https://docs.rs/crate/${this.crateName}/=${this.num}/status.json`);
+    return await ajax(`https://docs.rs/crate/${this.crateName}/${this.num}/status.json`);
   });
 
   get docsRsResponse() {

--- a/tests/routes/crate/version/docs-link-test.js
+++ b/tests/routes/crate/version/docs-link-test.js
@@ -32,7 +32,12 @@ module('Route | crate.version | docs link', function (hooks) {
     await this.db.version.create({ crate, num: '1.0.0' });
 
     let response = HttpResponse.json({ doc_status: true, version: '1.0.0' });
-    this.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    this.worker.use(
+      http.get('https://docs.rs/crate/:crate/:version/status.json', ({ params }) => {
+        assert.strictEqual(params.version, '1.0.0');
+        return response;
+      }),
+    );
 
     await visit('/crates/foo');
     assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://docs.rs/foo/1.0.0');

--- a/tests/routes/crate/version/source-link-test.js
+++ b/tests/routes/crate/version/source-link-test.js
@@ -13,7 +13,12 @@ module('Route | crate.version | source link', function (hooks) {
     await this.db.version.create({ crate, num: '1.0.0' });
 
     let response = HttpResponse.json({ doc_status: false, version: '1.0.0' });
-    this.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    this.worker.use(
+      http.get('https://docs.rs/crate/:crate/:version/status.json', ({ params }) => {
+        assert.strictEqual(params.version, '1.0.0');
+        return response;
+      }),
+    );
 
     await visit('/crates/foo');
     assert.dom('[data-test-source-link] a').hasAttribute('href', 'https://docs.rs/crate/foo/1.0.0/source/');


### PR DESCRIPTION
( draft so I can see what fails in CI). 

in docs.rs, `/=1.2.3/` is equivalent to `/1.2.3/`, and we redirect one to the other. 