### PR TITLE
Block esp-rs.org domain that has expired

### DIFF
--- a/crates/crates_io_api_types/src/external_urls.rs
+++ b/crates/crates_io_api_types/src/external_urls.rs
@@ -7,6 +7,7 @@ const DOMAIN_BLOCKLIST: &[&str] = &[
     "rustless.org",
     "ironframework.io",
     "nebulanet.cc",
+    "esp-rs.org",
 ];
 
 /// Return `None` if the documentation URL host matches a blocked host


### PR DESCRIPTION
It used to host the documentation for https://crates.io/crates/esp-idf-svc

We got a report that this domain has expired, so we should now block it.