### PR TITLE
Replace `deadpool-diesel` with `deadpool-runtime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,7 @@ dependencies = [
  "crates_io_version",
  "crates_io_worker",
  "csv",
- "deadpool-diesel",
+ "deadpool-runtime",
  "derive_more",
  "dialoguer",
  "diesel",
@@ -2254,33 +2254,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "deadpool-diesel"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590573e9e29c5190a5ff782136f871e6e652e35d598a349888e028693601adf1"
-dependencies = [
- "deadpool",
- "deadpool-sync",
- "diesel",
-]
-
-[[package]]
 name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 dependencies = [
  "tokio",
-]
-
-[[package]]
-name = "deadpool-sync"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
-dependencies = [
- "deadpool-runtime",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ csv = "=1.4.0"
 chrono = { version = "=0.4.44", default-features = false, features = ["serde"] }
 clap = { version = "=4.6.0", features = ["derive", "env", "unicode", "wrap_help"] }
 cookie = { version = "=0.18.1", features = ["secure"] }
-deadpool-diesel = { version = "=0.6.1", features = ["postgres", "tracing"] }
+deadpool-runtime = { version = "=0.1.4", features = ["tokio_1"] }
 derive_more = { version = "=2.1.1", features = ["deref", "deref_mut", "display"] }
 dialoguer = "=0.12.0"
 diesel = { version = "=2.3.7", features = ["postgres", "serde_json", "chrono", "numeric"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,7 @@ use crates_io_github::GitHubClient;
 use crates_io_trustpub::github::GITHUB_ISSUER_URL;
 use crates_io_trustpub::gitlab::GITLAB_ISSUER_URL;
 use crates_io_trustpub::keystore::{OidcKeyStore, RealOidcKeyStore};
-use deadpool_diesel::Runtime;
+use deadpool_runtime::Runtime;
 use derive_more::Deref;
 use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;


### PR DESCRIPTION
The only import from `deadpool-diesel` was `deadpool_diesel::Runtime`, which is a re-export of `deadpool_runtime::Runtime`. The `postgres` feature only enabled `diesel/postgres`, which we already depend on directly. The `tracing` feature added spans in `deadpool-sync`'s `SyncWrapper`, which is not part of our async connection pool setup.

Depending on `deadpool-runtime` directly removes `deadpool-diesel` and `deadpool-sync` from the dependency tree.

This makes https://github.com/rust-lang/crates.io/pull/13215 a bit easier to fix too :)