### PR TITLE
msw: Fix response key for private crate owner invitations endpoint

### DIFF
--- a/packages/crates-io-msw/handlers/invites/list.js
+++ b/packages/crates-io-msw/handlers/invites/list.js
@@ -48,7 +48,7 @@ export default http.get('/api/private/crate_owner_invitations', ({ request }) =>
   let users = Array.from(new Set([...inviters, ...invitees])).sort((a, b) => a.id - b.id);
 
   return HttpResponse.json({
-    crate_owner_invitations: invites.map(invite => serializeInvite(invite)),
+    invitations: invites.map(invite => serializeInvite(invite)),
     users: users.map(user => serializeUser(user)),
     meta: { next_page: nextPage },
   });

--- a/packages/crates-io-msw/handlers/invites/list.test.js
+++ b/packages/crates-io-msw/handlers/invites/list.test.js
@@ -32,7 +32,7 @@ test('happy path (invitee_id)', async function () {
   expect(response.status).toBe(200);
   expect(await response.json()).toMatchInlineSnapshot(`
     {
-      "crate_owner_invitations": [
+      "invitations": [
         {
           "crate_id": 1,
           "crate_name": "nanomsg",
@@ -88,7 +88,7 @@ test('happy path with empty response (invitee_id)', async function () {
   expect(response.status).toBe(200);
   expect(await response.json()).toMatchInlineSnapshot(`
     {
-      "crate_owner_invitations": [],
+      "invitations": [],
       "meta": {
         "next_page": null,
       },
@@ -112,13 +112,13 @@ test('happy path with pagination (invitee_id)', async function () {
   let response = await fetch(`/api/private/crate_owner_invitations?invitee_id=${user.id}`);
   expect(response.status).toBe(200);
   let responseJSON = await response.json();
-  expect(responseJSON['crate_owner_invitations'].length).toBe(10);
+  expect(responseJSON['invitations'].length).toBe(10);
   expect(responseJSON.meta['next_page']).toBeTruthy();
 
   response = await fetch(`/api/private/crate_owner_invitations${responseJSON.meta['next_page']}`);
   expect(response.status).toBe(200);
   responseJSON = await response.json();
-  expect(responseJSON['crate_owner_invitations'].length).toBe(5);
+  expect(responseJSON['invitations'].length).toBe(5);
   expect(responseJSON.meta['next_page']).toBe(null);
 });
 
@@ -152,7 +152,7 @@ test('happy path (crate_name)', async function () {
   expect(response.status).toBe(200);
   expect(await response.json()).toMatchInlineSnapshot(`
     {
-      "crate_owner_invitations": [
+      "invitations": [
         {
           "crate_id": 2,
           "crate_name": "ember-rs",


### PR DESCRIPTION
The real API returns `invitations`, not `crate_owner_invitations` 🤦‍♂️ 

https://github.com/rust-lang/crates.io/blob/238319ab1e81446adec00bf233b139529cf64b21/src/controllers/crate_owner_invitation.rs#L308-L318