### PR TITLE
OpenAPI: Add missing `request_body` to `handle_crate_owner_invitation`

### DIFF
--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -3361,7 +3361,25 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": {
+                    crate_owner_invite: {
+                        /**
+                         * @description Whether the invitation was accepted.
+                         * @example true
+                         */
+                        accepted: boolean;
+                        /**
+                         * Format: int32
+                         * @description The opaque identifier for the crate this invitation is for.
+                         * @example 42
+                         */
+                        crate_id: number;
+                    };
+                };
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -324,8 +324,9 @@ struct ResponseMeta {
     next_page: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct OwnerInvitation {
+    #[schema(inline)]
     crate_owner_invite: InvitationResponse,
 }
 
@@ -342,6 +343,7 @@ pub struct HandleResponse {
     params(
         ("crate_id" = i32, Path, description = "ID of the crate"),
     ),
+    request_body = inline(OwnerInvitation),
     security(
         ("api_token" = []),
         ("cookie" = []),

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -3909,6 +3909,41 @@ expression: response.json()
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "crate_owner_invite": {
+                    "properties": {
+                      "accepted": {
+                        "description": "Whether the invitation was accepted.",
+                        "example": true,
+                        "type": "boolean"
+                      },
+                      "crate_id": {
+                        "description": "The opaque identifier for the crate this invitation is for.",
+                        "example": 42,
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "crate_id",
+                      "accepted"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "crate_owner_invite"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {


### PR DESCRIPTION
The handler expects `Json<OwnerInvitation>` but the utoipa annotation was missing `request_body`, causing the generated schema to show `requestBody?: never`.