### PR TITLE
script: always try to create the tarball directory when importing

### DIFF
--- a/script/import-database-dump.sh
+++ b/script/import-database-dump.sh
@@ -15,6 +15,10 @@ if [ -f "$TARBALL_PATH" ]; then
     echo "Skipping https://static.crates.io/db-dump.tar.gz download since it exists already "
 else
     echo "Downloading https://static.crates.io/db-dump.tar.gz to the 'tmp' folder"
+
+    # Ensure the directory exists.
+    mkdir -p "$(dirname "$TARBALL_PATH")"
+
     curl https://static.crates.io/db-dump.tar.gz -L --output $TARBALL_PATH
 fi
 


### PR DESCRIPTION
Noticed this while setting up a clean working directory for reasons.