### PR TITLE
e2e: Drop leading whitespace from assertions

### DIFF
--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -122,7 +122,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await page.click('[data-test-versions-tab] a');
 
     await expect(page.locator('[data-test-page-description]')).toHaveText(
-      /\s+13\s+of\s+13\s+nanomsg\s+versions since\s+December \d+th, 2014/,
+      /13\s+of\s+13\s+nanomsg\s+versions since\s+December \d+th, 2014/,
     );
   });
 
@@ -131,12 +131,12 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
 
     await page.goto('/crates/nanomsg/versions?per_page=10');
     await expect(page.locator('[data-test-page-description]')).toHaveText(
-      /\s+10\s+of\s+13\s+nanomsg\s+versions since\s+December \d+th, 2014/,
+      /10\s+of\s+13\s+nanomsg\s+versions since\s+December \d+th, 2014/,
     );
 
     await page.getByTestId('load-more').click();
     await expect(page.locator('[data-test-page-description]')).toHaveText(
-      /\s+13\s+of\s+13\s+nanomsg\s+versions since\s+December \d+th, 2014/,
+      /13\s+of\s+13\s+nanomsg\s+versions since\s+December \d+th, 2014/,
     );
   });
 


### PR DESCRIPTION
The leading whitespace is irrelevant to these tests and doesn't actually exist in the Svelte implementation of the route.