### PR TITLE
svelte: Read `per_page` query parameter on versions page

### DIFF
--- a/svelte/src/routes/crates/[crate_id]/versions/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/versions/+page.ts
@@ -1,20 +1,21 @@
 import { createClient } from '@crates-io/api-client';
 import { error } from '@sveltejs/kit';
 
-const PER_PAGE = 100;
+const DEFAULT_PER_PAGE = 100;
 
 export async function load({ fetch, params, url }) {
   let client = createClient({ fetch });
 
   let crateName = params.crate_id;
   let sort = url.searchParams.get('sort') ?? 'date';
+  let perPage = Number(url.searchParams.get('per_page')) || DEFAULT_PER_PAGE;
 
   let response;
   try {
     response = await client.GET('/api/v1/crates/{name}/versions', {
       params: {
         path: { name: crateName },
-        query: { sort, per_page: PER_PAGE, include: 'release_tracks' },
+        query: { sort, per_page: perPage, include: 'release_tracks' },
       },
     });
   } catch (_error) {


### PR DESCRIPTION
Looks like I missed that part when I implemented the versions page, but fortunately the Playwright test suite caught it :)

### Related

- https://github.com/rust-lang/crates.io/issues/12515