### PR TITLE
e2e: Remove asset blocking from read-only mode tests

### DIFF
--- a/e2e/acceptance/read-only-mode.spec.ts
+++ b/e2e/acceptance/read-only-mode.spec.ts
@@ -2,11 +2,6 @@ import { AppFixtures, expect, test } from '@/e2e/helper';
 import { http, HttpResponse } from 'msw';
 
 test.describe('Acceptance | Read-only Mode', { tag: '@acceptance' }, () => {
-  test.beforeEach(async ({ context }) => {
-    // Block some assets requests for each test in this file.
-    await context.route(/(css|png|woff|reload\.js)$/, route => route.abort());
-  });
-
   test('notification is not shown for read-write mode', async ({ page }) => {
     await page.goto('/');
 


### PR DESCRIPTION
The `beforeEach` hook that blocked CSS/PNG/WOFF/reload.js requests was an Ember-specific optimization that causes a white page in the SvelteKit dev server. This PR removes the blocking which we don't seem to actually need for these tests.