### PR TITLE
svelte: Fetch and display site metadata notifications

### DIFF
--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -54,6 +54,20 @@
 
   // svelte-ignore state_referenced_locally
   sessionState.initialPromise = data.userPromise.then(user => sessionState.setUser(user));
+
+  const READ_ONLY_MESSAGE =
+    'crates.io is currently in read-only mode for maintenance reasons. Some functionality will be temporarily unavailable.';
+
+  data.siteMetadataPromise
+    .then(response => {
+      if (!response.data) return;
+      let { read_only, banner_message } = response.data;
+      let message = banner_message ?? (read_only ? READ_ONLY_MESSAGE : undefined);
+      if (message) {
+        notifications.info(message, { autoClear: false });
+      }
+    })
+    .catch(() => {});
 </script>
 
 <svelte:head>

--- a/svelte/src/routes/+layout.ts
+++ b/svelte/src/routes/+layout.ts
@@ -10,6 +10,7 @@ export async function load({ fetch }) {
 
   return {
     playgroundCratesPromise: loadPlaygroundCrates(fetch),
+    siteMetadataPromise: client.GET('/api/v1/site_metadata'),
     userPromise: loadUser(client),
   };
 }


### PR DESCRIPTION
This adjusts the root layout to async load `/api/v1/site_metadata` and display the `banner_message` or the read-only mode message if either of these flags are currently active.

### Related

- https://github.com/rust-lang/crates.io/issues/12515