### PR TITLE
svelte: Fix `data-test-active` attribute on inactive nav tabs

### DIFF
--- a/svelte/src/lib/components/nav-tabs/Tab.svelte
+++ b/svelte/src/lib/components/nav-tabs/Tab.svelte
@@ -17,7 +17,7 @@
 
 <li {...restProps}>
   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-  <a {href} class="link" class:active={isActive} data-test-active={isActive}>
+  <a {href} class="link" class:active={isActive} data-test-active={isActive || undefined}>
     {@render children()}
   </a>
 </li>


### PR DESCRIPTION
Turns out that Svelte handles boolean attributes a bit differently and serialized both true and false to their string counterparts, while Ember.js does not set the attribute if the value is false. This PR fixes the small divergence in the `NavTabs/Tab` component.