### PR TITLE
svelte: Accept trailing slashes on crate URLs

### DIFF
--- a/svelte/src/routes/crates/[crate_id]/+layout.ts
+++ b/svelte/src/routes/crates/[crate_id]/+layout.ts
@@ -1,6 +1,10 @@
 import { createClient } from '@crates-io/api-client';
 import { error } from '@sveltejs/kit';
 
+// Match Ember.js behavior of accepting trailing slashes on crate URLs.
+// This can likely be removed once the Ember.js app is fully replaced.
+export const trailingSlash = 'ignore';
+
 export async function load({ fetch, params }) {
   let client = createClient({ fetch });
 


### PR DESCRIPTION
This probably isn't particularly relevant in practice, but that's the current Ember.js behavior that is validated by a Playwright test. Since we want to make the test suite pass against both apps, we will adjust the Svelte behavior for now to match the Ember.js impl.

### Related

- https://github.com/rust-lang/crates.io/issues/12515