### PR TITLE
svelte: Preload mermaid library before rendering README

### DIFF
--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -7,6 +7,7 @@
 
   import CrateIcon from '$lib/assets/crate.svg?component';
   import DownloadIcon from '$lib/assets/download.svg?component';
+  import { loadMermaid } from '$lib/attachments/mermaid';
   import CrateSidebar from '$lib/components/crate-sidebar/CrateSidebar.svelte';
   import CrateHeader from '$lib/components/CrateHeader.svelte';
   import DownloadChart from '$lib/components/download-chart/DownloadChart.svelte';
@@ -58,6 +59,17 @@
   let retryReadmePromise = $state<typeof readmePromise | null>(null);
   let activeReadmePromise = $derived(retryReadmePromise ?? readmePromise);
 
+  // Ensure the mermaid library is loaded before the README is rendered,
+  // so that the `renderMermaids` attachment can use it synchronously.
+  let readmeWithMermaid = $derived(
+    activeReadmePromise.then(async html => {
+      if (html?.includes('language-mermaid')) {
+        await loadMermaid().catch(e => console.error(e));
+      }
+      return html;
+    }),
+  );
+
   function retryReadme() {
     retryReadmePromise = loadReadme(fetch, crate.name, version.num);
   }
@@ -67,7 +79,7 @@
 
 <div class="crate-info">
   <div class="docs" data-test-docs>
-    {#await activeReadmePromise}
+    {#await readmeWithMermaid}
       <ReadmePlaceholder />
     {:then readme}
       {#if readme}


### PR DESCRIPTION
This loads the `mermaid` library after fetching the README HTML but before rendering it, so that the `renderMermaids` attachment can use the library synchronously. This matches the Ember.js implementation where the mermaid library is loaded in the component before the modifier runs.