### PR TITLE
svelte: Remove redundant `page=1` query parameter from search URL

### DIFF
--- a/svelte/src/lib/components/SearchForm.svelte
+++ b/svelte/src/lib/components/SearchForm.svelte
@@ -22,7 +22,7 @@
   function search(event: SubmitEvent) {
     event.preventDefault();
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() doesn't support query params
-    goto(`${resolve('/search')}?q=${encodeURIComponent(searchFormContext.value)}&page=1`);
+    goto(`${resolve('/search')}?q=${encodeURIComponent(searchFormContext.value)}`);
   }
 
   function handleKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
Using `page=1` is redundant in the Svelte app and actually causes a Playwright test to fail. This PR removes the unnecessary query parameter, which fixes the test assertion.

### Related

- https://github.com/rust-lang/crates.io/issues/12515