### PR TITLE
e2e: Use `data-test-current-order` selector for sort dropdown assertion

### DIFF
--- a/e2e/acceptance/search.spec.ts
+++ b/e2e/acceptance/search.spec.ts
@@ -16,9 +16,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
 
     await expect(page.locator('[data-test-header]')).toHaveText("Search Results for 'rust'");
     await expect(page.locator('[data-test-search-nav]')).toHaveText('Displaying 1-7 of 7 total results');
-    await expect(page.locator('[data-test-search-sort]')).toHaveText(
-      'Sort by Relevance Relevance All-Time Downloads Recent Downloads Recent Updates Newly Added',
-    );
+    await expect(page.locator('[data-test-search-sort] [data-test-current-order]')).toHaveText('Relevance');
     await expect(page.locator('[data-test-crate-row="0"] [data-test-crate-link]')).toHaveText('kinetic-rust');
     await expect(page.locator('[data-test-crate-row="0"] [data-test-version]')).toHaveText('v0.0.16');
     await expect(page.locator('[data-test-crate-row="0"] [data-test-crate-spec]')).toHaveRole('heading');


### PR DESCRIPTION
The previous assertion checked the full text content of the sort dropdown container, which included all menu options. This only works when the dropdown options are always present in the DOM, which is not the case for the Svelte dropdown component. Instead we use the more specific `data-test-current-order` selector, matching the pattern already used in other test files.