### PR TITLE
e2e: Remove unnecessary `await` from `msw.worker.use()` calls

### DIFF
--- a/e2e/acceptance/api-token.spec.ts
+++ b/e2e/acceptance/api-token.spec.ts
@@ -105,7 +105,7 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
   });
 
   test('failed API tokens revocation shows an error', async ({ page, msw }) => {
-    await msw.worker.use(http.delete('/api/v1/me/tokens/:id', () => HttpResponse.json({}, { status: 500 })));
+    msw.worker.use(http.delete('/api/v1/me/tokens/:id', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/settings/tokens');
     await expect(page).toHaveURL('/settings/tokens');

--- a/e2e/acceptance/crate-dependencies.spec.ts
+++ b/e2e/acceptance/crate-dependencies.spec.ts
@@ -40,7 +40,7 @@ test.describe('Acceptance | crate dependencies page', { tag: '@acceptance' }, ()
   });
 
   test('shows an error page if crate fails to load', async ({ page, msw }) => {
-    await msw.worker.use(http.get('/api/v1/crates/:crate_name', () => HttpResponse.json({}, { status: 500 })));
+    msw.worker.use(http.get('/api/v1/crates/:crate_name', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/crates/foo/1.0.0/dependencies');
     await expect(page).toHaveURL('/crates/foo/1.0.0/dependencies');
@@ -67,7 +67,7 @@ test.describe('Acceptance | crate dependencies page', { tag: '@acceptance' }, ()
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.get('/api/v1/crates/:crate_name/:version_num/dependencies', () => error));
+    msw.worker.use(http.get('/api/v1/crates/:crate_name/:version_num/dependencies', () => error));
 
     await page.goto('/crates/foo/1.0.0/dependencies');
     await expect(page).toHaveURL('/crates/foo/1.0.0/dependencies');
@@ -90,7 +90,7 @@ test.describe('Acceptance | crate dependencies page', { tag: '@acceptance' }, ()
     await msw.db.dependency.create({ crate: bar, version, req: '^2.0.0', kind: 'normal' });
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.get('/api/v1/crates', () => error));
+    msw.worker.use(http.get('/api/v1/crates', () => error));
 
     await page.goto('/crates/nanomsg/dependencies');
     await expect(page).toHaveURL('/crates/nanomsg/0.6.1/dependencies');

--- a/e2e/acceptance/crate-following.spec.ts
+++ b/e2e/acceptance/crate-following.spec.ts
@@ -26,7 +26,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     await prepare(msw);
 
     let followingDeferred = defer();
-    await msw.worker.use(http.get('/api/v1/crates/:crate_id/following', () => followingDeferred.promise));
+    msw.worker.use(http.get('/api/v1/crates/:crate_id/following', () => followingDeferred.promise));
 
     await page.goto('/crates/nanomsg');
 
@@ -42,7 +42,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     await expect(spinner).toHaveCount(0);
 
     let followDeferred = defer();
-    await msw.worker.use(http.put('/api/v1/crates/:crate_id/follow', () => followDeferred.promise));
+    msw.worker.use(http.put('/api/v1/crates/:crate_id/follow', () => followDeferred.promise));
     await followButton.click();
     await expect(followButton).toHaveText('Loading…');
     await expect(followButton).toBeDisabled();
@@ -54,7 +54,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     await expect(spinner).toHaveCount(0);
 
     let unfollowDeferred = defer();
-    await msw.worker.use(http.delete('/api/v1/crates/:crate_id/follow', () => unfollowDeferred.promise));
+    msw.worker.use(http.delete('/api/v1/crates/:crate_id/follow', () => unfollowDeferred.promise));
     await followButton.click();
     await expect(followButton).toHaveText('Loading…');
     await expect(followButton).toBeDisabled();
@@ -70,7 +70,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     await prepare(msw);
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.get('/api/v1/crates/:crate_id/following', () => error));
+    msw.worker.use(http.get('/api/v1/crates/:crate_id/following', () => error));
 
     await page.goto('/crates/nanomsg');
     const followButton = page.locator('[data-test-follow-button]');
@@ -85,7 +85,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     await prepare(msw);
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.put('/api/v1/crates/:crate_id/follow', () => error));
+    msw.worker.use(http.put('/api/v1/crates/:crate_id/follow', () => error));
 
     await page.goto('/crates/nanomsg');
     await page.locator('[data-test-follow-button]').click();
@@ -98,7 +98,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     await prepare(msw, { following: true });
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.delete('/api/v1/crates/:crate_id/follow', () => error));
+    msw.worker.use(http.delete('/api/v1/crates/:crate_id/follow', () => error));
 
     await page.goto('/crates/nanomsg');
     await page.locator('[data-test-follow-button]').click();

--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -78,7 +78,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
   });
 
   test('other crate loading error shows an error message', async ({ page, msw }) => {
-    await msw.worker.use(http.get('/api/v1/crates/:crate_name', () => HttpResponse.json({}, { status: 500 })));
+    msw.worker.use(http.get('/api/v1/crates/:crate_name', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/crates/nanomsg');
     await expect(page).toHaveURL('/crates/nanomsg');

--- a/e2e/acceptance/crates.spec.ts
+++ b/e2e/acceptance/crates.spec.ts
@@ -87,7 +87,7 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
     let detail =
       'Page 1 is unavailable for performance reasons. Please take a look at https://crates.io/data-access for alternatives.';
     let error = HttpResponse.json({ errors: [{ detail }] }, { status: 400 });
-    await msw.worker.use(http.get('/api/v1/crates', () => error));
+    msw.worker.use(http.get('/api/v1/crates', () => error));
 
     await page.goto('/crates');
     await expect(page.locator('[data-test-404-page]')).toBeVisible();

--- a/e2e/acceptance/email-change.spec.ts
+++ b/e2e/acceptance/email-change.spec.ts
@@ -107,7 +107,7 @@ test.describe('Acceptance | Email Change', { tag: '@acceptance' }, () => {
     await msw.authenticateAs(user);
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.put('/api/v1/users/:user_id', () => error));
+    msw.worker.use(http.put('/api/v1/users/:user_id', () => error));
 
     await page.goto('/settings/profile');
     const emailInput = page.locator('[data-test-email-input]');
@@ -154,7 +154,7 @@ test.describe('Acceptance | Email Change', { tag: '@acceptance' }, () => {
       await msw.authenticateAs(user);
 
       let error = HttpResponse.json({}, { status: 500 });
-      await msw.worker.use(http.put('/api/v1/users/:user_id/resend', () => error));
+      msw.worker.use(http.put('/api/v1/users/:user_id/resend', () => error));
 
       await page.goto('/settings/profile');
       await expect(page).toHaveURL('/settings/profile');

--- a/e2e/acceptance/front-page.spec.ts
+++ b/e2e/acceptance/front-page.spec.ts
@@ -43,7 +43,7 @@ test.describe('Acceptance | front page', { tag: '@acceptance' }, () => {
   });
 
   test('error handling', async ({ page, msw }) => {
-    await msw.worker.use(http.get('/api/v1/summary', () => HttpResponse.json({}, { status: 500 })));
+    msw.worker.use(http.get('/api/v1/summary', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/');
     await expect(page.locator('[data-test-lists]')).toHaveCount(0);
@@ -53,7 +53,7 @@ test.describe('Acceptance | front page', { tag: '@acceptance' }, () => {
     await msw.worker.resetHandlers();
 
     let deferred = defer();
-    await msw.worker.use(http.get('/api/v1/summary', () => deferred.promise));
+    msw.worker.use(http.get('/api/v1/summary', () => deferred.promise));
 
     const button = page.locator('[data-test-try-again-button]');
     await button.click();

--- a/e2e/acceptance/invites.spec.ts
+++ b/e2e/acceptance/invites.spec.ts
@@ -121,7 +121,7 @@ test.describe('Acceptance | /me/pending-invites', { tag: '@acceptance' }, () => 
     await expect(page).toHaveURL('/me/pending-invites');
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.put('/api/v1/me/crate_owner_invitations/:crate_id', () => error));
+    msw.worker.use(http.put('/api/v1/me/crate_owner_invitations/:crate_id', () => error));
 
     await page.click('[data-test-invite="nanomsg"] [data-test-decline-button]');
     await expect(page.locator('[data-test-notification-message="error"]')).toContainText('Error in declining invite');
@@ -174,7 +174,7 @@ test.describe('Acceptance | /me/pending-invites', { tag: '@acceptance' }, () => 
     await expect(page).toHaveURL('/me/pending-invites');
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.put('/api/v1/me/crate_owner_invitations/:crate_id', () => error));
+    msw.worker.use(http.put('/api/v1/me/crate_owner_invitations/:crate_id', () => error));
 
     await page.click('[data-test-invite="nanomsg"] [data-test-accept-button]');
     await expect(page.locator('[data-test-notification-message="error"]')).toHaveText('Error in accepting invite');
@@ -188,7 +188,7 @@ test.describe('Acceptance | /me/pending-invites', { tag: '@acceptance' }, () => 
     let errorMessage =
       'The invitation to become an owner of the demo_crate crate expired. Please reach out to an owner of the crate to request a new invitation.';
     let error = HttpResponse.json({ errors: [{ detail: errorMessage }] }, { status: 410 });
-    await msw.worker.use(http.put('/api/v1/me/crate_owner_invitations/:crate_id', () => error));
+    msw.worker.use(http.put('/api/v1/me/crate_owner_invitations/:crate_id', () => error));
 
     await page.goto('/me/pending-invites');
     await expect(page).toHaveURL('/me/pending-invites');

--- a/e2e/acceptance/login.spec.ts
+++ b/e2e/acceptance/login.spec.ts
@@ -31,7 +31,7 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
   test('successful login', async ({ page, msw }) => {
     await setupGitHubOAuthRoutes(page);
 
-    await msw.worker.use(
+    msw.worker.use(
       http.get('/api/private/session/authorize', async ({ request }) => {
         let url = new URL(request.url);
         expect([...url.searchParams.keys()]).toEqual(['code', 'state']);
@@ -66,7 +66,7 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
   test('failed login', async ({ page, msw }) => {
     await setupGitHubOAuthRoutes(page);
 
-    await msw.worker.use(
+    msw.worker.use(
       http.get('/api/private/session/authorize', () =>
         HttpResponse.json({ errors: [{ detail: 'Forbidden' }] }, { status: 403 }),
       ),

--- a/e2e/acceptance/publish-notifications.spec.ts
+++ b/e2e/acceptance/publish-notifications.spec.ts
@@ -55,7 +55,7 @@ test.describe('Acceptance | publish notifications', { tag: '@acceptance' }, () =
     await msw.authenticateAs(user);
 
     let deferred = defer();
-    await msw.worker.use(http.put('/api/v1/users/:user_id', () => deferred.promise));
+    msw.worker.use(http.put('/api/v1/users/:user_id', () => deferred.promise));
 
     await page.goto('/settings/profile');
     await expect(page).toHaveURL('/settings/profile');
@@ -75,7 +75,7 @@ test.describe('Acceptance | publish notifications', { tag: '@acceptance' }, () =
     let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
-    await msw.worker.use(http.put('/api/v1/users/:user_id', () => HttpResponse.text('', { status: 500 })));
+    msw.worker.use(http.put('/api/v1/users/:user_id', () => HttpResponse.text('', { status: 500 })));
 
     await page.goto('/settings/profile');
     await expect(page).toHaveURL('/settings/profile');

--- a/e2e/acceptance/read-only-mode.spec.ts
+++ b/e2e/acceptance/read-only-mode.spec.ts
@@ -15,16 +15,16 @@ test.describe('Acceptance | Read-only Mode', { tag: '@acceptance' }, () => {
 
   test('notification is shown for read-only mode', async ({ page, msw }) => {
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.put('/api/v1/me/crate_owner_invitations/:crate_id', () => error));
+    msw.worker.use(http.put('/api/v1/me/crate_owner_invitations/:crate_id', () => error));
 
-    await msw.worker.use(http.get('/api/v1/site_metadata', () => HttpResponse.json({ read_only: true })));
+    msw.worker.use(http.get('/api/v1/site_metadata', () => HttpResponse.json({ read_only: true })));
     await page.goto('/');
 
     await expect(page.locator('[data-test-notification-message="info"]')).toContainText('read-only mode');
   });
 
   test('server errors are handled gracefully', async ({ page, msw, ember }) => {
-    await msw.worker.use(http.get('/api/v1/site_metadata', () => HttpResponse.json({}, { status: 500 })));
+    msw.worker.use(http.get('/api/v1/site_metadata', () => HttpResponse.json({}, { status: 500 })));
     await page.goto('/');
 
     await expect(page.locator('[data-test-notification-message="info"]')).toHaveCount(0);
@@ -32,7 +32,7 @@ test.describe('Acceptance | Read-only Mode', { tag: '@acceptance' }, () => {
   });
 
   test('client errors are reported on sentry', async ({ page, msw, ember }) => {
-    await msw.worker.use(http.get('/api/v1/site_metadata', () => HttpResponse.json({}, { status: 404 })));
+    msw.worker.use(http.get('/api/v1/site_metadata', () => HttpResponse.json({}, { status: 404 })));
     await page.goto('/');
 
     await expect(page.locator('[data-test-notification-message="info"]')).toHaveCount(0);
@@ -41,16 +41,14 @@ test.describe('Acceptance | Read-only Mode', { tag: '@acceptance' }, () => {
   });
 
   test('banner message is shown when present', async ({ page, msw }) => {
-    await msw.worker.use(
-      http.get('/api/v1/site_metadata', () => HttpResponse.json({ banner_message: 'test message' })),
-    );
+    msw.worker.use(http.get('/api/v1/site_metadata', () => HttpResponse.json({ banner_message: 'test message' })));
     await page.goto('/');
 
     await expect(page.locator('[data-test-notification-message="info"]')).toContainText('test message');
   });
 
   test('banner message takes precedence over read-only mode', async ({ page, msw }) => {
-    await msw.worker.use(
+    msw.worker.use(
       http.get('/api/v1/site_metadata', () => HttpResponse.json({ read_only: true, banner_message: 'test message' })),
     );
     await page.goto('/');

--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -146,9 +146,7 @@ test.describe('Acceptance | README rendering', { tag: '@acceptance' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0', readme: 'foo' });
 
     // Simulate a server error when fetching the README
-    await msw.worker.use(
-      http.get('/api/v1/crates/:name/:version/readme', () => HttpResponse.html('', { status: 500 })),
-    );
+    msw.worker.use(http.get('/api/v1/crates/:name/:version/readme', () => HttpResponse.html('', { status: 500 })));
 
     await page.goto('/crates/serde');
     await expect(page.locator('[data-test-readme-error]')).toBeVisible();

--- a/e2e/acceptance/reverse-dependencies.spec.ts
+++ b/e2e/acceptance/reverse-dependencies.spec.ts
@@ -69,7 +69,7 @@ test.describe('Acceptance | /crates/:crate_id/reverse_dependencies', { tag: '@ac
     let { foo } = await prepare(msw);
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.get('/api/v1/crates/:crate_id/reverse_dependencies', () => error));
+    msw.worker.use(http.get('/api/v1/crates/:crate_id/reverse_dependencies', () => error));
 
     await page.goto(`/crates/${foo.name}/reverse_dependencies`);
     await expect(page).toHaveURL(`/crates/${foo.name}/reverse_dependencies`);

--- a/e2e/acceptance/search.spec.ts
+++ b/e2e/acceptance/search.spec.ts
@@ -103,7 +103,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.get('/api/v1/crates', () => error));
+    msw.worker.use(http.get('/api/v1/crates', () => error));
 
     await page.goto('/');
     await page.fill('[data-test-search-input]', 'rust');
@@ -114,7 +114,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
 
     await msw.worker.resetHandlers();
     let deferred = defer();
-    await msw.worker.use(http.get('/api/v1/crates', () => deferred.promise));
+    msw.worker.use(http.get('/api/v1/crates', () => deferred.promise));
 
     await page.click('[data-test-try-again-button]');
     await expect(page.locator('[data-test-page-header] [data-test-spinner]')).toBeVisible();
@@ -138,7 +138,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-try-again-button]')).toHaveCount(0);
 
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.get('/api/v1/crates', () => error));
+    msw.worker.use(http.get('/api/v1/crates', () => error));
 
     await page.fill('[data-test-search-input]', 'ru');
     await page.locator('[data-test-search-form]').getByRole('button', { name: 'Submit' }).click();
@@ -148,7 +148,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
 
     await msw.worker.resetHandlers();
     let deferred = defer();
-    await msw.worker.use(http.get('/api/v1/crates', () => deferred.promise));
+    msw.worker.use(http.get('/api/v1/crates', () => deferred.promise));
 
     await page.click('[data-test-try-again-button]');
     await expect(page.locator('[data-test-page-header] [data-test-spinner]')).toBeVisible();
@@ -161,7 +161,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
   });
 
   test('passes query parameters to the backend', async ({ page, msw }) => {
-    await msw.worker.use(
+    msw.worker.use(
       http.get('/api/v1/crates', function ({ request }) {
         let url = new URL(request.url);
         expect(Object.fromEntries(url.searchParams.entries())).toEqual({
@@ -180,7 +180,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
   });
 
   test('supports `keyword:bla` filters', async ({ page, msw }) => {
-    await msw.worker.use(
+    msw.worker.use(
       http.get('/api/v1/crates', function ({ request }) {
         let url = new URL(request.url);
         expect(Object.fromEntries(url.searchParams.entries())).toEqual({
@@ -199,7 +199,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
   });
 
   test('`all_keywords` query parameter takes precedence over `keyword` filters', async ({ page, msw }) => {
-    await msw.worker.use(
+    msw.worker.use(
       http.get('/api/v1/crates', function ({ request }) {
         let url = new URL(request.url);
         expect(Object.fromEntries(url.searchParams.entries())).toEqual({

--- a/e2e/acceptance/security.spec.ts
+++ b/e2e/acceptance/security.spec.ts
@@ -31,7 +31,7 @@ test.describe('Acceptance | crate security page', { tag: '@acceptance' }, () => 
       },
     ];
 
-    await msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
+    msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
 
     await page.goto('/crates/foo/security');
 
@@ -92,7 +92,7 @@ test.describe('Acceptance | crate security page', { tag: '@acceptance' }, () => 
     let crate = await msw.db.crate.create({ name: 'safe-crate' });
     await msw.db.version.create({ crate, num: '1.0.0' });
 
-    await msw.worker.use(
+    msw.worker.use(
       http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.text('not found', { status: 404 })),
     );
 
@@ -106,7 +106,7 @@ test.describe('Acceptance | crate security page', { tag: '@acceptance' }, () => 
     let crate = await msw.db.crate.create({ name: 'error-crate' });
     await msw.db.version.create({ crate, num: '1.0.0' });
 
-    await msw.worker.use(
+    msw.worker.use(
       http.get('https://rustsec.org/packages/:crateId.json', () =>
         HttpResponse.text('Internal Server Error', { status: 500 }),
       ),
@@ -133,7 +133,7 @@ test.describe('Acceptance | crate security page', { tag: '@acceptance' }, () => 
       },
     ];
 
-    await msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
+    msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
 
     await page.goto('/crates/xss-test/security');
 
@@ -178,7 +178,7 @@ test.describe('Acceptance | crate security page', { tag: '@acceptance' }, () => 
       },
     ];
 
-    await msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
+    msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
     await page.goto('/crates/unmaintained-test/security');
 
     // Should only show 2 advisories (the unmaintained one should be filtered out)
@@ -211,7 +211,7 @@ test.describe('Acceptance | crate security page', { tag: '@acceptance' }, () => 
       },
     ];
 
-    await msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
+    msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
     await page.goto('/crates/withdrawn-test/security');
 
     // Should only show 1 advisory (the withdrawn one should be filtered out)
@@ -242,7 +242,7 @@ test.describe('Acceptance | crate security page', { tag: '@acceptance' }, () => 
       },
     ];
 
-    await msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
+    msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
     await page.goto('/crates/cvss-test/security');
 
     let advisory = page.locator('[data-test-list] li').first();
@@ -270,7 +270,7 @@ test.describe('Acceptance | crate security page', { tag: '@acceptance' }, () => 
       },
     ];
 
-    await msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
+    msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
     await page.goto('/crates/cvss30-test/security');
 
     let advisory = page.locator('[data-test-list] > li').first();

--- a/e2e/acceptance/settings/remove-owner.spec.ts
+++ b/e2e/acceptance/settings/remove-owner.spec.ts
@@ -34,7 +34,7 @@ test.describe('Acceptance | Settings | Remove Owner', { tag: '@acceptance' }, ()
     // we are intentionally returning a 200 response here, because is what
     // the real backend also returns due to legacy reasons
     let error = HttpResponse.json({ errors: [{ detail: 'nope' }] });
-    await msw.worker.use(http.delete('/api/v1/crates/nanomsg/owners', () => error));
+    msw.worker.use(http.delete('/api/v1/crates/nanomsg/owners', () => error));
 
     await page.goto(`/crates/${crate.name}/settings`);
     await page.click(`[data-test-owner-user="${user2.login}"] [data-test-remove-owner-button]`);
@@ -59,7 +59,7 @@ test.describe('Acceptance | Settings | Remove Owner', { tag: '@acceptance' }, ()
     // we are intentionally returning a 200 response here, because is what
     // the real backend also returns due to legacy reasons
     let error = HttpResponse.json({ errors: [{ detail: 'nope' }] });
-    await msw.worker.use(http.delete('/api/v1/crates/nanomsg/owners', () => error));
+    msw.worker.use(http.delete('/api/v1/crates/nanomsg/owners', () => error));
 
     await page.goto(`/crates/${crate.name}/settings`);
     await page.click(`[data-test-owner-team="${team1.login}"] [data-test-remove-owner-button]`);

--- a/e2e/acceptance/token-invites.spec.ts
+++ b/e2e/acceptance/token-invites.spec.ts
@@ -26,7 +26,7 @@ test.describe('Acceptance | /accept-invite/:token', { tag: '@acceptance' }, () =
     let errorMessage =
       'The invitation to become an owner of the demo_crate crate expired. Please reach out to an owner of the crate to request a new invitation.';
     let error = HttpResponse.json({ errors: [{ detail: errorMessage }] }, { status: 410 });
-    await msw.worker.use(http.put('/api/v1/me/crate_owner_invitations/accept/:token', () => error));
+    msw.worker.use(http.put('/api/v1/me/crate_owner_invitations/accept/:token', () => error));
 
     await page.goto('/accept-invite/secret123');
     await expect(page).toHaveURL('/accept-invite/secret123');

--- a/e2e/routes/category.spec.ts
+++ b/e2e/routes/category.spec.ts
@@ -12,7 +12,7 @@ test.describe('Route | category', { tag: '@routes' }, () => {
   });
 
   test('server error causes the error page to be shown', async ({ page, msw }) => {
-    await msw.worker.use(http.get('/api/v1/categories/:categoryId', () => HttpResponse.json({}, { status: 500 })));
+    msw.worker.use(http.get('/api/v1/categories/:categoryId', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/categories/foo');
     await expect(page).toHaveURL('/categories/foo');

--- a/e2e/routes/crate/delete.spec.ts
+++ b/e2e/routes/crate/delete.spec.ts
@@ -65,7 +65,7 @@ test.describe('Route: crate.delete', { tag: '@routes' }, () => {
     await prepare(msw);
 
     let deferred = defer();
-    await msw.worker.use(http.delete('/api/v1/crates/:name', () => deferred.promise));
+    msw.worker.use(http.delete('/api/v1/crates/:name', () => deferred.promise));
 
     await page.goto('/crates/foo/delete');
     await page.fill('[data-test-reason]', "I don't need this crate anymore");
@@ -83,7 +83,7 @@ test.describe('Route: crate.delete', { tag: '@routes' }, () => {
     await prepare(msw);
 
     let payload = { errors: [{ detail: 'only crates without reverse dependencies can be deleted after 72 hours' }] };
-    await msw.worker.use(http.delete('/api/v1/crates/:name', () => HttpResponse.json(payload, { status: 422 })));
+    msw.worker.use(http.delete('/api/v1/crates/:name', () => HttpResponse.json(payload, { status: 422 })));
 
     await page.goto('/crates/foo/delete');
     await page.fill('[data-test-reason]', "I don't need this crate anymore");

--- a/e2e/routes/crate/range.spec.ts
+++ b/e2e/routes/crate/range.spec.ts
@@ -82,7 +82,7 @@ test.describe('Route | crate.range', { tag: '@routes' }, () => {
   });
 
   test('shows an error page if crate fails to load', async ({ page, msw }) => {
-    await msw.worker.use(http.get('/api/v1/crates/:crate_name', () => HttpResponse.json({}, { status: 500 })));
+    msw.worker.use(http.get('/api/v1/crates/:crate_name', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/crates/foo/range/^3');
     await expect(page).toHaveURL('/crates/foo/range/%5E3');
@@ -111,7 +111,7 @@ test.describe('Route | crate.range', { tag: '@routes' }, () => {
     let crate = await msw.db.crate.create({ name: 'foo' });
     await msw.db.version.create({ crate, num: '3.2.1' });
 
-    await msw.worker.use(http.get('/api/v1/crates/:crate_name/versions', () => HttpResponse.json({}, { status: 500 })));
+    msw.worker.use(http.get('/api/v1/crates/:crate_name/versions', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/crates/foo/range/^3');
     await expect(page).toHaveURL('/crates/foo/range/%5E3');

--- a/e2e/routes/crate/settings.spec.ts
+++ b/e2e/routes/crate/settings.spec.ts
@@ -173,7 +173,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
         });
 
         // Mock the server to return an error when trying to delete the config
-        await msw.worker.use(
+        msw.worker.use(
           http.delete(`/api/v1/trusted_publishing/github_configs/${config.id}`, () => {
             return HttpResponse.json({ errors: [{ detail: 'Server error' }] }, { status: 500 });
           }),
@@ -260,7 +260,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
         });
 
         // Mock the server to return an error when trying to delete the config
-        await msw.worker.use(
+        msw.worker.use(
           http.delete(`/api/v1/trusted_publishing/gitlab_configs/${config.id}`, () => {
             return HttpResponse.json({ errors: [{ detail: 'Server error' }] }, { status: 500 });
           }),
@@ -506,7 +506,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
         });
 
         let deferred = defer();
-        await msw.worker.use(http.patch('/api/v1/crates/:name', () => deferred.promise));
+        msw.worker.use(http.patch('/api/v1/crates/:name', () => deferred.promise));
 
         await page.goto('/crates/foo/settings');
 

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
@@ -245,7 +245,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
 
       // Mock the server to return an error
       let deferred = defer();
-      await msw.worker.use(http.post('/api/v1/trusted_publishing/github_configs', () => deferred.promise));
+      msw.worker.use(http.post('/api/v1/trusted_publishing/github_configs', () => deferred.promise));
 
       await page.goto(`/crates/${crate.name}/settings/new-trusted-publisher`);
       await expect(page).toHaveURL(`/crates/${crate.name}/settings/new-trusted-publisher`);
@@ -292,7 +292,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
         await page.goto(`/crates/${crate.name}/settings/new-trusted-publisher`);
         await expect(page).toHaveURL(`/crates/${crate.name}/settings/new-trusted-publisher`);
 
-        await msw.worker.use(
+        msw.worker.use(
           http.head('https://raw.githubusercontent.com/rust-lang/crates.io/HEAD/.github/workflows/ci.yml', () => {
             return new HttpResponse(null, { status: 200 });
           }),
@@ -317,7 +317,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
         await page.goto(`/crates/${crate.name}/settings/new-trusted-publisher`);
         await expect(page).toHaveURL(`/crates/${crate.name}/settings/new-trusted-publisher`);
 
-        await msw.worker.use(
+        msw.worker.use(
           http.head('https://raw.githubusercontent.com/rust-lang/crates.io/HEAD/.github/workflows/missing.yml', () => {
             return new HttpResponse(null, { status: 404 });
           }),
@@ -342,7 +342,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
         await page.goto(`/crates/${crate.name}/settings/new-trusted-publisher`);
         await expect(page).toHaveURL(`/crates/${crate.name}/settings/new-trusted-publisher`);
 
-        await msw.worker.use(
+        msw.worker.use(
           http.head('https://raw.githubusercontent.com/rust-lang/crates.io/HEAD/.github/workflows/ci.yml', () => {
             return new HttpResponse(null, { status: 500 });
           }),
@@ -463,7 +463,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
 
       // Mock the server to return an error
       let deferred = defer();
-      await msw.worker.use(http.post('/api/v1/trusted_publishing/gitlab_configs', () => deferred.promise));
+      msw.worker.use(http.post('/api/v1/trusted_publishing/gitlab_configs', () => deferred.promise));
 
       await page.goto(`/crates/${crate.name}/settings/new-trusted-publisher`);
       await expect(page).toHaveURL(`/crates/${crate.name}/settings/new-trusted-publisher`);

--- a/e2e/routes/crate/version/docs-link.spec.ts
+++ b/e2e/routes/crate/version/docs-link.spec.ts
@@ -18,7 +18,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('not found', { status: 404 });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.getByRole('link', { name: 'crates.io', exact: true })).toHaveCount(1);
@@ -37,7 +37,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
       doc_status: true,
       version: '1.0.0',
     });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-docs-link] a')).toHaveAttribute('href', 'https://docs.rs/foo/1.0.0');
@@ -51,7 +51,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('not found', { status: 404 });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-docs-link] a')).toHaveAttribute('href', 'https://docs.rs/foo/0.6.2');
@@ -68,7 +68,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
       doc_status: true,
       version: '1.0.0',
     });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-docs-link] a')).toHaveAttribute('href', 'https://docs.rs/foo/1.0.0');
@@ -79,7 +79,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('error', { status: 500 });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-docs-link] a')).toHaveAttribute('href', 'https://docs.rs/foo/0.6.2');
@@ -90,7 +90,7 @@ test.describe('Route | crate.version | docs link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '0.6.2' });
 
     let response = HttpResponse.json({});
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-docs-link] a')).toHaveAttribute('href', 'https://docs.rs/foo/0.6.2');

--- a/e2e/routes/crate/version/source-link.spec.ts
+++ b/e2e/routes/crate/version/source-link.spec.ts
@@ -10,7 +10,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
       doc_status: false,
       version: '1.0.0',
     });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveAttribute(
@@ -24,7 +24,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('not found', { status: 404 });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.getByRole('link', { name: 'crates.io', exact: true })).toHaveCount(1);
@@ -43,7 +43,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
       doc_status: true,
       version: '1.0.0',
     });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveAttribute(
@@ -60,7 +60,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('not found', { status: 404 });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveCount(0);
@@ -77,7 +77,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
       doc_status: true,
       version: '1.0.0',
     });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveAttribute(
@@ -91,7 +91,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0' });
 
     let error = HttpResponse.text('error', { status: 500 });
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => error));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveCount(0);
@@ -102,7 +102,7 @@ test.describe('Route | crate.version | source link', { tag: '@routes' }, () => {
     await msw.db.version.create({ crate, num: '0.6.2' });
 
     let response = HttpResponse.json({});
-    await msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
+    msw.worker.use(http.get('https://docs.rs/crate/:crate/:version/status.json', () => response));
 
     await page.goto('/crates/foo');
     await expect(page.locator('[data-test-source-link] a')).toHaveAttribute(

--- a/e2e/routes/keyword.spec.ts
+++ b/e2e/routes/keyword.spec.ts
@@ -10,7 +10,7 @@ test.describe('Route | keyword', { tag: '@routes' }, () => {
 
   test('server error causes the error page to be shown', async ({ page, msw }) => {
     let error = HttpResponse.json({}, { status: 500 });
-    await msw.worker.use(http.get('/api/v1/crates', () => error));
+    msw.worker.use(http.get('/api/v1/crates', () => error));
 
     await page.goto('/keywords/foo');
     await expect(page).toHaveURL('/keywords/foo');

--- a/e2e/routes/settings/tokens/new.spec.ts
+++ b/e2e/routes/settings/tokens/new.spec.ts
@@ -235,7 +235,7 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     await prepare(msw);
 
     let deferred = defer();
-    await msw.worker.use(http.put('/api/v1/me/tokens', () => deferred.promise));
+    msw.worker.use(http.put('/api/v1/me/tokens', () => deferred.promise));
 
     await page.goto('/settings/tokens/new');
     await expect(page).toHaveURL('/settings/tokens/new');

--- a/e2e/routes/team.spec.ts
+++ b/e2e/routes/team.spec.ts
@@ -12,7 +12,7 @@ test.describe('Route | team', { tag: '@routes' }, () => {
   });
 
   test('server error causes the error page to be shown', async ({ page, msw }) => {
-    await msw.worker.use(http.get('/api/v1/teams/:id', () => HttpResponse.json({}, { status: 500 })));
+    msw.worker.use(http.get('/api/v1/teams/:id', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/teams/foo');
     await expect(page).toHaveURL('/teams/foo');

--- a/e2e/routes/user.spec.ts
+++ b/e2e/routes/user.spec.ts
@@ -12,7 +12,7 @@ test.describe('Route | user', { tag: '@routes' }, () => {
   });
 
   test('server error causes the error page to be shown', async ({ page, msw }) => {
-    await msw.worker.use(http.get('/api/v1/users/:id', () => HttpResponse.json({}, { status: 500 })));
+    msw.worker.use(http.get('/api/v1/users/:id', () => HttpResponse.json({}, { status: 500 })));
 
     await page.goto('/users/foo');
     await expect(page).toHaveURL('/users/foo');


### PR DESCRIPTION
With https://github.com/mswjs/playwright this does not appear to be necessary anymore according to the TypeScript fn signature