### PR TITLE
svelte: Fix query parameter order in crate report URL

### DIFF
--- a/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
@@ -54,7 +54,7 @@
 
   let hasLinks = $derived(crate.homepage || crate.repository);
 
-  let reportUrl = $derived(`${resolve('/support')}?inquire=crate-violation&crate=${encodeURIComponent(crate.name)}`);
+  let reportUrl = $derived(`${resolve('/support')}?crate=${encodeURIComponent(crate.name)}&inquire=crate-violation`);
 
   let purl = $derived(getPurl(crate.name, version.num));
 </script>


### PR DESCRIPTION
This matches the Ember implementation's parameter order (`crate` before `inquire`) so that the shared Playwright tests pass.

### Related

- https://github.com/rust-lang/crates.io/issues/12515