### PR TITLE
tests: Use proper HTTP error status in remove-owner tests

### DIFF
--- a/e2e/acceptance/settings/remove-owner.spec.ts
+++ b/e2e/acceptance/settings/remove-owner.spec.ts
@@ -31,9 +31,7 @@ test.describe('Acceptance | Settings | Remove Owner', { tag: '@acceptance' }, ()
   });
 
   test('remove a user crate owner (error behavior)', async ({ page, msw }) => {
-    // we are intentionally returning a 200 response here, because is what
-    // the real backend also returns due to legacy reasons
-    let error = HttpResponse.json({ errors: [{ detail: 'nope' }] });
+    let error = HttpResponse.json({ errors: [{ detail: 'nope' }] }, { status: 400 });
     msw.worker.use(http.delete('/api/v1/crates/nanomsg/owners', () => error));
 
     await page.goto(`/crates/${crate.name}/settings`);
@@ -56,9 +54,7 @@ test.describe('Acceptance | Settings | Remove Owner', { tag: '@acceptance' }, ()
   });
 
   test('remove a team crate owner (error behavior)', async ({ page, msw }) => {
-    // we are intentionally returning a 200 response here, because is what
-    // the real backend also returns due to legacy reasons
-    let error = HttpResponse.json({ errors: [{ detail: 'nope' }] });
+    let error = HttpResponse.json({ errors: [{ detail: 'nope' }] }, { status: 400 });
     msw.worker.use(http.delete('/api/v1/crates/nanomsg/owners', () => error));
 
     await page.goto(`/crates/${crate.name}/settings`);

--- a/tests/acceptance/settings/remove-owner-test.js
+++ b/tests/acceptance/settings/remove-owner-test.js
@@ -41,10 +41,10 @@ module('Acceptance | Settings | Remove Owner', function (hooks) {
   test('remove a user crate owner (error behavior)', async function (assert) {
     let { crate, user2 } = await prepare(this);
 
-    // we are intentionally returning a 200 response here, because is what
-    // the real backend also returns due to legacy reasons
     this.worker.use(
-      http.delete('/api/v1/crates/nanomsg/owners', () => HttpResponse.json({ errors: [{ detail: 'nope' }] })),
+      http.delete('/api/v1/crates/nanomsg/owners', () =>
+        HttpResponse.json({ errors: [{ detail: 'nope' }] }, { status: 400 }),
+      ),
     );
 
     await visit(`/crates/${crate.name}/settings`);
@@ -69,10 +69,10 @@ module('Acceptance | Settings | Remove Owner', function (hooks) {
   test('remove a team crate owner (error behavior)', async function (assert) {
     let { crate, team1 } = await prepare(this);
 
-    // we are intentionally returning a 200 response here, because is what
-    // the real backend also returns due to legacy reasons
     this.worker.use(
-      http.delete('/api/v1/crates/nanomsg/owners', () => HttpResponse.json({ errors: [{ detail: 'nope' }] })),
+      http.delete('/api/v1/crates/nanomsg/owners', () =>
+        HttpResponse.json({ errors: [{ detail: 'nope' }] }, { status: 400 }),
+      ),
     );
 
     await visit(`/crates/${crate.name}/settings`);


### PR DESCRIPTION
The mock handlers were returning 200 with `{ errors: [...] }` in the body, which is outdated behavior that no longer matches what the real backend does. The backend now returns proper HTTP error status codes through its standard error handling.