### PR TITLE
svelte: Implement documentation and source links in crate sidebar

### DIFF
--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { components } from '@crates-io/api-client';
   import type { DownloadChartData } from '$lib/components/download-chart/data';
+  import type { DocsRsStatus } from '$lib/utils/docs-rs';
   import type { PlaygroundCrate } from '$lib/utils/playground';
 
   import { resolve } from '$app/paths';
@@ -31,6 +32,7 @@
     requestedVersion?: string;
     readmePromise: Promise<string | null>;
     playgroundCratesPromise: Promise<PlaygroundCrate[]>;
+    docsRsStatusPromise: Promise<DocsRsStatus | null>;
     downloadsPromise: Promise<DownloadChartData>;
   }
 
@@ -43,6 +45,7 @@
     requestedVersion,
     readmePromise,
     playgroundCratesPromise,
+    docsRsStatusPromise,
     downloadsPromise,
   }: Props = $props();
   let owners: Owner[] = $state([]);
@@ -107,6 +110,7 @@
       {owners}
       requestedVersion={requestedVersion !== undefined}
       {playgroundCratesPromise}
+      {docsRsStatusPromise}
     />
   </div>
 </div>

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { components } from '@crates-io/api-client';
+  import type { DocsRsStatus } from '$lib/utils/docs-rs';
   import type { PlaygroundCrate } from '$lib/utils/playground';
 
   import { resolve } from '$app/paths';
@@ -41,9 +42,18 @@
     owners: Owner[];
     requestedVersion?: boolean;
     playgroundCratesPromise: Promise<PlaygroundCrate[]>;
+    docsRsStatusPromise: Promise<DocsRsStatus | null>;
   }
 
-  let { crate, version, categories, owners, requestedVersion = false, playgroundCratesPromise }: Props = $props();
+  let {
+    crate,
+    version,
+    categories,
+    owners,
+    requestedVersion = false,
+    playgroundCratesPromise,
+    docsRsStatusPromise,
+  }: Props = $props();
 
   let canHover = new MediaQuery('hover: hover', false);
 
@@ -52,11 +62,44 @@
     return homepage && (!repository || simplifyUrl(repository) !== simplifyUrl(homepage));
   });
 
-  let hasLinks = $derived(crate.homepage || crate.repository);
-
   let reportUrl = $derived(`${resolve('/support')}?crate=${encodeURIComponent(crate.name)}&inquire=crate-violation`);
 
   let purl = $derived(getPurl(crate.name, version.num));
+
+  /** Computes the documentation link for a crate version. */
+  function computeDocumentationLink(docsRsStatus: DocsRsStatus | null): string | null {
+    let { documentation, name } = crate;
+
+    // if this is *not* a docs.rs link we'll return it directly
+    if (documentation && !documentation.startsWith('https://docs.rs/')) {
+      return documentation;
+    }
+
+    // if we know about a successful docs.rs build, we'll return a link to that
+    if (docsRsStatus?.doc_status === true) {
+      return `https://docs.rs/${name}/${version.num}`;
+    }
+
+    // finally, we'll return the specified documentation link, whatever it is
+    return documentation ?? null;
+  }
+
+  /**
+   * Computes the "Browse source" link for a crate version.
+   *
+   * Returns a link to docs.rs if we get any successful response from docs.rs,
+   * so that we show the source link regardless of this crate being a library or
+   * binary, regardless of whether the docs built successfully, regardless of
+   * whether the build is queued or completed, and regardless of whether a
+   * documentation link is specified.
+   */
+  function computeSourceLink(docsRsStatus: DocsRsStatus | null): string | null {
+    if (docsRsStatus) {
+      return `https://docs.rs/crate/${crate.name}/${version.num}/source/`;
+    }
+
+    return null;
+  }
 </script>
 
 <section aria-label="Crate metadata" class="sidebar">
@@ -151,28 +194,37 @@
     </div>
   {/if}
 
-  {#if hasLinks}
-    <div class="links">
-      {#if showHomepage}
-        <Link title="Homepage" url={crate.homepage!} data-test-homepage-link />
-      {/if}
+  {#snippet linksSection(docsRsStatus: DocsRsStatus | null)}
+    {@const documentationLink = computeDocumentationLink(docsRsStatus)}
+    {@const sourceLink = computeSourceLink(docsRsStatus)}
+    {#if showHomepage || documentationLink || sourceLink || crate.repository}
+      <div class="links">
+        {#if showHomepage}
+          <Link title="Homepage" url={crate.homepage!} data-test-homepage-link />
+        {/if}
 
-      <!-- TODO: Documentation link
-           Requires async docs.rs status check to determine if docs are available.
-           Falls back to crate.documentation if not a docs.rs link.
-           See app/models/version.js documentationLink getter.
-      -->
+        {#if documentationLink}
+          <Link title="Documentation" url={documentationLink} data-test-docs-link />
+        {/if}
 
-      <!-- TODO: Browse source link
-           Requires async docs.rs status check.
-           See app/models/version.js sourceLink getter.
-      -->
+        {#if sourceLink}
+          <Link title="Browse source" url={sourceLink} data-test-source-link />
+        {/if}
 
-      {#if crate.repository}
-        <Link title="Repository" url={crate.repository} data-test-repository-link />
-      {/if}
-    </div>
-  {/if}
+        {#if crate.repository}
+          <Link title="Repository" url={crate.repository} data-test-repository-link />
+        {/if}
+      </div>
+    {/if}
+  {/snippet}
+
+  {#await docsRsStatusPromise}
+    {@render linksSection(null)}
+  {:then docsRsStatus}
+    {@render linksSection(docsRsStatus)}
+  {:catch}
+    {@render linksSection(null)}
+  {/await}
 
   <div>
     <h2 class="heading">Owners</h2>

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebarTestWrapper.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebarTestWrapper.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { components } from '@crates-io/api-client';
+  import type { DocsRsStatus } from '$lib/utils/docs-rs';
   import type { PlaygroundCrate } from '$lib/utils/playground';
 
   import { NotificationsState, setNotifications } from '$lib/notifications.svelte';
@@ -17,12 +18,29 @@
     owners: Owner[];
     requestedVersion?: boolean;
     playgroundCratesPromise: Promise<PlaygroundCrate[]>;
+    docsRsStatusPromise: Promise<DocsRsStatus | null>;
   }
 
-  let { crate, version, categories = [], owners, playgroundCratesPromise, requestedVersion = false }: Props = $props();
+  let {
+    crate,
+    version,
+    categories = [],
+    owners,
+    playgroundCratesPromise,
+    docsRsStatusPromise,
+    requestedVersion = false,
+  }: Props = $props();
 
   let notifications = new NotificationsState();
   setNotifications(notifications);
 </script>
 
-<CrateSidebar {crate} {version} {categories} {owners} {playgroundCratesPromise} {requestedVersion} />
+<CrateSidebar
+  {crate}
+  {version}
+  {categories}
+  {owners}
+  {playgroundCratesPromise}
+  {docsRsStatusPromise}
+  {requestedVersion}
+/>

--- a/svelte/src/lib/components/crate-sidebar/PlaygroundButton.svelte.test.ts
+++ b/svelte/src/lib/components/crate-sidebar/PlaygroundButton.svelte.test.ts
@@ -98,8 +98,9 @@ describe('CrateSidebar Playground Button', () => {
     let version = createVersion('1.0.0');
     let owners = [createOwner(1)];
     let playgroundCratesPromise = Promise.resolve(PLAYGROUND_CRATES);
+    let docsRsStatusPromise = Promise.resolve(null);
 
-    render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise });
+    render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise, docsRsStatusPromise });
 
     // Button should not exist for crates not in the playground list
     expect(page.getByCSS('[data-test-playground-button]').query()).toBeNull();
@@ -110,8 +111,9 @@ describe('CrateSidebar Playground Button', () => {
     let version = createVersion('1.0.0');
     let owners = [createOwner(1)];
     let playgroundCratesPromise = Promise.resolve(PLAYGROUND_CRATES);
+    let docsRsStatusPromise = Promise.resolve(null);
 
-    render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise });
+    render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise, docsRsStatusPromise });
 
     let expectedHref =
       'https://play.rust-lang.org/?edition=2021&code=use%20aho_corasick%3B%0A%0Afn%20main()%20%7B%0A%20%20%20%20%2F%2F%20try%20using%20the%20%60aho_corasick%60%20crate%20here%0A%7D';
@@ -125,8 +127,15 @@ describe('CrateSidebar Playground Button', () => {
     let version = createVersion('1.0.0');
     let owners = [createOwner(1)];
     let deferred = defer<PlaygroundCrate[]>();
+    let docsRsStatusPromise = Promise.resolve(null);
 
-    render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise: deferred.promise });
+    render(CrateSidebarTestWrapper, {
+      crate,
+      version,
+      owners,
+      playgroundCratesPromise: deferred.promise,
+      docsRsStatusPromise,
+    });
 
     await expect.element(page.getByCSS('[data-test-owners]')).toBeVisible();
 
@@ -142,8 +151,9 @@ describe('CrateSidebar Playground Button', () => {
     let version = createVersion('1.0.0');
     let owners = [createOwner(1)];
     let playgroundCratesPromise = Promise.reject(new Error('Failed to load'));
+    let docsRsStatusPromise = Promise.resolve(null);
 
-    render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise });
+    render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise, docsRsStatusPromise });
 
     // Button should not exist when the request fails
     expect(page.getByCSS('[data-test-playground-button]').query()).toBeNull();

--- a/svelte/src/lib/utils/docs-rs.ts
+++ b/svelte/src/lib/utils/docs-rs.ts
@@ -1,0 +1,25 @@
+export interface DocsRsStatus {
+  doc_status?: boolean;
+}
+
+/**
+ * Fetches the docs.rs build status for a crate version.
+ *
+ * Returns `null` if the request fails (e.g. 404, 500, network error).
+ */
+export async function loadDocsRsStatus(
+  fetch: typeof globalThis.fetch,
+  crateName: string,
+  versionNum: string,
+): Promise<DocsRsStatus | null> {
+  try {
+    let response = await fetch(`https://docs.rs/crate/${crateName}/${versionNum}/status.json`);
+    if (!response.ok) {
+      return null;
+    }
+
+    return await response.json();
+  } catch {
+    return null;
+  }
+}

--- a/svelte/src/routes/crates/[crate_id]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/+page.svelte
@@ -16,5 +16,6 @@
   ownersPromise={data.ownersPromise}
   readmePromise={data.readmePromise}
   playgroundCratesPromise={data.playgroundCratesPromise}
+  docsRsStatusPromise={data.docsRsStatusPromise}
   {downloadsPromise}
 />

--- a/svelte/src/routes/crates/[crate_id]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/+page.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@crates-io/api-client';
 
+import { loadDocsRsStatus } from '$lib/utils/docs-rs';
 import { loadReadme } from '$lib/utils/readme';
 
 export async function load({ fetch, params, parent }) {
@@ -10,8 +11,9 @@ export async function load({ fetch, params, parent }) {
 
   let { crate, defaultVersion } = await parent();
   let readmePromise = loadReadme(fetch, crate.name, defaultVersion.num);
+  let docsRsStatusPromise = loadDocsRsStatus(fetch, crate.name, defaultVersion.num);
 
-  return { readmePromise, downloadsPromise };
+  return { readmePromise, downloadsPromise, docsRsStatusPromise };
 }
 
 /**

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
@@ -17,5 +17,6 @@
   requestedVersion={data.requestedVersion}
   readmePromise={data.readmePromise}
   playgroundCratesPromise={data.playgroundCratesPromise}
+  docsRsStatusPromise={data.docsRsStatusPromise}
   {downloadsPromise}
 />

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@crates-io/api-client';
 
+import { loadDocsRsStatus } from '$lib/utils/docs-rs';
 import { loadReadme } from '$lib/utils/readme';
 
 export async function load({ fetch, params }) {
@@ -8,8 +9,9 @@ export async function load({ fetch, params }) {
 
   let readmePromise = loadReadme(fetch, crateName, versionNum);
   let downloadsPromise = loadDownloads(fetch, crateName, versionNum);
+  let docsRsStatusPromise = loadDocsRsStatus(fetch, crateName, versionNum);
 
-  return { readmePromise, downloadsPromise };
+  return { readmePromise, downloadsPromise, docsRsStatusPromise };
 }
 
 /**


### PR DESCRIPTION
This fetches the docs.rs build status and uses it to compute documentation and "Browse source" links, matching the Ember app behavior. It uses a snippet + `{#await}` pattern to show synchronous links immediately while docs.rs status loads asynchronously. This passes all existing Playwright tests for this now.

### Related

- https://github.com/rust-lang/crates.io/issues/12515