### PR TITLE
e2e: Wait for navigation after sort change in versions test

### DIFF
--- a/e2e/acceptance/versions.spec.ts
+++ b/e2e/acceptance/versions.spec.ts
@@ -27,7 +27,7 @@ test.describe('Acceptance | crate versions page', { tag: '@acceptance' }, () => 
     await page.click('[data-test-current-order]');
     await page.click('[data-test-semver-sort] a');
 
-    await expect(page.locator('[data-test-version]').first()).toBeVisible();
+    await expect(page).toHaveURL(/sort=semver/);
     versions = await page.locator('[data-test-version]').evaluateAll(el => el.map(it => it.dataset.testVersion));
     expect(versions).toEqual(['0.3.0', '0.2.1', '0.2.0', '0.1.0']);
   });


### PR DESCRIPTION
The visibility check passed instantly since version elements were already visible from the initial render, causing the test to read stale DOM before SvelteKit navigation completed.