### PR TITLE
style: Preserve aspect ratio for images in text-content 

### DIFF
--- a/app/components/text-content.css
+++ b/app/components/text-content.css
@@ -19,6 +19,7 @@
 
     :global(img) {
         max-width: 100%;
+        height: auto;
     }
 
     :global(pre) {


### PR DESCRIPTION
Style images on create pages with `height: auto;`, to allow the height to be automatically scaled based on width, even if an explicit height was used on the img tags.

Note: You might consider the `img` is wrong for adding height and width but explicit width and height attributes are helpful reduce re-layout as the image loads. Github has started adding the automatically, without this fix the width would be clamped to page, but height would be value that was specified causing image to be distorted.

[Where I originally noticed the issue.](https://crates.io/crates/toml-spanner#compile-time)

![example](https://github.com/user-attachments/assets/742c6a5f-a994-4e86-a4fc-0c0665b31653)

