### PR TITLE
svelte: Show yanked crates on own user profile

### DIFF
--- a/svelte/src/lib/utils/session.svelte.ts
+++ b/svelte/src/lib/utils/session.svelte.ts
@@ -93,7 +93,6 @@ export class SessionState {
    */
   initialPromise: Promise<void> | null = null;
 
-  // TODO: implement `ownedCrates` (loaded from the `/api/v1/me` response)
   // TODO: implement sudo mode (`sudoEnabledUntil`, `isSudoEnabled`, `setSudo()`)
   //   Sudo mode enables admin actions for a limited duration. The expiry
   //   timestamp is persisted in localStorage under the 'sudo' key so it

--- a/svelte/src/routes/users/[user_id]/+page.ts
+++ b/svelte/src/routes/users/[user_id]/+page.ts
@@ -3,7 +3,9 @@ import type { paths } from '@crates-io/api-client';
 import { createClient } from '@crates-io/api-client';
 import { error } from '@sveltejs/kit';
 
-export async function load({ fetch, params, url }) {
+import { isLoggedIn } from '$lib/utils/session.svelte';
+
+export async function load({ fetch, params, parent, url }) {
   let client = createClient({ fetch });
 
   let pageStr = url.searchParams.get('page') ?? '1';
@@ -13,13 +15,27 @@ export async function load({ fetch, params, url }) {
 
   let user = await loadUser(client, params.user_id);
 
+  // Check if the logged-in user is viewing their own profile, so that
+  // yanked crates are included in the results. We gate the `parent()`
+  // call behind `isLoggedIn()` to avoid the overhead of waiting for
+  // the `/api/v1/me` request for unauthenticated users.
+  //
+  // NOTE: `isLoggedIn()` reads from localStorage, which is only
+  // available in the browser. This will need to be revisited if SSR
+  // is implemented in the future.
+  let isOwnProfile = false;
+  if (isLoggedIn()) {
+    let { userPromise } = await parent();
+    let currentUser = await userPromise;
+    isOwnProfile = currentUser?.login === params.user_id;
+  }
+
   let cratesResponse = await loadCrates(client, params.user_id, {
     user_id: user.id,
     page,
     per_page: perPage,
     sort,
-    // TODO: check if user is current user and conditionally include yanked crates
-    include_yanked: 'n',
+    include_yanked: isOwnProfile ? 'yes' : 'n',
   });
 
   return { user, cratesResponse, page, perPage, sort };


### PR DESCRIPTION
When a logged-in user views their own profile, pass `include_yanked=yes` to the crates API so that yanked crates appear in the list. The `parent()` call is gated behind `isLoggedIn()` to skip the `/api/v1/me` overhead for unauthenticated users.

Also removes the `ownedCrates` TODO from the session module since it turned out to be unnecessary. Comparing the profile login against the current user is sufficient.

All three `e2e/routes/user/yanked-crates.spec.ts` Playwright tests pass with this change.

### Related

- https://github.com/rust-lang/crates.io/issues/12515