### PR TITLE
app: enable HTML for banner messages

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -73,7 +73,10 @@ export default class ApplicationRoute extends Route {
     }
 
     if (banner_message) {
-      this.notifications.info(banner_message, { autoClear: false });
+      // We have to enclose the banner message in a <div> with HTML content
+      // enabled, otherwise every element in the banner will be subject to the
+      // flex rules in the ember-cli-notifications CSS and things get weird.
+      this.notifications.info(`<div>${banner_message}</div>`, { autoClear: false, htmlContent: true });
     }
   });
 

--- a/svelte/src/lib/components/notifications/NotificationMessage.svelte
+++ b/svelte/src/lib/components/notifications/NotificationMessage.svelte
@@ -58,7 +58,12 @@
   </div>
 
   <div class="notification__content">
-    {notification.message}
+    {#if notification.htmlContent}
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html notification.message}
+    {:else}
+      {notification.message}
+    {/if}
   </div>
 
   <button type="button" class="notification__close" onclick={handleClose} aria-label="Dismiss notification">
@@ -122,11 +127,9 @@
   }
 
   .notification__content {
-    display: flex;
     flex: 1 1 auto;
     min-width: 0;
     min-height: 0;
-    justify-content: space-between;
     padding: 0.5rem 1rem;
     word-break: break-word;
     line-height: 1.5;

--- a/svelte/src/lib/components/notifications/Notifications.stories.svelte
+++ b/svelte/src/lib/components/notifications/Notifications.stories.svelte
@@ -38,6 +38,23 @@
         >
           Show Persistent
         </button>
+        <button
+          type="button"
+          onclick={() =>
+            notifications.info('The last word in this message is <strong>stronk</strong>.', { autoClear: false })}
+        >
+          Show HTML without HTML content enabled
+        </button>
+        <button
+          type="button"
+          onclick={() =>
+            notifications.info('The last word in this message is <strong>stronk</strong>.', {
+              autoClear: false,
+              htmlContent: true,
+            })}
+        >
+          Show HTML with HTML content enabled
+        </button>
         <button type="button" onclick={() => notifications.clearAll()}>Clear All</button>
       </div>
     {/snippet}

--- a/svelte/src/lib/notifications.svelte.ts
+++ b/svelte/src/lib/notifications.svelte.ts
@@ -5,6 +5,7 @@ export type NotificationType = 'info' | 'success' | 'warning' | 'error';
 export interface NotificationOptions {
   autoClear?: boolean;
   clearDuration?: number;
+  htmlContent?: boolean;
 }
 
 export class Notification {
@@ -12,28 +13,38 @@ export class Notification {
   message: string;
   autoClear: boolean;
   clearDuration: number;
+  htmlContent: boolean;
   remaining: number;
   startTime: number | undefined;
   timer: ReturnType<typeof setTimeout> | undefined;
   dismiss = $state(false);
 
-  constructor(options: { type: NotificationType; message: string; autoClear: boolean; clearDuration: number }) {
+  constructor(options: {
+    type: NotificationType;
+    message: string;
+    autoClear: boolean;
+    clearDuration: number;
+    htmlContent: boolean;
+  }) {
     this.type = options.type;
     this.message = options.message;
     this.autoClear = options.autoClear;
     this.clearDuration = options.clearDuration;
+    this.htmlContent = options.htmlContent;
     this.remaining = options.clearDuration;
   }
 }
 
 const DEFAULT_AUTO_CLEAR = !__TEST__;
 const DEFAULT_CLEAR_DURATION = 10_000;
+const DEFAULT_HTML_CONTENT = false;
 
 export class NotificationsState {
   content = $state.raw<Notification[]>([]);
 
   #defaultAutoClear = DEFAULT_AUTO_CLEAR;
   #defaultClearDuration = DEFAULT_CLEAR_DURATION;
+  #defaultHtmlContent = DEFAULT_HTML_CONTENT;
 
   addNotification(options: { message: string; type?: NotificationType } & NotificationOptions): Notification {
     if (!options.message) {
@@ -45,6 +56,7 @@ export class NotificationsState {
       message: options.message,
       autoClear: options.autoClear ?? this.#defaultAutoClear,
       clearDuration: options.clearDuration ?? this.#defaultClearDuration,
+      htmlContent: options.htmlContent ?? this.#defaultHtmlContent,
     });
 
     this.content = [...this.content, notification];

--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -64,7 +64,7 @@
       let { read_only, banner_message } = response.data;
       let message = banner_message ?? (read_only ? READ_ONLY_MESSAGE : undefined);
       if (message) {
-        notifications.info(message, { autoClear: false });
+        notifications.info(message, { autoClear: false, htmlContent: true });
       }
     })
     .catch(() => {});


### PR DESCRIPTION
Since banner messages can only be set by crates.io admins, enabling HTML should be safe enough.

This adds a new `htmlContent` option to Svelte notification messages which gives the same behaviour as the `ember-cli-notifications` option of the same name. This is only used when adding banner messages; other notifications are unchanged, as shown in the storybook update.

---

Obviously the motivation here is [this Zulip message](https://rust-lang.zulipchat.com/#narrow/channel/356853-t-docs-rs/topic/only.20build.20default.20target.20by.20default.3F/near/583384440), since I'd like to link to the relevant blog post directly.