### PR TITLE
CI: Run Playwright tests against Svelte app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
       - run: pnpm playwright install chromium
 
       - if: github.repository == 'rust-lang/crates.io'
-        run: pnpm percy exec -- pnpm e2e
+        run: pnpm percy exec -- pnpm e2e:svelte
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}

--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -68,6 +68,13 @@ export const test = base.extend<AppOptions & AppFixtures>({
       };
 
       await use({ worker, db, authenticateAs });
+
+      // Close pages before disabling MSW. Otherwise any request still in
+      // flight (or fired by late-running hydration code) bypasses the
+      // mocks once `worker.disable()` removes the interception, and hits
+      // the real network instead.
+      await Promise.all(context.pages().map(p => p.close()));
+
       await db.reset();
       await worker.disable();
     },

--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -68,15 +68,11 @@ export const test = base.extend<AppOptions & AppFixtures>({
       };
 
       await use({ worker, db, authenticateAs });
-
-      // Close pages before disabling MSW. Otherwise any request still in
-      // flight (or fired by late-running hydration code) bypasses the
-      // mocks once `worker.disable()` removes the interception, and hits
-      // the real network instead.
-      await Promise.all(context.pages().map(p => p.close()));
-
       await db.reset();
-      await worker.disable();
+      // Intentionally not calling `worker.disable()`. It sends
+      // `Fetch.disable` to the still-alive page, opening a window where
+      // late hydration requests bypass the mocks and hit the real
+      // network. The route is cleaned up when the context is torn down.
     },
     { auto: true, scope: 'test' },
   ],


### PR DESCRIPTION
This should allow us to run the Percy visual regression checks against the Svelte app, as a final check whether we have missed anything significant in our porting process.
### Related

- https://github.com/rust-lang/crates.io/issues/12515