### PR TITLE
smoke-test: Use Trusted Publishing for staging token

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -16,6 +16,9 @@ jobs:
   test:
     runs-on: ubuntu-24.04
 
+    permissions:
+      id-token: write
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -23,6 +26,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo build --package crates_io_smoke_test
+
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
+        with:
+          url: https://staging.crates.io
+
       - run: cargo run --package crates_io_smoke_test --quiet
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.STAGING_SMOKE_TEST_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Replace the long-lived `STAGING_SMOKE_TEST_TOKEN` secret with a short-lived token obtained via `rust-lang/crates-io-auth-action` pointed at staging.crates.io.

As a nice side effect, each smoke test run now also exercises the Trusted Publishing GitHub Action and the token exchange endpoint end-to-end, giving us continuous coverage of that flow against staging.

Dropping the repo secret also resolves the `secrets-outside-env` zizmor warning on this workflow.