### PR TITLE
workflows: Address zizmor audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,7 @@ jobs:
     needs: filter-jobs
     if: needs.filter-jobs.outputs.zizmor == 'true'
     permissions:
-      security-events: write
+      security-events: write  # needed by `codeql-action/upload-sarif` to upload zizmor results to GitHub code scanning
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     permissions:
-      id-token: write
+      id-token: write  # needed by `crates-io-auth-action` to mint an OIDC token for Trusted Publishing
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-cdn-ip-ranges.yml
+++ b/.github/workflows/update-cdn-ip-ranges.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'rust-lang' }}
     permissions:
-      contents: write
+      contents: write  # needed to `git push` the updated CDN IP ranges back to the `main` branch
 
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/update-cdn-ip-ranges.yml
+++ b/.github/workflows/update-cdn-ip-ranges.yml
@@ -13,8 +13,7 @@ on:
   schedule:
     - cron: "42 * * * *"
 
-permissions:
-  contents: write
+permissions: {}
 
 concurrency:
   group: update-cdn-ip-ranges
@@ -27,6 +26,9 @@ jobs:
   run:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'rust-lang' }}
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token

--- a/.github/workflows/update-cdn-ip-ranges.yml
+++ b/.github/workflows/update-cdn-ip-ranges.yml
@@ -34,7 +34,7 @@ jobs:
         id: app-token
         with:
           app-id: ${{ vars.WORKFLOWS_CRATES_IO_APP_ID }}
-          private-key: ${{ secrets.WORKFLOWS_CRATES_IO_PRIVATE_KEY }}
+          private-key: ${{ secrets.WORKFLOWS_CRATES_IO_PRIVATE_KEY }}  # zizmor: ignore[secrets-outside-env] repository write access is already the effective boundary; an environment adds no meaningful protection
 
       - name: Get GitHub App User ID
         id: get-user-id


### PR DESCRIPTION
zizmor against this repo's workflows flagged a few things. This PR fixes three of them:

- `excessive-permissions`: `update-cdn-ip-ranges.yml` had `contents: write` at the workflow level. Moved it down to the `run` job. Doesn't actually matter since there's only one job in this workflow, but it resolves the warning.
- `undocumented-permissions`: Added inline comments for the three permissions blocks that needed them.
- `secrets-outside-env` on `WORKFLOWS_CRATES_IO_PRIVATE_KEY`: I looked into migrating this to a GitHub environment and couldn't convince myself it would narrow access in our setup. Required reviewers aren't viable for a scheduled job, and a branch-restricted environment wouldn't narrow the effective access boundary (repository write access) any further. Suppressed with an inline comment that spells out the reasoning.