### PR TITLE
svelte/test: Start MSW worker once per worker process

### DIFF
--- a/svelte/src/test/msw.ts
+++ b/svelte/src/test/msw.ts
@@ -1,16 +1,23 @@
 import { setupWorker } from 'msw/browser';
 import { test as testBase } from 'vitest';
 
-let worker = setupWorker();
+type Worker = ReturnType<typeof setupWorker>;
 
-export let test = testBase.extend<{ worker: ReturnType<typeof setupWorker> }>({
-  worker: [
+export let test = testBase.extend<{ _mswWorker: Worker; worker: Worker }>({
+  _mswWorker: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
+      let worker = setupWorker();
       await worker.start({ quiet: true, onUnhandledRequest: 'error' });
       await use(worker);
-      worker.resetHandlers();
       worker.stop();
+    },
+    { scope: 'worker' },
+  ],
+  worker: [
+    async ({ _mswWorker }, use) => {
+      await use(_mswWorker);
+      _mswWorker.resetHandlers();
     },
     { auto: true },
   ],


### PR DESCRIPTION
Split the `worker` fixture into a worker-scoped `_mswWorker` that starts and stops `setupWorker()` once per Vitest worker, plus a test-scoped `worker` fixture that calls `resetHandlers()` after each test. This matches the idiomatic MSW lifecycle. The previous fixture brought the worker up and down for every test, which MSW v2.13's new network source architecture no longer tolerates.

This should unblock https://github.com/rust-lang/crates.io/pull/13378

### Related

- https://github.com/rust-lang/crates.io/issues/12515