### PR TITLE
new-trusted-publisher: Fix grammar and whitespace in workflow group note

### DIFF
--- a/app/templates/crate/settings/new-trusted-publisher.gjs
+++ b/app/templates/crate/settings/new-trusted-publisher.gjs
@@ -124,7 +124,7 @@ import WorkflowVerification from 'crates-io/components/workflow-verification';
               Please enter a workflow filename.
             </div>
           {{else}}
-            <div class='note'>
+            <div class='note' data-test-note>
               The filename of the publishing workflow. This file should be present in the
               <code>
                 {{#if @controller.repository}}
@@ -259,7 +259,7 @@ import WorkflowVerification from 'crates-io/components/workflow-verification';
               Please enter a workflow filepath.
             </div>
           {{else}}
-            <div class='note'>
+            <div class='note' data-test-note>
               The filepath to the GitLab CI configuration file, relative to the
               {{#if @controller.repository}}<a
                   href='https://gitlab.com/{{@controller.repository}}/'

--- a/app/templates/crate/settings/new-trusted-publisher.gjs
+++ b/app/templates/crate/settings/new-trusted-publisher.gjs
@@ -260,15 +260,14 @@ import WorkflowVerification from 'crates-io/components/workflow-verification';
             </div>
           {{else}}
             <div class='note' data-test-note>
-              The filepath to the GitLab CI configuration file, relative to the
+              The filepath to the GitLab CI configuration file, relative to the root of the
               {{#if @controller.repository}}<a
                   href='https://gitlab.com/{{@controller.repository}}/'
                   target='_blank'
                   rel='noopener noreferrer'
                 >{{@controller.repository}}</a>
               {{/if}}
-              repository{{unless @controller.repository ' configured above'}}
-              root. For example:
+              repository{{unless @controller.repository ' configured above'}}. For example:
               <code>.gitlab-ci.yml</code>
               or
               <code>ci/publish.yml</code>.

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
@@ -401,7 +401,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
       await expect(page.locator('[data-test-cancel]')).toBeVisible();
 
       await expect(page.locator('[data-test-workflow-group] [data-test-note]')).toHaveText(
-        'The filepath to the GitLab CI configuration file, relative to the repository configured above root. For example: .gitlab-ci.yml or ci/publish.yml.',
+        'The filepath to the GitLab CI configuration file, relative to the root of the repository configured above. For example: .gitlab-ci.yml or ci/publish.yml.',
       );
 
       // Fill in the repository fields and confirm the note updates
@@ -409,7 +409,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
       await page.fill('[data-test-project]', 'crates.io');
 
       await expect(page.locator('[data-test-workflow-group] [data-test-note]')).toHaveText(
-        'The filepath to the GitLab CI configuration file, relative to the rust-lang/crates.io repository root. For example: .gitlab-ci.yml or ci/publish.yml.',
+        'The filepath to the GitLab CI configuration file, relative to the root of the rust-lang/crates.io repository. For example: .gitlab-ci.yml or ci/publish.yml.',
       );
 
       await page.fill('[data-test-workflow]', '.gitlab-ci.yml');

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
@@ -176,9 +176,18 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
       await expect(page.locator('[data-test-add]')).toBeVisible();
       await expect(page.locator('[data-test-cancel]')).toBeVisible();
 
-      // Fill in the form
+      await expect(page.locator('[data-test-workflow-group] [data-test-note]')).toHaveText(
+        'The filename of the publishing workflow. This file should be present in the .github/workflows/ directory of the repository configured above. For example: release.yml or publish.yml.',
+      );
+
+      // Fill in the repository fields and confirm the note updates
       await page.fill('[data-test-namespace]', 'rust-lang');
       await page.fill('[data-test-project]', 'crates.io');
+
+      await expect(page.locator('[data-test-workflow-group] [data-test-note]')).toHaveText(
+        'The filename of the publishing workflow. This file should be present in the .github/workflows/ directory of the rust-lang/crates.io repository. For example: release.yml or publish.yml.',
+      );
+
       await page.fill('[data-test-workflow]', 'ci.yml');
       await page.fill('[data-test-environment]', 'release');
 
@@ -391,9 +400,18 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
       await expect(page.locator('[data-test-add]')).toBeVisible();
       await expect(page.locator('[data-test-cancel]')).toBeVisible();
 
-      // Fill in the form
+      await expect(page.locator('[data-test-workflow-group] [data-test-note]')).toHaveText(
+        'The filepath to the GitLab CI configuration file, relative to the repository configured above root. For example: .gitlab-ci.yml or ci/publish.yml.',
+      );
+
+      // Fill in the repository fields and confirm the note updates
       await page.fill('[data-test-namespace]', 'rust-lang');
       await page.fill('[data-test-project]', 'crates.io');
+
+      await expect(page.locator('[data-test-workflow-group] [data-test-note]')).toHaveText(
+        'The filepath to the GitLab CI configuration file, relative to the rust-lang/crates.io repository root. For example: .gitlab-ci.yml or ci/publish.yml.',
+      );
+
       await page.fill('[data-test-workflow]', '.gitlab-ci.yml');
       await page.fill('[data-test-environment]', 'production');
 

--- a/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
@@ -255,7 +255,7 @@
       {#if workflowInvalid}
         <div class="form-group-error" data-test-error>Please enter a workflow filename.</div>
       {:else}
-        <div class="note">
+        <div class="note" data-test-note>
           The filename of the publishing workflow. This file should be present in the
           <code>
             {#if repository}
@@ -372,7 +372,7 @@
       {#if workflowInvalid}
         <div class="form-group-error" data-test-error>Please enter a workflow filepath.</div>
       {:else}
-        <div class="note">
+        <div class="note" data-test-note>
           The filepath to the GitLab CI configuration file, relative to the
           {#if repository}
             <a href="https://gitlab.com/{repository}/" target="_blank" rel="noopener noreferrer">{repository}</a>

--- a/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
@@ -272,8 +272,7 @@
           {#if repository}
             <a href="https://github.com/{repository}/" target="_blank" rel="noopener noreferrer">{repository}</a>
           {/if}
-          repository{#if !repository}
-            configured above{/if}. For example:
+          repository{repository ? '' : ' configured above'}. For example:
           <code>release.yml</code>
           or
           <code>publish.yml</code>.
@@ -373,13 +372,11 @@
         <div class="form-group-error" data-test-error>Please enter a workflow filepath.</div>
       {:else}
         <div class="note" data-test-note>
-          The filepath to the GitLab CI configuration file, relative to the
+          The filepath to the GitLab CI configuration file, relative to the root of the
           {#if repository}
             <a href="https://gitlab.com/{repository}/" target="_blank" rel="noopener noreferrer">{repository}</a>
           {/if}
-          repository{#if !repository}
-            configured above{/if}
-          root. For example:
+          repository{repository ? '' : ' configured above'}. For example:
           <code>.gitlab-ci.yml</code>
           or
           <code>ci/publish.yml</code>.


### PR DESCRIPTION
The GitLab workflow filepath note on the "Add a new Trusted Publisher" form currently reads "... relative to the repository configured above root. For example: ...", which is grammatically awkward. The intent is "relative to the root of the repository configured above". Reworded to parse naturally in both the filled and empty variants.

On the Svelte side, the same note also had a whitespace bug: the multi-line `{#if !repository}\n  configured above{/if}` block had its leading whitespace trimmed by Svelte, rendering `"repositoryconfigured above"` without a separator. Rewritten as a ternary so the space is preserved verbatim regardless of Svelte's text-node whitespace rules.

The Playwright test for this page now asserts the exact text of the workflow group note in both the empty-repository and filled-repository variants, on both GitHub and GitLab happy paths. A `data-test-note` marker is added to the `.note` element in both apps to provide a stable selector across scoped-CSS class mangling.

### Related

- https://github.com/rust-lang/crates.io/issues/12515