### PR TITLE
svelte: Use `&rsquo;` in hero title to match Ember app

### DIFF
--- a/svelte/src/lib/components/Header.svelte
+++ b/svelte/src/lib/components/Header.svelte
@@ -44,7 +44,7 @@
     </a>
 
     <div class="search-form">
-      <h1 class="hero-title">The Rust community's crate registry</h1>
+      <h1 class="hero-title">The Rust community&rsquo;s crate registry</h1>
 
       <SearchForm size={hero ? 'big' : undefined} autofocus={hero} />
     </div>


### PR DESCRIPTION
The Ember app uses `&rsquo;` for the apostrophe in the hero title ("The Rust community's crate registry"), while the Svelte app used an ASCII apostrophe. Switch Svelte to the same entity so the rendered character matches.

### Related

- https://github.com/rust-lang/crates.io/issues/12515