### PR TITLE
svelte: Normalize two-component MSRV to full semver

### DIFF
--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -30,6 +30,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-heading] [data-test-crate-name]')).toHaveText('nanomsg');
     await expect(page.locator('[data-test-heading] [data-test-crate-version]')).toHaveText('v0.6.1');
     await expect(page.locator('[data-test-crate-stats-label]')).toHaveText('Stats Overview');
+    await expect(page.locator('[data-test-msrv]')).toContainText('v1.69.0');
 
     await percy.snapshot();
     await a11y.audit();

--- a/e2e/acceptance/versions.spec.ts
+++ b/e2e/acceptance/versions.spec.ts
@@ -22,6 +22,8 @@ test.describe('Acceptance | crate versions page', { tag: '@acceptance' }, () => 
     let versions = await page.locator('[data-test-version]').evaluateAll(el => el.map(it => it.dataset.testVersion));
     expect(versions).toEqual(['0.2.1', '0.3.0', '0.2.0', '0.1.0']);
 
+    await expect(page.locator('[data-test-version="0.3.0"]')).toContainText('v1.69.0');
+
     await percy.snapshot();
 
     await page.click('[data-test-current-order]');

--- a/svelte/src/lib/components/crate-sidebar/Msrv.svelte
+++ b/svelte/src/lib/components/crate-sidebar/Msrv.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Tooltip from '$lib/components/Tooltip.svelte';
+  import { normalizeMsrv } from '$lib/utils/msrv';
 
   interface Props {
     msrv: string;
@@ -7,10 +8,12 @@
   }
 
   let { msrv, edition }: Props = $props();
+
+  let displayMsrv = $derived(normalizeMsrv(msrv));
 </script>
 
 <span>
-  v{msrv}
+  v{displayMsrv}
 
   <Tooltip>
     "Minimum Supported Rust Version"

--- a/svelte/src/lib/utils/msrv.test.ts
+++ b/svelte/src/lib/utils/msrv.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeMsrv } from './msrv';
+
+describe('normalizeMsrv', () => {
+  it('appends `.0` when the rust-version has two components', () => {
+    expect(normalizeMsrv('1.69')).toBe('1.69.0');
+    expect(normalizeMsrv('1.23')).toBe('1.23.0');
+  });
+
+  it('returns three-component versions unchanged', () => {
+    expect(normalizeMsrv('1.69.0')).toBe('1.69.0');
+    expect(normalizeMsrv('1.69.2')).toBe('1.69.2');
+  });
+});

--- a/svelte/src/lib/utils/msrv.ts
+++ b/svelte/src/lib/utils/msrv.ts
@@ -1,0 +1,9 @@
+/**
+ * Normalizes a `rust-version` string for display. If the value has only two
+ * version components (e.g. `1.69`), a `.0` patch component is appended to
+ * produce a full semver-shaped string (`1.69.0`). All other inputs are
+ * returned unchanged.
+ */
+export function normalizeMsrv(rustVersion: string): string {
+  return /^[^.]+\.[^.]+$/.test(rustVersion) ? `${rustVersion}.0` : rustVersion;
+}


### PR DESCRIPTION
The Ember `Version.msrv` getter appends `.0` to any `rust_version` that only has two components, so `1.69` becomes `1.69.0`. The Svelte app passed the raw field through, so the version list and crate sidebar showed `v1.69` instead of `v1.69.0`.

Add a `normalizeMsrv()` util with unit tests and apply it inside the `Msrv` component so every call site benefits without having to remember. Also adds Playwright assertions for the rendered MSRV text on the crate details page sidebar and the version list row.

### Related

- https://github.com/rust-lang/crates.io/issues/12515