### PR TITLE
svelte: Fix extra vertical spacing inside markdown alerts

### DIFF
--- a/svelte/src/lib/components/TextContent.svelte
+++ b/svelte/src/lib/components/TextContent.svelte
@@ -206,11 +206,11 @@
       color: inherit;
       border-left: 0.25em solid var(--gray-border);
 
-      & > :first-child {
+      & > :global(:first-child) {
         margin-top: 0;
       }
 
-      & > :last-child {
+      & > :global(:last-child) {
         margin-bottom: 0;
       }
 


### PR DESCRIPTION
Tip/warning/note/caution markdown alerts rendered with extra vertical space in the Svelte app because Svelte's CSS scoper added `:where(.svelte-xxx)` to the `& > :first-child` / `& > :last-child` rules nested inside `:global(.markdown-alert)`:

```css
.markdown-alert > :where(.svelte-xxx):first-child { margin-top: 0 }
.markdown-alert > :where(.svelte-xxx):last-child  { margin-bottom: 0 }
```

The `<p>` tags inside an alert come from `{@html readme}` and don't carry the `.svelte-xxx` scope class, so those rules never matched and the browser-default paragraph margins leaked through. Wrap the pseudo-classes in `:global(...)` so the scoper leaves them alone.

### Related

- https://github.com/rust-lang/crates.io/issues/12515