### PR TITLE
svelte: Show authenticated owner's email on crate settings page

### DIFF
--- a/app/templates/crate/settings/index.gjs
+++ b/app/templates/crate/settings/index.gjs
@@ -62,7 +62,7 @@ import UserAvatar from 'crates-io/components/user-avatar';
         <LinkTo @route={{team.kind}} @model={{team.login}}>
           {{team.display_name}}
         </LinkTo>
-        <div class='email-column'>
+        <div class='email-column' data-test-email>
           {{team.email}}
         </div>
         <button
@@ -85,7 +85,7 @@ import UserAvatar from 'crates-io/components/user-avatar';
             {{user.login}}
           {{/if}}
         </LinkTo>
-        <div class='email-column'>
+        <div class='email-column' data-test-email>
           {{user.email}}
         </div>
         <button

--- a/e2e/routes/crate/settings.spec.ts
+++ b/e2e/routes/crate/settings.spec.ts
@@ -58,6 +58,24 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
     await expect(page.locator('[data-test-delete-button]')).toBeVisible();
   });
 
+  test('only the authenticated owner has their email shown in the owners list', async ({ msw, page }) => {
+    let user1 = await msw.db.user.create({ login: 'authenticated-owner' });
+    let user2 = await msw.db.user.create({ login: 'other-owner' });
+
+    let crate = await msw.db.crate.create({ name: 'foo' });
+    await msw.db.version.create({ crate });
+    await msw.db.crateOwnership.create({ crate, user: user1 });
+    await msw.db.crateOwnership.create({ crate, user: user2 });
+
+    await msw.authenticateAs(user1);
+
+    await page.goto('/crates/foo/settings');
+    await expect(page).toHaveURL('/crates/foo/settings');
+
+    await expect(page.locator(`[data-test-owner-user="${user1.login}"] [data-test-email]`)).toHaveText(user1.email);
+    await expect(page.locator(`[data-test-owner-user="${user2.login}"] [data-test-email]`)).toHaveText('');
+  });
+
   test.describe('Trusted Publishing', () => {
     test('mixed GitHub and GitLab configs', async ({ msw, page, percy }) => {
       const { crate } = await prepare(msw);

--- a/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
@@ -12,6 +12,7 @@
   import Tooltip from '$lib/components/Tooltip.svelte';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import { getNotifications } from '$lib/notifications.svelte';
+  import { getSession } from '$lib/utils/session.svelte';
 
   type Owner = components['schemas']['Owner'];
   type GitHubConfig = components['schemas']['GitHubConfig'];
@@ -20,6 +21,7 @@
   let { data } = $props();
 
   let notifications = getNotifications();
+  let session = getSession();
   let client = createClient({ fetch });
 
   let addOwnerVisible = $state(false);
@@ -232,7 +234,7 @@
       <a {href}>
         {teamDisplayName(team)}
       </a>
-      <div class="email-column"></div>
+      <div class="email-column" data-test-email></div>
       <button
         type="button"
         class="button button--small"
@@ -254,7 +256,16 @@
       <a {href}>
         {user.name ?? user.login}
       </a>
-      <div class="email-column"></div>
+      <!--
+        TODO: Showing only the authenticated user's own email here is a bit
+        questionable. This matches the Ember.js app's behavior (an emergent
+        consequence of Ember Data's identity map) and is reproduced here for
+        parity during the migration. Revisit whether this column should exist
+        at all once the Svelte app is the primary frontend.
+      -->
+      <div class="email-column" data-test-email>
+        {session.currentUser?.id === user.id ? (session.currentUser?.email ?? '') : ''}
+      </div>
       <button
         type="button"
         class="button button--small"


### PR DESCRIPTION
The crate settings page shows an email column next to each owner. In the Ember app, the currently authenticated user's email appears in their own row as an emergent side effect of Ember Data's identity map: `/api/v1/me` pre-populates the `User` record with `email`, which is preserved when the same user also appears in the owners list (the owners API itself does not expose emails). Other owners' rows are empty.

The Svelte app had no equivalent, so the email column was always empty. This PR compares `session.currentUser.id` against each user owner explicitly to reproduce the Ember behavior. Playwright test added to check the asymmetry, plus a `data-test-email` marker on the email column in both apps for a stable selector.

There is also a TODO note at the usage site, since showing only the authenticated user's own email is a bit questionable and probably worth revisiting once the Svelte app is the primary frontend.

### Related

- https://github.com/rust-lang/crates.io/issues/12515