### PR TITLE
svelte: Don't render `CrateHeader` on new trusted publisher page

### DIFF
--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
@@ -37,6 +37,15 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
     await expect(page.locator('[data-test-go-back]')).toBeVisible();
   });
 
+  test('does not render the crate header', async ({ msw, page }) => {
+    let { crate } = await prepare(msw);
+
+    await page.goto(`/crates/${crate.name}/settings/new-trusted-publisher`);
+    await expect(page).toHaveURL(`/crates/${crate.name}/settings/new-trusted-publisher`);
+
+    await expect(page.locator('[data-test-heading]')).not.toBeVisible();
+  });
+
   test('cancel button', async ({ msw, page }) => {
     let { crate } = await prepare(msw);
 

--- a/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
@@ -4,7 +4,6 @@
   import { createClient } from '@crates-io/api-client';
 
   import Alert from '$lib/components/Alert.svelte';
-  import CrateHeader from '$lib/components/CrateHeader.svelte';
   import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
   import PageTitle from '$lib/components/PageTitle.svelte';
   import WorkflowVerification from '$lib/components/WorkflowVerification.svelte';
@@ -159,8 +158,6 @@
 </script>
 
 <PageTitle title="Add Trusted Publisher" />
-
-<CrateHeader crate={data.crate} ownersPromise={data.ownersPromise} />
 
 <form class="form" onsubmit={handleSubmit}>
   <h2>Add a new Trusted Publisher</h2>


### PR DESCRIPTION
Match the Ember app, which does not render the crate header on `/crates/:id/settings/new-trusted-publisher`. Also adds a Playwright regression test that asserts the `data-test-heading` element is not visible on that route.

### Related

- https://github.com/rust-lang/crates.io/issues/12515