### PR TITLE
tests: Add coverage for `BulkSyncToGitIndex` and `NormalizeIndex` jobs

### DIFF
--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -112,3 +112,90 @@ async fn test_config_changes() {
     // Check that the `config.json` changes on the upstream index are preserved
     assert_ok_eq!(upstream.read_file("config.json"), UPDATED_CONFIG);
 }
+
+/// Exercises `BulkSyncToGitIndex` with a mix of create/update/delete/no-op
+/// crates and verifies that the job produces a single commit covering them
+/// all.
+#[tokio::test(flavor = "multi_thread")]
+async fn bulk_sync_to_git_index() {
+    use crates_io::schema::crates;
+
+    let (app, _, _, token) = TestApp::full().with_token().await;
+    let mut conn = app.db_conn().await;
+    let upstream = app.upstream_index();
+
+    // Publish three crates and let the per-crate sync jobs land them in the
+    // upstream index.
+    for name in ["alpha", "beta", "gamma"] {
+        let body = PublishBuilder::new(name, "1.0.0").body();
+        let response = token.put::<()>("/api/v1/crates/new", body).await;
+        insta::allow_duplicates! {
+            assert_snapshot!(response.status(), @"200 OK");
+        }
+    }
+    app.run_pending_background_jobs().await;
+    for name in ["alpha", "beta", "gamma"] {
+        assert_ok_eq!(upstream.crate_exists(name), true);
+    }
+
+    // Capture the DB-derived contents that `SyncToGitIndex` wrote above so
+    // we can assert the bulk sync restores them after corruption.
+    let beta_expected = upstream.read_file("be/ta/beta").unwrap();
+    let gamma_expected = upstream.read_file("ga/mm/gamma").unwrap();
+
+    // Delete `alpha` from the DB so the bulk sync sees it as "present in
+    // index, missing from DB" → delete. Corrupt `beta`'s entry so the bulk
+    // sync sees it as stale → update. Leave `gamma` untouched → no-op.
+    let alpha: Crate = assert_ok!(Crate::by_name("alpha").first(&mut conn).await);
+    assert_ok!(
+        diesel::delete(crates::table.find(alpha.id))
+            .execute(&mut conn)
+            .await
+    );
+    upstream.write_file("be/ta/beta", "stale\n").unwrap();
+
+    let before = upstream.list_commits().unwrap().len();
+
+    // Enqueue a bulk sync covering all three names.
+    let bulk = jobs::BulkSyncToGitIndex::new(
+        vec!["alpha".into(), "beta".into(), "gamma".into()],
+        "Bulk sync",
+    );
+    assert_ok!(bulk.enqueue(&conn).await);
+    app.run_pending_background_jobs().await;
+
+    // Exactly one new commit on `master`, touching alpha (delete) + beta
+    // (update) in a single commit.
+    let commits = upstream.list_commits().unwrap();
+    assert_eq!(commits.len(), before + 1);
+    assert_eq!(commits.last().unwrap(), "Bulk sync");
+
+    // alpha's entry was deleted.
+    assert_ok_eq!(upstream.crate_exists("alpha"), false);
+    // beta's entry was restored to the DB-derived bytes.
+    assert_eq!(upstream.read_file("be/ta/beta").unwrap(), beta_expected);
+    // gamma's entry is unchanged.
+    assert_eq!(upstream.read_file("ga/mm/gamma").unwrap(), gamma_expected);
+}
+
+/// Exercises the no-op path: a `BulkSyncToGitIndex` over crates whose index
+/// entries already match the DB should not create a new commit.
+#[tokio::test(flavor = "multi_thread")]
+async fn bulk_sync_to_git_index_noop() {
+    let (app, _, _, token) = TestApp::full().with_token().await;
+    let conn = app.db_conn().await;
+    let upstream = app.upstream_index();
+
+    let body = PublishBuilder::new("serde", "1.0.0").body();
+    let response = token.put::<()>("/api/v1/crates/new", body).await;
+    assert_snapshot!(response.status(), @"200 OK");
+    app.run_pending_background_jobs().await;
+
+    let before = upstream.list_commits().unwrap();
+
+    let bulk = jobs::BulkSyncToGitIndex::new(vec!["serde".into()], "no-op bulk");
+    assert_ok!(bulk.enqueue(&conn).await);
+    app.run_pending_background_jobs().await;
+
+    assert_eq!(upstream.list_commits().unwrap(), before);
+}

--- a/src/tests/worker/mod.rs
+++ b/src/tests/worker/mod.rs
@@ -1,5 +1,6 @@
 mod generate_og_image;
 mod git;
+mod normalize_index;
 mod readmes;
 mod rss;
 mod send_publish_notifications;

--- a/src/tests/worker/normalize_index.rs
+++ b/src/tests/worker/normalize_index.rs
@@ -1,0 +1,106 @@
+use crate::util::TestApp;
+use claims::assert_ok;
+use crates_io::worker::jobs;
+use crates_io_worker::BackgroundJob;
+use insta::assert_json_snapshot;
+
+/// An unnormalized index entry: deps out of alphabetical order, one dep
+/// with a `null` kind, one dep with an empty string inside `features`.
+const UNNORMALIZED_ENTRY: &str = concat!(
+    r#"{"name":"foo","vers":"1.0.0","deps":[{"name":"zeta","req":"^1","features":["x",""],"optional":false,"default_features":true,"target":null,"kind":null},{"name":"alpha","req":"^1","features":[],"optional":false,"default_features":true,"target":null,"kind":null}],"cksum":"0","features":{},"yanked":false}"#,
+    "\n",
+);
+
+/// `NormalizeIndex` should rewrite unnormalized entries (sort deps, set null
+/// `kind` to `normal`, drop empty feature strings) and push the rewrite as a
+/// single commit on `master`.
+#[tokio::test(flavor = "multi_thread")]
+async fn normalize_index() {
+    let (app, _, _, _) = TestApp::full().with_token().await;
+    let conn = app.db_conn().await;
+    let upstream = app.upstream_index();
+
+    upstream.write_file("3/f/foo", UNNORMALIZED_ENTRY).unwrap();
+    let before = upstream.list_commits().unwrap().len();
+
+    assert_ok!(jobs::NormalizeIndex::new(false).enqueue(&conn).await);
+    app.run_pending_background_jobs().await;
+
+    let commits = upstream.list_commits().unwrap();
+    assert_eq!(commits.len(), before + 1);
+    assert!(
+        commits
+            .last()
+            .unwrap()
+            .starts_with("Normalize index format")
+    );
+
+    // The normalized entry should:
+    // - have `deps` sorted alphabetically (alpha before zeta)
+    // - have null `kind` values rewritten to `"normal"`
+    // - have the empty string stripped from `zeta`'s `features`
+    let normalized = upstream.read_file("3/f/foo").unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&normalized).unwrap();
+    assert_json_snapshot!(parsed, @r#"
+    {
+      "cksum": "0",
+      "deps": [
+        {
+          "default_features": true,
+          "features": [],
+          "kind": "normal",
+          "name": "alpha",
+          "optional": false,
+          "req": "^1",
+          "target": null
+        },
+        {
+          "default_features": true,
+          "features": [
+            "x"
+          ],
+          "kind": "normal",
+          "name": "zeta",
+          "optional": false,
+          "req": "^1",
+          "target": null
+        }
+      ],
+      "features": {},
+      "name": "foo",
+      "vers": "1.0.0",
+      "yanked": false
+    }
+    "#);
+}
+
+/// Dry-run mode should push the normalization commit to the
+/// `normalization-dry-run` branch, leaving `master` untouched.
+#[tokio::test(flavor = "multi_thread")]
+async fn normalize_index_dry_run() {
+    let (app, _, _, _) = TestApp::full().with_token().await;
+    let conn = app.db_conn().await;
+    let upstream = app.upstream_index();
+
+    upstream.write_file("3/f/foo", UNNORMALIZED_ENTRY).unwrap();
+    let master_before = upstream.list_commits().unwrap();
+
+    assert_ok!(jobs::NormalizeIndex::new(true).enqueue(&conn).await);
+    app.run_pending_background_jobs().await;
+
+    // master is untouched
+    assert_eq!(upstream.list_commits().unwrap(), master_before);
+
+    // the `normalization-dry-run` branch now exists and has the normalize commit
+    let bare = upstream.repository.lock().unwrap();
+    let dry_run_ref = bare
+        .find_reference("refs/heads/normalization-dry-run")
+        .unwrap();
+    let commit = bare.find_commit(dry_run_ref.target().unwrap()).unwrap();
+    assert!(
+        commit
+            .message()
+            .unwrap()
+            .starts_with("Normalize index format")
+    );
+}


### PR DESCRIPTION
Neither of these jobs had any tests. Adding some regression guards.

- `BulkSyncToGitIndex`: one test covers a delete/update/no-op mix in a single bulk job; one covers the no-op short-circuit.
- `NormalizeIndex`: one test snapshots the normalized JSON for a seeded unnormalized entry; one covers `dry_run = true` pushing to `normalization-dry-run` instead of `master`.

Pulled out of a larger refactor branch since they stand on their own.