### PR TITLE
index: Switch the crate-index clone to a bare repository

### DIFF
--- a/crates/crates_io_index/commit_builder.rs
+++ b/crates/crates_io_index/commit_builder.rs
@@ -9,13 +9,22 @@ use tracing::{info, instrument};
 /// [`Repository::commit_builder_to`]. Stage changes through [`Self::upsert_entry`]
 /// and [`Self::remove_entry`], then call [`Self::commit_and_push`] to write the
 /// commit and push it to the target branch. Dropping the builder without
-/// calling `commit_and_push` leaves the staged worktree writes in place; they
-/// will be cleaned up by the next [`Repository::reset_head`] call.
+/// calling `commit_and_push` discards the staged operations; any blobs that
+/// were written to the ODB become unreachable and will be cleaned up by
+/// `git gc`.
+///
+/// ### Limitation
+///
+/// Each path may be touched at most once per builder: mixing or repeating
+/// `upsert_entry` / `remove_entry` for the same `name` is unsupported and
+/// will fail at commit time. libgit2's `git_tree_create_updated` rejects
+/// duplicate operations on the same path, upserts of previously-removed
+/// paths, and type-changing upserts.
 pub struct CommitBuilder<'a> {
     repo: &'a Repository,
     msg: String,
     branch: String,
-    index: git2::Index,
+    tub: git2::build::TreeUpdateBuilder,
 }
 
 impl<'a> CommitBuilder<'a> {
@@ -24,47 +33,31 @@ impl<'a> CommitBuilder<'a> {
         msg: impl Into<String>,
         branch: impl Into<String>,
     ) -> anyhow::Result<Self> {
-        let index = repo
-            .git_repo()
-            .index()
-            .context("Failed to open git index")?;
         Ok(Self {
             repo,
             msg: msg.into(),
             branch: branch.into(),
-            index,
+            tub: git2::build::TreeUpdateBuilder::new(),
         })
     }
 
     /// Stage `bytes` as the contents of the index entry for `name`, creating
     /// or overwriting the entry.
     pub fn upsert_entry(&mut self, name: &str, bytes: &[u8]) -> anyhow::Result<()> {
-        let rel = Repository::relative_index_file(name);
-        let abs = self.repo.workdir().join(&rel);
-        if let Some(parent) = abs.parent() {
-            std::fs::create_dir_all(parent).with_context(|| {
-                format!("Failed to create parent directory for `{}`", abs.display())
-            })?;
-        }
-        std::fs::write(&abs, bytes)
-            .with_context(|| format!("Failed to write `{}`", abs.display()))?;
-        self.index
-            .add_path(&rel)
-            .with_context(|| format!("Failed to stage `{}`", rel.display()))?;
+        let oid = self
+            .repo
+            .git_repo()
+            .blob(bytes)
+            .with_context(|| format!("Failed to write blob for `{name}`"))?;
+        let path = Repository::relative_index_file_for_url(name);
+        self.tub.upsert(&path, oid, git2::FileMode::Blob);
         Ok(())
     }
 
-    /// Stage removal of the index entry for `name`. No-op if no entry exists.
+    /// Stage removal of the index entry for `name`.
     pub fn remove_entry(&mut self, name: &str) -> anyhow::Result<()> {
-        let rel = Repository::relative_index_file(name);
-        let abs = self.repo.workdir().join(&rel);
-        if abs.exists() {
-            std::fs::remove_file(&abs)
-                .with_context(|| format!("Failed to remove `{}`", abs.display()))?;
-        }
-        self.index
-            .remove_path(&rel)
-            .with_context(|| format!("Failed to unstage `{}`", rel.display()))?;
+        let path = Repository::relative_index_file_for_url(name);
+        self.tub.remove(&path);
         Ok(())
     }
 
@@ -77,9 +70,12 @@ impl<'a> CommitBuilder<'a> {
     pub fn commit_and_push(mut self) -> anyhow::Result<()> {
         let gitrepo = self.repo.git_repo();
         let parent = gitrepo.find_commit(self.repo.head_oid()?)?;
+        let parent_tree = parent.tree().context("Failed to load parent tree")?;
 
-        self.index.write().context("Failed to write git index")?;
-        let tree_oid = self.index.write_tree().context("Failed to write tree")?;
+        let tree_oid = self
+            .tub
+            .create_updated(gitrepo, &parent_tree)
+            .context("Failed to build updated tree")?;
 
         if tree_oid == parent.tree_id() {
             info!("No changes to commit");
@@ -172,19 +168,6 @@ mod tests {
 
         let mut builder = commit_builder(&repo, "no-op upsert");
         builder.upsert_entry("serde", b"hello\n").unwrap();
-        builder.commit_and_push().unwrap();
-
-        assert_eq!(upstream.list_commits().unwrap(), before);
-    }
-
-    #[test]
-    fn upsert_then_remove_same_entry_does_not_commit() {
-        let (upstream, repo) = setup();
-        let before = upstream.list_commits().unwrap();
-
-        let mut builder = commit_builder(&repo, "no-op");
-        builder.upsert_entry("serde", b"hello\n").unwrap();
-        builder.remove_entry("serde").unwrap();
         builder.commit_and_push().unwrap();
 
         assert_eq!(upstream.list_commits().unwrap(), before);

--- a/crates/crates_io_index/commit_builder.rs
+++ b/crates/crates_io_index/commit_builder.rs
@@ -1,0 +1,253 @@
+use crate::repo::Repository;
+use anyhow::Context;
+use std::process::Command;
+use tracing::{info, instrument};
+
+/// Buffers staged index mutations and produces a single commit when finalized.
+///
+/// Obtain one via [`Repository::commit_builder`] or
+/// [`Repository::commit_builder_to`]. Stage changes through [`Self::upsert_entry`]
+/// and [`Self::remove_entry`], then call [`Self::commit_and_push`] to write the
+/// commit and push it to the target branch. Dropping the builder without
+/// calling `commit_and_push` leaves the staged worktree writes in place; they
+/// will be cleaned up by the next [`Repository::reset_head`] call.
+pub struct CommitBuilder<'a> {
+    repo: &'a Repository,
+    msg: String,
+    branch: String,
+    index: git2::Index,
+}
+
+impl<'a> CommitBuilder<'a> {
+    pub(crate) fn new(
+        repo: &'a Repository,
+        msg: impl Into<String>,
+        branch: impl Into<String>,
+    ) -> anyhow::Result<Self> {
+        let index = repo
+            .git_repo()
+            .index()
+            .context("Failed to open git index")?;
+        Ok(Self {
+            repo,
+            msg: msg.into(),
+            branch: branch.into(),
+            index,
+        })
+    }
+
+    /// Stage `bytes` as the contents of the index entry for `name`, creating
+    /// or overwriting the entry.
+    pub fn upsert_entry(&mut self, name: &str, bytes: &[u8]) -> anyhow::Result<()> {
+        let rel = Repository::relative_index_file(name);
+        let abs = self.repo.workdir().join(&rel);
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create parent directory for `{}`", abs.display())
+            })?;
+        }
+        std::fs::write(&abs, bytes)
+            .with_context(|| format!("Failed to write `{}`", abs.display()))?;
+        self.index
+            .add_path(&rel)
+            .with_context(|| format!("Failed to stage `{}`", rel.display()))?;
+        Ok(())
+    }
+
+    /// Stage removal of the index entry for `name`. No-op if no entry exists.
+    pub fn remove_entry(&mut self, name: &str) -> anyhow::Result<()> {
+        let rel = Repository::relative_index_file(name);
+        let abs = self.repo.workdir().join(&rel);
+        if abs.exists() {
+            std::fs::remove_file(&abs)
+                .with_context(|| format!("Failed to remove `{}`", abs.display()))?;
+        }
+        self.index
+            .remove_path(&rel)
+            .with_context(|| format!("Failed to unstage `{}`", rel.display()))?;
+        Ok(())
+    }
+
+    /// Writes the staged changes as a new commit and pushes it to the
+    /// configured branch on the `origin` remote.
+    ///
+    /// Returns `Ok(())` without creating a commit if the resulting tree is
+    /// identical to the parent commit's tree (no effective changes).
+    #[instrument(skip_all, fields(message = %self.msg, branch = %self.branch))]
+    pub fn commit_and_push(mut self) -> anyhow::Result<()> {
+        let gitrepo = self.repo.git_repo();
+        let parent = gitrepo.find_commit(self.repo.head_oid()?)?;
+
+        self.index.write().context("Failed to write git index")?;
+        let tree_oid = self.index.write_tree().context("Failed to write tree")?;
+
+        if tree_oid == parent.tree_id() {
+            info!("No changes to commit");
+            return Ok(());
+        }
+
+        let sig = gitrepo.signature()?;
+        let tree = gitrepo.find_tree(tree_oid)?;
+        gitrepo.commit(Some("HEAD"), &sig, &sig, &self.msg, &tree, &[&parent])?;
+
+        self.repo.run_command(Command::new("git").args([
+            "push",
+            "origin",
+            &format!("HEAD:{}", self.branch),
+        ]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::repo::{Repository, RepositoryConfig};
+    use crate::testing::UpstreamIndex;
+    use crate::{Credentials, commit_builder::CommitBuilder};
+    use claims::assert_ok_eq;
+
+    fn setup() -> (UpstreamIndex, Repository) {
+        let upstream = UpstreamIndex::new().unwrap();
+        let config = RepositoryConfig {
+            index_location: upstream.url(),
+            credentials: Credentials::Missing,
+        };
+        let repo = Repository::open(&config).unwrap();
+        (upstream, repo)
+    }
+
+    fn commit_builder<'a>(repo: &'a Repository, msg: &str) -> CommitBuilder<'a> {
+        repo.commit_builder(msg).unwrap()
+    }
+
+    #[test]
+    fn empty_builder_does_not_commit() {
+        let (upstream, repo) = setup();
+        let before = upstream.list_commits().unwrap();
+
+        commit_builder(&repo, "should not appear")
+            .commit_and_push()
+            .unwrap();
+
+        assert_eq!(upstream.list_commits().unwrap(), before);
+    }
+
+    #[test]
+    fn upsert_creates_commit() {
+        let (upstream, repo) = setup();
+
+        let mut builder = commit_builder(&repo, "Create crate `serde`");
+        builder.upsert_entry("serde", b"hello\n").unwrap();
+        builder.commit_and_push().unwrap();
+
+        assert_ok_eq!(
+            upstream.list_commits(),
+            vec!["Initial Commit", "Create crate `serde`"]
+        );
+        assert_ok_eq!(upstream.read_file("se/rd/serde"), "hello\n".to_string());
+    }
+
+    #[test]
+    fn remove_commits_deletion() {
+        let (upstream, repo) = setup();
+        upstream.write_file("se/rd/serde", "hello\n").unwrap();
+        repo.reset_head().unwrap();
+
+        let mut builder = commit_builder(&repo, "Delete crate `serde`");
+        builder.remove_entry("serde").unwrap();
+        builder.commit_and_push().unwrap();
+
+        assert_ok_eq!(upstream.crate_exists("serde"), false);
+        assert_eq!(
+            upstream.list_commits().unwrap().last().unwrap(),
+            "Delete crate `serde`"
+        );
+    }
+
+    #[test]
+    fn upsert_with_identical_content_does_not_commit() {
+        let (upstream, repo) = setup();
+        upstream.write_file("se/rd/serde", "hello\n").unwrap();
+        repo.reset_head().unwrap();
+        let before = upstream.list_commits().unwrap();
+
+        let mut builder = commit_builder(&repo, "no-op upsert");
+        builder.upsert_entry("serde", b"hello\n").unwrap();
+        builder.commit_and_push().unwrap();
+
+        assert_eq!(upstream.list_commits().unwrap(), before);
+    }
+
+    #[test]
+    fn upsert_then_remove_same_entry_does_not_commit() {
+        let (upstream, repo) = setup();
+        let before = upstream.list_commits().unwrap();
+
+        let mut builder = commit_builder(&repo, "no-op");
+        builder.upsert_entry("serde", b"hello\n").unwrap();
+        builder.remove_entry("serde").unwrap();
+        builder.commit_and_push().unwrap();
+
+        assert_eq!(upstream.list_commits().unwrap(), before);
+    }
+
+    #[test]
+    fn multi_entry_changes_produce_single_commit() {
+        let (upstream, repo) = setup();
+        upstream.write_file("ol/d_/old_crate", "old\n").unwrap();
+        repo.reset_head().unwrap();
+        let before_count = upstream.list_commits().unwrap().len();
+
+        let mut builder = commit_builder(&repo, "Bulk update");
+        builder.upsert_entry("serde", b"serde\n").unwrap();
+        builder.upsert_entry("anyhow", b"anyhow\n").unwrap();
+        builder.remove_entry("old_crate").unwrap();
+        builder.commit_and_push().unwrap();
+
+        let commits = upstream.list_commits().unwrap();
+        assert_eq!(commits.len(), before_count + 1);
+        assert_eq!(commits.last().unwrap(), "Bulk update");
+        assert_ok_eq!(upstream.read_file("se/rd/serde"), "serde\n".to_string());
+        assert_ok_eq!(upstream.read_file("an/yh/anyhow"), "anyhow\n".to_string());
+        assert_ok_eq!(upstream.crate_exists("old_crate"), false);
+    }
+
+    #[test]
+    fn top_level_files_are_preserved_across_commits() {
+        let (upstream, repo) = setup();
+        upstream.write_file("config.json", "{}").unwrap();
+        repo.reset_head().unwrap();
+
+        let mut builder = commit_builder(&repo, "Create crate `serde`");
+        builder.upsert_entry("serde", b"serde\n").unwrap();
+        builder.commit_and_push().unwrap();
+
+        assert_ok_eq!(upstream.read_file("config.json"), "{}".to_string());
+    }
+
+    #[test]
+    fn commit_builder_to_targets_specific_branch() {
+        let (upstream, repo) = setup();
+
+        // Create the target branch on the upstream so the push has somewhere
+        // to land. We simply start it at the current HEAD.
+        {
+            let bare = upstream.repository.lock().unwrap();
+            let head = bare.head().unwrap().target().unwrap();
+            bare.reference("refs/heads/side", head, false, "set up side branch")
+                .unwrap();
+        }
+
+        let mut builder = repo.commit_builder_to("Sideways", "side").unwrap();
+        builder.upsert_entry("serde", b"serde\n").unwrap();
+        builder.commit_and_push().unwrap();
+
+        // master is untouched
+        assert_ok_eq!(upstream.list_commits(), vec!["Initial Commit".to_string()]);
+
+        // the side branch has the new commit
+        let bare = upstream.repository.lock().unwrap();
+        let side = bare.find_reference("refs/heads/side").unwrap();
+        let commit = bare.find_commit(side.target().unwrap()).unwrap();
+        assert_eq!(commit.message().unwrap(), "Sideways");
+    }
+}

--- a/crates/crates_io_index/lib.rs
+++ b/crates/crates_io_index/lib.rs
@@ -10,7 +10,7 @@ mod data;
 pub mod features;
 mod repo;
 mod ser;
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
 pub use crate::credentials::Credentials;

--- a/crates/crates_io_index/lib.rs
+++ b/crates/crates_io_index/lib.rs
@@ -5,6 +5,7 @@ extern crate serde;
 #[macro_use]
 extern crate tracing;
 
+mod commit_builder;
 mod credentials;
 mod data;
 pub mod features;
@@ -13,6 +14,7 @@ mod ser;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
+pub use crate::commit_builder::CommitBuilder;
 pub use crate::credentials::Credentials;
 pub use crate::data::{Crate, Dependency, DependencyKind};
 pub use crate::repo::{Repository, RepositoryConfig};

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -288,8 +288,8 @@ impl Repository {
         Ok(files)
     }
 
-    /// Fetches any changes from the `origin` remote and performs a hard reset
-    /// to the tip of the `origin/master` branch.
+    /// Fetches any changes from the `origin` remote and force-updates the
+    /// local `refs/heads/master` ref to the fetched tip.
     #[instrument(skip_all)]
     pub fn reset_head(&self) -> anyhow::Result<()> {
         let original_head = self.head_oid()?;
@@ -298,15 +298,16 @@ impl Repository {
         self.run_command(Command::new("git").args(["fetch", "origin", "master"]))?;
         info!(duration = fetch_start.elapsed().as_nanos(), "Index fetched");
 
-        let reset_start = Instant::now();
-        self.run_command(Command::new("git").args(["reset", "--hard", "origin/master"]))?;
-        info!(duration = reset_start.elapsed().as_nanos(), "Index reset");
+        let fetch_head = self
+            .repository
+            .refname_to_id("FETCH_HEAD")
+            .context("Failed to resolve FETCH_HEAD")?;
+        self.repository
+            .reference("refs/heads/master", fetch_head, true, "reset_head")
+            .context("Failed to update refs/heads/master")?;
 
         let head = self.head_oid()?;
         if head != original_head {
-            // Ensure that the internal state of `self.repository` is updated correctly
-            self.repository.checkout_head(None)?;
-
             info!("Index reset from {original_head} to {head}");
         }
 

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -307,21 +307,22 @@ impl Repository {
         Ok(())
     }
 
-    /// Reset `HEAD` to a single commit with all the index contents, but no parent
+    /// Rewrite the `master` branch to a single parentless commit wrapping the
+    /// current HEAD tree.
+    ///
+    /// The tree is reused by OID, so no blobs are read and no files are
+    /// touched. This stays cheap regardless of index size.
     #[instrument(skip_all)]
     pub fn squash_to_single_commit(&self, msg: &str) -> anyhow::Result<()> {
-        let tree = self.repository.find_commit(self.head_oid()?)?.tree()?;
-        let sig = self.repository.signature()?;
+        let repo = &self.repository;
+        let tree = repo.find_commit(self.head_oid()?)?.tree()?;
+        let sig = repo.signature()?;
 
-        // We cannot update an existing `update_ref`, because that requires the
-        // first parent of this commit to match the ref's current value.
-        // Instead, create the commit and then do a hard reset.
-        let commit = self.repository.commit(None, &sig, &sig, msg, &tree, &[])?;
-        let commit = self
-            .repository
-            .find_object(commit, Some(git2::ObjectType::Commit))?;
-        self.repository
-            .reset(&commit, git2::ResetType::Hard, None)?;
+        // `repo.commit(Some("HEAD"), ...)` would reject a parentless commit
+        // when HEAD is not itself parentless. Create the commit detached,
+        // then force-update `refs/heads/master` to point at it.
+        let commit = repo.commit(None, &sig, &sig, msg, &tree, &[])?;
+        repo.reference("refs/heads/master", commit, true, msg)?;
 
         Ok(())
     }

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -164,6 +164,22 @@ impl Repository {
         Self::relative_index_file_helper(&name).join("/")
     }
 
+    /// Reads the contents of the index entry for the given crate name.
+    ///
+    /// Returns `Ok(None)` if no entry exists for the crate.
+    pub fn read_entry(&self, name: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        let path = self
+            .checkout_path
+            .path()
+            .join(Self::relative_index_file(name));
+
+        match std::fs::read(&path) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     /// Returns the [Object ID](git2::Oid) of the currently checked out commit
     /// in the local crate index repository.
     ///
@@ -371,4 +387,46 @@ pub fn run_via_cli(command: &mut Command, credentials: &Credentials) -> anyhow::
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::UpstreamIndex;
+    use claims::{assert_none, assert_ok_eq, assert_some_eq};
+
+    fn setup() -> (UpstreamIndex, Repository) {
+        let upstream = UpstreamIndex::new().unwrap();
+        let config = RepositoryConfig {
+            index_location: upstream.url(),
+            credentials: Credentials::Missing,
+        };
+        let repo = Repository::open(&config).unwrap();
+        (upstream, repo)
+    }
+
+    #[test]
+    fn read_entry_missing() {
+        let (_upstream, repo) = setup();
+        assert_ok_eq!(repo.read_entry("serde"), None::<Vec<u8>>);
+    }
+
+    #[test]
+    fn read_entry_present() {
+        let (upstream, repo) = setup();
+        upstream.write_file("se/rd/serde", "hello\n").unwrap();
+        repo.reset_head().unwrap();
+
+        let entry = repo.read_entry("serde").unwrap();
+        assert_some_eq!(entry, b"hello\n".to_vec());
+    }
+
+    #[test]
+    fn read_entry_ignores_top_level_files() {
+        let (upstream, repo) = setup();
+        upstream.write_file("config.json", "{}").unwrap();
+        repo.reset_head().unwrap();
+
+        assert_none!(repo.read_entry("config.json").unwrap());
+    }
 }

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, anyhow};
 use base64::{Engine, engine::general_purpose};
 use crates_io_env_vars::{required_var, required_var_parsed, var};
 use secrecy::{ExposeSecret, SecretString};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 use std::time::Instant;
 use tempfile::TempDir;
@@ -175,10 +175,6 @@ impl Repository {
 
     pub(crate) fn git_repo(&self) -> &git2::Repository {
         &self.repository
-    }
-
-    pub(crate) fn workdir(&self) -> &Path {
-        self.checkout_path.path()
     }
 
     /// Returns the crate names of all entries currently stored in the index.

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -233,7 +233,9 @@ impl Repository {
                 Ok(Some(blob.content().to_vec()))
             }
             Err(error) if error.code() == git2::ErrorCode::NotFound => Ok(None),
-            Err(error) => Err(error).context("Failed to look up tree entry"),
+            Err(error) => {
+                Err(error).with_context(|| format!("Failed to look up tree entry for `{name}`"))
+            }
         }
     }
 
@@ -391,7 +393,7 @@ pub fn run_via_cli(command: &mut Command, credentials: &Credentials) -> anyhow::
 mod tests {
     use super::*;
     use crate::testing::UpstreamIndex;
-    use claims::{assert_none, assert_ok_eq, assert_some_eq};
+    use claims::{assert_err, assert_none, assert_ok_eq, assert_some_eq};
 
     fn setup() -> (UpstreamIndex, Repository) {
         let upstream = UpstreamIndex::new().unwrap();
@@ -417,6 +419,17 @@ mod tests {
 
         let entry = repo.read_entry("serde").unwrap();
         assert_some_eq!(entry, b"hello\n".to_vec());
+    }
+
+    #[test]
+    fn read_entry_error_mentions_name() {
+        let (_upstream, repo) = setup();
+
+        // A null byte in the crate name forces `git2` to fail the path
+        // conversion with a non-`NotFound` error, exercising the error
+        // context branch of `read_entry()`.
+        let err = assert_err!(repo.read_entry("\0serde"));
+        insta::assert_snapshot!(err, @"Failed to look up tree entry for `\0serde`");
     }
 
     #[test]

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -125,17 +125,6 @@ impl Repository {
         })
     }
 
-    /// Returns the absolute path to the crate index file that corresponds to
-    /// the given crate name.
-    ///
-    /// This is similar to [Self::relative_index_file], but returns the absolute
-    /// path.
-    pub fn index_file(&self, name: &str) -> PathBuf {
-        self.checkout_path
-            .path()
-            .join(Self::relative_index_file(name))
-    }
-
     /// Returns the relative path to the crate index file.
     /// Does not perform conversion to lowercase.
     fn relative_index_file_helper(name: &str) -> Vec<&str> {
@@ -248,37 +237,6 @@ impl Repository {
         Ok(head.target().unwrap())
     }
 
-    /// Commits the specified files with the specified commit message and pushes
-    /// the commit to the `master` branch on the `origin` remote.
-    ///
-    /// Note that `modified_files` expects file paths **relative** to the
-    /// repository working folder!
-    #[instrument(skip_all, fields(message = %msg, num_files = modified_files.len()))]
-    fn perform_commit_and_push(&self, msg: &str, modified_files: &[&Path]) -> anyhow::Result<()> {
-        let mut index = self.repository.index()?;
-
-        for modified_file in modified_files {
-            if self.checkout_path.path().join(modified_file).exists() {
-                index.add_path(modified_file)?;
-            } else {
-                index.remove_path(modified_file)?;
-            }
-        }
-
-        index.write()?;
-        let tree_id = index.write_tree()?;
-        let tree = self.repository.find_tree(tree_id)?;
-
-        // git commit -m "..."
-        let head = self.head_oid()?;
-        let parent = self.repository.find_commit(head)?;
-        let sig = self.repository.signature()?;
-        self.repository
-            .commit(Some("HEAD"), &sig, &sig, msg, &tree, &[&parent])?;
-
-        self.push()
-    }
-
     /// Gets a list of files that have been modified since a given `starting_commit`
     /// (use `starting_commit = None` for a list of all files).
     #[instrument(skip_all)]
@@ -322,36 +280,6 @@ impl Repository {
             .collect();
 
         Ok(files)
-    }
-
-    /// Push the current branch to the provided refname
-    #[instrument(skip_all)]
-    fn push(&self) -> anyhow::Result<()> {
-        self.run_command(Command::new("git").args(["push", "origin", "HEAD:master"]))
-    }
-
-    /// Commits the specified files with the specified commit message and pushes
-    /// the commit to the `master` branch on the `origin` remote.
-    ///
-    /// Note that `modified_files` expects **absolute** file paths!
-    ///
-    /// This function also prints the commit message and a success or failure
-    /// message to the console.
-    pub fn commit_and_push(&self, message: &str, modified_files: &[&Path]) -> anyhow::Result<()> {
-        info!("Committing and pushing \"{message}\"");
-
-        let checkout_path = self.checkout_path.path();
-        let relative_paths: Vec<&Path> = modified_files
-            .iter()
-            .map(|p| p.strip_prefix(checkout_path))
-            .collect::<Result<_, _>>()?;
-
-        self.perform_commit_and_push(message, &relative_paths)
-            .map(|_| info!("Commit and push finished for \"{message}\""))
-            .map_err(|err| {
-                error!(?err, "Commit and push for \"{message}\" errored");
-                err
-            })
     }
 
     /// Fetches any changes from the `origin` remote and performs a hard reset

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -180,8 +180,9 @@ impl Repository {
 
     /// Returns the crate names of all entries currently stored in the index.
     ///
-    /// Top-level files (e.g. `config.json`) are excluded; only blobs nested
-    /// under the sharded `N[/prefix]/name` layout are returned.
+    /// Top-level files (e.g. `config.json`) and the top-level `.github`
+    /// folder are excluded; only blobs nested under the sharded
+    /// `N[/prefix]/name` layout are returned.
     pub fn list_entries(&self) -> anyhow::Result<Vec<String>> {
         let tree = self
             .repository
@@ -192,6 +193,11 @@ impl Repository {
 
         let mut names = Vec::new();
         tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
+            // Skip the top-level `.github` folder (GitHub Actions workflows, etc.).
+            if root.is_empty() && entry.name() == Some(".github") {
+                return git2::TreeWalkResult::Skip;
+            }
+
             if !root.is_empty()
                 && entry.kind() == Some(git2::ObjectType::Blob)
                 && let Some(name) = entry.name()
@@ -446,6 +452,18 @@ mod tests {
     fn list_entries_excludes_top_level_files() {
         let (upstream, repo) = setup();
         upstream.write_file("config.json", "{}").unwrap();
+        upstream.write_file("se/rd/serde", "").unwrap();
+        repo.reset_head().unwrap();
+
+        assert_ok_eq!(repo.list_entries(), vec!["serde".to_string()]);
+    }
+
+    #[test]
+    fn list_entries_excludes_github_folder() {
+        let (upstream, repo) = setup();
+        upstream
+            .write_file(".github/workflows/ci.yml", "name: CI\n")
+            .unwrap();
         upstream.write_file("se/rd/serde", "").unwrap();
         repo.reset_head().unwrap();
 

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -164,6 +164,33 @@ impl Repository {
         Self::relative_index_file_helper(&name).join("/")
     }
 
+    /// Returns the crate names of all entries currently stored in the index.
+    ///
+    /// Top-level files (e.g. `config.json`) are excluded; only blobs nested
+    /// under the sharded `N[/prefix]/name` layout are returned.
+    pub fn list_entries(&self) -> anyhow::Result<Vec<String>> {
+        let tree = self
+            .repository
+            .head()
+            .context("Failed to read HEAD reference")?
+            .peel_to_tree()
+            .context("Failed to find tree for HEAD")?;
+
+        let mut names = Vec::new();
+        tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
+            if !root.is_empty()
+                && entry.kind() == Some(git2::ObjectType::Blob)
+                && let Some(name) = entry.name()
+            {
+                names.push(name.to_string());
+            }
+            git2::TreeWalkResult::Ok
+        })
+        .context("Failed to walk HEAD tree")?;
+
+        Ok(names)
+    }
+
     /// Reads the contents of the index entry for the given crate name.
     ///
     /// Returns `Ok(None)` if no entry exists for the crate.
@@ -428,5 +455,35 @@ mod tests {
         repo.reset_head().unwrap();
 
         assert_none!(repo.read_entry("config.json").unwrap());
+    }
+
+    #[test]
+    fn list_entries_empty() {
+        let (_upstream, repo) = setup();
+        assert_ok_eq!(repo.list_entries(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn list_entries_returns_crate_names() {
+        let (upstream, repo) = setup();
+        upstream.write_file("1/a", "").unwrap();
+        upstream.write_file("2/ab", "").unwrap();
+        upstream.write_file("3/a/abc", "").unwrap();
+        upstream.write_file("se/rd/serde", "").unwrap();
+        repo.reset_head().unwrap();
+
+        let mut entries = repo.list_entries().unwrap();
+        entries.sort();
+        assert_eq!(entries, vec!["a", "ab", "abc", "serde"]);
+    }
+
+    #[test]
+    fn list_entries_excludes_top_level_files() {
+        let (upstream, repo) = setup();
+        upstream.write_file("config.json", "{}").unwrap();
+        upstream.write_file("se/rd/serde", "").unwrap();
+        repo.reset_head().unwrap();
+
+        assert_ok_eq!(repo.list_entries(), vec!["serde".to_string()]);
     }
 }

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -212,15 +212,25 @@ impl Repository {
     ///
     /// Returns `Ok(None)` if no entry exists for the crate.
     pub fn read_entry(&self, name: &str) -> anyhow::Result<Option<Vec<u8>>> {
-        let path = self
-            .checkout_path
-            .path()
-            .join(Self::relative_index_file(name));
+        let tree = self
+            .repository
+            .head()
+            .context("Failed to read HEAD reference")?
+            .peel_to_tree()
+            .context("Failed to find tree for HEAD")?;
 
-        match std::fs::read(&path) {
-            Ok(bytes) => Ok(Some(bytes)),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(error.into()),
+        let path = Self::relative_index_file(name);
+        match tree.get_path(&path) {
+            Ok(entry) => {
+                let blob = entry
+                    .to_object(&self.repository)
+                    .context("Failed to resolve tree entry")?
+                    .peel_to_blob()
+                    .context("Failed to peel tree entry to blob")?;
+                Ok(Some(blob.content().to_vec()))
+            }
+            Err(error) if error.code() == git2::ErrorCode::NotFound => Ok(None),
+            Err(error) => Err(error).context("Failed to look up tree entry"),
         }
     }
 

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -1,3 +1,4 @@
+use crate::commit_builder::CommitBuilder;
 use crate::credentials::Credentials;
 use anyhow::{Context, anyhow};
 use base64::{Engine, engine::general_purpose};
@@ -162,6 +163,33 @@ impl Repository {
     pub fn relative_index_file_for_url(name: &str) -> String {
         let name = name.to_lowercase();
         Self::relative_index_file_helper(&name).join("/")
+    }
+
+    /// Starts a new commit targeting the `master` branch.
+    ///
+    /// See [`Self::commit_builder_to`] for details.
+    pub fn commit_builder(&self, msg: impl Into<String>) -> anyhow::Result<CommitBuilder<'_>> {
+        CommitBuilder::new(self, msg, "master")
+    }
+
+    /// Starts a new commit targeting the given remote branch.
+    ///
+    /// Stage changes on the returned [`CommitBuilder`] and call
+    /// [`CommitBuilder::commit_and_push`] to finalize them.
+    pub fn commit_builder_to(
+        &self,
+        msg: impl Into<String>,
+        branch: impl Into<String>,
+    ) -> anyhow::Result<CommitBuilder<'_>> {
+        CommitBuilder::new(self, msg, branch)
+    }
+
+    pub(crate) fn git_repo(&self) -> &git2::Repository {
+        &self.repository
+    }
+
+    pub(crate) fn workdir(&self) -> &Path {
+        self.checkout_path.path()
     }
 
     /// Returns the crate names of all entries currently stored in the index.

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -94,6 +94,7 @@ impl Repository {
         run_via_cli(
             Command::new("git").args([
                 "clone",
+                "--bare",
                 "--single-branch",
                 repository_config.index_location.as_str(),
                 checkout_path_str,
@@ -102,7 +103,7 @@ impl Repository {
         )
         .context("Failed to clone index repository")?;
 
-        let repository = git2::Repository::open(checkout_path.path())
+        let repository = git2::Repository::open_bare(checkout_path.path())
             .context("Failed to open cloned index repository")?;
 
         // All commits to the index registry made through crates.io will be made by bors, the Rust

--- a/src/bin/crates-admin/upload_index.rs
+++ b/src/bin/crates-admin/upload_index.rs
@@ -1,5 +1,5 @@
 use crate::dialoguer;
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use crates_io::storage::Storage;
 use crates_io::tasks::spawn_blocking;
 use crates_io_index::{Repository, RepositoryConfig};
@@ -52,13 +52,14 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
             anyhow!("Failed to convert file name to utf8: {file_name}",)
         })?;
 
-        let path = repo.index_file(crate_name);
-        if !path.exists() {
+        let Some(bytes) = repo.read_entry(crate_name)? else {
             pb.suspend(|| println!("skipping file `{crate_name}`"));
             continue;
-        }
+        };
 
-        let contents = tokio::fs::read_to_string(&path).await?;
+        let contents = String::from_utf8(bytes)
+            .with_context(|| format!("Failed to decode `{crate_name}` as UTF-8"))?;
+
         storage.sync_index(crate_name, Some(contents)).await?;
     }
 

--- a/src/tests/worker/mod.rs
+++ b/src/tests/worker/mod.rs
@@ -4,6 +4,7 @@ mod normalize_index;
 mod readmes;
 mod rss;
 mod send_publish_notifications;
+mod squash_index;
 mod sync_admins;
 mod trustpub;
 mod update_default_version;

--- a/src/tests/worker/squash_index.rs
+++ b/src/tests/worker/squash_index.rs
@@ -1,0 +1,54 @@
+use crate::util::TestApp;
+use chrono::Utc;
+use claims::assert_ok;
+use crates_io::worker::jobs;
+use crates_io_worker::BackgroundJob;
+
+/// `SquashIndex` should collapse the upstream index into a single parentless
+/// commit on `master`, while preserving tree content and archiving the previous
+/// HEAD on a `snapshot-<date>` branch.
+#[tokio::test(flavor = "multi_thread")]
+async fn squash_index() {
+    let (app, _) = TestApp::full().empty().await;
+    let conn = app.db_conn().await;
+    let upstream = app.upstream_index();
+
+    // Seed a couple of entries so the squash has real content to collapse.
+    upstream.write_file("1/a", "a\n").unwrap();
+    upstream.write_file("se/rd/serde", "serde\n").unwrap();
+
+    // Capture upstream `master` state before the squash.
+    let (original_head, original_tree) = {
+        let repo = upstream.repository.lock().unwrap();
+        let head = repo.find_reference("refs/heads/master").unwrap();
+        let commit = head.peel_to_commit().unwrap();
+        (commit.id(), commit.tree().unwrap().id())
+    };
+
+    let now = Utc::now().format("%F");
+
+    assert_ok!(jobs::SquashIndex.enqueue(&conn).await);
+    app.run_pending_background_jobs().await;
+
+    let repo = upstream.repository.lock().unwrap();
+
+    // `master` now points to a parentless commit with the squash message.
+    let master = repo.find_reference("refs/heads/master").unwrap();
+    let squashed = master.peel_to_commit().unwrap();
+    assert_eq!(squashed.parent_count(), 0);
+    assert!(
+        squashed
+            .message()
+            .unwrap()
+            .starts_with("Collapse index into one commit")
+    );
+
+    // Tree content is preserved — the squashed commit references the exact
+    // same tree as the pre-squash HEAD.
+    assert_eq!(squashed.tree().unwrap().id(), original_tree);
+
+    // The archive branch captures the previous HEAD.
+    let snapshot_ref = format!("refs/heads/snapshot-{now}");
+    let snapshot = repo.find_reference(&snapshot_ref).unwrap();
+    assert_eq!(snapshot.peel_to_commit().unwrap().id(), original_head);
+}

--- a/src/worker/jobs/index/normalize.rs
+++ b/src/worker/jobs/index/normalize.rs
@@ -1,11 +1,8 @@
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
-use crates_io_index::Crate;
+use crates_io_index::{Crate, DependencyKind};
 use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
-use std::fs;
-use std::io::{BufRead, BufReader};
-use std::process::Command;
 use std::sync::Arc;
 use tracing::info;
 
@@ -33,69 +30,67 @@ impl BackgroundJob for NormalizeIndex {
         spawn_blocking(move || {
             let repo = env.lock_index()?;
 
-            let files = repo.get_files_modified_since(None)?;
-            let num_files = files.len();
+            let entries = repo.list_entries()?;
+            let num_entries = entries.len();
 
-            for (i, file) in files.iter().enumerate() {
+            let branch = if dry_run {
+                "normalization-dry-run"
+            } else {
+                "master"
+            };
+            let msg = "Normalize index format\n\n\
+                More information can be found at https://github.com/rust-lang/crates.io/pull/5066";
+
+            let mut builder = repo.commit_builder_to(msg, branch)?;
+            for (i, name) in entries.iter().enumerate() {
                 if i % 50 == 0 {
-                    info!(num_files, i, ?file);
+                    info!(num_entries, i, %name);
                 }
 
-                let crate_name = file.file_name().unwrap().to_str().unwrap();
-                let path = repo.index_file(crate_name);
-                if !path.exists() {
+                let Some(bytes) = repo.read_entry(name)? else {
                     continue;
+                };
+                let normalized = normalize_entry(&bytes)?;
+                if normalized != bytes {
+                    builder.upsert_entry(name, &normalized)?;
                 }
-
-                let mut body: Vec<u8> = Vec::new();
-                let file = fs::File::open(&path)?;
-                let reader = BufReader::new(file);
-                let mut versions = Vec::new();
-                for line in reader.lines() {
-                    let line = line?;
-                    if line.is_empty() {
-                        continue;
-                    }
-
-                    let mut krate: Crate = serde_json::from_str(&line)?;
-                    for dep in &mut krate.deps {
-                        // Remove deps with empty features
-                        dep.features.retain(|d| !d.is_empty());
-                        // Set null DependencyKind to Normal
-                        dep.kind =
-                            Some(dep.kind.unwrap_or(crates_io_index::DependencyKind::Normal));
-                    }
-                    krate.deps.sort();
-                    versions.push(krate);
-                }
-                for version in versions {
-                    serde_json::to_writer(&mut body, &version).unwrap();
-                    body.push(b'\n');
-                }
-                fs::write(path, body)?;
             }
 
             info!("Committing normalization");
-            let msg = "Normalize index format\n\n\
-        More information can be found at https://github.com/rust-lang/crates.io/pull/5066";
-            repo.run_command(Command::new("git").args(["commit", "-am", msg]))?;
-
-            let branch = match dry_run {
-                false => "master",
-                true => "normalization-dry-run",
-            };
-
-            info!(?branch, "Pushing to upstream repository");
-            repo.run_command(Command::new("git").args([
-                "push",
-                "origin",
-                &format!("HEAD:{branch}"),
-            ]))?;
-
+            builder.commit_and_push()?;
             info!("Index normalization completed");
 
             Ok(())
         })
         .await?
     }
+}
+
+/// Parses a newline-delimited JSON index entry, applies the normalization
+/// rules (strip empty feature names, default null `kind` to `Normal`, sort
+/// deps), and returns the rewritten bytes.
+fn normalize_entry(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let mut versions = Vec::new();
+    for line in bytes.split(|&b| b == b'\n') {
+        if line.is_empty() {
+            continue;
+        }
+
+        let mut krate: Crate = serde_json::from_slice(line)?;
+        for dep in &mut krate.deps {
+            // Remove deps with empty features
+            dep.features.retain(|d| !d.is_empty());
+            // Set null DependencyKind to Normal
+            dep.kind = Some(dep.kind.unwrap_or(DependencyKind::Normal));
+        }
+        krate.deps.sort();
+        versions.push(krate);
+    }
+
+    let mut body: Vec<u8> = Vec::new();
+    for version in versions {
+        serde_json::to_writer(&mut body, &version)?;
+        body.push(b'\n');
+    }
+    Ok(body)
 }

--- a/src/worker/jobs/index/sync.rs
+++ b/src/worker/jobs/index/sync.rs
@@ -50,31 +50,27 @@ impl BackgroundJob for SyncToGitIndex {
 
         spawn_blocking(move || {
             let repo = env.lock_index()?;
-            let dst = repo.index_file(&crate_name);
-
-            // Read the previous crate contents
-            let old = match fs::read_to_string(&dst) {
-                Ok(content) => Some(content),
-                Err(error) if error.kind() == ErrorKind::NotFound => None,
-                Err(error) => return Err(error.into()),
-            };
+            let old = repo.read_entry(&crate_name)?;
 
             let commit_and_push_start = Instant::now();
             match (old, new) {
                 (None, Some(new)) => {
-                    fs::create_dir_all(dst.parent().unwrap())?;
-                    let mut file = File::create(&dst)?;
-                    file.write_all(new.as_bytes())?;
-                    repo.commit_and_push(&format!("Create crate `{}`", &crate_name), &[&dst])?;
+                    let msg = format!("Create crate `{crate_name}`");
+                    let mut builder = repo.commit_builder(msg)?;
+                    builder.upsert_entry(&crate_name, new.as_bytes())?;
+                    builder.commit_and_push()?;
                 }
-                (Some(old), Some(new)) if old != new => {
-                    let mut file = File::create(&dst)?;
-                    file.write_all(new.as_bytes())?;
-                    repo.commit_and_push(&format!("Update crate `{}`", &crate_name), &[&dst])?;
+                (Some(old), Some(new)) if old != new.as_bytes() => {
+                    let msg = format!("Update crate `{crate_name}`");
+                    let mut builder = repo.commit_builder(msg)?;
+                    builder.upsert_entry(&crate_name, new.as_bytes())?;
+                    builder.commit_and_push()?;
                 }
                 (Some(_old), None) => {
-                    fs::remove_file(&dst)?;
-                    repo.commit_and_push(&format!("Delete crate `{}`", &crate_name), &[&dst])?;
+                    let msg = format!("Delete crate `{crate_name}`");
+                    let mut builder = repo.commit_builder(msg)?;
+                    builder.remove_entry(&crate_name)?;
+                    builder.commit_and_push()?;
                 }
                 _ => debug!("Skipping sync because index is up-to-date"),
             }

--- a/src/worker/jobs/index/sync.rs
+++ b/src/worker/jobs/index/sync.rs
@@ -7,10 +7,6 @@ use crates_io_database::models::{CloudFrontDistribution, CloudFrontInvalidationQ
 use crates_io_index::Repository;
 use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
-use std::fs;
-use std::fs::File;
-use std::io::{ErrorKind, Write};
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::runtime::Handle;
@@ -119,7 +115,8 @@ impl BackgroundJob for BulkSyncToGitIndex {
             let repo = env.lock_index()?;
             let include_pubtime = env.config.index_include_pubtime;
 
-            let mut modified_files = Vec::new();
+            let mut builder = repo.commit_builder(commit_message)?;
+            let mut num_changes = 0;
 
             for crate_name in &crate_names {
                 // Fetch index data using async database queries
@@ -130,42 +127,32 @@ impl BackgroundJob for BulkSyncToGitIndex {
                     })
                     .with_context(|| format!("Failed to get index data for `{crate_name}`"))?;
 
-                let dst = repo.index_file(crate_name);
-
-                let old = match fs::read_to_string(&dst) {
-                    Ok(content) => Some(content),
-                    Err(error) if error.kind() == ErrorKind::NotFound => None,
-                    Err(error) => return Err(error.into()),
-                };
+                let old = repo.read_entry(crate_name)?;
 
                 match (old, new) {
                     (None, Some(new)) => {
-                        fs::create_dir_all(dst.parent().unwrap())?;
-                        let mut file = File::create(&dst)?;
-                        file.write_all(new.as_bytes())?;
-                        modified_files.push(dst);
+                        builder.upsert_entry(crate_name, new.as_bytes())?;
+                        num_changes += 1;
                     }
-                    (Some(old), Some(new)) if old != new => {
-                        let mut file = File::create(&dst)?;
-                        file.write_all(new.as_bytes())?;
-                        modified_files.push(dst);
+                    (Some(old), Some(new)) if old != new.as_bytes() => {
+                        builder.upsert_entry(crate_name, new.as_bytes())?;
+                        num_changes += 1;
                     }
                     (Some(_old), None) => {
-                        fs::remove_file(&dst)?;
-                        modified_files.push(dst);
+                        builder.remove_entry(crate_name)?;
+                        num_changes += 1;
                     }
                     _ => debug!(%crate_name, "Skipping sync because index is up-to-date"),
                 }
             }
 
-            if modified_files.is_empty() {
+            if num_changes == 0 {
                 info!("No changes to commit");
                 return Ok(());
             }
 
-            info!("Committing {} modified files", modified_files.len());
-            let modified_refs: Vec<&Path> = modified_files.iter().map(|p| p.as_path()).collect();
-            repo.commit_and_push(&commit_message, &modified_refs)?;
+            info!("Committing {num_changes} modified files");
+            builder.commit_and_push()?;
 
             Ok(())
         })


### PR DESCRIPTION
`reset_head()` used to run `git fetch` + `git reset --hard` before every index job. On Heroku's overlay FS the reset is slow. It had to stat all ~254k tracked files (one per published crate). A bare clone has neither a worktree nor a staging index, so the cost disappears.

Migrating meant refactoring `Repository` to no longer use the filesystem:
- `read_entry` used to `fs::read` a path in the checkout. It now reads the corresponding blob from the HEAD tree.
- a `CommitBuilder` was introduced to allow us to write blobs straight to the ODB and compose the new tree with
  `TreeUpdateBuilder`.
- `reset_head` and `squash_to_single_commit` both depended on `git reset --hard` to move HEAD, and now use a forced ref write on `refs/heads/master` instead.

With those rewrites in place I was able to switch the `open()` call to use `--bare` and no longer write any files to disk.

I temporarily deployed this branch to staging.crates.io for manual testing. Regular `cargo publish` behaves identically to the current backend. `SquashIndex` produces the expected collapsed history too.

I recommend reviewing this commit-by-commit, to avoid being overwhelmed by the diff 😅 