### PR TITLE
svelte: Fix search input focus stealing on client-side navigation

### DIFF
--- a/e2e/acceptance/search.spec.ts
+++ b/e2e/acceptance/search.spec.ts
@@ -59,33 +59,60 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-search-input]')).toHaveValue('');
   });
 
-  test('pressing S key to focus the search bar', async ({ page, msw }) => {
-    await loadFixtures(msw.db);
+  test.describe('search input focus behavior', () => {
+    test('pressing S key focuses the search input', async ({ page, msw }) => {
+      await loadFixtures(msw.db);
 
-    await page.goto('/');
+      await page.goto('/');
 
-    const searchInput = page.locator('[data-test-search-input]');
-    await searchInput.blur();
-    await page.keyboard.press('a');
-    await expect(searchInput).not.toBeFocused();
+      const searchInput = page.locator('[data-test-search-input]');
+      await searchInput.blur();
+      await page.keyboard.press('a');
+      await expect(searchInput).not.toBeFocused();
 
-    await searchInput.blur();
-    await page.keyboard.press('s');
-    await expect(page.locator('[data-test-search-input]')).toBeFocused();
+      await searchInput.blur();
+      await page.keyboard.press('s');
+      await expect(page.locator('[data-test-search-input]')).toBeFocused();
 
-    await searchInput.blur();
-    await page.keyboard.press('s');
-    await expect(page.locator('[data-test-search-input]')).toBeFocused();
+      await searchInput.blur();
+      await page.keyboard.press('s');
+      await expect(page.locator('[data-test-search-input]')).toBeFocused();
 
-    await searchInput.blur();
-    await page.keyboard.press('S');
-    await expect(page.locator('[data-test-search-input]')).toBeFocused();
+      await searchInput.blur();
+      await page.keyboard.press('S');
+      await expect(page.locator('[data-test-search-input]')).toBeFocused();
 
-    await searchInput.blur();
-    await page.keyboard.down('Shift');
-    await page.keyboard.press('s');
-    await page.keyboard.up('Shift');
-    await expect(page.locator('[data-test-search-input]')).toBeFocused();
+      await searchInput.blur();
+      await page.keyboard.down('Shift');
+      await page.keyboard.press('s');
+      await page.keyboard.up('Shift');
+      await expect(page.locator('[data-test-search-input]')).toBeFocused();
+    });
+
+    test('search input stays focused after submitting the search form with Enter', async ({ page, msw }) => {
+      await loadFixtures(msw.db);
+
+      await page.goto('/');
+      await expect(page.locator('[data-test-search-input]')).toBeFocused();
+
+      await page.keyboard.type('rust');
+      await page.keyboard.press('Enter');
+
+      await expect(page).toHaveURL('/search?q=rust');
+      await expect(page.locator('[data-test-search-input]')).toBeFocused();
+    });
+
+    test('focus is not stolen when navigating from the front page', async ({ page, msw }) => {
+      let crate = await msw.db.crate.create({ name: 'nanomsg' });
+      await msw.db.version.create({ crate, num: '0.6.1' });
+
+      await page.goto('/');
+      await expect(page.locator('[data-test-search-input]')).toBeFocused();
+
+      await page.click('[data-test-just-updated] [data-test-crate-link="0"]');
+      await expect(page).toHaveURL('/crates/nanomsg/0.6.1');
+      await expect(page.locator('[data-test-search-input]')).not.toBeFocused();
+    });
   });
 
   test('check search results are by default displayed by relevance', async ({ page, msw }) => {

--- a/svelte/src/lib/components/SearchForm.svelte
+++ b/svelte/src/lib/components/SearchForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
+  import { afterNavigate, goto } from '$app/navigation';
   import { resolve } from '$app/paths';
 
   import SearchIcon from '$lib/assets/search.svg?component';
@@ -15,10 +15,23 @@
   let searchFormContext = getSearchFormContext();
   let inputElement: HTMLInputElement | undefined = $state();
 
+  // Focus the input imperatively instead of using the `autofocus` attribute.
+  // Svelte only sets the attribute on mount and never removes it, and
+  // SvelteKit's `reset_focus()` refocuses any `[autofocus]` element after
+  // each client-side navigation, which would steal focus back to the
+  // search bar on every nav once the attribute has been set.
+  let hasAutoFocused = false;
+  afterNavigate(() => {
+    if (autofocus && !hasAutoFocused) {
+      hasAutoFocused = true;
+      inputElement?.focus();
+    }
+  });
+
   function search(event: SubmitEvent) {
     event.preventDefault();
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() doesn't support query params
-    goto(`${resolve('/search')}?q=${encodeURIComponent(searchFormContext.value)}`);
+    goto(`${resolve('/search')}?q=${encodeURIComponent(searchFormContext.value)}`, { keepFocus: true });
   }
 
   function handleKeydown(event: KeyboardEvent) {
@@ -40,7 +53,6 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<!-- svelte-ignore a11y_autofocus -->
 <form
   action="/search"
   role="search"
@@ -51,7 +63,6 @@
   class="form"
   class:size-big={size === 'big'}
   onsubmit={search}
-  data-sveltekit-keepfocus
 >
   <!-- Large screen input with keyboard shortcut hint -->
   <input
@@ -64,7 +75,6 @@
     placeholder="Type 'S' or '/' to search"
     autocorrect="off"
     bind:value={searchFormContext.value}
-    {autofocus}
     required
     aria-label="Search"
     data-test-search-input

--- a/svelte/src/lib/components/SearchForm.svelte
+++ b/svelte/src/lib/components/SearchForm.svelte
@@ -15,10 +15,6 @@
   let searchFormContext = getSearchFormContext();
   let inputElement: HTMLInputElement | undefined = $state();
 
-  function updateSearchValue(event: Event) {
-    searchFormContext.value = (event.target as HTMLInputElement).value;
-  }
-
   function search(event: SubmitEvent) {
     event.preventDefault();
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- resolve() doesn't support query params
@@ -67,8 +63,7 @@
     id="cargo-desktop-search"
     placeholder="Type 'S' or '/' to search"
     autocorrect="off"
-    value={searchFormContext.value}
-    oninput={updateSearchValue}
+    bind:value={searchFormContext.value}
     {autofocus}
     required
     aria-label="Search"
@@ -83,8 +78,7 @@
     name="q"
     placeholder="Search"
     autocorrect="off"
-    value={searchFormContext.value}
-    oninput={updateSearchValue}
+    bind:value={searchFormContext.value}
     required
     aria-label="Search"
   />


### PR DESCRIPTION
Fixes a regression reported on Zulip where interacting with a filter, internal link, or navigation tab in the Svelte app steals focus back to the main search bar.

Root cause: Svelte 5's `{autofocus}` handler seems to set the attribute on mount but never remove it when the value changes. `SearchForm` lives in `+layout.svelte` and is first rendered on `/` with `autofocus=true`, so the attribute sticks. SvelteKit's `reset_focus()` then refocuses any `[autofocus]` element after each client-side navigation.

Replaces the attribute with an `afterNavigate` callback that focuses the input once on the initial navigation. Passes `keepFocus: true` to `goto()` in the submit handler so pressing Enter keeps focus on the input, matching the Ember app. Also switches `SearchForm` to `bind:value`, which fixes a separate reactive-state race on fast typing followed by Enter, and adds regression tests in `e2e/acceptance/search.spec.ts`.
### Related

- https://github.com/rust-lang/crates.io/issues/12515
- https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/Crates.20and.20svelte/near/587669795