### PR TITLE
script: Add crate-backup.py

### DIFF
--- a/script/crate-backup.py
+++ b/script/crate-backup.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 import argparse
+import csv
 import json
 import sys
 import urllib.request
 from pathlib import Path
 
 USER_AGENT = "crate-backup (https://github.com/rust-lang/crates.io)"
+DOWNLOADS_CSV = "downloads.csv"
 
 
 def fetch(url):
@@ -17,7 +19,7 @@ def list_versions(crate):
     url = f"https://crates.io/api/v1/crates/{crate}/versions"
     with fetch(url) as resp:
         data = json.load(resp)
-    return [v["num"] for v in data["versions"]]
+    return [(v["num"], v["downloads"]) for v in data["versions"]]
 
 
 def download_version(crate, version):
@@ -37,11 +39,17 @@ def main():
     parser.add_argument("crates", nargs="+", metavar="CRATE", help="Name of a crate")
     args = parser.parse_args()
 
-    for crate in args.crates:
-        versions = list_versions(crate)
-        print(f"found {len(versions)} versions of {crate}")
-        for version in versions:
-            download_version(crate, version)
+    csv_path = Path.cwd() / DOWNLOADS_CSV
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["crate", "version", "downloads"])
+        for crate in args.crates:
+            versions = list_versions(crate)
+            print(f"found {len(versions)} versions of {crate}")
+            for version, downloads in versions:
+                writer.writerow([crate, version, downloads])
+                download_version(crate, version)
+    print(f"wrote download counts to {csv_path.name}")
 
 
 if __name__ == "__main__":

--- a/script/crate-backup.py
+++ b/script/crate-backup.py
@@ -33,14 +33,15 @@ def download_version(crate, version):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Download all versions of a crate.")
-    parser.add_argument("crate", help="Name of the crate")
+    parser = argparse.ArgumentParser(description="Download all versions of one or more crates.")
+    parser.add_argument("crates", nargs="+", metavar="CRATE", help="Name of a crate")
     args = parser.parse_args()
 
-    versions = list_versions(args.crate)
-    print(f"found {len(versions)} versions of {args.crate}")
-    for version in versions:
-        download_version(args.crate, version)
+    for crate in args.crates:
+        versions = list_versions(crate)
+        print(f"found {len(versions)} versions of {crate}")
+        for version in versions:
+            download_version(crate, version)
 
 
 if __name__ == "__main__":

--- a/script/crate-backup.py
+++ b/script/crate-backup.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+USER_AGENT = "crate-backup (https://github.com/rust-lang/crates.io)"
+
+
+def fetch(url):
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    return urllib.request.urlopen(req)
+
+
+def list_versions(crate):
+    url = f"https://crates.io/api/v1/crates/{crate}/versions"
+    with fetch(url) as resp:
+        data = json.load(resp)
+    return [v["num"] for v in data["versions"]]
+
+
+def download_version(crate, version):
+    url = f"https://static.crates.io/crates/{crate}/{crate}-{version}.crate"
+    dest = Path.cwd() / f"{crate}-{version}.crate"
+    if dest.exists():
+        print(f"skip {dest.name} (already exists)")
+        return
+    print(f"download {dest.name}")
+    with fetch(url) as resp, open(dest, "wb") as f:
+        while chunk := resp.read(64 * 1024):
+            f.write(chunk)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download all versions of a crate.")
+    parser.add_argument("crate", help="Name of the crate")
+    args = parser.parse_args()
+
+    versions = list_versions(args.crate)
+    print(f"found {len(versions)} versions of {args.crate}")
+    for version in versions:
+        download_version(args.crate, version)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except urllib.error.HTTPError as e:
+        print(f"HTTP error: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Adds a small Python script that downloads all published `.crate` files for one or more crates into the current working directory.

Useful during security incident response to preserve all versions of a crate for later analysis after the immediate issue has been handled.

## Usage

```
python3 script/crate-backup.py serde tokio
```