### PR TITLE
svelte: Drop `scroll-behavior: smooth` from global CSS

### DIFF
--- a/svelte/src/lib/css/global.css
+++ b/svelte/src/lib/css/global.css
@@ -109,7 +109,6 @@
   html,
   body {
     margin: 0;
-    scroll-behavior: smooth;
   }
 
   body {


### PR DESCRIPTION
On Firefox, especially at narrow viewports, clicking a crate on the `/crates` listing page sometimes left the crate detail page scrolled near the previous page's offset instead of at the top. The global `scroll-behavior: smooth` rule on `html, body` interacts poorly with SvelteKit's programmatic scroll-to-top on navigation, animating the reset in a way Firefox often fails to complete.

Dropping the rule restores reliable scroll reset on route change. Smooth in-page anchor scrolling can be reintroduced per use-site if needed via `scrollIntoView({ behavior: 'smooth' })`.

### Related

- https://github.com/rust-lang/crates.io/issues/12515
- https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/Crates.20and.20svelte/near/587821713