### PR TITLE
Extract archive push into `ArchiveIndexBranch` background job

### DIFF
--- a/crates/crates_io_index/testing.rs
+++ b/crates/crates_io_index/testing.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use git2::build::TreeUpdateBuilder;
-use git2::{ErrorCode, FileMode, Repository, Sort};
+use git2::{ErrorCode, FileMode, Oid, Repository, Sort};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::thread;
@@ -164,6 +164,14 @@ impl UpstreamIndex {
         repo.commit(Some("HEAD"), &sig, &sig, &message, &new_tree, &[&parent])?;
 
         Ok(())
+    }
+
+    /// Resolve the given branch to the commit it points at.
+    pub fn branch_oid(&self, branch: &str) -> anyhow::Result<Oid> {
+        let repo = self.repository.lock().unwrap();
+        let ref_name = format!("refs/heads/{branch}");
+        let reference = repo.find_reference(&ref_name)?;
+        Ok(reference.peel_to_commit()?.id())
     }
 }
 

--- a/crates/crates_io_index/testing.rs
+++ b/crates/crates_io_index/testing.rs
@@ -173,6 +173,35 @@ impl UpstreamIndex {
         let reference = repo.find_reference(&ref_name)?;
         Ok(reference.peel_to_commit()?.id())
     }
+
+    /// Create a branch with a single parentless commit containing the given
+    /// file. Mirrors the shape of post-squash snapshot branches, which share
+    /// no common ancestor with `master`.
+    pub fn create_orphan_branch(
+        &self,
+        branch: &str,
+        path: &str,
+        content: &str,
+    ) -> anyhow::Result<()> {
+        let repo = self.repository.lock().unwrap();
+        let sig = repo.signature()?;
+
+        let blob_oid = repo.blob(content.as_bytes())?;
+        let empty_tree_oid = repo.treebuilder(None)?.write()?;
+        let empty_tree = repo.find_tree(empty_tree_oid)?;
+        let tree_oid = TreeUpdateBuilder::new()
+            .upsert(PathBuf::from(path), blob_oid, FileMode::Blob)
+            .create_updated(&repo, &empty_tree)?;
+        let tree = repo.find_tree(tree_oid)?;
+
+        let message = format!("Orphan commit on `{branch}`");
+        let commit_oid = repo.commit(None, &sig, &sig, &message, &tree, &[])?;
+
+        let ref_name = format!("refs/heads/{branch}");
+        repo.reference(&ref_name, commit_oid, true, "create orphan branch")?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/bin/crates-admin/enqueue_job.rs
+++ b/src/bin/crates-admin/enqueue_job.rs
@@ -15,6 +15,12 @@ use diesel_async::RunQueryDsl;
     rename_all = "snake_case"
 )]
 pub enum Command {
+    /// Archive the given snapshot branch to the configured archive repository
+    /// (`GIT_ARCHIVE_REPO_URL`). No-op if the archive URL is not configured.
+    ArchiveIndexBranch {
+        /// Name of the snapshot branch to archive (e.g. `snapshot-2026-04-21`)
+        branch: String,
+    },
     ArchiveVersionDownloads {
         #[arg(long)]
         /// The date before which to archive version downloads (default: 90 days ago)
@@ -57,6 +63,9 @@ pub async fn run(command: Command) -> Result<()> {
     println!("Enqueueing background job: {command:?}");
 
     match command {
+        Command::ArchiveIndexBranch { branch } => {
+            jobs::ArchiveIndexBranch::new(branch).enqueue(&conn).await?;
+        }
         Command::ArchiveVersionDownloads { before } => {
             before
                 .map(jobs::ArchiveVersionDownloads::before)

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -102,6 +102,11 @@ pub struct Server {
 
     /// Enable Fastly CDN invalidation for sparse index files.
     pub sparse_index_fastly_enabled: bool,
+
+    /// URL of a git repository to mirror the crate index's snapshot branches
+    /// to. When set, the `ArchiveIndexBranch` background job pushes snapshot
+    /// branches to this remote; when unset the job is a no-op.
+    pub index_archive_url: Option<Url>,
 }
 
 impl Server {
@@ -133,6 +138,8 @@ impl Server {
     ///   by an operator (e.g. `/crates/{crate_id}/{version}/download`).
     /// - `DISABLE_TOKEN_CREATION`: If set to any non-empty value, disables API token creation
     ///   and uses the value as the error message returned to users.
+    /// - `GIT_ARCHIVE_REPO_URL`: URL of a git repository to mirror the crate index's snapshot
+    ///   branches to. If unset the `ArchiveIndexBranch` background job is a no-op.
     ///
     /// # Panics
     ///
@@ -255,6 +262,7 @@ impl Server {
             index_include_pubtime,
             sparse_index_fastly_enabled: var_parsed("SPARSE_INDEX_FASTLY_ENABLED")?
                 .unwrap_or(false),
+            index_archive_url: var_parsed("GIT_ARCHIVE_REPO_URL")?,
         })
     }
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -216,14 +216,22 @@ impl TestApp {
     }
 
     pub async fn run_pending_background_jobs(&self) {
+        self.try_run_pending_background_jobs()
+            .await
+            .expect("Could not determine if jobs failed");
+    }
+
+    /// Run all pending background jobs and return an error if any of them
+    /// failed. Intended for tests that deliberately exercise a job's failure
+    /// path.
+    pub async fn try_run_pending_background_jobs(&self) -> anyhow::Result<()> {
         let runner = &self.0.runner;
         let runner = runner.as_ref().expect("Index has not been initialized");
 
         let handle = runner.start();
         handle.wait_for_shutdown().await;
 
-        let result = runner.check_for_failed_jobs().await;
-        result.expect("Could not determine if jobs failed");
+        runner.check_for_failed_jobs().await
     }
 
     /// Obtain a reference to the inner `App` value

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -530,6 +530,7 @@ fn simple_config() -> config::Server {
         banner_message: None,
         index_include_pubtime: false,
         sparse_index_fastly_enabled: true,
+        index_archive_url: None,
     }
 }
 

--- a/src/tests/worker/archive_index_branch.rs
+++ b/src/tests/worker/archive_index_branch.rs
@@ -1,0 +1,97 @@
+use crate::util::TestApp;
+use claims::assert_ok;
+use crates_io::schema::background_jobs;
+use crates_io::worker::jobs;
+use crates_io_index::testing::UpstreamIndex;
+use crates_io_worker::BackgroundJob;
+use diesel_async::RunQueryDsl;
+use insta::assert_snapshot;
+
+const SNAPSHOT_BRANCH: &str = "snapshot-test";
+
+/// Seed a `snapshot-test` branch on the primary upstream. Mirrors the
+/// post-squash shape: a parentless commit holding pre-squash index entries,
+/// sharing no common ancestor with `master`.
+fn seed_snapshot_branch(upstream: &UpstreamIndex) {
+    upstream
+        .create_orphan_branch(SNAPSHOT_BRANCH, "1/a", "a\n")
+        .unwrap();
+}
+
+/// `ArchiveIndexBranch` should mirror the snapshot branch to the configured
+/// archive repository.
+#[tokio::test(flavor = "multi_thread")]
+async fn archive_index_branch() {
+    let archive = UpstreamIndex::new().unwrap();
+    let archive_url = archive.url();
+
+    let (app, _) = TestApp::full()
+        .with_config(|c| c.index_archive_url = Some(archive_url))
+        .empty()
+        .await;
+
+    let conn = app.db_conn().await;
+    seed_snapshot_branch(app.upstream_index());
+    let expected_oid = app.upstream_index().branch_oid(SNAPSHOT_BRANCH).unwrap();
+
+    let job = jobs::ArchiveIndexBranch::new(SNAPSHOT_BRANCH);
+    assert_ok!(job.enqueue(&conn).await);
+    app.run_pending_background_jobs().await;
+
+    assert_eq!(archive.branch_oid(SNAPSHOT_BRANCH).unwrap(), expected_oid);
+}
+
+/// With no `index_archive_url` configured, the job should succeed as a no-op
+/// without touching any repositories.
+#[tokio::test(flavor = "multi_thread")]
+async fn archive_index_branch_without_url_configured() {
+    let (app, _) = TestApp::full().empty().await;
+    let conn = app.db_conn().await;
+
+    // Seed a branch on origin so the test isn't trivially vacuous: the job
+    // should return before ever attempting a fetch, regardless.
+    seed_snapshot_branch(app.upstream_index());
+
+    let job = jobs::ArchiveIndexBranch::new(SNAPSHOT_BRANCH);
+    assert_ok!(job.enqueue(&conn).await);
+    app.run_pending_background_jobs().await;
+}
+
+/// If the requested branch does not exist on origin, the job should fail so
+/// that an operator typo or a stale enqueue produces loud feedback rather
+/// than a silent success.
+#[tokio::test(flavor = "multi_thread")]
+async fn archive_index_branch_missing_branch() {
+    let archive = UpstreamIndex::new().unwrap();
+    let archive_url = archive.url();
+
+    let (app, _) = TestApp::full()
+        .with_config(|c| c.index_archive_url = Some(archive_url))
+        .empty()
+        .await;
+
+    let mut conn = app.db_conn().await;
+
+    let job = jobs::ArchiveIndexBranch::new("does-not-exist");
+    assert_ok!(job.enqueue(&conn).await);
+    assert_snapshot!(app.try_run_pending_background_jobs().await.unwrap_err(), @"1 jobs failed");
+
+    // The archive repo must not have gained a matching branch; we expect a
+    // `NotFound` error back with a stable message.
+    {
+        let archive_repo = archive.repository.lock().unwrap();
+        let err = archive_repo
+            .find_reference("refs/heads/does-not-exist")
+            .err()
+            .unwrap();
+
+        assert_snapshot!(err, @"reference 'refs/heads/does-not-exist' not found; class=Reference (4); code=NotFound (-3)");
+    }
+
+    // Drain the failed job so the `TestAppInner::drop` post-condition that
+    // asserts an empty queue is satisfied.
+    diesel::delete(background_jobs::table)
+        .execute(&mut conn)
+        .await
+        .unwrap();
+}

--- a/src/tests/worker/mod.rs
+++ b/src/tests/worker/mod.rs
@@ -1,3 +1,4 @@
+mod archive_index_branch;
 mod generate_og_image;
 mod git;
 mod normalize_index;

--- a/src/worker/jobs/index/archive.rs
+++ b/src/worker/jobs/index/archive.rs
@@ -1,0 +1,57 @@
+use crate::tasks::spawn_blocking;
+use crate::worker::Environment;
+use crates_io_worker::BackgroundJob;
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+use std::sync::Arc;
+use tracing::{info, instrument};
+
+#[derive(Serialize, Deserialize)]
+pub struct ArchiveIndexBranch {
+    branch: String,
+}
+
+impl ArchiveIndexBranch {
+    pub fn new(branch: impl Into<String>) -> Self {
+        Self {
+            branch: branch.into(),
+        }
+    }
+}
+
+impl BackgroundJob for ArchiveIndexBranch {
+    const JOB_NAME: &'static str = "archive_index_branch";
+    const DEDUPLICATED: bool = true;
+    const QUEUE: &'static str = "repository";
+
+    type Context = Arc<Environment>;
+
+    /// Mirror a snapshot branch from the crate index to the configured archive
+    /// repository. No-op when no archive URL is configured.
+    #[instrument(skip_all, fields(branch = self.branch))]
+    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+        let Some(archive_url) = env.config.index_archive_url.clone() else {
+            info!("`index_archive_url` not configured, skipping archive push");
+            return Ok(());
+        };
+
+        info!(%archive_url, "Pushing snapshot to archive repository");
+
+        let branch = self.branch.clone();
+        spawn_blocking(move || {
+            let repo = env.lock_index()?;
+
+            repo.run_command(Command::new("git").args(["fetch", "origin", &branch]))?;
+
+            repo.run_command(Command::new("git").args([
+                "push",
+                archive_url.as_str(),
+                &format!("FETCH_HEAD:refs/heads/{branch}"),
+            ]))?;
+
+            info!("Snapshot pushed to archive repository.");
+            Ok(())
+        })
+        .await?
+    }
+}

--- a/src/worker/jobs/index/mod.rs
+++ b/src/worker/jobs/index/mod.rs
@@ -1,10 +1,12 @@
 //! This module contains all background jobs related to the git and
 //! sparse indexes.
 
+mod archive;
 mod normalize;
 mod squash;
 mod sync;
 
+pub use archive::ArchiveIndexBranch;
 pub use normalize::NormalizeIndex;
 pub use squash::SquashIndex;
 pub use sync::{BulkSyncToGitIndex, SyncToGitIndex, SyncToSparseIndex};

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -1,12 +1,13 @@
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
+use crate::worker::jobs::ArchiveIndexBranch;
 use chrono::Utc;
 use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 use std::sync::Arc;
 use std::time::Instant;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 #[derive(Serialize, Deserialize)]
 pub struct SquashIndex;
@@ -23,8 +24,9 @@ impl BackgroundJob for SquashIndex {
     async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         info!("Squashing the index into a single commit");
 
-        spawn_blocking(move || {
-            let repo = env.lock_index()?;
+        let env_for_blocking = env.clone();
+        let snapshot_branch = spawn_blocking(move || {
+            let repo = env_for_blocking.lock_index()?;
 
             let now = Utc::now().format("%F");
             let snapshot_branch = format!("snapshot-{now}");
@@ -67,24 +69,21 @@ impl BackgroundJob for SquashIndex {
                 "Squashed index pushed to origin",
             );
 
-            if let Some(archive_url) = env.config.index_archive_url.as_ref() {
-                info!(%archive_url, "Pushing snapshot to archive repository");
-                let archive_start = Instant::now();
-                repo.run_command(Command::new("git").args([
-                    "push",
-                    archive_url.as_str(),
-                    &format!("{original_head}:{snapshot_branch}"),
-                ]))?;
-                info!(
-                    duration = archive_start.elapsed().as_nanos(),
-                    "Snapshot pushed to archive repository",
-                );
-            }
-
             info!("The index has been successfully squashed.");
-
-            Ok(())
+            Ok::<_, anyhow::Error>(snapshot_branch)
         })
-        .await?
+        .await??;
+
+        if let Err(error) = enqueue_archive_job(&env, &snapshot_branch).await {
+            warn!("Failed to enqueue `ArchiveIndexBranch` job for `{snapshot_branch}`: {error}");
+        }
+
+        Ok(())
     }
+}
+
+async fn enqueue_archive_job(env: &Environment, branch: &str) -> anyhow::Result<()> {
+    let conn = env.deadpool.get().await?;
+    ArchiveIndexBranch::new(branch).enqueue(&conn).await?;
+    Ok(())
 }

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -1,14 +1,12 @@
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
 use chrono::Utc;
-use crates_io_env_vars::var_parsed;
 use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::{info, instrument};
-use url::Url;
 
 #[derive(Serialize, Deserialize)]
 pub struct SquashIndex;
@@ -69,7 +67,7 @@ impl BackgroundJob for SquashIndex {
                 "Squashed index pushed to origin",
             );
 
-            if let Some(archive_url) = var_parsed::<Url>("GIT_ARCHIVE_REPO_URL")? {
+            if let Some(archive_url) = env.config.index_archive_url.as_ref() {
                 info!(%archive_url, "Pushing snapshot to archive repository");
                 let archive_start = Instant::now();
                 repo.run_command(Command::new("git").args([

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -29,11 +29,13 @@ impl BackgroundJob for SquashIndex {
             let repo = env.lock_index()?;
 
             let now = Utc::now().format("%F");
+            let snapshot_branch = format!("snapshot-{now}");
+
             let original_head = repo.head_oid()?;
             info!("Read original HEAD: {original_head}");
 
             let msg = format!("Collapse index into one commit\n\n\
-            Previous HEAD was {original_head}, now on the `snapshot-{now}` branch\n\n\
+            Previous HEAD was {original_head}, now on the `{snapshot_branch}` branch\n\n\
             More information about this change can be found [online] and on [this issue].\n\n\
             [online]: https://internals.rust-lang.org/t/cargos-crate-index-upcoming-squash-into-one-commit/8440\n\
             [this issue]: https://github.com/rust-lang/crates-io-cargo-teams/issues/47");
@@ -60,7 +62,7 @@ impl BackgroundJob for SquashIndex {
                 // The new squashed commit is pushed to master
                 "HEAD:refs/heads/master",
                 // The previous value of HEAD is pushed to a snapshot branch
-                &format!("{original_head}:refs/heads/snapshot-{now}"),
+                &format!("{original_head}:refs/heads/{snapshot_branch}"),
             ]))?;
             info!(
                 duration = push_start.elapsed().as_nanos(),
@@ -73,7 +75,7 @@ impl BackgroundJob for SquashIndex {
                 repo.run_command(Command::new("git").args([
                     "push",
                     archive_url.as_str(),
-                    &format!("{original_head}:snapshot-{now}"),
+                    &format!("{original_head}:{snapshot_branch}"),
                 ]))?;
                 info!(
                     duration = archive_start.elapsed().as_nanos(),

--- a/src/worker/jobs/mod.rs
+++ b/src/worker/jobs/mod.rs
@@ -31,7 +31,8 @@ pub use self::dump_db::DumpDb;
 pub use self::expiry_notification::SendTokenExpiryNotifications;
 pub use self::generate_og_image::GenerateOgImage;
 pub use self::index::{
-    BulkSyncToGitIndex, NormalizeIndex, SquashIndex, SyncToGitIndex, SyncToSparseIndex,
+    ArchiveIndexBranch, BulkSyncToGitIndex, NormalizeIndex, SquashIndex, SyncToGitIndex,
+    SyncToSparseIndex,
 };
 pub use self::index_version_downloads_archive::IndexVersionDownloadsArchive;
 pub use self::invalidate_cdns::InvalidateCdns;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -20,6 +20,7 @@ pub trait RunnerExt {
 impl RunnerExt for Runner<Arc<Environment>> {
     fn register_crates_io_job_types(self) -> Self {
         self.register_job_type::<jobs::AnalyzeCrateFile>()
+            .register_job_type::<jobs::ArchiveIndexBranch>()
             .register_job_type::<jobs::ArchiveVersionDownloads>()
             .register_job_type::<jobs::BulkSyncToGitIndex>()
             .register_job_type::<jobs::CheckTyposquat>()


### PR DESCRIPTION
Extract the archive push from `SquashIndex` into a new `ArchiveIndexBranch` background job. The job reads `GIT_ARCHIVE_REPO_URL` from `config::Server` (loaded once at startup) and is a no-op if no URL is configured. `SquashIndex` enqueues it after a successful squash-and-push, warning but not failing if the enqueue itself fails. The job is also manually enqueuable via `crates-admin enqueue-job archive_index_branch <branch>`.

This change ensures that a failing archival will not unintentionally retrigger another index squash. It also allows us in the future to move the `ArchiveIndexBranch` job to a low-priority job on the default background worker queue, which unlocks the regular index repository earlier, allowing the git index sync jobs to continue earlier too.

### Related

- https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/index.20squashing/near/587817099