### PR TITLE
svelte/CrateRow: Match Ember's `updated_at` tooltip formatting

### DIFF
--- a/svelte/src/lib/components/CrateRow.svelte
+++ b/svelte/src/lib/components/CrateRow.svelte
@@ -22,6 +22,7 @@
 
   let showVersion = $derived(crate.default_version && !crate.yanked);
   let cargoTomlSnippet = $derived(`${crate.name} = "${crate.default_version}"`);
+  let updatedAt = $derived(new Date(crate.updated_at));
 </script>
 
 <div class="crate-row" data-test-crate-row {...restProps}>
@@ -77,9 +78,9 @@
           Updated:
           <Tooltip text="The last time the crate was updated" />
         </span>
-        <time datetime={formatISO(crate.updated_at)} data-test-updated-at>
-          {formatDistanceToNow(crate.updated_at, { addSuffix: true })}
-          <Tooltip text={crate.updated_at} />
+        <time datetime={formatISO(updatedAt)} data-test-updated-at>
+          {formatDistanceToNow(updatedAt, { addSuffix: true })}
+          <Tooltip text={updatedAt.toString()} />
         </time>
       </span>
     </div>


### PR DESCRIPTION
Convert the API's ISO string to a `Date` so the tooltip renders via `Date.prototype.toString()`, matching the Ember app where the model attribute is declared with `@attr('date')`. Reuse the derived `Date` for the `datetime` attribute and `formatDistanceToNow()` call.

### Related

- https://github.com/rust-lang/crates.io/issues/12515
- Resolves https://github.com/rust-lang/crates.io/issues/13502