### PR TITLE
svelte/CrateHeader: Match Ember's flex wrap on keywords

### DIFF
--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -171,17 +171,12 @@
   }
 
   .keywords {
+    display: flex;
+    flex-wrap: wrap;
     list-style: none;
     margin: var(--space-xs) 0 0;
     padding: 0;
-
-    > * {
-      display: inline;
-
-      + * {
-        margin-left: var(--space-s);
-      }
-    }
+    gap: 0 var(--space-xs);
   }
 
   .hash {


### PR DESCRIPTION
Add flex-wrap to keywords class to fix wrap on mobile devices.

### Related
- https://github.com/rust-lang/crates.io/issues/12515
- Resolves: https://github.com/rust-lang/crates.io/issues/13506