### PR TITLE
svelte/CrateHeader: Match Ember's keyword list wrap behavior

### DIFF
--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -93,7 +93,10 @@
       {#each keywords as keyword (keyword.id)}
         <li>
           <a href={resolve('/keywords/[keyword_id]', { keyword_id: keyword.id })} data-test-keyword={keyword.id}>
-            <span class="hash">#</span>{keyword.id}
+            <!-- TODO: Replace with `flex-wrap` after the Svelte migration. The leading whitespace
+                 inside the <a> mirrors the Ember rendering and is what allows the list to wrap. -->
+            <!-- eslint-disable-next-line svelte/no-useless-mustaches -->
+            {' '}<span class="hash">#</span>{keyword.id}
           </a>
         </li>
       {/each}


### PR DESCRIPTION
Svelte's compiler strips inter-element whitespace, removing the soft wrap opportunities that the Ember rendering relies on. As a result the keyword list overflowed on narrow viewports instead of wrapping.

Insert an explicit space inside the `<a>` before the `<span>` to recreate the wrap point. Placing the whitespace inside the `<a>` (rather than between `<li>` siblings) avoids indenting wrapped items by the `<li>`'s `margin-left`.

### Related
- https://github.com/rust-lang/crates.io/issues/12515
- Resolves https://github.com/rust-lang/crates.io/issues/13506
- Closes https://github.com/rust-lang/crates.io/pull/13505