### PR TITLE
jobs/index: Add `SquashIndexViaApi` job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,6 +1663,7 @@ dependencies = [
  "reqwest 0.13.3",
  "secrecy",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
  "async-trait",
  "clap",
  "mockall",
+ "mockito",
  "oauth2",
  "reqwest 0.13.3",
  "secrecy",

--- a/crates/crates_io_github/Cargo.toml
+++ b/crates/crates_io_github/Cargo.toml
@@ -23,6 +23,7 @@ url = "=2.5.8"
 
 [dev-dependencies]
 clap = { version = "=4.6.1", features = ["derive", "env", "unicode", "wrap_help"] }
+mockito = "=1.7.2"
 secrecy = "=0.10.3"
 tokio = { version = "=1.52.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "=0.3.23", features = ["env-filter"] }

--- a/crates/crates_io_github/Cargo.toml
+++ b/crates/crates_io_github/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = { version = "=0.13.3", features = ["json"] }
 serde = { version = "=1.0.228", features = ["derive"] }
 thiserror = "=2.0.18"
 tracing = "=0.1.44"
+url = "=2.5.8"
 
 [dev-dependencies]
 clap = { version = "=4.6.1", features = ["derive", "env", "unicode", "wrap_help"] }

--- a/crates/crates_io_github/Cargo.toml
+++ b/crates/crates_io_github/Cargo.toml
@@ -25,5 +25,6 @@ url = "=2.5.8"
 clap = { version = "=4.6.1", features = ["derive", "env", "unicode", "wrap_help"] }
 mockito = "=1.7.2"
 secrecy = "=0.10.3"
+serde_json = "=1.0.149"
 tokio = { version = "=1.52.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "=0.3.23", features = ["env-filter"] }

--- a/crates/crates_io_github/examples/fetch_ref.rs
+++ b/crates/crates_io_github/examples/fetch_ref.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use clap::Parser;
+use crates_io_github::{GitHubClient, RealGitHubClient, parse_github_slug};
+use reqwest::Client;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+use url::Url;
+
+#[derive(Debug, Parser)]
+#[command(about = "Prints the head commit and tree SHAs for a branch of a GitHub repo.")]
+struct Opts {
+    /// GitHub repository URL, e.g. `https://github.com/rust-lang/crates.io-index`.
+    repo: Url,
+
+    /// Branch to resolve. Defaults to `master` because that is what the
+    /// crates.io index uses; pass `--branch main` (or similar) for other
+    /// repositories.
+    #[arg(long, default_value = "master")]
+    branch: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    init_tracing();
+
+    let opts = Opts::parse();
+    let (owner, repo) = parse_github_slug(&opts.repo)?;
+    let ref_name = format!("refs/heads/{}", opts.branch);
+
+    let client = RealGitHubClient::new(Client::new());
+    let git_ref = client.get_ref(&owner, &repo, &ref_name).await?;
+    let commit = client
+        .get_commit(&owner, &repo, &git_ref.object.sha)
+        .await?;
+
+    println!("ref:      {}", git_ref.ref_name);
+    println!("commit:   {}", commit.sha);
+    println!("tree:     {}", commit.tree.sha);
+    Ok(())
+}
+
+fn init_tracing() {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::DEBUG.into())
+        .from_env_lossy();
+
+    tracing_subscriber::fmt()
+        .compact()
+        .with_env_filter(env_filter)
+        .init();
+}

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -3,6 +3,10 @@
 #[macro_use]
 extern crate tracing;
 
+mod slug;
+
+pub use crate::slug::{ParseSlugError, parse_github_slug};
+
 use oauth2::AccessToken;
 use reqwest::{self, RequestBuilder, header};
 

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -17,6 +17,7 @@ use std::str;
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::Deserialize;
+use url::Url;
 
 type Result<T> = std::result::Result<T, GitHubError>;
 
@@ -51,11 +52,17 @@ pub trait GitHubClient: Send + Sync {
 #[derive(Debug)]
 pub struct RealGitHubClient {
     client: Client,
+    base_url: Url,
 }
 
 impl RealGitHubClient {
     pub fn new(client: Client) -> Self {
-        Self { client }
+        let base_url = Url::parse("https://api.github.com").expect("base URL must parse");
+        Self::with_base_url(client, base_url)
+    }
+
+    fn with_base_url(client: Client, base_url: Url) -> Self {
+        Self { client, base_url }
     }
 
     /// Does all the nonsense for sending a GET to GitHub.
@@ -64,12 +71,15 @@ impl RealGitHubClient {
         T: DeserializeOwned,
         A: Fn(RequestBuilder) -> RequestBuilder,
     {
-        let url = format!("https://api.github.com{url}");
+        let url = self
+            .base_url
+            .join(url.trim_start_matches('/'))
+            .map_err(|e| GitHubError::Other(e.into()))?;
         info!("GitHub request: GET {url}");
 
         let request = self
             .client
-            .get(&url)
+            .get(url)
             .header(header::ACCEPT, "application/vnd.github.v3+json")
             .header(header::USER_AGENT, "crates.io (https://crates.io)");
 

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -261,3 +261,50 @@ pub struct GitHubPublicKey {
 pub struct GitHubPublicKeyList {
     pub public_keys: Vec<GitHubPublicKey>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::{Server, ServerOpts};
+
+    async fn mock_server() -> Server {
+        Server::new_with_opts_async(ServerOpts {
+            assert_on_drop: true,
+            ..Default::default()
+        })
+        .await
+    }
+
+    fn client_with_server(server: &Server) -> RealGitHubClient {
+        let base_url = Url::parse(&server.url()).unwrap();
+        RealGitHubClient::with_base_url(Client::new(), base_url)
+    }
+
+    const USER_BODY: &str = r#"{
+        "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+        "email": null,
+        "id": 1,
+        "login": "johnnydee",
+        "name": "John Doe"
+    }"#;
+
+    #[tokio::test]
+    async fn get_user_hits_configured_base_url() {
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock("GET", "/users/johnnydee")
+            .match_header("authorization", "Bearer test-token")
+            .with_status(200)
+            .with_body(USER_BODY)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let auth = AccessToken::new("test-token".into());
+        let user = client.get_user("johnnydee", &auth).await.unwrap();
+
+        assert_eq!(user.login, "johnnydee");
+        assert_eq!(user.id, 1);
+    }
+}

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -47,6 +47,20 @@ pub trait GitHubClient: Send + Sync {
         auth: &AccessToken,
     ) -> Result<Option<GitHubOrgMembership>>;
     async fn public_keys(&self, username: &str, password: &str) -> Result<Vec<GitHubPublicKey>>;
+
+    /// Fetches a single git ref.
+    ///
+    /// `ref_name` may be given either fully qualified (e.g.
+    /// `"refs/heads/master"`) or without the `refs/` prefix (e.g.
+    /// `"heads/master"`). The call is unauthenticated; the crates.io
+    /// index repositories are public and the 60/hour unauthenticated
+    /// rate limit is plenty for this use case.
+    async fn get_ref(&self, owner: &str, repo: &str, ref_name: &str) -> Result<GitRef>;
+
+    /// Fetches a single commit object by its SHA.
+    ///
+    /// Unauthenticated, same rationale as [`GitHubClient::get_ref`].
+    async fn get_commit(&self, owner: &str, repo: &str, sha: &str) -> Result<GitCommit>;
 }
 
 #[derive(Debug)]
@@ -178,6 +192,17 @@ impl GitHubClient for RealGitHubClient {
             Err(e) => Err(e),
         }
     }
+
+    async fn get_ref(&self, owner: &str, repo: &str, ref_name: &str) -> Result<GitRef> {
+        let ref_path = ref_name.strip_prefix("refs/").unwrap_or(ref_name);
+        let path = format!("/repos/{owner}/{repo}/git/ref/{ref_path}");
+        self._request(&path, std::convert::identity).await
+    }
+
+    async fn get_commit(&self, owner: &str, repo: &str, sha: &str) -> Result<GitCommit> {
+        let path = format!("/repos/{owner}/{repo}/git/commits/{sha}");
+        self._request(&path, std::convert::identity).await
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -262,6 +287,28 @@ pub struct GitHubPublicKeyList {
     pub public_keys: Vec<GitHubPublicKey>,
 }
 
+/// A git ref on GitHub.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GitRef {
+    /// The fully qualified ref name (e.g. `"refs/heads/master"`).
+    #[serde(rename = "ref")]
+    pub ref_name: String,
+    pub object: GitObject,
+}
+
+/// A git object referenced from a ref or commit.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GitObject {
+    pub sha: String,
+}
+
+/// A git commit on GitHub.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GitCommit {
+    pub sha: String,
+    pub tree: GitObject,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -288,6 +335,32 @@ mod tests {
         "name": "John Doe"
     }"#;
 
+    const REF_BODY: &str = r#"{
+        "ref": "refs/heads/master",
+        "node_id": "abc",
+        "url": "https://api.github.com/ignored",
+        "object": {
+            "type": "commit",
+            "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "url": "https://api.github.com/ignored"
+        }
+    }"#;
+
+    const COMMIT_BODY: &str = r#"{
+        "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "node_id": "abc",
+        "url": "https://api.github.com/ignored",
+        "html_url": "https://github.com/ignored",
+        "author": {"name": "bors", "email": "bors@rust-lang.org", "date": "2026-04-24T00:00:00Z"},
+        "committer": {"name": "bors", "email": "bors@rust-lang.org", "date": "2026-04-24T00:00:00Z"},
+        "tree": {
+            "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "url": "https://api.github.com/ignored"
+        },
+        "message": "ignored",
+        "parents": []
+    }"#;
+
     #[tokio::test]
     async fn get_user_hits_configured_base_url() {
         let mut server = mock_server().await;
@@ -306,5 +379,80 @@ mod tests {
 
         assert_eq!(user.login, "johnnydee");
         assert_eq!(user.id, 1);
+    }
+
+    #[tokio::test]
+    async fn get_ref_strips_refs_prefix_and_returns_sha() {
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock(
+                "GET",
+                "/repos/rust-lang/crates.io-index/git/ref/heads/master",
+            )
+            .match_header("accept", "application/vnd.github.v3+json")
+            .match_header("user-agent", "crates.io (https://crates.io)")
+            .with_status(200)
+            .with_body(REF_BODY)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let got = client
+            .get_ref("rust-lang", "crates.io-index", "refs/heads/master")
+            .await
+            .unwrap();
+
+        assert_eq!(got.ref_name, "refs/heads/master");
+        assert_eq!(got.object.sha, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    }
+
+    #[tokio::test]
+    async fn get_ref_accepts_unqualified_ref_name() {
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock(
+                "GET",
+                "/repos/rust-lang/crates.io-index/git/ref/heads/master",
+            )
+            .with_status(200)
+            .with_body(REF_BODY)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let got = client
+            .get_ref("rust-lang", "crates.io-index", "heads/master")
+            .await
+            .unwrap();
+
+        assert_eq!(got.ref_name, "refs/heads/master");
+    }
+
+    #[tokio::test]
+    async fn get_commit_returns_sha_and_tree_sha() {
+        let mut server = mock_server().await;
+        let sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let _mock = server
+            .mock(
+                "GET",
+                format!("/repos/rust-lang/crates.io-index/git/commits/{sha}").as_str(),
+            )
+            .match_header("accept", "application/vnd.github.v3+json")
+            .with_status(200)
+            .with_body(COMMIT_BODY)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let got = client
+            .get_commit("rust-lang", "crates.io-index", sha)
+            .await
+            .unwrap();
+
+        assert_eq!(got.sha, sha);
+        assert_eq!(got.tree.sha, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
     }
 }

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -16,7 +16,7 @@ use std::str;
 
 use async_trait::async_trait;
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 type Result<T> = std::result::Result<T, GitHubError>;
@@ -61,6 +61,47 @@ pub trait GitHubClient: Send + Sync {
     ///
     /// Unauthenticated, same rationale as [`GitHubClient::get_ref`].
     async fn get_commit(&self, owner: &str, repo: &str, sha: &str) -> Result<GitCommit>;
+
+    /// Creates a new commit object in the given repository.
+    ///
+    /// Passing an empty `parents` slice produces a parentless root
+    /// commit. The returned [`GitCommit`] contains the newly assigned
+    /// SHA.
+    async fn create_commit<'a>(
+        &self,
+        owner: &str,
+        repo: &str,
+        input: &CreateCommit<'a>,
+        auth: &AccessToken,
+    ) -> Result<GitCommit>;
+
+    /// Creates a new git ref.
+    ///
+    /// `ref_name` must be the fully qualified form (e.g.
+    /// `"refs/heads/my-branch"`).
+    async fn create_ref(
+        &self,
+        owner: &str,
+        repo: &str,
+        ref_name: &str,
+        sha: &str,
+        auth: &AccessToken,
+    ) -> Result<GitRef>;
+
+    /// Updates an existing git ref to point at `sha`.
+    ///
+    /// `ref_name` may be given either fully qualified or without the
+    /// `refs/` prefix, matching [`GitHubClient::get_ref`]. Set `force`
+    /// to allow non-fast-forward updates.
+    async fn update_ref(
+        &self,
+        owner: &str,
+        repo: &str,
+        ref_name: &str,
+        sha: &str,
+        force: bool,
+        auth: &AccessToken,
+    ) -> Result<GitRef>;
 }
 
 #[derive(Debug)]
@@ -96,6 +137,42 @@ impl RealGitHubClient {
             .get(url)
             .header(header::ACCEPT, "application/vnd.github.v3+json")
             .header(header::USER_AGENT, "crates.io (https://crates.io)");
+
+        let response = apply_auth(request).send().await?.error_for_status()?;
+
+        let headers = response.headers();
+        let remaining = headers.get("x-ratelimit-remaining");
+        let limit = headers.get("x-ratelimit-limit");
+        debug!("GitHub rate limit remaining: {remaining:?}/{limit:?}");
+
+        response.json().await.map_err(Into::into)
+    }
+
+    /// Sends a request with a JSON body to GitHub.
+    async fn _mutate<B, T, A>(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        body: &B,
+        apply_auth: A,
+    ) -> Result<T>
+    where
+        B: Serialize + ?Sized,
+        T: DeserializeOwned,
+        A: Fn(RequestBuilder) -> RequestBuilder,
+    {
+        let url = self
+            .base_url
+            .join(url.trim_start_matches('/'))
+            .map_err(|e| GitHubError::Other(e.into()))?;
+        info!("GitHub request: {method} {url}");
+
+        let request = self
+            .client
+            .request(method, url)
+            .header(header::ACCEPT, "application/vnd.github.v3+json")
+            .header(header::USER_AGENT, "crates.io (https://crates.io)")
+            .json(body);
 
         let response = apply_auth(request).send().await?.error_for_status()?;
 
@@ -203,6 +280,67 @@ impl GitHubClient for RealGitHubClient {
         let path = format!("/repos/{owner}/{repo}/git/commits/{sha}");
         self._request(&path, std::convert::identity).await
     }
+
+    async fn create_commit<'a>(
+        &self,
+        owner: &str,
+        repo: &str,
+        input: &CreateCommit<'a>,
+        auth: &AccessToken,
+    ) -> Result<GitCommit> {
+        let path = format!("/repos/{owner}/{repo}/git/commits");
+        self._mutate(reqwest::Method::POST, &path, input, |r| {
+            r.bearer_auth(auth.secret())
+        })
+        .await
+    }
+
+    async fn create_ref(
+        &self,
+        owner: &str,
+        repo: &str,
+        ref_name: &str,
+        sha: &str,
+        auth: &AccessToken,
+    ) -> Result<GitRef> {
+        #[derive(Serialize)]
+        struct Body<'a> {
+            #[serde(rename = "ref")]
+            ref_name: &'a str,
+            sha: &'a str,
+        }
+
+        let path = format!("/repos/{owner}/{repo}/git/refs");
+        let body = Body { ref_name, sha };
+        self._mutate(reqwest::Method::POST, &path, &body, |r| {
+            r.bearer_auth(auth.secret())
+        })
+        .await
+    }
+
+    async fn update_ref(
+        &self,
+        owner: &str,
+        repo: &str,
+        ref_name: &str,
+        sha: &str,
+        force: bool,
+        auth: &AccessToken,
+    ) -> Result<GitRef> {
+        #[derive(Serialize)]
+        struct Body<'a> {
+            sha: &'a str,
+            force: bool,
+        }
+
+        let ref_path = ref_name.strip_prefix("refs/").unwrap_or(ref_name);
+        let path = format!("/repos/{owner}/{repo}/git/refs/{ref_path}");
+        let body = Body { sha, force };
+        self._mutate(reqwest::Method::PATCH, &path, &body, |r| {
+            r.bearer_auth(auth.secret())
+        })
+        .await
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -309,10 +447,21 @@ pub struct GitCommit {
     pub tree: GitObject,
 }
 
+/// Input payload for [`GitHubClient::create_commit`].
+///
+/// An empty `parents` slice produces a parentless root commit.
+#[derive(Debug, Serialize)]
+pub struct CreateCommit<'a> {
+    pub message: &'a str,
+    pub tree: &'a str,
+    pub parents: &'a [&'a str],
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockito::{Server, ServerOpts};
+    use mockito::{Matcher, Server, ServerOpts};
+    use serde_json::json;
 
     async fn mock_server() -> Server {
         Server::new_with_opts_async(ServerOpts {
@@ -454,5 +603,146 @@ mod tests {
 
         assert_eq!(got.sha, sha);
         assert_eq!(got.tree.sha, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+    }
+
+    #[tokio::test]
+    async fn create_commit_posts_body_and_returns_commit() {
+        let parent = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let new_sha = "cccccccccccccccccccccccccccccccccccccccc";
+        let tree = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let response = format!(
+            r#"{{
+                "sha": "{new_sha}",
+                "tree": {{"sha": "{tree}", "url": "https://api.github.com/ignored"}},
+                "message": "collapse",
+                "parents": [
+                    {{"sha": "{parent}", "url": "https://api.github.com/ignored"}}
+                ]
+            }}"#
+        );
+
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock("POST", "/repos/rust-lang/crates.io-index/git/commits")
+            .match_header("authorization", "Bearer test-token")
+            .match_header("accept", "application/vnd.github.v3+json")
+            .match_body(Matcher::Json(json!({
+                "message": "collapse",
+                "tree": tree,
+                "parents": [parent],
+            })))
+            .with_status(201)
+            .with_body(&response)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let auth = AccessToken::new("test-token".into());
+        let parents = [parent];
+        let input = CreateCommit {
+            message: "collapse",
+            tree,
+            parents: &parents,
+        };
+
+        let got = client
+            .create_commit("rust-lang", "crates.io-index", &input, &auth)
+            .await
+            .unwrap();
+
+        assert_eq!(got.sha, new_sha);
+        assert_eq!(got.tree.sha, tree);
+    }
+
+    #[tokio::test]
+    async fn create_ref_sends_fully_qualified_ref() {
+        let ref_name = "refs/heads/snapshot-2026-04-24";
+        let sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let response = format!(
+            r#"{{
+                "ref": "{ref_name}",
+                "object": {{
+                    "type": "commit",
+                    "sha": "{sha}",
+                    "url": "https://api.github.com/ignored"
+                }}
+            }}"#
+        );
+
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock("POST", "/repos/rust-lang/crates.io-index/git/refs")
+            .match_header("authorization", "Bearer test-token")
+            .match_body(Matcher::Json(json!({
+                "ref": ref_name,
+                "sha": sha,
+            })))
+            .with_status(201)
+            .with_body(&response)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let auth = AccessToken::new("test-token".into());
+
+        let got = client
+            .create_ref("rust-lang", "crates.io-index", ref_name, sha, &auth)
+            .await
+            .unwrap();
+
+        assert_eq!(got.ref_name, ref_name);
+        assert_eq!(got.object.sha, sha);
+    }
+
+    #[tokio::test]
+    async fn update_ref_strips_refs_prefix_and_sends_force_flag() {
+        let new_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let response = format!(
+            r#"{{
+                "ref": "refs/heads/master",
+                "object": {{
+                    "type": "commit",
+                    "sha": "{new_sha}",
+                    "url": "https://api.github.com/ignored"
+                }}
+            }}"#
+        );
+
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock(
+                "PATCH",
+                "/repos/rust-lang/crates.io-index/git/refs/heads/master",
+            )
+            .match_header("authorization", "Bearer test-token")
+            .match_body(Matcher::Json(json!({
+                "sha": new_sha,
+                "force": true,
+            })))
+            .with_status(200)
+            .with_body(&response)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let auth = AccessToken::new("test-token".into());
+
+        let got = client
+            .update_ref(
+                "rust-lang",
+                "crates.io-index",
+                "refs/heads/master",
+                new_sha,
+                true,
+                &auth,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(got.ref_name, "refs/heads/master");
+        assert_eq!(got.object.sha, new_sha);
     }
 }

--- a/crates/crates_io_github/src/slug.rs
+++ b/crates/crates_io_github/src/slug.rs
@@ -1,0 +1,119 @@
+use url::Url;
+
+/// Parses `(owner, repo)` from a GitHub repository URL.
+///
+/// Accepts `ssh://git@github.com/OWNER/REPO.git` and
+/// `https://github.com/OWNER/REPO` (with or without a trailing `.git`).
+/// Rejects URLs that do not point at `github.com` or that do not contain
+/// both an owner and a repository name.
+pub fn parse_github_slug(url: &Url) -> Result<(String, String), ParseSlugError> {
+    match url.host_str() {
+        Some("github.com") => {}
+        Some(host) => return Err(ParseSlugError::UnsupportedHost(host.to_string())),
+        None => return Err(ParseSlugError::MissingHost),
+    }
+
+    let mut segments = url
+        .path_segments()
+        .ok_or(ParseSlugError::MissingPath)?
+        .filter(|segment| !segment.is_empty());
+
+    let owner = segments.next().ok_or(ParseSlugError::MissingOwner)?;
+    let repo = segments.next().ok_or(ParseSlugError::MissingRepo)?;
+
+    let repo = repo.strip_suffix(".git").unwrap_or(repo);
+    if repo.is_empty() {
+        return Err(ParseSlugError::MissingRepo);
+    }
+
+    Ok((owner.to_string(), repo.to_string()))
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ParseSlugError {
+    #[error("URL is missing a host")]
+    MissingHost,
+    #[error("unsupported host `{0}`, only `github.com` URLs are accepted")]
+    UnsupportedHost(String),
+    #[error("URL has no path")]
+    MissingPath,
+    #[error("URL is missing the repository owner")]
+    MissingOwner,
+    #[error("URL is missing the repository name")]
+    MissingRepo,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(input: &str) -> Result<(String, String), ParseSlugError> {
+        let url = Url::parse(input).expect("valid URL in test input");
+        parse_github_slug(&url)
+    }
+
+    #[test]
+    fn parses_ssh_url_with_dot_git() {
+        let (owner, repo) = parse("ssh://git@github.com/rust-lang/crates.io-index.git").unwrap();
+        assert_eq!(owner, "rust-lang");
+        assert_eq!(repo, "crates.io-index");
+    }
+
+    #[test]
+    fn parses_https_url_without_dot_git() {
+        let (owner, repo) = parse("https://github.com/rust-lang/crates.io-index").unwrap();
+        assert_eq!(owner, "rust-lang");
+        assert_eq!(repo, "crates.io-index");
+    }
+
+    #[test]
+    fn parses_https_url_with_dot_git() {
+        let (owner, repo) = parse("https://github.com/rust-lang/crates.io-index.git").unwrap();
+        assert_eq!(owner, "rust-lang");
+        assert_eq!(repo, "crates.io-index");
+    }
+
+    #[test]
+    fn ignores_trailing_slash() {
+        let (owner, repo) = parse("https://github.com/rust-lang/crates.io-index/").unwrap();
+        assert_eq!(owner, "rust-lang");
+        assert_eq!(repo, "crates.io-index");
+    }
+
+    #[test]
+    fn parses_https_url_with_extra_path_segments() {
+        let (owner, repo) = parse("https://github.com/rust-lang/crates.io/pull/123").unwrap();
+        assert_eq!(owner, "rust-lang");
+        assert_eq!(repo, "crates.io");
+    }
+
+    #[test]
+    fn rejects_non_github_host() {
+        let err = parse("https://gitlab.com/rust-lang/crates.io-index").unwrap_err();
+        assert_eq!(err, ParseSlugError::UnsupportedHost("gitlab.com".into()));
+    }
+
+    #[test]
+    fn rejects_missing_host() {
+        let err = parse("ssh:///rust-lang/crates.io-index.git").unwrap_err();
+        assert_eq!(err, ParseSlugError::MissingHost);
+    }
+
+    #[test]
+    fn rejects_missing_repo() {
+        let err = parse("https://github.com/rust-lang").unwrap_err();
+        assert_eq!(err, ParseSlugError::MissingRepo);
+    }
+
+    #[test]
+    fn rejects_missing_owner_and_repo() {
+        let err = parse("https://github.com/").unwrap_err();
+        assert_eq!(err, ParseSlugError::MissingOwner);
+    }
+
+    #[test]
+    fn rejects_bare_dot_git_repo_name() {
+        let err = parse("https://github.com/rust-lang/.git").unwrap_err();
+        assert_eq!(err, ParseSlugError::MissingRepo);
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -40,7 +40,7 @@ pub struct App {
     pub replica_database: Option<DeadpoolPool<AsyncPgConnection>>,
 
     /// GitHub API client
-    pub github: Box<dyn GitHubClient>,
+    pub github: Arc<dyn GitHubClient>,
 
     /// The GitHub OAuth2 configuration
     pub github_oauth:

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -23,12 +23,14 @@ use crates_io::{Emails, config};
 use crates_io_docs_rs::RealDocsRsClient;
 use crates_io_env_vars::{required_var, var};
 use crates_io_fastly::Fastly;
+use crates_io_github::{GitHubClient, RealGitHubClient};
 use crates_io_github_app::{GitHubApp, GitHubAppClient};
 use crates_io_index::RepositoryConfig;
 use crates_io_og_image::OgImageGenerator;
 use crates_io_team_repo::TeamRepoImpl;
 use crates_io_worker::Runner;
 use object_store::prefix::PrefixStore;
+use reqwest::Client;
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
@@ -74,6 +76,9 @@ fn main() -> anyhow::Result<()> {
 
     let repository_config = RepositoryConfig::from_environment()?;
 
+    let user_agent = crates_io_version::user_agent();
+    let http_client = Client::builder().user_agent(user_agent).build()?;
+
     let cloudfront = CloudFront::from_environment();
     let storage = Arc::new(Storage::from_config(&config.storage));
 
@@ -89,6 +94,7 @@ fn main() -> anyhow::Result<()> {
 
     let docs_rs = RealDocsRsClient::from_environment().map(|cl| Box::new(cl) as _);
 
+    let github: Arc<dyn GitHubClient> = Arc::new(RealGitHubClient::new(http_client));
     let github_app = build_github_app(config.index_archive_url.as_ref())?;
 
     let deadpool = create_database_pool(&config.db.primary);
@@ -105,6 +111,7 @@ fn main() -> anyhow::Result<()> {
         .maybe_docs_rs(docs_rs)
         .team_repo(Box::new(team_repo))
         .maybe_github_app(github_app)
+        .github(github)
         .og_image_generator(OgImageGenerator::from_environment()?)
         .build();
 

--- a/src/bin/crates-admin/enqueue_job.rs
+++ b/src/bin/crates-admin/enqueue_job.rs
@@ -47,6 +47,7 @@ pub enum Command {
     ProcessCdnLogQueue(jobs::ProcessCdnLogQueue),
     SendTokenExpiryNotifications,
     SquashIndex,
+    SquashIndexViaApi,
     SyncAdmins {
         /// Force a sync even if one is already in progress
         #[arg(long)]
@@ -117,6 +118,9 @@ pub async fn run(command: Command) -> Result<()> {
         }
         Command::SquashIndex => {
             jobs::SquashIndex.enqueue(&conn).await?;
+        }
+        Command::SquashIndexViaApi => {
+            jobs::SquashIndexViaApi.enqueue(&conn).await?;
         }
         Command::SyncAdmins { force } => {
             if !force {

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -34,7 +34,7 @@ fn main() -> anyhow::Result<()> {
     let client = Client::builder().user_agent(user_agent).build()?;
 
     let github = RealGitHubClient::new(client);
-    let github = Box::new(github);
+    let github = Arc::new(github);
 
     let app = App::builder()
         .databases_from_config(&config.db)

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -33,6 +33,7 @@ use std::sync::LazyLock;
 use std::{rc::Rc, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 use tokio::task::block_in_place;
+use url::Url;
 
 struct TestAppInner {
     app: Arc<App>,
@@ -109,6 +110,7 @@ impl TestApp {
         TestAppBuilder {
             config: simple_config(),
             index: None,
+            index_location: None,
             build_job_runner: false,
             use_chaos_proxy: false,
             team_repo: MockTeamRepo::new(),
@@ -269,6 +271,7 @@ impl TestApp {
 pub struct TestAppBuilder {
     config: config::Server,
     index: Option<UpstreamIndex>,
+    index_location: Option<Url>,
     build_job_runner: bool,
     use_chaos_proxy: bool,
     team_repo: MockTeamRepo,
@@ -323,13 +326,14 @@ impl TestAppBuilder {
         let (app, router) = build_app(self.config, Arc::clone(&github), self.oidc_key_stores);
 
         let runner = if self.build_job_runner {
-            let index = self
-                .index
-                .as_ref()
-                .expect("Index must be initialized to build a job runner");
+            let index_location = self
+                .index_location
+                .clone()
+                .or_else(|| self.index.as_ref().map(|i| i.url()))
+                .expect("Index or `index_location` must be configured to build a job runner");
 
             let repository_config = RepositoryConfig {
-                index_location: index.url(),
+                index_location,
                 credentials: Credentials::Missing,
             };
 
@@ -414,6 +418,15 @@ impl TestAppBuilder {
 
     pub fn with_git_index(mut self) -> Self {
         self.index = Some(UpstreamIndex::new().unwrap());
+        self
+    }
+
+    /// Override the `index_location` URL used for the worker
+    /// [`RepositoryConfig`]. Used by tests that exercise jobs which
+    /// parse the URL (e.g. [`crates_io::worker::jobs::SquashIndexViaApi`])
+    /// but do not touch the local bare repo.
+    pub fn with_index_location(mut self, url: Url) -> Self {
+        self.index_location = Some(url);
         self
     }
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -14,7 +14,7 @@ use crates_io::util::gh_token_encryption::GitHubTokenEncryption;
 use crates_io::worker::{Environment, RunnerExt};
 use crates_io::{App, Emails, Env};
 use crates_io_docs_rs::MockDocsRsClient;
-use crates_io_github::MockGitHubClient;
+use crates_io_github::{GitHubClient, MockGitHubClient};
 use crates_io_github_app::MockGitHubApp;
 use crates_io_index::testing::UpstreamIndex;
 use crates_io_index::{Credentials, RepositoryConfig};
@@ -315,7 +315,12 @@ impl TestAppBuilder {
             (primary_proxy, replica_proxy)
         };
 
-        let (app, router) = build_app(self.config, self.github, self.oidc_key_stores);
+        let github: Arc<dyn GitHubClient> = match self.github {
+            Some(github) => Arc::new(github),
+            None => Arc::new(MOCK_GITHUB_DATA.as_mock_client()),
+        };
+
+        let (app, router) = build_app(self.config, Arc::clone(&github), self.oidc_key_stores);
 
         let runner = if self.build_job_runner {
             let index = self
@@ -337,6 +342,7 @@ impl TestAppBuilder {
                 .maybe_docs_rs(self.docs_rs.map(|cl| Box::new(cl) as _))
                 .team_repo(Box::new(self.team_repo))
                 .maybe_github_app(self.github_app.map(|a| Arc::new(a) as _))
+                .github(github)
                 .maybe_og_image_generator(self.og_image_generator)
                 .build();
 
@@ -558,15 +564,12 @@ fn simple_config() -> config::Server {
 
 fn build_app(
     config: config::Server,
-    github: Option<MockGitHubClient>,
+    github: Arc<dyn GitHubClient>,
     oidc_key_stores: HashMap<String, Box<dyn OidcKeyStore>>,
 ) -> (Arc<App>, axum::Router) {
     // Use the in-memory email backend for all tests, allowing tests to analyze the emails sent by
     // the application. This will also prevent cluttering the filesystem.
     let emails = Emails::new_in_memory();
-
-    let github = github.unwrap_or_else(|| MOCK_GITHUB_DATA.as_mock_client());
-    let github = Box::new(github);
 
     let app = App::builder()
         .databases_from_config(&config.db)

--- a/src/tests/worker/squash_index.rs
+++ b/src/tests/worker/squash_index.rs
@@ -1,8 +1,32 @@
 use crate::util::TestApp;
 use chrono::Utc;
 use claims::assert_ok;
+use crates_io::schema::background_jobs;
 use crates_io::worker::jobs;
+use crates_io_github::{GitCommit, GitObject, GitRef, MockGitHubClient};
 use crates_io_worker::BackgroundJob;
+use diesel_async::RunQueryDsl;
+use url::Url;
+
+const OWNER: &str = "rust-lang";
+const REPO: &str = "crates.io-index";
+const MASTER_REF: &str = "refs/heads/master";
+const ORIGINAL_SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const TREE_SHA: &str = "ffffffffffffffffffffffffffffffffffffffff";
+const NEW_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn index_url() -> Url {
+    format!("https://github.com/{OWNER}/{REPO}.git")
+        .parse()
+        .unwrap()
+}
+
+fn master_ref(sha: &str) -> GitRef {
+    GitRef {
+        ref_name: MASTER_REF.into(),
+        object: GitObject { sha: sha.into() },
+    }
+}
 
 /// `SquashIndex` should collapse the upstream index into a single parentless
 /// commit on `master`, while preserving tree content and archiving the previous
@@ -51,4 +75,157 @@ async fn squash_index() {
     let snapshot_ref = format!("refs/heads/snapshot-{now}");
     let snapshot = repo.find_reference(&snapshot_ref).unwrap();
     assert_eq!(snapshot.peel_to_commit().unwrap().id(), original_head);
+}
+
+/// Queue a one-shot `get_ref(refs/heads/master)` that returns `sha`.
+fn expect_get_master(mock: &mut MockGitHubClient, sha: &'static str) {
+    mock.expect_get_ref()
+        .withf(|owner, repo, ref_name| owner == OWNER && repo == REPO && ref_name == MASTER_REF)
+        .times(1)
+        .returning(move |_, _, _| Ok(master_ref(sha)));
+}
+
+/// Queue a `get_commit(commit_sha)` that returns a commit pointing at `tree_sha`.
+fn expect_get_commit(
+    mock: &mut MockGitHubClient,
+    commit_sha: &'static str,
+    tree_sha: &'static str,
+) {
+    mock.expect_get_commit()
+        .withf(move |owner, repo, sha| owner == OWNER && repo == REPO && sha == commit_sha)
+        .times(1)
+        .returning(move |_, _, _| {
+            Ok(GitCommit {
+                sha: commit_sha.into(),
+                tree: GitObject {
+                    sha: tree_sha.into(),
+                },
+            })
+        });
+}
+
+/// Queue a parentless `create_commit(tree=tree_sha)` that returns `new_sha`.
+fn expect_create_commit(
+    mock: &mut MockGitHubClient,
+    tree_sha: &'static str,
+    new_sha: &'static str,
+) {
+    mock.expect_create_commit()
+        .withf(move |owner, repo, input, _| {
+            owner == OWNER
+                && repo == REPO
+                && input.tree == tree_sha
+                && input.parents.is_empty()
+                && input.message.starts_with("Collapse index into one commit")
+        })
+        .times(1)
+        .returning(move |_, _, _, _| {
+            Ok(GitCommit {
+                sha: new_sha.into(),
+                tree: GitObject {
+                    sha: tree_sha.into(),
+                },
+            })
+        });
+}
+
+/// Queue a `create_ref(refs/heads/snapshot-*, original_sha)`.
+fn expect_create_snapshot_ref(mock: &mut MockGitHubClient, original_sha: &'static str) {
+    mock.expect_create_ref()
+        .withf(move |owner, repo, ref_name, sha, _| {
+            owner == OWNER
+                && repo == REPO
+                && ref_name.starts_with("refs/heads/snapshot-")
+                && sha == original_sha
+        })
+        .times(1)
+        .returning(|_, _, ref_name, sha, _| {
+            Ok(GitRef {
+                ref_name: ref_name.to_string(),
+                object: GitObject {
+                    sha: sha.to_string(),
+                },
+            })
+        });
+}
+
+/// Queue a forced `update_ref(refs/heads/master, new_sha, force=true)`.
+fn expect_update_master(mock: &mut MockGitHubClient, new_sha: &'static str) {
+    mock.expect_update_ref()
+        .withf(move |owner, repo, ref_name, sha, force, _| {
+            owner == OWNER && repo == REPO && ref_name == MASTER_REF && sha == new_sha && *force
+        })
+        .times(1)
+        .returning(|_, _, ref_name, sha, _, _| {
+            Ok(GitRef {
+                ref_name: ref_name.to_string(),
+                object: GitObject {
+                    sha: sha.to_string(),
+                },
+            })
+        });
+}
+
+/// `SquashIndexViaApi` should drive the squash entirely via the GitHub REST
+/// API: read master, read its tree, create a parentless commit on the same
+/// tree, create the snapshot ref, re-read master to guard against drift, and
+/// fast-forward master to the new commit.
+#[tokio::test(flavor = "multi_thread")]
+async fn squash_index_via_api() {
+    let mut github = MockGitHubClient::new();
+    expect_get_master(&mut github, ORIGINAL_SHA);
+    expect_get_commit(&mut github, ORIGINAL_SHA, TREE_SHA);
+    expect_create_commit(&mut github, TREE_SHA, NEW_SHA);
+    expect_create_snapshot_ref(&mut github, ORIGINAL_SHA);
+    expect_get_master(&mut github, ORIGINAL_SHA); // drift check — still the same
+    expect_update_master(&mut github, NEW_SHA);
+
+    let (app, _) = TestApp::init()
+        .with_github(github)
+        .with_index_location(index_url())
+        .with_job_runner()
+        .empty()
+        .await;
+
+    let conn = app.db_conn().await;
+    assert_ok!(jobs::SquashIndexViaApi.enqueue(&conn).await);
+    app.run_pending_background_jobs().await;
+}
+
+/// If `master` has moved between the initial read and the drift check, the
+/// job should bail without calling `update_ref`, leaving `master` unchanged
+/// on the remote. The snapshot ref created earlier remains as a harmless
+/// pointer to the pre-squash HEAD.
+#[tokio::test(flavor = "multi_thread")]
+async fn squash_index_via_api_bails_on_master_drift() {
+    const DRIFTED_SHA: &str = "cccccccccccccccccccccccccccccccccccccccc";
+
+    let mut github = MockGitHubClient::new();
+    expect_get_master(&mut github, ORIGINAL_SHA);
+    expect_get_commit(&mut github, ORIGINAL_SHA, TREE_SHA);
+    expect_create_commit(&mut github, TREE_SHA, NEW_SHA);
+    expect_create_snapshot_ref(&mut github, ORIGINAL_SHA);
+    expect_get_master(&mut github, DRIFTED_SHA); // drift check — master has moved
+
+    // `update_ref` is intentionally not queued; mockall panics on an
+    // unexpected call, which is the assertion we want.
+
+    let (app, _) = TestApp::init()
+        .with_github(github)
+        .with_index_location(index_url())
+        .with_job_runner()
+        .empty()
+        .await;
+
+    let mut conn = app.db_conn().await;
+    assert_ok!(jobs::SquashIndexViaApi.enqueue(&conn).await);
+    let err = app.try_run_pending_background_jobs().await.unwrap_err();
+    assert_eq!(err.to_string(), "1 jobs failed");
+
+    // Drain the failed job so the `TestAppInner::drop` empty-queue
+    // post-condition is satisfied.
+    diesel::delete(background_jobs::table)
+        .execute(&mut conn)
+        .await
+        .unwrap();
 }

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -28,7 +28,7 @@ use tracing::{info, instrument};
 pub struct Environment {
     pub config: Arc<crate::config::Server>,
 
-    repository_config: RepositoryConfig,
+    pub repository_config: RepositoryConfig,
     #[builder(skip)]
     repository: Mutex<Option<Repository>>,
     cloudfront: Option<CloudFront>,

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -8,6 +8,7 @@ use bon::Builder;
 use crates_io_database::models::{CloudFrontDistribution, CloudFrontInvalidationQueueItem};
 use crates_io_docs_rs::DocsRsClient;
 use crates_io_fastly::Fastly;
+use crates_io_github::GitHubClient;
 use crates_io_github_app::GitHubApp;
 use crates_io_index::{Repository, RepositoryConfig};
 use crates_io_og_image::OgImageGenerator;
@@ -38,6 +39,7 @@ pub struct Environment {
     pub emails: Emails,
     pub team_repo: Box<dyn TeamRepo + Send + Sync>,
     pub github_app: Option<Arc<dyn GitHubApp>>,
+    pub github: Arc<dyn GitHubClient>,
     pub docs_rs: Option<Box<dyn DocsRsClient>>,
     pub og_image_generator: Option<OgImageGenerator>,
 

--- a/src/worker/jobs/index/mod.rs
+++ b/src/worker/jobs/index/mod.rs
@@ -8,5 +8,5 @@ mod sync;
 
 pub use archive::ArchiveIndexBranch;
 pub use normalize::NormalizeIndex;
-pub use squash::SquashIndex;
+pub use squash::{SquashIndex, SquashIndexViaApi};
 pub use sync::{BulkSyncToGitIndex, SyncToGitIndex, SyncToSparseIndex};

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -1,14 +1,20 @@
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
 use crate::worker::jobs::ArchiveIndexBranch;
+use anyhow::{Context, anyhow};
 use chrono::Utc;
+use crates_io_github::{CreateCommit, parse_github_slug};
 use crates_io_worker::BackgroundJob;
+use oauth2::AccessToken;
+use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::process::Command;
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::{info, instrument, warn};
+
+const MASTER_REF: &str = "refs/heads/master";
 
 #[derive(Serialize, Deserialize)]
 pub struct SquashIndex;
@@ -82,6 +88,94 @@ async fn enqueue_archive_job(env: &Environment, branch: &str) -> anyhow::Result<
     let conn = env.deadpool.get().await?;
     ArchiveIndexBranch::new(branch).enqueue(&conn).await?;
     Ok(())
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SquashIndexViaApi;
+
+impl BackgroundJob for SquashIndexViaApi {
+    const JOB_NAME: &'static str = "squash_index_via_api";
+    const DEDUPLICATED: bool = true;
+    // Same queue as `SquashIndex`, `SyncToGitIndex`, etc. so index-writing
+    // jobs serialize against each other, even though this job does not
+    // touch the local bare repo.
+    const QUEUE: &'static str = "repository";
+
+    type Context = Arc<Environment>;
+
+    /// Collapse the index into a single commit by driving the GitHub
+    /// REST API directly, without touching the local bare clone. This
+    /// avoids the pack generation that `git push` triggers for the full
+    /// squash, which has been OOMing the worker.
+    #[instrument(skip_all)]
+    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+        info!("Squashing the index into a single commit via the GitHub API");
+
+        let github_app = env
+            .github_app
+            .as_ref()
+            .ok_or_else(|| anyhow!("GitHub App is not configured"))?;
+
+        let (owner, repo) = parse_github_slug(&env.repository_config.index_location)
+            .context("Failed to parse index URL as `owner/repo`")?;
+
+        let github = env.github.as_ref();
+
+        let original_head = github.get_ref(&owner, &repo, MASTER_REF).await?;
+        let original_sha = original_head.object.sha;
+        info!("Read original HEAD: {original_sha}");
+
+        let original_commit = github.get_commit(&owner, &repo, &original_sha).await?;
+        let tree_sha = original_commit.tree.sha;
+
+        let snapshot_branch = snapshot_branch_name();
+        let message = squash_commit_message(&original_sha, &snapshot_branch);
+
+        let token = github_app.installation_token().await?;
+        let auth = AccessToken::new(token.expose_secret().into());
+
+        let squash_start = Instant::now();
+        let input = CreateCommit {
+            message: &message,
+            tree: &tree_sha,
+            parents: &[],
+        };
+        let new_commit = github.create_commit(&owner, &repo, &input, &auth).await?;
+        let new_sha = new_commit.sha;
+        let duration = squash_start.elapsed().as_nanos();
+        info!(duration, "Squash commit created: {new_sha}",);
+
+        // Create the snapshot ref first so that if anything after this
+        // fails, `master` is still unmoved and the snapshot ref is
+        // harmless (it points at the same SHA as `master`).
+        let snapshot_ref = format!("refs/heads/{snapshot_branch}");
+        github
+            .create_ref(&owner, &repo, &snapshot_ref, &original_sha, &auth)
+            .await?;
+
+        // Best-effort drift check. GitHub has no CAS for refs, so the
+        // `repository` queue is the real primary defense; this only
+        // shrinks the race window.
+        let current_head = github.get_ref(&owner, &repo, MASTER_REF).await?;
+        if current_head.object.sha != original_sha {
+            return Err(anyhow!(
+                "`master` drifted during squash (was {original_sha}, now {})",
+                current_head.object.sha
+            ));
+        }
+
+        github
+            .update_ref(&owner, &repo, MASTER_REF, &new_sha, true, &auth)
+            .await?;
+
+        info!("The index has been successfully squashed.");
+
+        if let Err(error) = enqueue_archive_job(&env, &snapshot_branch).await {
+            warn!("Failed to enqueue `ArchiveIndexBranch` job for `{snapshot_branch}`: {error}");
+        }
+
+        Ok(())
+    }
 }
 
 fn snapshot_branch_name() -> String {

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -143,7 +143,7 @@ impl BackgroundJob for SquashIndexViaApi {
         let new_commit = github.create_commit(&owner, &repo, &input, &auth).await?;
         let new_sha = new_commit.sha;
         let duration = squash_start.elapsed().as_nanos();
-        info!(duration, "Squash commit created: {new_sha}",);
+        info!(duration, "Squash commit created: {new_sha}");
 
         // Create the snapshot ref first so that if anything after this
         // fails, `master` is still unmoved and the snapshot ref is
@@ -159,7 +159,8 @@ impl BackgroundJob for SquashIndexViaApi {
         let current_head = github.get_ref(&owner, &repo, MASTER_REF).await?;
         if current_head.object.sha != original_sha {
             return Err(anyhow!(
-                "`master` drifted during squash (was {original_sha}, now {})",
+                "`{}` drifted during squash (was {original_sha}, now {})",
+                MASTER_REF,
                 current_head.object.sha
             ));
         }

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -90,6 +90,25 @@ async fn enqueue_archive_job(env: &Environment, branch: &str) -> anyhow::Result<
     Ok(())
 }
 
+/// Collapses the index into a single commit by driving the GitHub API
+/// directly, without touching the local bare clone. This avoids the
+/// pack generation that `git push` triggers for the full squash, which
+/// has been OOMing the worker.
+///
+/// Git's object model has three layers we care about here: blobs hold
+/// file contents, a tree maps names to blobs (and to nested trees) to
+/// describe a directory snapshot, and a commit points at exactly one
+/// top-level tree plus its parent commits and metadata. Crucially, a
+/// tree is fully addressed by its SHA and is independent of any commit
+/// that happens to reference it.
+///
+/// That independence is what makes this squash cheap: the current
+/// `master` already points at a commit whose tree is exactly the state
+/// we want to preserve, so we can build a brand-new parentless commit
+/// that reuses that same tree SHA. No blobs or trees need to be
+/// recomputed or uploaded; GitHub already has every object we
+/// reference, and we just hand it a tiny new commit object and move
+/// `master` to point at it.
 #[derive(Serialize, Deserialize)]
 pub struct SquashIndexViaApi;
 
@@ -103,10 +122,6 @@ impl BackgroundJob for SquashIndexViaApi {
 
     type Context = Arc<Environment>;
 
-    /// Collapse the index into a single commit by driving the GitHub
-    /// REST API directly, without touching the local bare clone. This
-    /// avoids the pack generation that `git push` triggers for the full
-    /// squash, which has been OOMing the worker.
     #[instrument(skip_all)]
     async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         info!("Squashing the index into a single commit via the GitHub API");

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -4,6 +4,7 @@ use crate::worker::jobs::ArchiveIndexBranch;
 use chrono::Utc;
 use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::process::Command;
 use std::sync::Arc;
 use std::time::Instant;
@@ -28,17 +29,12 @@ impl BackgroundJob for SquashIndex {
         let snapshot_branch = spawn_blocking(move || {
             let repo = env_for_blocking.lock_index()?;
 
-            let now = Utc::now().format("%F");
-            let snapshot_branch = format!("snapshot-{now}");
+            let snapshot_branch = snapshot_branch_name();
 
             let original_head = repo.head_oid()?;
             info!("Read original HEAD: {original_head}");
 
-            let msg = format!("Collapse index into one commit\n\n\
-            Previous HEAD was {original_head}, now on the `{snapshot_branch}` branch\n\n\
-            More information about this change can be found [online] and on [this issue].\n\n\
-            [online]: https://internals.rust-lang.org/t/cargos-crate-index-upcoming-squash-into-one-commit/8440\n\
-            [this issue]: https://github.com/rust-lang/crates-io-cargo-teams/issues/47");
+            let msg = squash_commit_message(original_head, &snapshot_branch);
 
             let squash_start = Instant::now();
             repo.squash_to_single_commit(&msg)?;
@@ -86,4 +82,19 @@ async fn enqueue_archive_job(env: &Environment, branch: &str) -> anyhow::Result<
     let conn = env.deadpool.get().await?;
     ArchiveIndexBranch::new(branch).enqueue(&conn).await?;
     Ok(())
+}
+
+fn snapshot_branch_name() -> String {
+    let now = Utc::now().format("%F");
+    format!("snapshot-{now}")
+}
+
+fn squash_commit_message(original_head: impl fmt::Display, snapshot_branch: &str) -> String {
+    format!(
+        "Collapse index into one commit\n\n\
+        Previous HEAD was {original_head}, now on the `{snapshot_branch}` branch\n\n\
+        More information about this change can be found [online] and on [this issue].\n\n\
+        [online]: https://internals.rust-lang.org/t/cargos-crate-index-upcoming-squash-into-one-commit/8440\n\
+        [this issue]: https://github.com/rust-lang/crates-io-cargo-teams/issues/47"
+    )
 }

--- a/src/worker/jobs/mod.rs
+++ b/src/worker/jobs/mod.rs
@@ -31,8 +31,8 @@ pub use self::dump_db::DumpDb;
 pub use self::expiry_notification::SendTokenExpiryNotifications;
 pub use self::generate_og_image::GenerateOgImage;
 pub use self::index::{
-    ArchiveIndexBranch, BulkSyncToGitIndex, NormalizeIndex, SquashIndex, SyncToGitIndex,
-    SyncToSparseIndex,
+    ArchiveIndexBranch, BulkSyncToGitIndex, NormalizeIndex, SquashIndex, SquashIndexViaApi,
+    SyncToGitIndex, SyncToSparseIndex,
 };
 pub use self::index_version_downloads_archive::IndexVersionDownloadsArchive;
 pub use self::invalidate_cdns::InvalidateCdns;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -38,6 +38,7 @@ impl RunnerExt for Runner<Arc<Environment>> {
             .register_job_type::<jobs::ProcessCloudfrontInvalidationQueue>()
             .register_job_type::<jobs::RenderAndUploadReadme>()
             .register_job_type::<jobs::SquashIndex>()
+            .register_job_type::<jobs::SquashIndexViaApi>()
             .register_job_type::<jobs::SyncAdmins>()
             .register_job_type::<jobs::SyncToGitIndex>()
             .register_job_type::<jobs::SyncToSparseIndex>()


### PR DESCRIPTION
The existing `SquashIndex` job has been OOMing the production worker because `git push` regenerates the full pack on every squash. This adds an alternative job that drives the same squash through GitHub's API (`get_ref` -> `get_commit` -> `create_commit` -> `create_ref` -> drift re-check -> `update_ref`), so the server can reuse objects it already has instead of receiving a fresh pack.

The original `SquashIndex` job stays in place as a fallback. Both share the `repository` queue so index-writing jobs continue to serialize, even though the new job does not write to the local bare repo.

Along the way the `crates_io_github` crate gains:

- `parse_github_slug()` helper
- A configurable base URL on `RealGitHubClient` plus a mockito-based test harness
- `get_ref()` / `get_commit()` trait methods (unauthenticated, sufficient for the public index repos)
- `create_commit()` / `create_ref()` / `update_ref()` write methods authenticated via `AccessToken`

`Environment` now carries an `Arc<dyn GitHubClient>` so jobs can talk to GitHub directly, and `crates-admin enqueue-job` exposes the new job for manual operator use.

### Related

- https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/index.20squashing/near/587817099
- https://github.com/rust-lang/crates.io/pull/13472
- https://github.com/rust-lang/crates.io/pull/13489