### PR TITLE
Support regexes to block traffic by user agent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ paste = "=1.0.15"
 postgres-native-tls = "=0.5.3"
 prometheus = { version = "=0.14.0", default-features = false }
 rand = "=0.10.1"
+regex = "=1.12.3"
 reqwest = { version = "=0.13.3", features = ["gzip", "json", "stream"] }
 rss = { version = "=2.0.12", default-features = false, features = ["atom"] }
 secrecy = "=0.10.3"
@@ -170,7 +171,6 @@ googletest = "=0.14.2"
 insta = { version = "=1.47.2", features = ["glob", "json", "redactions"] }
 jsonwebtoken = { version = "=10.3.0", features = ["aws_lc_rs"] }
 quoted_printable = "=0.5.2"
-regex = "=1.12.3"
 sentry = { version = "=0.48.0", features = ["test"] }
 tokio = "=1.52.1"
 zip = { version = "=8.6.0", default-features = false, features = ["deflate"] }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -280,12 +280,17 @@ fn blocked_traffic() -> Vec<(String, Vec<String>)> {
     parse_traffic_patterns(&pattern_list)
         .map(|(header, value_env_var)| {
             let value_list = dotenvy::var(value_env_var).unwrap_or_default();
-            let values = value_list.split(',').map(String::from).collect();
+            let values = parse_traffic_pattern_values(&value_list);
             (header.into(), values)
         })
         .collect()
 }
 
+/// Extract from the `BLOCKED_TRAFFIC` env var value a comma-separated list of pairs containing a
+/// header name, an equals sign, and the name of another environment variable that contains the
+/// values of that header that should be blocked. For example, if `BLOCKED_TRAFFIC` is set to
+/// `User-Agent=BLOCKED_UAS,custom-header=BLOCKED_CUSTOM`, this function will return the pairs
+/// (`User-Agent`, `BLOCKED_UAS`) and (`custom-header`, `BLOCKED_CUSTOM`).
 fn parse_traffic_patterns(patterns: &str) -> impl Iterator<Item = (&str, &str)> {
     patterns.split_terminator(',').map(|pattern| {
         pattern.split_once('=').unwrap_or_else(|| {
@@ -295,6 +300,13 @@ fn parse_traffic_patterns(patterns: &str) -> impl Iterator<Item = (&str, &str)> 
             )
         })
     })
+}
+
+/// After reading the value of an environment variable whose name was specified in the value of
+/// `BLOCKED_TRAFFIC`, parse a comma-separated list of values to be used as exact matches of the
+/// values of the header name specified in the `BLOCKED_TRAFFIC` pair.
+fn parse_traffic_pattern_values(value_list: &str) -> Vec<String> {
+    value_list.split(',').map(String::from).collect()
 }
 
 #[derive(Clone, Debug, Default)]
@@ -340,5 +352,20 @@ mod tests {
         assert_eq!(vec![("Baz", "QUX")], patterns_2);
 
         assert_none!(parse_traffic_patterns(pattern_string_3).next());
+    }
+
+    #[test]
+    fn parse_traffic_pattern_values_splits_on_comma_even_if_escaping_is_attempted() {
+        let pattern = "web-tool 1.2.3,fancy-crate\\, run by fancy-author v4.5.6";
+
+        let values = parse_traffic_pattern_values(pattern);
+        assert_eq!(
+            vec![
+                String::from("web-tool 1.2.3"),
+                String::from("fancy-crate\\"),
+                String::from(" run by fancy-author v4.5.6"),
+            ],
+            values
+        );
     }
 }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -9,11 +9,10 @@ use super::base::Base;
 use super::database_pools::DatabasePools;
 use crate::config::CdnLogQueueConfig;
 use crate::config::cdn_log_storage::CdnLogStorageConfig;
-use crate::middleware::cargo_compat::StatusCodeConfig;
+use crate::middleware::{block_traffic::BlockCriteria, cargo_compat::StatusCodeConfig};
 use crate::storage::StorageConfig;
 use crates_io_env_vars::{list, list_parsed, required_var, var, var_parsed};
 use http::HeaderValue;
-use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::net::IpAddr;
@@ -49,7 +48,7 @@ pub struct Server {
     pub max_features: usize,
     pub rate_limiter: HashMap<LimitedAction, RateLimiterConfig>,
     pub new_version_rate_limit: Option<u32>,
-    pub blocked_traffic: Vec<(String, Vec<Regex>)>,
+    pub blocked_traffic: Vec<(String, Vec<BlockCriteria>)>,
     pub blocked_ips: HashSet<IpAddr>,
     pub max_allowed_page_offset: u32,
     pub excluded_crate_names: Vec<String>,
@@ -276,7 +275,7 @@ impl Server {
     }
 }
 
-fn blocked_traffic() -> Vec<(String, Vec<Regex>)> {
+fn blocked_traffic() -> Vec<(String, Vec<BlockCriteria>)> {
     let pattern_list = dotenvy::var("BLOCKED_TRAFFIC").unwrap_or_default();
     parse_traffic_patterns(&pattern_list)
         .map(|(header, value_env_var)| {
@@ -304,21 +303,10 @@ fn parse_traffic_patterns(patterns: &str) -> impl Iterator<Item = (&str, &str)> 
 }
 
 /// After reading the value of an environment variable whose name was specified in the value of
-/// `BLOCKED_TRAFFIC`, parse a comma-separated list of values to be used as full regex matches of
-/// the values of the header name specified in the `BLOCKED_TRAFFIC` pair.
-fn parse_traffic_pattern_values(value_list: &str) -> Vec<Regex> {
-    value_list
-        .split(',')
-        .map(|value| {
-            let anchored = format!("^{}$", value);
-            Regex::new(&anchored).unwrap_or_else(|e| {
-                panic!(
-                    "BLOCKED_TRAFFIC values must be a valid regex after `^` and `$` are added, \
-                     got invalid regex {anchored}: {e}"
-                )
-            })
-        })
-        .collect()
+/// `BLOCKED_TRAFFIC`, parse a comma-separated list of values to be used as either regex matches or
+/// full string equality with the values of the header name specified in the `BLOCKED_TRAFFIC` pair.
+fn parse_traffic_pattern_values(value_list: &str) -> Vec<BlockCriteria> {
+    value_list.split(',').map(BlockCriteria::new).collect()
 }
 
 #[derive(Clone, Debug, Default)]
@@ -368,23 +356,17 @@ mod tests {
 
     #[test]
     fn parse_traffic_pattern_values_splits_on_comma_even_if_escaping_is_attempted() {
-        let pattern = "web-tool 1.2.3,fancy-crate\\, run by fancy-author v4.5.6";
+        let pattern = "web-tool 1.2.3,fancy-crate\\, run by fancy-author v4.5.6,/.*foo.*/";
 
         let values = parse_traffic_pattern_values(pattern);
         assert_eq!(
             vec![
-                "^web-tool 1.2.3$",
-                "^fancy-crate\\$",
-                "^ run by fancy-author v4.5.6$",
+                "web-tool 1.2.3",
+                "fancy-crate\\",
+                " run by fancy-author v4.5.6",
+                ".*foo.*",
             ],
             values.iter().map(|r| r.as_str()).collect::<Vec<_>>()
         );
-    }
-
-    #[test]
-    #[should_panic(expected = "BLOCKED_TRAFFIC values must be a valid regex")]
-    fn parse_traffic_pattern_values_panics_on_invalid_regex() {
-        let pattern = ")";
-        parse_traffic_pattern_values(pattern);
     }
 }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -18,6 +18,7 @@ use std::convert::Infallible;
 use std::net::IpAddr;
 use std::str::FromStr;
 use std::time::Duration;
+use tracing::warn;
 
 const DEFAULT_VERSION_ID_CACHE_SIZE: u64 = 10_000;
 const DEFAULT_VERSION_ID_CACHE_TTL: u64 = 5 * 60; // 5 minutes
@@ -280,7 +281,7 @@ fn blocked_traffic() -> Vec<(String, Vec<BlockCriteria>)> {
     parse_traffic_patterns(&pattern_list)
         .map(|(header, value_env_var)| {
             let value_list = dotenvy::var(value_env_var).unwrap_or_default();
-            let values = parse_traffic_pattern_values(&value_list);
+            let values = parse_traffic_pattern_values(header, &value_list);
             (header.into(), values)
         })
         .collect()
@@ -305,10 +306,21 @@ fn parse_traffic_patterns(patterns: &str) -> impl Iterator<Item = (&str, &str)> 
 /// After reading the value of an environment variable whose name was specified in the value of
 /// `BLOCKED_TRAFFIC`, parse a comma-separated list of values to be used as either regex matches or
 /// full string equality with the values of the header name specified in the `BLOCKED_TRAFFIC` pair.
-fn parse_traffic_pattern_values(value_list: &str) -> Vec<BlockCriteria> {
+///
+/// Values that fail to parse are skipped with a warning, so that a single misconfigured entry
+/// does not prevent the remaining values from taking effect.
+fn parse_traffic_pattern_values(header: &str, value_list: &str) -> Vec<BlockCriteria> {
     value_list
         .split(',')
-        .map(|value| value.try_into().unwrap())
+        .filter_map(|value| match value.try_into() {
+            Ok(criteria) => Some(criteria),
+            Err(error) => {
+                warn!(
+                    "Skipping invalid BLOCKED_TRAFFIC value `{value}` for header `{header}`: {error}"
+                );
+                None
+            }
+        })
         .collect()
 }
 
@@ -361,7 +373,7 @@ mod tests {
     fn parse_traffic_pattern_values_splits_on_comma_even_if_escaping_is_attempted() {
         let pattern = "web-tool 1.2.3,fancy-crate\\, run by fancy-author v4.5.6,/.*foo.*/";
 
-        let values = parse_traffic_pattern_values(pattern);
+        let values = parse_traffic_pattern_values("User-Agent", pattern);
         assert_eq!(
             vec![
                 "web-tool 1.2.3",
@@ -369,6 +381,17 @@ mod tests {
                 " run by fancy-author v4.5.6",
                 ".*foo.*",
             ],
+            values.iter().map(|r| r.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn parse_traffic_pattern_values_skips_invalid_regexes() {
+        let pattern = "/valid-regex/,/[invalid-regex/,exact-string";
+
+        let values = parse_traffic_pattern_values("User-Agent", pattern);
+        assert_eq!(
+            vec!["valid-regex", "exact-string"],
             values.iter().map(|r| r.as_str()).collect::<Vec<_>>()
         );
     }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -306,7 +306,10 @@ fn parse_traffic_patterns(patterns: &str) -> impl Iterator<Item = (&str, &str)> 
 /// `BLOCKED_TRAFFIC`, parse a comma-separated list of values to be used as either regex matches or
 /// full string equality with the values of the header name specified in the `BLOCKED_TRAFFIC` pair.
 fn parse_traffic_pattern_values(value_list: &str) -> Vec<BlockCriteria> {
-    value_list.split(',').map(BlockCriteria::new).collect()
+    value_list
+        .split(',')
+        .map(|value| value.try_into().unwrap())
+        .collect()
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -13,6 +13,7 @@ use crate::middleware::cargo_compat::StatusCodeConfig;
 use crate::storage::StorageConfig;
 use crates_io_env_vars::{list, list_parsed, required_var, var, var_parsed};
 use http::HeaderValue;
+use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::net::IpAddr;
@@ -48,7 +49,7 @@ pub struct Server {
     pub max_features: usize,
     pub rate_limiter: HashMap<LimitedAction, RateLimiterConfig>,
     pub new_version_rate_limit: Option<u32>,
-    pub blocked_traffic: Vec<(String, Vec<String>)>,
+    pub blocked_traffic: Vec<(String, Vec<Regex>)>,
     pub blocked_ips: HashSet<IpAddr>,
     pub max_allowed_page_offset: u32,
     pub excluded_crate_names: Vec<String>,
@@ -275,7 +276,7 @@ impl Server {
     }
 }
 
-fn blocked_traffic() -> Vec<(String, Vec<String>)> {
+fn blocked_traffic() -> Vec<(String, Vec<Regex>)> {
     let pattern_list = dotenvy::var("BLOCKED_TRAFFIC").unwrap_or_default();
     parse_traffic_patterns(&pattern_list)
         .map(|(header, value_env_var)| {
@@ -303,10 +304,21 @@ fn parse_traffic_patterns(patterns: &str) -> impl Iterator<Item = (&str, &str)> 
 }
 
 /// After reading the value of an environment variable whose name was specified in the value of
-/// `BLOCKED_TRAFFIC`, parse a comma-separated list of values to be used as exact matches of the
-/// values of the header name specified in the `BLOCKED_TRAFFIC` pair.
-fn parse_traffic_pattern_values(value_list: &str) -> Vec<String> {
-    value_list.split(',').map(String::from).collect()
+/// `BLOCKED_TRAFFIC`, parse a comma-separated list of values to be used as full regex matches of
+/// the values of the header name specified in the `BLOCKED_TRAFFIC` pair.
+fn parse_traffic_pattern_values(value_list: &str) -> Vec<Regex> {
+    value_list
+        .split(',')
+        .map(|value| {
+            let anchored = format!("^{}$", value);
+            Regex::new(&anchored).unwrap_or_else(|e| {
+                panic!(
+                    "BLOCKED_TRAFFIC values must be a valid regex after `^` and `$` are added, \
+                     got invalid regex {anchored}: {e}"
+                )
+            })
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug, Default)]
@@ -361,11 +373,18 @@ mod tests {
         let values = parse_traffic_pattern_values(pattern);
         assert_eq!(
             vec![
-                String::from("web-tool 1.2.3"),
-                String::from("fancy-crate\\"),
-                String::from(" run by fancy-author v4.5.6"),
+                "^web-tool 1.2.3$",
+                "^fancy-crate\\$",
+                "^ run by fancy-author v4.5.6$",
             ],
-            values
+            values.iter().map(|r| r.as_str()).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "BLOCKED_TRAFFIC values must be a valid regex")]
+    fn parse_traffic_pattern_values_panics_on_invalid_regex() {
+        let pattern = ")";
+        parse_traffic_pattern_values(pattern);
     }
 }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -292,13 +292,14 @@ fn blocked_traffic() -> Vec<(String, Vec<BlockCriteria>)> {
 /// values of that header that should be blocked. For example, if `BLOCKED_TRAFFIC` is set to
 /// `User-Agent=BLOCKED_UAS,custom-header=BLOCKED_CUSTOM`, this function will return the pairs
 /// (`User-Agent`, `BLOCKED_UAS`) and (`custom-header`, `BLOCKED_CUSTOM`).
+///
+/// Patterns that do not contain an `=` are skipped with a warning, so that a single
+/// misconfigured entry does not prevent the remaining patterns from taking effect.
 fn parse_traffic_patterns(patterns: &str) -> impl Iterator<Item = (&str, &str)> {
-    patterns.split_terminator(',').map(|pattern| {
-        pattern.split_once('=').unwrap_or_else(|| {
-            panic!(
-                "BLOCKED_TRAFFIC must be in the form HEADER=VALUE_ENV_VAR, \
-                 got invalid pattern {pattern}"
-            )
+    patterns.split_terminator(',').filter_map(|pattern| {
+        pattern.split_once('=').or_else(|| {
+            warn!("Skipping invalid BLOCKED_TRAFFIC pattern `{pattern}`: expected HEADER=VALUE_ENV_VAR");
+            None
         })
     })
 }
@@ -367,6 +368,14 @@ mod tests {
         assert_eq!(vec![("Baz", "QUX")], patterns_2);
 
         assert_none!(parse_traffic_patterns(pattern_string_3).next());
+    }
+
+    #[test]
+    fn parse_traffic_patterns_skips_entries_missing_equals_sign() {
+        let pattern_string = "Foo=BAR,no-equals,Baz=QUX";
+
+        let patterns = parse_traffic_patterns(pattern_string).collect::<Vec<_>>();
+        assert_eq!(vec![("Foo", "BAR"), ("Baz", "QUX")], patterns);
     }
 
     #[test]

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,5 +1,5 @@
 pub mod app;
-mod block_traffic;
+pub mod block_traffic;
 pub mod cargo_compat;
 mod common_headers;
 mod debug;

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -159,6 +159,7 @@ pub fn block_routes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use insta::assert_compact_debug_snapshot;
 
     #[test]
     #[should_panic(expected = "BLOCKED_TRAFFIC values must be a valid regex")]
@@ -168,43 +169,11 @@ mod tests {
 
     #[test]
     fn new_block_criteria_string_vs_regex() {
-        let one_slash = BlockCriteria::new("/");
-        assert!(
-            matches!(one_slash, BlockCriteria::String(_)),
-            "Expected BlockCriteria::String, got {one_slash:?}",
-        );
-
-        let two_slashes_no_content = BlockCriteria::new("//");
-        assert!(
-            matches!(two_slashes_no_content, BlockCriteria::String(_)),
-            "Expected BlockCriteria::String, got {two_slashes_no_content:?}",
-        );
-
-        let starting_slash_only = BlockCriteria::new("/hello i am not regex");
-        assert!(
-            matches!(starting_slash_only, BlockCriteria::String(_)),
-            "Expected BlockCriteria::String, got {starting_slash_only:?}",
-        );
-
-        let ending_slash_only = BlockCriteria::new("hello me neither//");
-        assert!(
-            matches!(ending_slash_only, BlockCriteria::String(_)),
-            "Expected BlockCriteria::String, got {ending_slash_only:?}",
-        );
-
-        let string_doesnt_need_to_be_valid_regex = BlockCriteria::new("+");
-        assert!(
-            matches!(
-                string_doesnt_need_to_be_valid_regex,
-                BlockCriteria::String(_)
-            ),
-            "Expected BlockCriteria::String, got {string_doesnt_need_to_be_valid_regex:?}",
-        );
-
-        let now_thats_what_i_call_regex = BlockCriteria::new("/yes this is regex/");
-        assert!(
-            matches!(now_thats_what_i_call_regex, BlockCriteria::Regex(_)),
-            "Expected BlockCriteria::Regex, got {now_thats_what_i_call_regex:?}",
-        );
+        assert_compact_debug_snapshot!(BlockCriteria::new("/"), @r#"String("/")"#);
+        assert_compact_debug_snapshot!(BlockCriteria::new("//"), @r#"String("//")"#);
+        assert_compact_debug_snapshot!(BlockCriteria::new("/hello i am not regex"), @r#"String("/hello i am not regex")"#);
+        assert_compact_debug_snapshot!(BlockCriteria::new("hello me neither//"), @r#"String("hello me neither//")"#);
+        assert_compact_debug_snapshot!(BlockCriteria::new("+"), @r#"String("+")"#);
+        assert_compact_debug_snapshot!(BlockCriteria::new("/yes this is regex/"), @r#"Regex(Regex("yes this is regex"))"#);
     }
 }

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -29,32 +29,6 @@ pub enum BlockCriteria {
 }
 
 impl BlockCriteria {
-    /// Create new criteria to use when deciding whether to block a request.
-    ///
-    /// - If the specified string starts and ends with `/` and has at least one character between
-    ///   the slashes, interpret the value as a `Regex`.
-    /// - Otherwise, interpret the value as an exact equality match.
-    ///
-    /// # Panics
-    ///
-    /// This will panic if the specified string is interpreted as a `Regex` but the regex is
-    /// invalid.
-    pub fn new(s: &str) -> Self {
-        let is_regex = s.starts_with('/') && s.ends_with('/') && s.len() > 2;
-        if is_regex {
-            // Slicing is safe here because we checked the starting and ending characters and the
-            // length before entering this branch
-            Self::Regex(Regex::new(&s[1..s.len() - 1]).unwrap_or_else(|e| {
-                panic!(
-                    "BLOCKED_TRAFFIC values must be a valid regex after surrounding slashes are \
-                     removed, got invalid regex {s}: {e}"
-                )
-            }))
-        } else {
-            Self::String(s.into())
-        }
-    }
-
     pub fn matches(&self, value: &str) -> bool {
         match self {
             Self::Regex(r) => r.is_match(value),
@@ -70,9 +44,25 @@ impl BlockCriteria {
     }
 }
 
-impl From<&str> for BlockCriteria {
-    fn from(s: &str) -> Self {
-        Self::new(s)
+impl TryFrom<&str> for BlockCriteria {
+    type Error = regex::Error;
+
+    /// Parse a string into a [`BlockCriteria`].
+    ///
+    /// - If the specified string starts and ends with `/` and has at least one character between
+    ///   the slashes, interpret the value as a [`Regex`].
+    /// - Otherwise, interpret the value as an exact equality match.
+    ///
+    /// Returns `Err` if the value is interpreted as a regex but does not parse as one.
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let is_regex = s.starts_with('/') && s.ends_with('/') && s.len() > 2;
+        if is_regex {
+            // Slicing is safe here because we checked the starting and ending characters and the
+            // length before entering this branch
+            Ok(Self::Regex(Regex::new(&s[1..s.len() - 1])?))
+        } else {
+            Ok(Self::String(s.into()))
+        }
     }
 }
 
@@ -162,18 +152,22 @@ mod tests {
     use insta::assert_compact_debug_snapshot;
 
     #[test]
-    #[should_panic(expected = "BLOCKED_TRAFFIC values must be a valid regex")]
-    fn new_block_criteria_panics_on_invalid_regex() {
-        BlockCriteria::new("/)/");
-    }
-
-    #[test]
-    fn new_block_criteria_string_vs_regex() {
-        assert_compact_debug_snapshot!(BlockCriteria::new("/"), @r#"String("/")"#);
-        assert_compact_debug_snapshot!(BlockCriteria::new("//"), @r#"String("//")"#);
-        assert_compact_debug_snapshot!(BlockCriteria::new("/hello i am not regex"), @r#"String("/hello i am not regex")"#);
-        assert_compact_debug_snapshot!(BlockCriteria::new("hello me neither//"), @r#"String("hello me neither//")"#);
-        assert_compact_debug_snapshot!(BlockCriteria::new("+"), @r#"String("+")"#);
-        assert_compact_debug_snapshot!(BlockCriteria::new("/yes this is regex/"), @r#"Regex(Regex("yes this is regex"))"#);
+    fn try_from_str() {
+        assert_compact_debug_snapshot!(BlockCriteria::try_from("/"), @r#"Ok(String("/"))"#);
+        assert_compact_debug_snapshot!(BlockCriteria::try_from("//"), @r#"Ok(String("//"))"#);
+        assert_compact_debug_snapshot!(BlockCriteria::try_from("/hello i am not regex"), @r#"Ok(String("/hello i am not regex"))"#);
+        assert_compact_debug_snapshot!(BlockCriteria::try_from("hello me neither//"), @r#"Ok(String("hello me neither//"))"#);
+        assert_compact_debug_snapshot!(BlockCriteria::try_from("+"), @r#"Ok(String("+"))"#);
+        assert_compact_debug_snapshot!(BlockCriteria::try_from("/yes this is regex/"), @r#"Ok(Regex(Regex("yes this is regex")))"#);
+        assert_compact_debug_snapshot!(BlockCriteria::try_from("/)/"), @"
+        Err(Syntax(
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        regex parse error:
+            )
+            ^
+        error: unopened group
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ))
+        ");
     }
 }

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -80,14 +80,14 @@ impl From<&str> for BlockCriteria {
 ///
 /// To use, set the `BLOCKED_TRAFFIC` environment variable to a comma-separated list of pairs
 /// containing a header name, an equals sign, and the name of another environment variable that
-/// contains the regex pattern values of that header that should be blocked.
+/// contains the regex pattern or string values of that header that should be blocked.
 ///
 /// For example, set `BLOCKED_TRAFFIC` to `User-Agent=BLOCKED_UAS` and `BLOCKED_UAS` to
-/// `curl/[\d]+\.[\d]+\.[\d]+,cargo 1\.36\.0 \(c4fcfb725 2019-05-15\)` to block requests from any
+/// `/curl\/[\d]+\.[\d]+\.[\d]+/,cargo 1.36.0 (c4fcfb725 2019-05-15)` to block requests from any
 /// version of curl and the exact version of Cargo specified (values are nonsensical examples).
 ///
-/// Values of the headers must fully match the regex; that is, `^` and `$` are automatically added
-/// around every regex specified.
+/// Values of the headers must start and end with `/` to be interpreted as a regex. Values
+/// interpreted as strings must match exactly, in full.
 pub fn block_by_header(state: &AppState, req: &Request) -> Result<(), impl IntoResponse> {
     let blocked_traffic = &state.config.blocked_traffic;
 

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -6,6 +6,7 @@ use axum::extract::{Extension, MatchedPath, Request};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use http::{HeaderMap, StatusCode};
+use regex::Regex;
 
 pub async fn middleware(
     Extension(real_ip): Extension<RealIp>,
@@ -21,7 +22,61 @@ pub async fn middleware(
     Ok(next.run(req).await)
 }
 
-/// Middleware that blocks requests if a header matches the given regex list
+#[derive(Debug)]
+pub enum BlockCriteria {
+    Regex(Regex),
+    String(String),
+}
+
+impl BlockCriteria {
+    /// Create new criteria to use when deciding whether to block a request.
+    ///
+    /// - If the specified string starts and ends with `/` and has at least one character between
+    ///   the slashes, interpret the value as a `Regex`.
+    /// - Otherwise, interpret the value as an exact equality match.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the specified string is interpreted as a `Regex` but the regex is
+    /// invalid.
+    pub fn new(s: &str) -> Self {
+        let is_regex = s.starts_with('/') && s.ends_with('/') && s.len() > 2;
+        if is_regex {
+            // Slicing is safe here because we checked the starting and ending characters and the
+            // length before entering this branch
+            Self::Regex(Regex::new(&s[1..s.len() - 1]).unwrap_or_else(|e| {
+                panic!(
+                    "BLOCKED_TRAFFIC values must be a valid regex after surrounding slashes are \
+                     removed, got invalid regex {s}: {e}"
+                )
+            }))
+        } else {
+            Self::String(s.into())
+        }
+    }
+
+    pub fn matches(&self, value: &str) -> bool {
+        match self {
+            Self::Regex(r) => r.is_match(value),
+            Self::String(s) => s == value,
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Regex(r) => r.as_str(),
+            Self::String(s) => s,
+        }
+    }
+}
+
+impl From<&str> for BlockCriteria {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+/// Middleware that blocks requests if a header matches the given criteria list
 ///
 /// To use, set the `BLOCKED_TRAFFIC` environment variable to a comma-separated list of pairs
 /// containing a header name, an equals sign, and the name of another environment variable that
@@ -40,7 +95,7 @@ pub fn block_by_header(state: &AppState, req: &Request) -> Result<(), impl IntoR
         let has_blocked_value = req.headers().get_all(header_name).iter().any(|value| {
             value
                 .to_str()
-                .map(|ascii_val| blocked_values.iter().any(|v| v.is_match(ascii_val)))
+                .map(|ascii_val| blocked_values.iter().any(|v| v.matches(ascii_val)))
                 .unwrap_or(false)
         });
         if has_blocked_value {
@@ -99,4 +154,57 @@ pub fn block_routes(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "BLOCKED_TRAFFIC values must be a valid regex")]
+    fn new_block_criteria_panics_on_invalid_regex() {
+        BlockCriteria::new("/)/");
+    }
+
+    #[test]
+    fn new_block_criteria_string_vs_regex() {
+        let one_slash = BlockCriteria::new("/");
+        assert!(
+            matches!(one_slash, BlockCriteria::String(_)),
+            "Expected BlockCriteria::String, got {one_slash:?}",
+        );
+
+        let two_slashes_no_content = BlockCriteria::new("//");
+        assert!(
+            matches!(two_slashes_no_content, BlockCriteria::String(_)),
+            "Expected BlockCriteria::String, got {two_slashes_no_content:?}",
+        );
+
+        let starting_slash_only = BlockCriteria::new("/hello i am not regex");
+        assert!(
+            matches!(starting_slash_only, BlockCriteria::String(_)),
+            "Expected BlockCriteria::String, got {starting_slash_only:?}",
+        );
+
+        let ending_slash_only = BlockCriteria::new("hello me neither//");
+        assert!(
+            matches!(ending_slash_only, BlockCriteria::String(_)),
+            "Expected BlockCriteria::String, got {ending_slash_only:?}",
+        );
+
+        let string_doesnt_need_to_be_valid_regex = BlockCriteria::new("+");
+        assert!(
+            matches!(
+                string_doesnt_need_to_be_valid_regex,
+                BlockCriteria::String(_)
+            ),
+            "Expected BlockCriteria::String, got {string_doesnt_need_to_be_valid_regex:?}",
+        );
+
+        let now_thats_what_i_call_regex = BlockCriteria::new("/yes this is regex/");
+        assert!(
+            matches!(now_thats_what_i_call_regex, BlockCriteria::Regex(_)),
+            "Expected BlockCriteria::Regex, got {now_thats_what_i_call_regex:?}",
+        );
+    }
 }

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -21,23 +21,28 @@ pub async fn middleware(
     Ok(next.run(req).await)
 }
 
-/// Middleware that blocks requests if a header matches the given list
+/// Middleware that blocks requests if a header matches the given regex list
 ///
 /// To use, set the `BLOCKED_TRAFFIC` environment variable to a comma-separated list of pairs
 /// containing a header name, an equals sign, and the name of another environment variable that
-/// contains the values of that header that should be blocked. For example, set `BLOCKED_TRAFFIC`
-/// to `User-Agent=BLOCKED_UAS` and `BLOCKED_UAS` to `curl/7.54.0,cargo 1.36.0 (c4fcfb725 2019-05-15)`
-/// to block requests from the versions of curl or Cargo specified (values are nonsensical examples).
-/// Values of the headers must match exactly.
+/// contains the regex pattern values of that header that should be blocked.
+///
+/// For example, set `BLOCKED_TRAFFIC` to `User-Agent=BLOCKED_UAS` and `BLOCKED_UAS` to
+/// `curl/[\d]+\.[\d]+\.[\d]+,cargo 1\.36\.0 \(c4fcfb725 2019-05-15\)` to block requests from any
+/// version of curl and the exact version of Cargo specified (values are nonsensical examples).
+///
+/// Values of the headers must fully match the regex; that is, `^` and `$` are automatically added
+/// around every regex specified.
 pub fn block_by_header(state: &AppState, req: &Request) -> Result<(), impl IntoResponse> {
     let blocked_traffic = &state.config.blocked_traffic;
 
     for (header_name, blocked_values) in blocked_traffic {
-        let has_blocked_value = req
-            .headers()
-            .get_all(header_name)
-            .iter()
-            .any(|value| blocked_values.iter().any(|v| v == value));
+        let has_blocked_value = req.headers().get_all(header_name).iter().any(|value| {
+            value
+                .to_str()
+                .map(|ascii_val| blocked_values.iter().any(|v| v.is_match(ascii_val)))
+                .unwrap_or(false)
+        });
         if has_blocked_value {
             let cause = format!("blocked due to contents of header {header_name}");
             req.request_log().add("cause", cause);

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -42,7 +42,7 @@ async fn user_agent_is_not_required_for_download() {
 async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
-            config.blocked_traffic = vec![("Never-Given".into(), vec!["1".into()])];
+            config.blocked_traffic = vec![("Never-Given".into(), vec!["1".try_into().unwrap()])];
         })
         .with_user()
         .await;
@@ -67,12 +67,14 @@ async fn block_traffic_via_arbitrary_header_and_value() {
                 "User-Agent".into(),
                 vec![
                     // This is an exact string match because it doesn't start with `/`
-                    "1/".into(),
+                    "1/".try_into().unwrap(),
                     // This is also an exact string match, not interpreted as regex without slashes
-                    "2+".into(),
+                    "2+".try_into().unwrap(),
                     // Last two are regexes
-                    "/fancy-crate, run by fancy-author v[\\d]+\\.[\\d]+\\.[\\d]+/".into(),
-                    "/^anchored$/".into(),
+                    "/fancy-crate, run by fancy-author v[\\d]+\\.[\\d]+\\.[\\d]+/"
+                        .try_into()
+                        .unwrap(),
+                    "/^anchored$/".try_into().unwrap(),
                 ],
             )];
         })

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -42,7 +42,7 @@ async fn user_agent_is_not_required_for_download() {
 async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
-            config.blocked_traffic = vec![("Never-Given".into(), vec!["1".into()])];
+            config.blocked_traffic = vec![("Never-Given".into(), vec!["^1$".try_into().unwrap()])];
         })
         .with_user()
         .await;
@@ -63,16 +63,18 @@ async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
 async fn block_traffic_via_arbitrary_header_and_value() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
-            config.blocked_traffic = vec![
-                (
-                    "User-Agent".into(),
-                    vec![
-                        "1".into(),
-                        "2".into(),
-                        "fancy-crate, run by fancy-author v[\\d]+\\.[\\d]+\\.[\\d]+".into(),
-                    ]
-                )
-            ];
+            config.blocked_traffic = vec![(
+                "User-Agent".into(),
+                vec![
+                    // The `parse_traffic_pattern_values` function automatically adds `^` and `$`
+                    // around the specified values, but these tests set the regex values directly
+                    "^1$".try_into().unwrap(),
+                    "^2$".try_into().unwrap(),
+                    "^fancy-crate, run by fancy-author v[\\d]+\\.[\\d]+\\.[\\d]+$"
+                        .try_into()
+                        .unwrap(),
+                ],
+            )];
         })
         .with_user()
         .await;
@@ -108,19 +110,20 @@ async fn block_traffic_via_arbitrary_header_and_value() {
     assert_eq!(resp.status(), StatusCode::FOUND);
 
     let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
-        // A request with a header value that literally matches the regex we want to block isn't
-        // allowed; regexes aren't supported as regexes yet
-        .header(header::USER_AGENT, "fancy-crate, run by fancy-author v[\\d]+\\.[\\d]+\\.[\\d]+")
+        // A request with a header value that has a substring match for the regex we want to block
+        // is allowed; regexes must be complete matches
+        .header(
+            header::USER_AGENT,
+            "fancy-crate, run by fancy-author v1.2.3 oh and other stuff too",
+        )
         .header("x-request-id", "abcd")
         .body("")
         .unwrap();
-
     let resp = anon.run::<()>(req).await;
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert_eq!(resp.status(), StatusCode::FOUND);
 
     let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
-        // A request with a header value we want to block via regex is allowed; regexes aren't
-        // supported yet
+        // A request with a header value we want to block via regex isn't allowed
         .header(
             header::USER_AGENT,
             "fancy-crate, run by fancy-author v14.105.6234",
@@ -129,7 +132,7 @@ async fn block_traffic_via_arbitrary_header_and_value() {
         .unwrap();
 
     let resp = anon.run::<()>(req).await;
-    assert_eq!(resp.status(), StatusCode::FOUND);
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -63,7 +63,16 @@ async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
 async fn block_traffic_via_arbitrary_header_and_value() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
-            config.blocked_traffic = vec![("User-Agent".into(), vec!["1".into(), "2".into()])];
+            config.blocked_traffic = vec![
+                (
+                    "User-Agent".into(),
+                    vec![
+                        "1".into(),
+                        "2".into(),
+                        "fancy-crate, run by fancy-author v[\\d]+\\.[\\d]+\\.[\\d]+".into(),
+                    ]
+                )
+            ];
         })
         .with_user()
         .await;
@@ -91,6 +100,30 @@ async fn block_traffic_via_arbitrary_header_and_value() {
         .header(
             header::USER_AGENT,
             "1value-must-match-exactly-this-is-allowed",
+        )
+        .body("")
+        .unwrap();
+
+    let resp = anon.run::<()>(req).await;
+    assert_eq!(resp.status(), StatusCode::FOUND);
+
+    let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
+        // A request with a header value that literally matches the regex we want to block isn't
+        // allowed; regexes aren't supported as regexes yet
+        .header(header::USER_AGENT, "fancy-crate, run by fancy-author v[\\d]+\\.[\\d]+\\.[\\d]+")
+        .header("x-request-id", "abcd")
+        .body("")
+        .unwrap();
+
+    let resp = anon.run::<()>(req).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
+        // A request with a header value we want to block via regex is allowed; regexes aren't
+        // supported yet
+        .header(
+            header::USER_AGENT,
+            "fancy-crate, run by fancy-author v14.105.6234",
         )
         .body("")
         .unwrap();

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -42,7 +42,7 @@ async fn user_agent_is_not_required_for_download() {
 async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
-            config.blocked_traffic = vec![("Never-Given".into(), vec!["^1$".try_into().unwrap()])];
+            config.blocked_traffic = vec![("Never-Given".into(), vec!["1".into()])];
         })
         .with_user()
         .await;
@@ -66,13 +66,13 @@ async fn block_traffic_via_arbitrary_header_and_value() {
             config.blocked_traffic = vec![(
                 "User-Agent".into(),
                 vec![
-                    // The `parse_traffic_pattern_values` function automatically adds `^` and `$`
-                    // around the specified values, but these tests set the regex values directly
-                    "^1$".try_into().unwrap(),
-                    "^2$".try_into().unwrap(),
-                    "^fancy-crate, run by fancy-author v[\\d]+\\.[\\d]+\\.[\\d]+$"
-                        .try_into()
-                        .unwrap(),
+                    // This is an exact string match because it doesn't start with `/`
+                    "1/".into(),
+                    // This is also an exact string match, not interpreted as regex without slashes
+                    "2+".into(),
+                    // Last two are regexes
+                    "/fancy-crate, run by fancy-author v[\\d]+\\.[\\d]+\\.[\\d]+/".into(),
+                    "/^anchored$/".into(),
                 ],
             )];
         })
@@ -87,7 +87,7 @@ async fn block_traffic_via_arbitrary_header_and_value() {
 
     let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
         // A request with a header value we want to block isn't allowed
-        .header(header::USER_AGENT, "1")
+        .header(header::USER_AGENT, "2+")
         .header("x-request-id", "abcd")
         .body("")
         .unwrap();
@@ -101,24 +101,11 @@ async fn block_traffic_via_arbitrary_header_and_value() {
         // be a substring match
         .header(
             header::USER_AGENT,
-            "1value-must-match-exactly-this-is-allowed",
+            "1/value-must-match-exactly-this-is-allowed",
         )
         .body("")
         .unwrap();
 
-    let resp = anon.run::<()>(req).await;
-    assert_eq!(resp.status(), StatusCode::FOUND);
-
-    let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
-        // A request with a header value that has a substring match for the regex we want to block
-        // is allowed; regexes must be complete matches
-        .header(
-            header::USER_AGENT,
-            "fancy-crate, run by fancy-author v1.2.3 oh and other stuff too",
-        )
-        .header("x-request-id", "abcd")
-        .body("")
-        .unwrap();
     let resp = anon.run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FOUND);
 
@@ -133,6 +120,37 @@ async fn block_traffic_via_arbitrary_header_and_value() {
 
     let resp = anon.run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
+        // A request with a header value that has a partial match for the regex we want to block
+        // isn't allowed because we didn't anchor the regex
+        .header(
+            header::USER_AGENT,
+            "fancy-crate, run by fancy-author v1.2.3 oh and other stuff too",
+        )
+        .header("x-request-id", "abcd")
+        .body("")
+        .unwrap();
+    let resp = anon.run::<()>(req).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
+        // A request with a header value that exactly matches an anchored regex isn't allowed
+        .header(header::USER_AGENT, "anchored")
+        .body("")
+        .unwrap();
+
+    let resp = anon.run::<()>(req).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
+        // A request with a header value that doesn't match an anchored regex is allowed
+        .header(header::USER_AGENT, "anchored, it's a pirate's life for me")
+        .body("")
+        .unwrap();
+
+    let resp = anon.run::<()>(req).await;
+    assert_eq!(resp.status(), StatusCode::FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
So that we don't have to keep up with version numbers ;)

A few things that worry me:

- Splitting on commas is a problem regardless of this PR, if you wanted the comma to be part of the specified match. I'm worried with the addition of regex support we'll think "oh right, i'll just escape it and it won't be split on that comma" which... won't work, which at least I've documented in a test?
- ~~Deploying this will be a little tricky... we have the `BLOCKED_TRAFFIC` env var that we can use as a bit of indirection so that we could set an entirely new env var, deploy and maybe have everything broken for a second, then change the value of `BLOCKED_TRAFFIC` to use the new env var? Then after letting everything settle unset the old env var?~~
  ~~The main problem is a bunch of the current values have literal parens and periods that need to be escaped... maybe we could _duplicate_ those values _within_ the current env var's values (so we'd change a current value of `foo,bar (1.2.3)` to `foo,bar (1.2.3), bar \(1\.2\.3\)` [and then eventually to `foo,bar \([\d]+\.[\d]+\.[\d]+\)` to take advantage of the new capabilities] and just accept that some weird stuff is getting matched during the transition?~~

~~EDIT: Just checked that there's at least one value in the current env var value that contains a `+` that would panic with this PR, so I'm switching this to draft so that it doesn't get merged, but I would love a review and thoughts about how to merge+deploy this :)~~

The deploy worry has been mitigated by supporting both strings _and_ regex and you have to opt in to the regex behavior by surrounding the value with `/`, so all existing values should continue to be interpreted as the regular old string equality matches they are before this PR :)