### PR TITLE
jobs/index/archive: Run on default queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,6 +1457,7 @@ dependencies = [
  "dotenvy",
  "flate2",
  "futures-util",
+ "git2",
  "googletest",
  "hex",
  "http 1.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ diesel_migrations = { version = "=2.3.2", features = ["postgres"] }
 dotenvy = "=0.15.7"
 flate2 = "=1.1.9"
 futures-util = "=0.3.32"
+git2 = "=0.20.4"
 hex = "=0.4.3"
 http = "=1.4.0"
 hyper = { version = "=1.9.0", features = ["client", "http1"] }

--- a/crates/crates_io_index/lib.rs
+++ b/crates/crates_io_index/lib.rs
@@ -17,5 +17,5 @@ pub mod testing;
 pub use crate::commit_builder::CommitBuilder;
 pub use crate::credentials::Credentials;
 pub use crate::data::{Crate, Dependency, DependencyKind};
-pub use crate::repo::{Repository, RepositoryConfig, TemporaryRemote};
+pub use crate::repo::{Repository, RepositoryConfig};
 pub use crate::ser::write_crates;

--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -354,47 +354,6 @@ impl Repository {
 
         run_via_cli(command, &self.credentials)
     }
-
-    /// Registers a git remote under the given `name` pointing at `url` and
-    /// returns a [`TemporaryRemote`] guard that removes it on drop.
-    ///
-    /// Any pre-existing remote with the same name is removed first.
-    pub fn add_temporary_remote<'a>(
-        &'a self,
-        name: &str,
-        url: &Url,
-    ) -> anyhow::Result<TemporaryRemote<'a>> {
-        let name = name.to_string();
-
-        let _ = self.remove_remote(&name);
-        self.add_remote(&name, url)?;
-        Ok(TemporaryRemote { repo: self, name })
-    }
-
-    fn add_remote(&self, name: &str, url: &Url) -> anyhow::Result<()> {
-        self.repository.remote(name, url.as_str())?;
-        Ok(())
-    }
-
-    fn remove_remote(&self, name: &str) -> anyhow::Result<()> {
-        self.repository.remote_delete(name)?;
-        Ok(())
-    }
-}
-
-/// RAII guard returned by [`Repository::add_temporary_remote`]. Removes the
-/// associated remote from the repository when dropped.
-pub struct TemporaryRemote<'a> {
-    repo: &'a Repository,
-    name: String,
-}
-
-impl Drop for TemporaryRemote<'_> {
-    fn drop(&mut self) {
-        if let Err(error) = self.repo.remove_remote(&self.name) {
-            error!("Failed to remove `{}` remote: {error}", self.name);
-        }
-    }
 }
 
 /// Runs the specified `git` command through the `git` CLI.
@@ -444,17 +403,6 @@ mod tests {
         };
         let repo = Repository::open(&config).unwrap();
         (upstream, repo)
-    }
-
-    fn added_remotes(repo: &Repository) -> Vec<String> {
-        repo.git_repo()
-            .remotes()
-            .unwrap()
-            .iter()
-            .flatten()
-            .filter(|name| *name != "origin")
-            .map(str::to_string)
-            .collect()
     }
 
     #[test]
@@ -533,32 +481,5 @@ mod tests {
         repo.reset_head().unwrap();
 
         assert_ok_eq!(repo.list_entries(), vec!["serde".to_string()]);
-    }
-
-    #[test]
-    fn temporary_remote_is_removed_on_drop() {
-        let (upstream, repo) = setup();
-        let url = upstream.url();
-
-        let guard = repo.add_temporary_remote("archive", &url).unwrap();
-        assert_eq!(added_remotes(&repo), vec!["archive".to_string()]);
-
-        drop(guard);
-        assert_eq!(added_remotes(&repo), Vec::<String>::new());
-    }
-
-    #[test]
-    fn temporary_remote_replaces_pre_existing_remote() {
-        let (upstream, repo) = setup();
-        let old_url = Url::parse("https://example.invalid/old.git").unwrap();
-        let new_url = upstream.url();
-
-        repo.add_remote("archive", &old_url).unwrap();
-
-        let _guard = repo.add_temporary_remote("archive", &new_url).unwrap();
-        assert_eq!(added_remotes(&repo), vec!["archive".to_string()]);
-
-        let remote = repo.git_repo().find_remote("archive").unwrap();
-        assert_eq!(remote.url(), Some(new_url.as_str()));
     }
 }

--- a/src/worker/jobs/index/archive.rs
+++ b/src/worker/jobs/index/archive.rs
@@ -4,8 +4,9 @@ use anyhow::anyhow;
 use crates_io_worker::BackgroundJob;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
-use std::process::Command;
 use std::sync::Arc;
+use std::time::Instant;
+use tokio::process::Command;
 use tracing::{info, instrument, warn};
 use url::Url;
 
@@ -33,50 +34,112 @@ impl BackgroundJob for ArchiveIndexBranch {
 
     /// Mirror a snapshot branch from the crate index to the configured archive
     /// repository. No-op when no archive URL is configured.
+    ///
+    /// Each invocation works against a fresh, ephemeral bare clone of the
+    /// snapshot branch in a `TempDir`. The job does not share state with the
+    /// long-lived bare clone behind `Environment::lock_index()`.
     #[instrument(skip_all, fields(branch = self.branch))]
     async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
-        let Some(archive_url) = env.config.index_archive_url.clone() else {
+        let Some(archive_url) = env.config.index_archive_url.as_ref() else {
             info!("`index_archive_url` not configured, skipping archive push");
             return Ok(());
         };
 
         let Some(github_app) = env.github_app.as_ref() else {
-            return Err(anyhow!(
-                "`index_archive_url` is set but GitHub App is not configured"
-            ));
+            let error = anyhow!("`index_archive_url` is set but GitHub App is not configured");
+            return Err(error);
         };
-        let github_app = github_app.clone();
 
-        info!(%archive_url, "Pushing snapshot to archive repository");
+        info!(
+            "Cloning snapshot branch ({branch}) from the index repository",
+            branch = self.branch
+        );
 
-        let branch = self.branch.clone();
-        let handle = tokio::runtime::Handle::current();
+        // `TempDir` create/drop are sync filesystem I/O. The bare clone is one
+        // large packfile plus a handful of small refs/config files, so
+        // `remove_dir_all` cost is bounded by inode count, not pack size, and
+        // should stay brief enough to run on the async runtime.
+        let tempdir = tempfile::Builder::new()
+            .prefix("snapshot-clone")
+            .tempdir()?;
 
-        spawn_blocking(move || {
-            let repo = env.lock_index()?;
+        let clone_start = Instant::now();
+        let output = Command::new("git")
+            .args([
+                "clone",
+                "--bare",
+                "--single-branch",
+                "--branch",
+                &self.branch,
+                env.repository_config.index_location.as_str(),
+            ])
+            // `tempdir.path()` is `&Path`, so it can't share the `&str` array above.
+            .arg(tempdir.path())
+            .output()
+            .await?;
 
-            repo.run_command(Command::new("git").args(["fetch", "origin", &branch]))?;
+        if !output.status.success() {
+            return Err(anyhow!(
+                "git clone failed: {}{}",
+                String::from_utf8_lossy(&output.stderr),
+                String::from_utf8_lossy(&output.stdout)
+            ));
+        }
 
-            let token = handle.block_on(github_app.installation_token())?;
-            let push_url = match build_credentialed_url(&archive_url, token.expose_secret()) {
-                Ok(url) => url,
-                Err(()) => {
-                    warn!(%archive_url, "Archive URL does not support credentials; pushing without auth");
-                    archive_url.clone()
-                }
-            };
+        info!(
+            duration = clone_start.elapsed().as_nanos(),
+            "Cloned snapshot branch ({branch})",
+            branch = self.branch,
+        );
 
-            let _remote = repo.add_temporary_remote(REMOTE_NAME, &push_url)?;
-            repo.run_command(Command::new("git").args([
-                "push",
-                REMOTE_NAME,
-                &format!("FETCH_HEAD:refs/heads/{branch}"),
-            ]))?;
+        let token = github_app.installation_token().await?;
+        let push_url = match build_credentialed_url(archive_url, token.expose_secret()) {
+            Ok(url) => url,
+            Err(()) => {
+                warn!(
+                    "Archive URL ({archive_url}) does not support credentials; pushing without auth"
+                );
+                archive_url.clone()
+            }
+        };
 
-            info!("Snapshot pushed to archive repository.");
+        let bare_path = tempdir.path().to_owned();
+        spawn_blocking(move || -> anyhow::Result<()> {
+            // Use `git2` here so the credentialed URL is written only into the
+            // tempdir's `.git/config` and never appears in process argv or logs.
+            let repo = git2::Repository::open_bare(&bare_path)?;
+            repo.remote(REMOTE_NAME, push_url.as_str())?;
             Ok(())
         })
-        .await?
+        .await??;
+        info!("Added archive repository as `{REMOTE_NAME}` remote");
+
+        info!(
+            "Pushing snapshot branch ({branch}) to archive repository ({archive_url})",
+            branch = self.branch
+        );
+        let refspec = format!("{branch}:refs/heads/{branch}", branch = self.branch);
+        let push_start = Instant::now();
+        let output = Command::new("git")
+            .current_dir(tempdir.path())
+            .args(["push", REMOTE_NAME, &refspec])
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            return Err(anyhow!(
+                "git push failed: {}{}",
+                String::from_utf8_lossy(&output.stderr),
+                String::from_utf8_lossy(&output.stdout)
+            ));
+        }
+
+        info!(
+            duration = push_start.elapsed().as_nanos(),
+            "Snapshot pushed to archive repository"
+        );
+
+        Ok(())
     }
 }
 

--- a/src/worker/jobs/index/archive.rs
+++ b/src/worker/jobs/index/archive.rs
@@ -28,7 +28,6 @@ impl ArchiveIndexBranch {
 impl BackgroundJob for ArchiveIndexBranch {
     const JOB_NAME: &'static str = "archive_index_branch";
     const DEDUPLICATED: bool = true;
-    const QUEUE: &'static str = "repository";
 
     type Context = Arc<Environment>;
 


### PR DESCRIPTION
Moves `ArchiveIndexBranch` off the single-worker `repository` queue onto the 5-worker `default` queue, so index sync jobs (`SyncToGitIndex` etc.) stop waiting behind long-running archive pushes. After a squash is queued up, the sync delay should drop significantly.

To make that safe, the job no longer shares the long-lived bare clone behind `Environment::lock_index()`. Instead it clones just the snapshot branch into a `TempDir` per invocation. Snapshot branches are immutable once the squash job creates them, so concurrent archive jobs touching different snapshots can't conflict, and `DEDUPLICATED = true` still prevents same-branch duplicates.

The last commit cleans up the now-unused `add_temporary_remote` helper in `crates_io_index`.