### PR TITLE
svelte: Disable `paths.relative` for Playwright tests

### DIFF
--- a/svelte/svelte.config.js
+++ b/svelte/svelte.config.js
@@ -18,6 +18,10 @@ const config = {
       // to be able to serve it alongside the Ember.js app at `/`.
       // Use empty base path for tests (Vitest unit tests and Playwright e2e tests).
       base: process.env.VITEST || process.env.PLAYWRIGHT ? '' : '/svelte',
+      // Force absolute asset URLs under Playwright so that Percy's DOM
+      // serializer captures hrefs that still resolve when the snapshot is
+      // rendered at a different URL.
+      ...(process.env.PLAYWRIGHT && { relative: false }),
     },
     prerender: {
       origin: `https://${process.env.DOMAIN_NAME ?? 'crates.io'}`,


### PR DESCRIPTION
SvelteKit 2.58.0 (sveltejs/kit#15718) emits root-layout stylesheets in the server HTML to fix FOUC. With `paths.relative: true` (the default), those hrefs are relative to the request URL. Percy preserves the attribute strings verbatim and renders the snapshot at its own URL, so the relative hrefs no longer resolve and the snapshot comes out unstyled.

Setting `paths.relative: false` under `PLAYWRIGHT=1` keeps Percy snapshots stable. The default applies in production and Vitest builds.

Discovered while running #13373.

### Related

- https://github.com/rust-lang/crates.io/issues/12515