### PR TITLE
svelte: Add security.txt to static dir

### DIFF
--- a/svelte/static/.well-known/security.txt
+++ b/svelte/static/.well-known/security.txt
@@ -1,0 +1,2 @@
+Contact: https://crates.io/policies/security
+Expires: 2026-06-25T00:00:00.000Z


### PR DESCRIPTION
Mirrors `public/.well-known/security.txt` from the Ember side. Once the Svelte app is served at `/`, the file ends up at `/.well-known/security.txt` again instead of disappearing alongside the Ember `dist/`.

### Related

- https://github.com/rust-lang/crates.io/issues/12515