### PR TITLE
svelte: Cache hashed assets long-term

### DIFF
--- a/src/middleware/common_headers.rs
+++ b/src/middleware/common_headers.rs
@@ -35,7 +35,7 @@ pub async fn add_common_headers(
         expires(&mut headers, ONE_DAY);
     }
 
-    if path.starts_with("/assets/") {
+    if path.starts_with("/assets/") || path.starts_with("/svelte/_app/immutable/") {
         expires(&mut headers, 10 * ONE_YEAR);
     }
 


### PR DESCRIPTION
Extends the existing 10-year cache rule in `common_headers` to also match `/svelte/_app/immutable/`. The existing `/assets/` rule covers Ember's hashed-asset path. This adds the SvelteKit equivalent so its hashed bundles benefit from the same long-lived caching.

### Related

- https://github.com/rust-lang/crates.io/issues/12515