### PR TITLE
middleware: Rename `ember_html` module to `frontend_html`

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -81,7 +81,7 @@ pub struct Server {
     pub og_image_base_url: Option<Url>,
 
     /// Maximum number of items that the HTML render
-    /// cache in `crate::middleware::ember_html::serve_html`
+    /// cache in `crate::middleware::frontend_html::serve`
     /// can hold. Defaults to 1024.
     pub html_render_cache_max_capacity: u64,
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -3,7 +3,7 @@ pub mod block_traffic;
 pub mod cargo_compat;
 mod common_headers;
 mod debug;
-mod ember_html;
+mod frontend_html;
 pub mod log_request;
 pub mod normalize_path;
 pub mod real_ip;
@@ -82,7 +82,7 @@ pub fn apply_axum_middleware(state: AppState, router: Router<()>) -> Router {
             from_fn(static_or_continue::serve_svelte)
         }))
         .layer(conditional_layer(config.serve_html, || {
-            from_fn_with_state(state.clone(), ember_html::serve_html)
+            from_fn_with_state(state.clone(), frontend_html::serve)
         }))
         .layer(AddExtensionLayer::new(state.clone()));
 

--- a/src/middleware/frontend_html.rs
+++ b/src/middleware/frontend_html.rs
@@ -1,4 +1,4 @@
-//! Serve the Ember.js frontend HTML
+//! Serve the frontend HTML.
 //!
 //! Paths intended for the inner `api_handler` are passed along to the remaining middleware layers
 //! as normal. Requests not intended for the backend will be served HTML to boot the Ember.js
@@ -84,7 +84,7 @@ fn init_html_cache(max_capacity: u64) -> TemplateCache {
         .build()
 }
 
-pub async fn serve_html(state: AppState, request: Request, next: Next) -> Response {
+pub async fn serve(state: AppState, request: Request, next: Next) -> Response {
     static TEMPLATE_ENV: LazyLock<TemplateEnvFut> =
         LazyLock::new(|| init_template_env().boxed().shared());
     static RENDERED_HTML_CACHE: OnceLock<TemplateCache> = OnceLock::new();
@@ -185,7 +185,7 @@ mod tests {
     use googletest::{assert_that, prelude::eq};
     use url::Url;
 
-    use crate::middleware::ember_html::{extract_crate_name, generate_og_image_url};
+    use crate::middleware::frontend_html::{extract_crate_name, generate_og_image_url};
 
     #[test]
     fn test_extract_crate_name() {

--- a/src/middleware/static_or_continue.rs
+++ b/src/middleware/static_or_continue.rs
@@ -28,7 +28,7 @@ async fn serve<P: AsRef<Path>>(
     request: Request,
     next: Next,
 ) -> Response {
-    // index.html is a Jinja template, which is to be rendered by `ember_html::serve_html`.
+    // index.html is a Jinja template, which is to be rendered by `frontend_html::serve`.
     if matches!(*request.method(), Method::GET | Method::HEAD)
         && !matches!(request.uri().path().as_bytes(), b"/" | b"/index.html")
         && strip_prefix.is_none_or(|prefix| request.uri().path().starts_with(prefix))


### PR DESCRIPTION
Pure rename in preparation for the Svelte-as-default switch. The module already serves both Ember and Svelte HTML, so the new name is a better fit. Also drops the redundant `_html` suffix on the public `serve_html` fn, which is now `frontend_html::serve`.

No behavior change.