### PR TITLE
svelte: Port `<noscript>` and `window.onerror` bootstrap from Ember

### DIFF
--- a/svelte/.prettierignore
+++ b/svelte/.prettierignore
@@ -7,3 +7,7 @@ bun.lockb
 
 # Miscellaneous
 /static/
+
+# `src/app.html` contains an inline `window.onerror` bootstrap whose CSP
+# hash (pinned in `svelte.config.js`) is sensitive to whitespace.
+/src/app.html

--- a/svelte/src/app.html
+++ b/svelte/src/app.html
@@ -28,6 +28,7 @@
   </head>
   <body data-sveltekit-preload-data="hover">
     <noscript>For full functionality of this site it is necessary to enable JavaScript.</noscript>
+    <script>window.onerror=function(){document.body.innerHTML='<p style="width: 70%;background: var(--main-bg);padding: 10px;">Sorry, it looks like we were not able to load the page. Please make sure your network connection works and you are using an up-to-date browser. If the issue persists, please visit our <a href="https://github.com/rust-lang/crates.io/issues/new/choose">issue tracker</a> to report the problem.</p>'}</script>
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/svelte/src/app.html
+++ b/svelte/src/app.html
@@ -27,6 +27,7 @@
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">
+    <noscript>For full functionality of this site it is necessary to enable JavaScript.</noscript>
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/svelte/src/app.html
+++ b/svelte/src/app.html
@@ -28,7 +28,7 @@
   </head>
   <body data-sveltekit-preload-data="hover">
     <noscript>For full functionality of this site it is necessary to enable JavaScript.</noscript>
-    <script>window.onerror=function(){document.body.innerHTML='<p style="width: 70%;background: var(--main-bg);padding: 10px;">Sorry, it looks like we were not able to load the page. Please make sure your network connection works and you are using an up-to-date browser. If the issue persists, please visit our <a href="https://github.com/rust-lang/crates.io/issues/new/choose">issue tracker</a> to report the problem.</p>'}</script>
+    <script>window.onerror=window.onunhandledrejection=function(){document.body.innerHTML='<p style="width: 70%;background: var(--main-bg);padding: 10px;">Sorry, it looks like we were not able to load the page. Please make sure your network connection works and you are using an up-to-date browser. If the issue persists, please visit our <a href="https://github.com/rust-lang/crates.io/issues/new/choose">issue tracker</a> to report the problem.</p>'}</script>
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/svelte/src/hooks.client.ts
+++ b/svelte/src/hooks.client.ts
@@ -1,4 +1,8 @@
 export async function init() {
+  // Clear the bootstrap `window.onerror` handler set in `app.html`; the app
+  // has loaded successfully, so the load-failure fallback is no longer needed.
+  window.onerror = null;
+
   if (import.meta.env.VITE_MSW_ENABLED) {
     let { http, passthrough } = await import('msw');
     let { setupWorker } = await import('msw/browser');

--- a/svelte/src/hooks.client.ts
+++ b/svelte/src/hooks.client.ts
@@ -1,7 +1,8 @@
 export async function init() {
-  // Clear the bootstrap `window.onerror` handler set in `app.html`; the app
-  // has loaded successfully, so the load-failure fallback is no longer needed.
+  // Clear the bootstrap error handlers set in `app.html`; the app has loaded
+  // successfully, so the load-failure fallback is no longer needed.
   window.onerror = null;
+  window.onunhandledrejection = null;
 
   if (import.meta.env.VITE_MSW_ENABLED) {
     let { http, passthrough } = await import('msw');

--- a/svelte/svelte.config.js
+++ b/svelte/svelte.config.js
@@ -49,7 +49,7 @@ const config = {
           'unsafe-eval',
           // Hash of the inline `window.onerror` bootstrap script in `app.html`.
           // If the script content changes, regenerate this hash.
-          'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE=',
+          'sha256-5Cz6+Mc7r7EqumpZ/iP8Bxa/U8yPvwbiANROmonMceg=',
         ],
         // Fira Sans is loaded from the Mozilla CDN via `@import` in `global.css`
         'style-src': ['self', 'unsafe-inline', 'https://code.cdn.mozilla.net'],

--- a/svelte/svelte.config.js
+++ b/svelte/svelte.config.js
@@ -44,7 +44,13 @@ const config = {
           'https://static.crates.io',
           'https://static.staging.crates.io',
         ],
-        'script-src': ['self', 'unsafe-eval'],
+        'script-src': [
+          'self',
+          'unsafe-eval',
+          // Hash of the inline `window.onerror` bootstrap script in `app.html`.
+          // If the script content changes, regenerate this hash.
+          'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE=',
+        ],
         // Fira Sans is loaded from the Mozilla CDN via `@import` in `global.css`
         'style-src': ['self', 'unsafe-inline', 'https://code.cdn.mozilla.net'],
         'font-src': ['https://code.cdn.mozilla.net'],


### PR DESCRIPTION
Brings two pieces of the Ember `app/index.html` shell over to the Svelte app:

- A `<noscript>` element with the same wording and styling as Ember (the matching CSS rule was already present in `svelte/src/lib/css/global.css`).
- An inline error-handling bootstrap that swaps in a friendly error message if the app bundle fails to load, cleared at the top of `init()` in `hooks.client.ts` once the app boots.

The bootstrap binds the handler to both `window.onerror` and `window.onunhandledrejection`. SvelteKit boots via dynamic `import()` calls whose failures surface as unhandled promise rejections rather than synchronous errors, so `window.onerror` alone would not catch the most common load-failure mode. `window.onerror` is kept for the case where the inline boot script itself fails to parse or throws synchronously, e.g. on a browser too old to understand `import()` syntax, which is exactly the scenario the fallback message hints at with "up-to-date browser".

SvelteKit's `csp.mode: 'hash'` only auto-hashes scripts SvelteKit emits itself, so the SHA-256 of the inline script in `app.html` is pinned manually in `csp.directives['script-src']`. `svelte/src/app.html` is added to `.prettierignore` so Prettier cannot reformat the script and invalidate the hash.

### Related

- https://github.com/rust-lang/crates.io/issues/12515
