### PR TITLE
svelte: Enable build-time asset precompression

### DIFF
--- a/script/precompress-assets.mjs
+++ b/script/precompress-assets.mjs
@@ -5,7 +5,7 @@ import { constants, createBrotliCompress, createGzip } from 'node:zlib';
 
 import { globby } from 'globby';
 
-const DIRECTORIES = ['dist', 'svelte/build'];
+const DIRECTORIES = ['dist'];
 const PATTERNS = ['**/*.css', '**/*.html', '**/*.js', '**/*.map', '**/*.svg', '**/*.txt', '**/*.xml'];
 
 for (let dir of DIRECTORIES) {

--- a/svelte/svelte.config.js
+++ b/svelte/svelte.config.js
@@ -12,6 +12,10 @@ const config = {
       // https://svelte.dev/docs/kit/single-page-apps#Usage recommends to
       // avoid using `index.html` as a fallback page, so we use `200.html` instead.
       fallback: '200.html',
+      // Emit `.br` and `.gz` siblings for static assets at build time. The
+      // backend's `static_or_continue` middleware serves them via
+      // `ServeDir::precompressed_br().precompressed_gzip()`.
+      precompress: true,
     }),
     paths: {
       // We are serving the app from the `/svelte` subdirectory for now


### PR DESCRIPTION
Sets `precompress: true` on `@sveltejs/adapter-static` so the build emits `.br` and `.gz` siblings for HTML, JS, CSS, JSON, SVG, XML, WASM, and TXT files. The backend's `static_or_continue` middleware already serves them via `ServeDir::precompressed_br().precompressed_gzip()`; this just populates the files for it to find.

Brotli is produced at `BROTLI_MAX_QUALITY` with `BROTLI_MODE_TEXT`. With the precompressed siblings in place, requests fall back to the runtime `CompressionLayer` only when no precomputed match exists.

Drops the now-redundant `svelte/build` entry from `script/precompress-assets.mjs`. That entry was already a no-op in production (the buildpack runs root `pnpm build` before `pnpm --filter ... build` for Svelte, so `svelte/build/` did not exist when the script walked it).

Verified locally: a fresh `pnpm build` in `svelte/` produces 253 `.br` and 253 `.gz` siblings, including hashed assets under `_app/immutable/chunks/`.

### Related

- https://github.com/rust-lang/crates.io/issues/12515