### PR TITLE
svelte: Show keywords in `CrateHeader` on the settings page

### DIFF
--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -285,6 +285,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await page.click('[data-test-settings-tab] a');
 
     await expect(page).toHaveURL('/crates/nanomsg/settings');
+    await expect(page.locator('[data-test-keyword="network"]')).toBeVisible();
   });
 
   test('keywords are shown when navigating from search', async ({ page, msw }) => {

--- a/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
@@ -188,7 +188,7 @@
 
 <PageTitle title="Manage Crate Settings" />
 
-<CrateHeader crate={data.crate} ownersPromise={data.ownersPromise} />
+<CrateHeader crate={data.crate} keywords={data.keywords} ownersPromise={data.ownersPromise} />
 
 <div class="header">
   <h2>Owners</h2>


### PR DESCRIPTION
Commit 6d6f71db41 fixed this for versions, dependencies, reverse dependencies, and security, but missed the settings page. This commit fixes the issue.