### PR TITLE
common_headers: Drop `/assets/` arm of the long-cache rule

### DIFF
--- a/src/middleware/common_headers.rs
+++ b/src/middleware/common_headers.rs
@@ -30,7 +30,7 @@ pub async fn add_common_headers(request: Request, next: Next) -> impl IntoRespon
         expires(&mut headers, ONE_DAY);
     }
 
-    if path.starts_with("/assets/") || path.starts_with("/_app/immutable/") {
+    if path.starts_with("/_app/immutable/") {
         expires(&mut headers, 10 * ONE_YEAR);
     }
 


### PR DESCRIPTION
Ember's content-hashed `dist/assets/*` was the reason for the 10-year cache on `/assets/`. After the Svelte switch the only path under that prefix is the OG-image fallback at `/assets/og-image.png`, which shouldn't be cached for a decade. SvelteKit-emitted hashed bundles live under `/_app/immutable/`, which keeps the long cache.

### Related

- https://github.com/rust-lang/crates.io/issues/12515