### PR TITLE
CI: Drop the Ember-only `frontend-test` job

### DIFF
--- a/.github/changed-files.yml
+++ b/.github/changed-files.yml
@@ -36,17 +36,6 @@ frontend_lint:
   # Include all markdown files for `prettier` checks
   - '**/*.md'
 
-frontend_test:
-  - .github/workflows/**
-  - app/**
-  - packages/crates-io-msw/**
-  - public/**
-  - tests/**
-  - ember-cli-build.js
-  - package.json
-  - pnpm-lock.yaml
-  - testem.js
-
 msw_test:
   - .github/workflows/**
   - packages/crates-io-msw/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
     needs: filter-jobs
     if: needs.filter-jobs.outputs.zizmor == 'true'
     permissions:
-      security-events: write  # needed by `codeql-action/upload-sarif` to upload zizmor results to GitHub code scanning
+      security-events: write # needed by `codeql-action/upload-sarif` to upload zizmor results to GitHub code scanning
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -327,7 +327,7 @@ jobs:
           category: zizmor
 
   svelte:
-    name: Svelte (experimental)
+    name: Frontend / Test
     runs-on: ubuntu-24.04
     needs: filter-jobs
     if: needs.filter-jobs.outputs.svelte == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
       backend-migrations: ${{ steps.changed-files.outputs.backend_migrations_any_modified }}
       backend-test: ${{ steps.changed-files.outputs.backend_test_any_modified }}
       frontend-lint: ${{ steps.changed-files.outputs.frontend_lint_any_modified }}
-      frontend-test: ${{ steps.changed-files.outputs.frontend_test_any_modified }}
       msw-test: ${{ steps.changed-files.outputs.msw_test_any_modified }}
       api-client-test: ${{ steps.changed-files.outputs.api_client_test_any_modified }}
       e2e-test: ${{ steps.changed-files.outputs.e2e_test_any_modified }}
@@ -213,33 +212,6 @@ jobs:
       - run: pnpm lint:js
       - run: pnpm lint:deps
       - run: pnpm prettier:check
-
-  frontend-test:
-    name: Frontend / Test
-    runs-on: ubuntu-24.04
-    needs: filter-jobs
-    if: needs.filter-jobs.outputs.frontend-test == 'true'
-
-    env:
-      JOBS: 1 # See https://git.io/vdao3 for details.
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          cache: pnpm
-          node-version-file: package.json
-
-      - run: pnpm install
-
-      - run: pnpm test
 
   msw-test:
     name: Frontend / Test (@crates-io/msw)


### PR DESCRIPTION
The `pnpm test` it invokes is the Ember test runner, which will be removed in a follow-up PR.

### Related

- https://github.com/rust-lang/crates.io/issues/12515