### PR TITLE
e2e: Take Percy snapshot after content is rendered in trustpub settings test

### DIFF
--- a/e2e/routes/crate/settings.spec.ts
+++ b/e2e/routes/crate/settings.spec.ts
@@ -101,8 +101,6 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       await page.goto('/crates/foo/settings');
       await expect(page).toHaveURL('/crates/foo/settings');
 
-      await percy.snapshot();
-
       // Check that both GitHub and GitLab configs are displayed
       await expect(page.locator('[data-test-trusted-publishing]')).toBeVisible();
       await expect(page.locator('[data-test-add-trusted-publisher-button]')).toBeVisible();
@@ -124,6 +122,8 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       await expect(details).toContainText('Environment: production');
 
       await expect(page.locator('[data-test-no-config]')).not.toBeVisible();
+
+      await percy.snapshot();
     });
 
     test.describe('GitHub', () => {


### PR DESCRIPTION
The 'mixed GitHub and GitLab configs' test was calling `percy.snapshot()` immediately after `page.goto()`, before any visibility assertions. This let Percy occasionally capture the page before SvelteKit had finished rendering, producing snapshots showing only the bare page background.

Move the snapshot call after the existing visibility checks so it only runs once the trusted publishing table and both config rows are present.