### PR TITLE
svelte: Add missing `mermaid` dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
+      mermaid:
+        specifier: 11.14.0
+        version: 11.14.0
       pretty-bytes:
         specifier: 7.1.0
         version: 7.1.0

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -29,6 +29,7 @@
     "chart.js": "4.5.1",
     "date-fns": "4.1.0",
     "highlight.js": "11.11.1",
+    "mermaid": "11.14.0",
     "pretty-bytes": "7.1.0",
     "semver": "7.7.4"
   },


### PR DESCRIPTION
`mermaid` is dynamically imported in `src/lib/attachments/mermaid.ts` but was only declared in the root `package.json`, where it was inherited via the workspace. Add it explicitly to `svelte/package.json` so the Svelte app keeps working once the Ember app is removed from the root.

### Related

- https://github.com/rust-lang/crates.io/issues/12515