### PR TITLE
svelte: Strip test selectors from production builds

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       globals:
         specifier: 17.5.0
         version: 17.5.0
+      magic-string:
+        specifier: 0.30.21
+        version: 0.30.21
       msw:
         specifier: 2.14.2
         version: 2.14.2(@types/node@24.12.2)(typescript@6.0.3)
@@ -267,6 +270,9 @@ importers:
       vitest-browser-svelte:
         specifier: 2.1.1
         version: 2.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vitest@4.1.5)
+      zimmerframe:
+        specifier: 1.1.2
+        version: 1.1.2
 
 packages:
 

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-storybook": "10.3.6",
     "eslint-plugin-svelte": "3.17.1",
     "globals": "17.5.0",
+    "magic-string": "0.30.21",
     "msw": "2.14.2",
     "playwright": "1.59.1",
     "prettier": "3.8.3",
@@ -73,7 +74,8 @@
     "vite": "8.0.10",
     "vite-bundle-analyzer": "1.3.8",
     "vitest": "4.1.5",
-    "vitest-browser-svelte": "2.1.1"
+    "vitest-browser-svelte": "2.1.1",
+    "zimmerframe": "1.1.2"
   },
   "msw": {
     "workerDirectory": [

--- a/svelte/src/build/strip-test-selectors.js
+++ b/svelte/src/build/strip-test-selectors.js
@@ -1,0 +1,45 @@
+import MagicString from 'magic-string';
+import { parse } from 'svelte/compiler';
+import { walk } from 'zimmerframe';
+
+/**
+ * Removes `data-test-*` and `data-testid` attributes from `.svelte` markup.
+ *
+ * Returns a Svelte preprocessor that always strips when invoked. The decision
+ * to invoke it lives in `svelte.config.js`.
+ *
+ * @returns {import('svelte/compiler').PreprocessorGroup}
+ */
+export default function stripTestSelectors() {
+  return {
+    name: 'strip-test-selectors',
+
+    markup({ content, filename }) {
+      let ast = parse(content, { modern: true, filename });
+
+      /** @type {Array<{ start: number, end: number }>} */
+      let removals = [];
+
+      walk(/** @type {import('svelte/compiler').AST.SvelteNode} */ (ast), null, {
+        Attribute(node, ctx) {
+          if (node.name.startsWith('data-test-') || node.name === 'data-testid') {
+            removals.push({ start: node.start, end: node.end });
+          }
+          ctx.next();
+        },
+      });
+
+      if (removals.length === 0) return undefined;
+
+      let s = new MagicString(content);
+      for (let { start, end } of removals) {
+        s.remove(start, end);
+      }
+
+      return {
+        code: s.toString(),
+        map: s.generateMap({ hires: 'boundary', source: filename }),
+      };
+    },
+  };
+}

--- a/svelte/src/build/strip-test-selectors.test.ts
+++ b/svelte/src/build/strip-test-selectors.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'vitest';
+
+import stripTestSelectors from './strip-test-selectors.js';
+
+interface PreprocessResult {
+  code: string;
+  map?: object;
+}
+
+function run(source: string): PreprocessResult | undefined {
+  let group = stripTestSelectors();
+  let result = group.markup!({ content: source, filename: 'Test.svelte' });
+  return result as PreprocessResult | undefined;
+}
+
+function transform(source: string): string {
+  return run(source)?.code ?? source;
+}
+
+describe('strip-test-selectors', () => {
+  describe('strips matching attributes', () => {
+    test('boolean attribute', () => {
+      expect(transform(`<div data-test-foo></div>`)).toMatchInlineSnapshot(`"<div ></div>"`);
+    });
+
+    test('multiple attributes on one element, mixed with other attributes', () => {
+      expect(transform(`<div class="x" data-test-a id="y" data-test-b></div>`)).toMatchInlineSnapshot(
+        `"<div class="x"  id="y" ></div>"`,
+      );
+    });
+
+    test('multiple elements, multiple selectors each', () => {
+      let input = [
+        `<div data-test-a data-test-b>1</div>`,
+        `<div data-test-c data-test-d>2</div>`,
+        `<div data-test-e data-test-f>3</div>`,
+      ].join('\n');
+
+      expect(transform(input)).toMatchInlineSnapshot(`
+        "<div  >1</div>
+        <div  >2</div>
+        <div  >3</div>"
+      `);
+    });
+
+    test('static string value', () => {
+      expect(transform(`<div data-test-foo="bar"></div>`)).toMatchInlineSnapshot(`"<div ></div>"`);
+    });
+
+    test('expression value', () => {
+      expect(transform(`<div data-test-foo={someExpr}></div>`)).toMatchInlineSnapshot(`"<div ></div>"`);
+    });
+
+    test('quoted value with interpolation', () => {
+      expect(transform(`<div data-test-foo="hello {name}"></div>`)).toMatchInlineSnapshot(`"<div ></div>"`);
+    });
+
+    test('data-testid exact match', () => {
+      expect(transform(`<div data-testid="x"></div>`)).toMatchInlineSnapshot(`"<div ></div>"`);
+    });
+
+    test('component attribute', () => {
+      expect(transform(`<PageHeader data-test-heading other={x}></PageHeader>`)).toMatchInlineSnapshot(
+        `"<PageHeader  other={x}></PageHeader>"`,
+      );
+    });
+
+    test('self-closing element', () => {
+      expect(transform(`<input data-test-foo />`)).toMatchInlineSnapshot(`"<input  />"`);
+    });
+  });
+
+  describe('preserves non-matching markup', () => {
+    test('non-matching data-* attribute', () => {
+      let input = `<div data-foo></div>`;
+      expect(transform(input)).toBe(input);
+    });
+
+    test('data-test with no hyphen and no `id` suffix', () => {
+      let input = `<div data-test></div>`;
+      expect(transform(input)).toBe(input);
+    });
+
+    test('text content containing the literal', () => {
+      let input = `<span>data-test-foo</span>`;
+      expect(transform(input)).toBe(input);
+    });
+
+    test('CSS selector inside <style>', () => {
+      let input = `<div></div>\n<style>[data-test-foo] { color: red; }</style>`;
+      expect(transform(input)).toBe(input);
+    });
+
+    test('string literal inside <script>', () => {
+      let input = `<script>let x = 'data-test-foo';</script>\n<div></div>`;
+      expect(transform(input)).toBe(input);
+    });
+
+    test('spread attribute alone', () => {
+      let input = `<div {...rest}></div>`;
+      expect(transform(input)).toBe(input);
+    });
+  });
+
+  describe('output shape', () => {
+    test('returns code and map when changes are made', () => {
+      let result = run(`<div data-test-foo></div>`);
+      expect(result).toBeDefined();
+      expect(result!.code).toBe(`<div ></div>`);
+      expect(result!.map).toBeDefined();
+      expect(typeof result!.map).toBe('object');
+    });
+
+    test('returns undefined when no changes are made', () => {
+      let result = run(`<div class="x"></div>`);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/svelte/svelte.config.js
+++ b/svelte/svelte.config.js
@@ -1,11 +1,19 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
+import stripTestSelectors from './src/build/strip-test-selectors.js';
+
+const preprocess = [vitePreprocess()];
+
+if (process.env.NODE_ENV === 'production' && !process.env.PLAYWRIGHT && !process.env.VITEST) {
+  preprocess.unshift(stripTestSelectors());
+}
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   // Consult https://svelte.dev/docs/kit/integrations
   // for more information about preprocessors
-  preprocess: vitePreprocess(),
+  preprocess,
 
   kit: {
     adapter: adapter({


### PR DESCRIPTION
Add a Svelte preprocessor that removes `data-test-*` and `data-testid` attributes from `.svelte` markup. Mirrors what `ember-test-selectors` did for the old Ember app: keep selectors in dev, vitest, and Playwright e2e builds; remove them from the shipped production bundle.

The preprocessor uses `svelte/compiler`'s `parse` to find `Attribute` nodes by name and `magic-string` to splice them out by character offsets. It is registered in `svelte.config.js` only when `NODE_ENV=production` and neither `PLAYWRIGHT` nor `VITEST` is set.