### PR TITLE
e2e/banner-messages: Set `read_only` to `false` in dismissal test

### DIFF
--- a/e2e/acceptance/banner-messages.spec.ts
+++ b/e2e/acceptance/banner-messages.spec.ts
@@ -6,7 +6,7 @@ const TEST_APP = process.env.TEST_APP ?? 'ember';
 test.describe('Acceptance | Banner Messages', { tag: '@acceptance' }, () => {
   test('banner message can be dismissed and that is remembered', async ({ page, msw }) => {
     msw.worker.use(
-      http.get('/api/v1/site_metadata', () => HttpResponse.json({ read_only: true, banner_message: 'test message' })),
+      http.get('/api/v1/site_metadata', () => HttpResponse.json({ read_only: false, banner_message: 'test message' })),
     );
     await page.goto('/');
 
@@ -37,7 +37,7 @@ test.describe('Acceptance | Banner Messages', { tag: '@acceptance' }, () => {
     // — appears.
     msw.worker.use(
       http.get('/api/v1/site_metadata', () =>
-        HttpResponse.json({ read_only: true, banner_message: 'second test message' }),
+        HttpResponse.json({ read_only: false, banner_message: 'second test message' }),
       ),
     );
     await page.reload();


### PR DESCRIPTION
After dismissing a custom banner message, the Svelte layout intentionally falls back to showing the read-only banner when `read_only` is true. The dismissal test sent `read_only: true` and then asserted no banner after reload, contradicting that behavior.

The interaction between `read_only` and `banner_message` is already covered by `read-only-mode.spec.ts`, so this test only needs `banner_message`.