### PR TITLE
trustpub: Align JTI lifetime with JWT validation leeway

### DIFF
--- a/crates/crates_io_trustpub/src/github/claims.rs
+++ b/crates/crates_io_trustpub/src/github/claims.rs
@@ -54,6 +54,7 @@ impl GitHubClaims {
 
 fn validation(audience: &str) -> Validation {
     let mut validation = Validation::new(Algorithm::RS256);
+    validation.leeway = crate::JWT_LEEWAY.num_seconds() as u64;
     validation.required_spec_claims.insert("iss".into());
     validation.required_spec_claims.insert("exp".into());
     validation.required_spec_claims.insert("aud".into());

--- a/crates/crates_io_trustpub/src/gitlab/claims.rs
+++ b/crates/crates_io_trustpub/src/gitlab/claims.rs
@@ -53,6 +53,7 @@ impl GitLabClaims {
 
 fn validation(audience: &str) -> Validation {
     let mut validation = Validation::new(Algorithm::RS256);
+    validation.leeway = crate::JWT_LEEWAY.num_seconds() as u64;
     validation.required_spec_claims.insert("iss".into());
     validation.required_spec_claims.insert("exp".into());
     validation.required_spec_claims.insert("aud".into());

--- a/crates/crates_io_trustpub/src/lib.rs
+++ b/crates/crates_io_trustpub/src/lib.rs
@@ -7,3 +7,15 @@ pub mod keystore;
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_keys;
 pub mod unverified;
+
+/// Leeway applied to JWT `exp`, `nbf`, and `iat` validation to account for
+/// clock skew between the OIDC issuer and crates.io.
+///
+/// The same value is added to the `expires_at` of stored JTIs in the
+/// `trustpub_used_jtis` table so that replay protection covers the full
+/// window during which a JWT's signature is still accepted by
+/// `jsonwebtoken::decode`. Keeping these two values in lock-step is a
+/// security invariant: if the JTI record expires before the JWT signature
+/// does, an attacker who has obtained the JWT can replay it to mint a fresh
+/// upload token.
+pub const JWT_LEEWAY: chrono::Duration = chrono::Duration::seconds(60);

--- a/src/controllers/trustpub/tokens/exchange/mod.rs
+++ b/src/controllers/trustpub/tokens/exchange/mod.rs
@@ -8,6 +8,7 @@ use crates_io_database::models::trustpub::{
 };
 use crates_io_database::schema::{trustpub_configs_github, trustpub_configs_gitlab};
 use crates_io_diesel_helpers::lower;
+use crates_io_trustpub::JWT_LEEWAY;
 use crates_io_trustpub::access_token::AccessToken;
 use crates_io_trustpub::github::{GITHUB_ISSUER_URL, GitHubClaims};
 use crates_io_trustpub::gitlab::{GITLAB_ISSUER_URL, GitLabClaims};
@@ -70,7 +71,11 @@ fn unsupported_issuer(issuer: &str) -> BoxedAppError {
 }
 
 async fn insert_jti(conn: &mut AsyncPgConnection, jti: &str, exp: DateTime<Utc>) -> AppResult<()> {
-    let used_jti = NewUsedJti::new(jti, exp);
+    // Keep the JTI record alive past the JWT's `exp` for the full validation
+    // leeway window. Otherwise the cleanup worker (`DeleteExpiredJtis`) can
+    // remove the row while `jsonwebtoken::decode` would still accept the same
+    // token, opening a replay window equal to the leeway value.
+    let used_jti = NewUsedJti::new(jti, exp + JWT_LEEWAY);
     match used_jti.insert(conn).await {
         Ok(_) => Ok(()), // JTI was successfully inserted, continue
         Err(DatabaseError(UniqueViolation, _)) => {

--- a/src/tests/routes/trustpub/tokens/exchange/github.rs
+++ b/src/tests/routes/trustpub/tokens/exchange/github.rs
@@ -1,8 +1,10 @@
 use crate::builders::CrateBuilder;
 use crate::util::{MockAnonymousUser, RequestHelper, TestApp};
+use chrono::{DateTime, Utc};
 use claims::assert_ok;
 use crates_io_database::models::trustpub::NewGitHubConfig;
-use crates_io_database::schema::trustpub_tokens;
+use crates_io_database::schema::{trustpub_tokens, trustpub_used_jtis};
+use crates_io_trustpub::JWT_LEEWAY;
 use crates_io_trustpub::access_token::AccessToken;
 use crates_io_trustpub::github::GITHUB_ISSUER_URL;
 use crates_io_trustpub::github::test_helpers::FullGitHubClaims;
@@ -297,6 +299,35 @@ async fn test_token_reuse() -> anyhow::Result<()> {
     let response = client.post::<()>(URL, body).await;
     assert_snapshot!(response.status(), @"400 Bad Request");
     assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"JWT has already been used"}]}"#);
+
+    Ok(())
+}
+
+/// The stored JTI's `expires_at` must outlive the JWT's `exp` by the same
+/// leeway window that JWT validation uses, so the cleanup worker cannot
+/// remove the row while the JWT signature is still being accepted.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_jti_expires_at_includes_leeway() -> anyhow::Result<()> {
+    let client = prepare().await?;
+
+    let claims = default_claims();
+    let exp = claims.exp;
+    let jti = claims.jti.clone();
+
+    let body = claims.as_exchange_body()?;
+    let response = client.post::<()>(URL, body).await;
+    assert_snapshot!(response.status(), @"200 OK");
+
+    let mut conn = client.app().db_conn().await;
+
+    let expires_at: DateTime<Utc> = trustpub_used_jtis::table
+        .filter(trustpub_used_jtis::jti.eq(&jti))
+        .select(trustpub_used_jtis::expires_at)
+        .first(&mut conn)
+        .await?;
+
+    let expected = DateTime::<Utc>::from_timestamp(exp, 0).unwrap() + JWT_LEEWAY;
+    assert_eq!(expires_at, expected);
 
     Ok(())
 }

--- a/src/tests/routes/trustpub/tokens/exchange/gitlab.rs
+++ b/src/tests/routes/trustpub/tokens/exchange/gitlab.rs
@@ -1,8 +1,10 @@
 use crate::builders::CrateBuilder;
 use crate::util::{MockAnonymousUser, RequestHelper, TestApp};
+use chrono::{DateTime, Utc};
 use claims::{assert_ok, assert_some_eq};
 use crates_io_database::models::trustpub::{GitLabConfig, NewGitLabConfig};
-use crates_io_database::schema::{trustpub_configs_gitlab, trustpub_tokens};
+use crates_io_database::schema::{trustpub_configs_gitlab, trustpub_tokens, trustpub_used_jtis};
+use crates_io_trustpub::JWT_LEEWAY;
 use crates_io_trustpub::access_token::AccessToken;
 use crates_io_trustpub::gitlab::GITLAB_ISSUER_URL;
 use crates_io_trustpub::gitlab::test_helpers::FullGitLabClaims;
@@ -294,6 +296,35 @@ async fn test_token_reuse() -> anyhow::Result<()> {
     let response = client.post::<()>(URL, body).await;
     assert_snapshot!(response.status(), @"400 Bad Request");
     assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"JWT has already been used"}]}"#);
+
+    Ok(())
+}
+
+/// The stored JTI's `expires_at` must outlive the JWT's `exp` by the same
+/// leeway window that JWT validation uses, so the cleanup worker cannot
+/// remove the row while the JWT signature is still being accepted.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_jti_expires_at_includes_leeway() -> anyhow::Result<()> {
+    let client = prepare().await?;
+
+    let claims = default_claims();
+    let exp = claims.exp;
+    let jti = claims.jti.clone();
+
+    let body = claims.as_exchange_body()?;
+    let response = client.post::<()>(URL, body).await;
+    assert_snapshot!(response.status(), @"200 OK");
+
+    let mut conn = client.app().db_conn().await;
+
+    let expires_at: DateTime<Utc> = trustpub_used_jtis::table
+        .filter(trustpub_used_jtis::jti.eq(&jti))
+        .select(trustpub_used_jtis::expires_at)
+        .first(&mut conn)
+        .await?;
+
+    let expected = DateTime::<Utc>::from_timestamp(exp, 0).unwrap() + JWT_LEEWAY;
+    assert_eq!(expires_at, expected);
 
     Ok(())
 }


### PR DESCRIPTION
`jsonwebtoken::decode` accepts JWTs for `Validation::leeway` seconds past `exp` (default 60s), but `insert_jti` was storing `expires_at = exp`. The `DeleteExpiredJtis` cleanup worker was therefore eligible to delete the JTI row while the same JWT signature was still accepted, opening a replay window equal to the leeway value.

Centralize the leeway as a `JWT_LEEWAY` constant, set it explicitly in both validators (no behavior change, matches the prior implicit 60s default), and store JTI rows with `expires_at = exp + JWT_LEEWAY` so replay protection covers the full validation window.

### Related

- https://socket.dev/blog/pypi-fixes-high-severity-issues-found-in-security-audit