### PR TITLE
openapi: Filter internal endpoints from default response

### DIFF
--- a/packages/crates-io-api-client/schema.test.ts
+++ b/packages/crates-io-api-client/schema.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import openapiTS, { astToString } from 'openapi-typescript';
 import { expect, test } from 'vitest';
 
-const SNAPSHOT_PATH = '../../src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap';
+const SNAPSHOT_PATH = '../../src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap';
 
 const HEADER = `/**
  * This file is auto-generated. Do not edit manually.

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -40,6 +40,7 @@ pub struct LegacyListResponse {
     path = "/api/v1/me/crate_owner_invitations",
     security(("cookie" = [])),
     tag = "owners",
+    extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(LegacyListResponse))),
 )]
 pub async fn list_crate_owner_invitations_for_user(
@@ -104,6 +105,7 @@ pub struct ListQueryParams {
     params(ListQueryParams, PaginationQueryParams),
     security(("cookie" = [])),
     tag = "owners",
+    extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(PrivateListResponse))),
 )]
 pub async fn list_crate_owner_invitations(

--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -52,6 +52,7 @@ impl DeleteQueryParams {
     params(CratePath, DeleteQueryParams),
     security(("cookie" = [])),
     tag = "crates",
+    extensions(("x-internal" = json!(true))),
     responses((status = 204, description = "Successful Response")),
 )]
 pub async fn delete_crate(

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -87,6 +87,7 @@ pub struct FollowingResponse {
     params(CratePath),
     security(("cookie" = [])),
     tag = "crates",
+    extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(FollowingResponse))),
 )]
 pub async fn get_following_crate(

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -42,6 +42,7 @@ pub struct BeginResponse {
     get,
     path = "/api/private/session/begin",
     tag = "session",
+    extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(BeginResponse))),
 )]
 pub async fn begin_session(app: AppState, session: SessionExtension) -> Json<BeginResponse> {
@@ -88,6 +89,7 @@ pub struct AuthorizeQuery {
     path = "/api/private/session/authorize",
     tag = "session",
     params(AuthorizeQuery),
+    extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(EncodableMe))),
 )]
 pub async fn authorize_session(
@@ -241,6 +243,7 @@ async fn find_user_by_gh_id(mut conn: &AsyncPgConnection, gh_id: i32) -> QueryRe
     path = "/api/private/session",
     security(("cookie" = [])),
     tag = "session",
+    extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response")),
 )]
 pub async fn end_session(session: SessionExtension) -> Json<bool> {

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -59,6 +59,7 @@ pub struct ListResponse {
     params(GetParams),
     security(("cookie" = [])),
     tag = "api_tokens",
+    extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(ListResponse))),
 )]
 pub async fn list_api_tokens(
@@ -113,6 +114,7 @@ pub struct CreateResponse {
     request_body = inline(NewApiTokenRequest),
     security(("cookie" = [])),
     tag = "api_tokens",
+    extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(CreateResponse))),
 )]
 pub async fn create_api_token(

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -20,6 +20,7 @@ use serde::Serialize;
     path = "/api/v1/me",
     security(("cookie" = [])),
     tag = "users",
+    extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(EncodableMe))),
 )]
 pub async fn get_authenticated_user(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
@@ -88,6 +89,7 @@ pub struct UpdatesResponseMeta {
     path = "/api/v1/me/updates",
     security(("cookie" = [])),
     tag = "versions",
+    extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(UpdatesResponse))),
 )]
 pub async fn get_authenticated_user_updates(

--- a/src/controllers/version/docs.rs
+++ b/src/controllers/version/docs.rs
@@ -20,6 +20,7 @@ use tracing::error;
         ("cookie" = []),
     ),
     tag = "versions",
+    extensions(("x-internal" = json!(true))),
     responses((status = 201, description = "Successful Response")),
 )]
 pub async fn rebuild_version_docs(

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,8 +1,16 @@
+use axum::Extension;
+use axum::Json;
+use axum::extract::Query;
 use crates_io_session::COOKIE_NAME;
 use http::header;
+use serde::Deserialize;
+use utoipa::openapi::OpenApi as OpenApiDoc;
+use utoipa::openapi::path::{Operation, PathItem};
 use utoipa::openapi::security::{ApiKey, ApiKeyValue, Http, HttpAuthScheme, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 use utoipa_axum::router::OpenApiRouter;
+
+const X_INTERNAL: &str = "x-internal";
 
 const DESCRIPTION: &str = r#"
 __Experimental API documentation for the [crates.io](https://crates.io/)
@@ -81,4 +89,67 @@ impl Modify for SecurityAddon {
 
         components.add_security_scheme("trustpub_token", SecurityScheme::Http(trustpub_token));
     }
+}
+
+#[derive(Deserialize)]
+pub struct Params {
+    #[serde(default)]
+    internal: Option<String>,
+}
+
+pub async fn handler(
+    Extension(mut doc): Extension<OpenApiDoc>,
+    Query(params): Query<Params>,
+) -> Json<OpenApiDoc> {
+    apply_visibility(&mut doc, params.internal.is_some());
+    Json(doc)
+}
+
+/// Mutate `openapi` in place: drop operations marked `x-internal: true` when
+/// `include_internal` is false, and strip the marker from any remaining
+/// operations regardless.
+fn apply_visibility(openapi: &mut OpenApiDoc, include_internal: bool) {
+    openapi.paths.paths.retain(|_, item| {
+        prune_path_item(item, include_internal);
+        !path_item_is_empty(item)
+    });
+}
+
+fn prune_path_item(item: &mut PathItem, include_internal: bool) {
+    for slot in [
+        &mut item.get,
+        &mut item.put,
+        &mut item.post,
+        &mut item.delete,
+        &mut item.options,
+        &mut item.head,
+        &mut item.patch,
+        &mut item.trace,
+    ] {
+        let Some(op) = slot.as_mut() else { continue };
+        if !include_internal && is_internal(op) {
+            *slot = None;
+        } else if let Some(ext) = op.extensions.as_mut() {
+            ext.remove(X_INTERNAL);
+        }
+    }
+}
+
+fn is_internal(op: &Operation) -> bool {
+    op.extensions
+        .as_ref()
+        .and_then(|ext| ext.get(X_INTERNAL))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+fn path_item_is_empty(item: &PathItem) -> bool {
+    item.get.is_none()
+        && item.put.is_none()
+        && item.post.is_none()
+        && item.delete.is_none()
+        && item.options.is_none()
+        && item.head.is_none()
+        && item.patch.is_none()
+        && item.trace.is_none()
 }

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,9 +1,13 @@
 use axum::Extension;
-use axum::Json;
+use axum::body::Bytes;
 use axum::extract::Query;
+use axum::response::IntoResponse;
+use axum_extra::TypedHeader;
+use axum_extra::headers::ContentType;
 use crates_io_session::COOKIE_NAME;
 use http::header;
 use serde::Deserialize;
+use std::sync::{Arc, OnceLock};
 use utoipa::openapi::OpenApi as OpenApiDoc;
 use utoipa::openapi::path::{Operation, PathItem};
 use utoipa::openapi::security::{ApiKey, ApiKeyValue, Http, HttpAuthScheme, SecurityScheme};
@@ -98,11 +102,24 @@ pub struct Params {
 }
 
 pub async fn handler(
-    Extension(mut doc): Extension<OpenApiDoc>,
+    Extension(doc): Extension<Arc<OpenApiDoc>>,
     Query(params): Query<Params>,
-) -> Json<OpenApiDoc> {
-    apply_visibility(&mut doc, params.internal.is_some());
-    Json(doc)
+) -> impl IntoResponse {
+    static PUBLIC_BYTES: OnceLock<Bytes> = OnceLock::new();
+    static FULL_BYTES: OnceLock<Bytes> = OnceLock::new();
+
+    let cache = match params.internal {
+        None => &PUBLIC_BYTES,
+        Some(_) => &FULL_BYTES,
+    };
+
+    let bytes = cache.get_or_init(|| {
+        let mut doc = (*doc).clone();
+        apply_visibility(&mut doc, params.internal.is_some());
+        Bytes::from(serde_json::to_vec(&doc).expect("OpenAPI serialization failed"))
+    });
+
+    (TypedHeader(ContentType::json()), bytes.clone())
 }
 
 /// Mutate `openapi` in place: drop operations marked `x-internal: true` when

--- a/src/router.rs
+++ b/src/router.rs
@@ -2,6 +2,7 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Extension, Router};
 use http::{Method, StatusCode};
+use std::sync::Arc;
 use utoipa_axum::routes;
 
 use crate::Env;
@@ -131,7 +132,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
     router
         .route(
             "/api/openapi.json",
-            get(openapi::handler).layer(Extension(openapi)),
+            get(openapi::handler).layer(Extension(Arc::new(openapi))),
         )
         .fallback(async |method: Method| match method {
             Method::HEAD => StatusCode::NOT_FOUND.into_response(),

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,13 +1,13 @@
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
-use axum::{Json, Router};
+use axum::{Extension, Router};
 use http::{Method, StatusCode};
 use utoipa_axum::routes;
 
 use crate::Env;
 use crate::app::AppState;
 use crate::controllers::*;
-use crate::openapi::BaseOpenApi;
+use crate::openapi::{self, BaseOpenApi};
 use crate::util::errors::not_found;
 
 #[allow(deprecated)]
@@ -129,7 +129,10 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
     }
 
     router
-        .route("/api/openapi.json", get(async || Json(openapi)))
+        .route(
+            "/api/openapi.json",
+            get(openapi::handler).layer(Extension(openapi)),
+        )
         .fallback(async |method: Method| match method {
             Method::HEAD => StatusCode::NOT_FOUND.into_response(),
             _ => not_found().into_response(),

--- a/src/tests/openapi.rs
+++ b/src/tests/openapi.rs
@@ -9,3 +9,12 @@ async fn test_openapi_snapshot() {
     assert_snapshot!(response.status(), @"200 OK");
     assert_json_snapshot!(response.json());
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_openapi_internal_snapshot() {
+    let (_app, anon) = TestApp::init().empty().await;
+
+    let response = anon.get::<()>("/api/openapi.json?internal").await;
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_json_snapshot!(response.json());
+}

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1331,6 +1331,256 @@ expression: response.json()
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/private/crate_owner_invitations": {
+      "get": {
+        "operationId": "list_crate_owner_invitations",
+        "parameters": [
+          {
+            "description": "Filter crate owner invitations by crate name.\n\nOnly crate owners can query pending invitations for their crate.",
+            "in": "query",
+            "name": "crate_name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the user who was invited to be a crate owner.\n\nThis parameter needs to match the authenticated user's ID.",
+            "in": "query",
+            "name": "invitee_id",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The page number to request.\n\nThis parameter is mutually exclusive with `seek` and not supported for\nall requests.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The number of items to request per page.",
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The seek key to request.\n\nThis parameter is mutually exclusive with `page` and not supported for\nall requests.\n\nThe seek key can usually be found in the `meta.next_page` field of\npaginated responses.",
+            "in": "query",
+            "name": "seek",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "invitations": {
+                      "description": "The list of crate owner invitations.",
+                      "items": {
+                        "$ref": "#/components/schemas/CrateOwnerInvitation"
+                      },
+                      "type": "array"
+                    },
+                    "meta": {
+                      "properties": {
+                        "next_page": {
+                          "description": "Query parameter string to fetch the next page of results.",
+                          "example": "?seek=c0ffee",
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "users": {
+                      "description": "The list of users referenced in the crate owner invitations.",
+                      "items": {
+                        "$ref": "#/components/schemas/User"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "invitations",
+                    "users",
+                    "meta"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          }
+        ],
+        "summary": "List all crate owner invitations for a crate or user.",
+        "tags": [
+          "owners"
+        ]
+      }
+    },
+    "/api/private/session": {
+      "delete": {
+        "operationId": "end_session",
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          }
+        ],
+        "summary": "End the current session.",
+        "tags": [
+          "session"
+        ]
+      }
+    },
+    "/api/private/session/authorize": {
+      "get": {
+        "description": "This route is called from the GitHub API OAuth flow after the user accepted or rejected\nthe data access permissions. It will check the `state` parameter and then call the GitHub API\nto exchange the temporary `code` for an API token. The API token is returned together with\nthe corresponding user information.\n\nsee <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>\n\n## Query Parameters\n\n- `code` – temporary code received from the GitHub API  **(Required)**\n- `state` – state parameter received from the GitHub API  **(Required)**",
+        "operationId": "authorize_session",
+        "parameters": [
+          {
+            "description": "Temporary code received from the GitHub API.",
+            "example": "901dd10e07c7e9fa1cd5",
+            "in": "query",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "State parameter received from the GitHub API.",
+            "example": "fYcUY3FMdUUz00FC7vLT7A",
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "owned_crates": {
+                      "description": "The crates that the authenticated user owns.",
+                      "items": {
+                        "properties": {
+                          "email_notifications": {
+                            "deprecated": true,
+                            "type": "boolean"
+                          },
+                          "id": {
+                            "description": "The opaque identifier of the crate.",
+                            "example": 123,
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "The name of the crate.",
+                            "example": "serde",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email_notifications"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/AuthenticatedUser",
+                      "description": "The authenticated user."
+                    }
+                  },
+                  "required": [
+                    "user",
+                    "owned_crates"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Complete authentication flow.",
+        "tags": [
+          "session"
+        ]
+      }
+    },
+    "/api/private/session/begin": {
+      "get": {
+        "description": "This route will return an authorization URL for the GitHub OAuth flow including the crates.io\n`client_id` and a randomly generated `state` secret.\n\nsee <https://developer.github.com/v3/oauth/#redirect-users-to-request-github-access>",
+        "operationId": "begin_session",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "state": {
+                      "example": "b84a63c4ea3fcb4ac84",
+                      "type": "string"
+                    },
+                    "url": {
+                      "example": "https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "state"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Begin authentication flow.",
+        "tags": [
+          "session"
+        ]
+      }
+    },
     "/api/v1/categories": {
       "get": {
         "operationId": "list_categories",
@@ -1861,6 +2111,43 @@ expression: response.json()
       }
     },
     "/api/v1/crates/{name}": {
+      "delete": {
+        "description": "The crate is immediately deleted from the database, and with a small delay\nfrom the git and sparse index, and the crate file storage.\n\nThe crate can only be deleted by the owner of the crate, and only if the\ncrate has been published for less than 72 hours, or if the crate has a\nsingle owner, has been downloaded less than 1000 times for each month it has\nbeen published, and is not depended upon by any other crate on crates.io.",
+        "operationId": "delete_crate",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "message",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          }
+        ],
+        "summary": "Delete a crate.",
+        "tags": [
+          "crates"
+        ]
+      },
       "get": {
         "operationId": "find_crate",
         "parameters": [
@@ -2209,6 +2496,52 @@ expression: response.json()
           }
         ],
         "summary": "Follow a crate.",
+        "tags": [
+          "crates"
+        ]
+      }
+    },
+    "/api/v1/crates/{name}/following": {
+      "get": {
+        "operationId": "get_following_crate",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "following": {
+                      "description": "Whether the authenticated user is following the crate.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "following"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          }
+        ],
+        "summary": "Check if a crate is followed.",
         "tags": [
           "crates"
         ]
@@ -3123,6 +3456,46 @@ expression: response.json()
         ]
       }
     },
+    "/api/v1/crates/{name}/{version}/rebuild_docs": {
+      "post": {
+        "operationId": "rebuild_version_docs",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number",
+            "example": "1.0.0",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          }
+        ],
+        "summary": "Trigger a rebuild for the crate documentation on docs.rs.",
+        "tags": [
+          "versions"
+        ]
+      }
+    },
     "/api/v1/crates/{name}/{version}/unyank": {
       "put": {
         "operationId": "unyank_version",
@@ -3372,6 +3745,117 @@ expression: response.json()
         ]
       }
     },
+    "/api/v1/me": {
+      "get": {
+        "operationId": "get_authenticated_user",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "owned_crates": {
+                      "description": "The crates that the authenticated user owns.",
+                      "items": {
+                        "properties": {
+                          "email_notifications": {
+                            "deprecated": true,
+                            "type": "boolean"
+                          },
+                          "id": {
+                            "description": "The opaque identifier of the crate.",
+                            "example": 123,
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "The name of the crate.",
+                            "example": "serde",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email_notifications"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/AuthenticatedUser",
+                      "description": "The authenticated user."
+                    }
+                  },
+                  "required": [
+                    "user",
+                    "owned_crates"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          }
+        ],
+        "summary": "Get the currently authenticated user.",
+        "tags": [
+          "users"
+        ]
+      }
+    },
+    "/api/v1/me/crate_owner_invitations": {
+      "get": {
+        "operationId": "list_crate_owner_invitations_for_user",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "crate_owner_invitations": {
+                      "description": "The list of crate owner invitations.",
+                      "items": {
+                        "$ref": "#/components/schemas/LegacyCrateOwnerInvitation"
+                      },
+                      "type": "array"
+                    },
+                    "users": {
+                      "description": "The list of users referenced in the crate owner invitations.",
+                      "items": {
+                        "$ref": "#/components/schemas/User"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "crate_owner_invitations",
+                    "users"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          }
+        ],
+        "summary": "List all crate owner invitations for the authenticated user.",
+        "tags": [
+          "owners"
+        ]
+      }
+    },
     "/api/v1/me/crate_owner_invitations/accept/{token}": {
       "put": {
         "operationId": "accept_crate_owner_invitation_with_token",
@@ -3570,6 +4054,140 @@ expression: response.json()
         ]
       }
     },
+    "/api/v1/me/tokens": {
+      "get": {
+        "operationId": "list_api_tokens",
+        "parameters": [
+          {
+            "description": "Include tokens that expired within the last `expired_days` days.\n\nBy default, expired tokens are excluded from the response.",
+            "in": "query",
+            "name": "expired_days",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "api_tokens": {
+                      "items": {
+                        "$ref": "#/components/schemas/ApiToken"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "api_tokens"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          }
+        ],
+        "summary": "List all API tokens of the authenticated user.",
+        "tags": [
+          "api_tokens"
+        ]
+      },
+      "put": {
+        "operationId": "create_api_token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Request body for creating a new API token.",
+                "properties": {
+                  "api_token": {
+                    "description": "Properties for a new API token.",
+                    "properties": {
+                      "crate_scopes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": [
+                          "array",
+                          "null"
+                        ]
+                      },
+                      "endpoint_scopes": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": [
+                          "array",
+                          "null"
+                        ]
+                      },
+                      "expired_at": {
+                        "format": "date-time",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "api_token"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "api_token": {
+                      "$ref": "#/components/schemas/ApiTokenWithToken"
+                    }
+                  },
+                  "required": [
+                    "api_token"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          }
+        ],
+        "summary": "Create a new API token.",
+        "tags": [
+          "api_tokens"
+        ]
+      }
+    },
     "/api/v1/me/tokens/{id}": {
       "delete": {
         "operationId": "revoke_api_token",
@@ -3655,6 +4273,57 @@ expression: response.json()
         "summary": "Find API token by id.",
         "tags": [
           "api_tokens"
+        ]
+      }
+    },
+    "/api/v1/me/updates": {
+      "get": {
+        "operationId": "get_authenticated_user_updates",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "meta": {
+                      "properties": {
+                        "more": {
+                          "description": "Whether there are more versions to be loaded.",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "more"
+                      ],
+                      "type": "object"
+                    },
+                    "versions": {
+                      "description": "The list of recent versions of crates that the authenticated user follows.",
+                      "items": {
+                        "$ref": "#/components/schemas/Version"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "versions",
+                    "meta"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          }
+        ],
+        "summary": "List versions of crates that the authenticated user follows.",
+        "tags": [
+          "versions"
         ]
       }
     },


### PR DESCRIPTION
Operations marked with the `x-internal` OpenAPI extension are stripped from `/api/openapi.json` by default. Pass `?internal` to receive the full surface. The marker itself is removed from both responses.

Endpoints under `/api/private/*` and endpoints that only accept cookie auth (and are therefore only reachable from our own web frontend) carry the marker. The frontend's typed API client now generates types from the internal variant so it keeps access to those endpoints.