### PR TITLE
svelte: Add missing `micromark` dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,12 @@ importers:
       mermaid:
         specifier: 11.14.0
         version: 11.14.0
+      micromark:
+        specifier: 4.0.2
+        version: 4.0.2
+      micromark-extension-gfm:
+        specifier: 3.0.0
+        version: 3.0.0
       pretty-bytes:
         specifier: 7.1.0
         version: 7.1.0

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -30,6 +30,8 @@
     "date-fns": "4.1.0",
     "highlight.js": "11.11.1",
     "mermaid": "11.14.0",
+    "micromark": "4.0.2",
+    "micromark-extension-gfm": "3.0.0",
     "pretty-bytes": "7.1.0",
     "semver": "7.7.4"
   },


### PR DESCRIPTION
`micromark` and the extension are dynamically imported but they were only declared in the root `package.json`, where they were inherited via the workspace. Add them explicitly to `svelte/package.json` so the Svelte app keeps working once the Ember app is removed from the root.

### Related

- https://github.com/rust-lang/crates.io/issues/12515
- https://github.com/rust-lang/crates.io/pull/13567