### PR TITLE
docs: Replace Ember with SvelteKit in the contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,14 +10,10 @@
   - `/src/tests/` - Backend integration tests with snapshot testing using `insta`
   - `/src/config/` - Configuration loading and validation
   - `/src/util/` - Shared utilities (errors, authentication, pagination)
-- `/app/` - Frontend Ember.js application
-  - `/app/components/` - Reusable UI components (80+ components with scoped CSS files)
-  - `/app/routes/` and `/app/controllers/` - Route handlers and data loading
-  - `/app/templates/` - Handlebars templates for pages
-  - `/app/models/` - Ember Data models (crate, version, user, keyword, etc.)
-  - `/app/adapters/`, `/app/serializers/` - Ember Data adapter layer
-  - `/app/services/` - Shared services (session, notifications, API client)
-- `/svelte/` - Frontend SvelteKit application (WIP)
+- `/svelte/` - Frontend SvelteKit application
+  - `/svelte/src/routes/` - File-based routes and page components
+  - `/svelte/src/lib/` - Shared components, stores, services, and utilities
+  - `/svelte/static/` - Static assets served at `/` (favicon, robots.txt, etc.)
 - `/crates/` - Workspace crates providing specialized functionality
   - `crates_io_api_types/` - API response serialization types
   - `crates_io_database/` - Database models and schema (Diesel ORM)
@@ -27,7 +23,6 @@
   - `crates_io_trustpub/` - Trusted Publishing implementation
   - `crates_io_markdown/`, `crates_io_linecount/` - Content processing
 - `/migrations/` - Database migrations (260+ historical migrations managed by Diesel)
-- `/tests/` - Frontend tests (acceptance, components, helpers, routes, unit tests)
 - `/e2e/` - Playwright tests for the frontend with accessibility checks
 - `/packages/` - MSW (Mock Service Worker) test utilities for API mocking
 - `/script/` - Development utilities
@@ -117,24 +112,31 @@ Test database setup: Set `TEST_DATABASE_URL` in `.env` to a separate database (e
 
 ## Frontend
 
+The frontend is a SvelteKit application living in `/svelte/`. Most frontend
+commands run from inside that directory or via `pnpm --filter
+crates.io-svelte <script>` from the repo root.
+
 ### Building and Running
 
-Install dependencies:
+Install dependencies (from the repo root):
 
 ```bash
 pnpm install
 pnpm playwright install chromium-headless-shell  # Install necessary Playwright browsers
 ```
 
-Development server options:
+Development server options (from `svelte/`):
 
 ```bash
-pnpm start:live      # Use production crates.io backend
-pnpm start:staging   # Use staging backend
-pnpm start:local     # Use local backend (requires backend setup)
+pnpm dev:live      # Use production crates.io backend
+pnpm dev:staging   # Use staging backend
+pnpm dev:local     # Use local backend (requires backend setup)
+pnpm dev:msw       # Use MSW handlers from /packages/crates-io-msw/ as the backend
 ```
 
-Build for production:
+The dev server listens on <http://localhost:5173>.
+
+Build for production (from `svelte/`):
 
 ```bash
 pnpm build
@@ -145,31 +147,30 @@ pnpm build
 Run tests:
 
 ```bash
-pnpm test                              # Run QUnit tests
-pnpm ember test --filter="<test_name>" # Run specific QUnit test
-pnpm e2e                               # Run Playwright tests
-pnpm e2e <test_file>                   # Run specific Playwright test
+pnpm --filter crates.io-svelte test        # Vitest unit/component tests
+pnpm --filter "@crates-io/msw" test        # MSW package tests
+pnpm e2e:svelte                            # Playwright end-to-end tests (from repo root)
+pnpm e2e:svelte <test_file>                # Run a specific Playwright spec
 ```
 
-Code quality:
+Code quality (from the repo root unless noted):
 
 ```bash
-pnpm lint:js         # JavaScript linting
-pnpm lint:hbs        # Template linting
-pnpm lint:deps       # Dependency linting
-pnpm prettier:check  # Check formatting
-pnpm prettier:write  # Fix formatting
+pnpm lint:js                            # ESLint over root, e2e/, packages/
+pnpm --filter crates.io-svelte lint     # Svelte/TypeScript ESLint + prettier check inside svelte/
+pnpm prettier:check                     # Check formatting (root files)
+pnpm prettier:write                     # Fix formatting (root files)
 ```
 
 ### Architecture and Conventions
 
-- Follow Ember Octane conventions: Glimmer components, tracked properties, GJS files.
-- Components use scoped CSS via `ember-scoped-css`; styles go in `<ComponentName>.css`.
-- Data fetching happens in routes via `model()` hooks; use Ember Data models for API communication.
-- Use services for shared state (session, notifications, progress tracking).
-- Accessibility is critical; use semantic HTML, ARIA attributes, and test with `ember-a11y-testing`.
+- Use Svelte 5 runes (`$state`, `$derived`, `$effect`) for reactivity; avoid the legacy `<script>` reactivity patterns.
+- Routes live under `/svelte/src/routes/` and follow SvelteKit's file-based conventions; data loading happens in `+page.ts` / `+page.server.ts` `load` functions.
+- Shared state goes in `/svelte/src/lib/` (stores, services); reusable UI in `/svelte/src/lib/components/`.
+- Components are styled with scoped `<style>` blocks in `.svelte` files.
+- Accessibility is critical; use semantic HTML, ARIA attributes, and verify with the e2e a11y fixtures.
 - MSW mocks for tests live in `/packages/crates-io-msw/`; define handlers for API endpoints.
-- Visual regression testing uses Percy; screenshots are captured automatically in CI.
+- Visual regression testing uses Percy (via Playwright) and Chromatic via Storybook
 - Follow existing component patterns for consistency; search for similar components before creating new ones.
 
 ## Commit Messages and Pull Requests
@@ -193,18 +194,22 @@ Examples:
 
 Keep first line under 72 characters. Be direct and technical; omit unnecessary articles. For complex changes, add a commit body explaining the reasoning.
 
-Pull requests run CI checks: backend tests, frontend tests, ESLint, Prettier, rustfmt, and clippy. Fix issues before merging. The `main` branch auto-deploys to staging; production deployments are manual promotions.
+Pull requests run CI checks: backend tests, Svelte and MSW unit tests, Playwright e2e tests, ESLint, Prettier, rustfmt, and clippy. Fix issues before merging. The `main` branch auto-deploys to staging; production deployments are manual promotions.
 
 ## Review Checklist
 
 Before submitting:
 
-- Run `cargo fmt --all` and `pnpm prettier:write` depending on the changed files for consistent formatting.
+- Run `cargo fmt --all` and the appropriate prettier command (`pnpm prettier:write` at the repo root, `pnpm --filter crates.io-svelte format` inside `svelte/`) for consistent formatting.
 - Run `cargo clippy` and fix warnings.
-- Run `cargo test` and `pnpm test` depending on the changed files; all tests must pass.
+- Run the relevant test suites for the changed files; all must pass:
+  - Backend: `cargo test`
+  - Svelte unit/component tests: `pnpm --filter crates.io-svelte test`
+  - MSW package tests: `pnpm --filter "@crates-io/msw" test`
+  - Playwright: `pnpm e2e:svelte`
 - Accept snapshot changes with `cargo insta accept` if expected.
 - Check that new backend functions/types have documentation comments.
-- Verify frontend changes work with `pnpm start:live` against production data.
+- Verify frontend changes work against production data with `pnpm dev:live` (from `svelte/`).
 - Ensure database migrations are reversible (test with `diesel migration redo`).
 - Confirm error messages are actionable and don't expose sensitive information.
 - Test accessibility with keyboard navigation and screen reader landmarks.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This service is maintained for you by the [crates.io team], with support from th
 
 We welcome contributions from the community! Whether you're fixing a bug, implementing a new feature, or improving documentation, your contributions help make [crates.io] better for everyone.
 
-[crates.io] is built with [Rust] for the backend services. More specifically, the [axum] web framework and [diesel] for database access, with a [custom-built background worker system](./crates/crates_io_worker). The frontend is an [Ember.js] application written in JavaScript.
+[crates.io] is built with [Rust] for the backend services. More specifically, the [axum] web framework and [diesel] for database access, with a [custom-built background worker system](./crates/crates_io_worker). The frontend is a [SvelteKit] application written in TypeScript.
 
 Please review our [contribution guidelines](./docs/CONTRIBUTING.md) before submitting your pull request. The same document also contains instructions on how to set up a local development environment, with additional structured documentation available in [AGENTS.md](./AGENTS.md).
 
@@ -70,4 +70,4 @@ Licensed under either of these:
 [GitHub Discussions]: https://github.com/rust-lang/crates.io/discussions
 [axum]: https://crates.io/crates/axum
 [diesel]: https://crates.io/crates/diesel
-[Ember.js]: https://emberjs.com/
+[SvelteKit]: https://svelte.dev/docs/kit/introduction

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,30 +35,32 @@ These files and directories have to do with the backend:
 
 The backend stores information in a Postgres database.
 
-## Frontend - Ember.js
+## Frontend - SvelteKit
 
-The frontend of crates.io is written in JavaScript using [Ember.js][]. More information about frontend development is in [`docs/CONTRIBUTING.md`](https://github.com/rust-lang/crates.io/blob/master/docs/CONTRIBUTING.md).
+The frontend of crates.io is a [SvelteKit][] application written in TypeScript, served as a
+static site via `@sveltejs/adapter-static`. More information about frontend development is in
+[`docs/CONTRIBUTING.md`](https://github.com/rust-lang/crates.io/blob/master/docs/CONTRIBUTING.md).
 
-[Ember.js]: https://emberjs.com/
+[SvelteKit]: https://svelte.dev/docs/kit/introduction
 
 These files have to do with the frontend:
 
-- `app/` - The frontend's source code
-- `config/{environment,targets}.js` - Configuration of the frontend
-- `dist/` - Contains the distributable (optimized and self-contained) output of building the
-  frontend; served under the root `/` url - (ignored in `.gitignore`)
-- `.ember-cli` - Settings for the `ember` command line interface
-- `ember-cli-build.js` - Contains the build specification for Broccoli
-- `eslint.config.mjs` - Defines Javascript coding style guidelines
+- `svelte/` - The frontend application (its own pnpm workspace package)
+  - `svelte/src/routes/` - File-based routes; pages, layouts, and `+server.ts` endpoints
+  - `svelte/src/lib/` - Shared components, runes-based stores, services, and utilities
+  - `svelte/static/` - Static assets served at `/`
+  - `svelte/svelte.config.js`, `svelte/vite.config.ts` - Build and dev-server configuration
+  - `svelte/build/` - Output of `pnpm build`; served under the root `/` url - (ignored in
+    `.gitignore`)
+- `e2e/` - Playwright end-to-end tests run against the Svelte app
+- `eslint.config.mjs` - JavaScript/TypeScript coding style for the root, `e2e/`, and `packages/`;
+  the Svelte app has its own `svelte/eslint.config.js`
 - `node_modules/` - npm dependencies - (ignored in `.gitignore`)
-- `packages/crates-io-msw` - A mock backend used for testing
-- `package.json` - Defines the npm package and its dependencies
-- `package-lock.json` - Locks dependencies to specific versions providing consistency across
+- `packages/crates-io-msw/` - A mock backend used for testing
+- `package.json` - Root npm package; defines workspace-wide scripts and dev tooling
+- `pnpm-lock.yaml` - Locks dependencies to specific versions providing consistency across
   development and deployment
-- `public/` - Static files that are merged into `dist/` during build
-- `testem.js` - Integration with Test'em Scripts
-- `tests/` - Frontend tests
-- `vendor/` - frontend dependencies not distributed by npm; not currently used
+- `pnpm-workspace.yaml` - pnpm workspace declaration (`packages/*`, `svelte/`)
 
 ## Deployment - Heroku
 
@@ -93,7 +95,6 @@ These files are mostly only relevant when running crates.io's code in developmen
   writable directory - (ignored in `.gitignore`)
 - `tmp/index-bare` - A bare git repository during development - (ignored in `.gitignore`)
 - `.github/workflows/*` - Configuration for continuous integration at [GitHub Actions]
-- `.watchmanconfig` - Use by Ember CLI to efficiently watch for file changes if you install watchman
 
 [GitHub Actions]: https://github.com/rust-lang/crates.io/actions
 [EditorConfig for VS Code]: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -129,34 +129,48 @@ into any trouble.
 
 ### Building and serving the frontend
 
-To install the npm packages that crates.io uses, run:
+To install the npm packages that crates.io uses, run this from the repo root:
 
 ```console
 pnpm install
 ```
 
-You'll need to run these commands any time the libraries or versions of these
-libraries that crates.io uses change. Usually you'll know they've changed
-because you'll run the next step and it will fail saying it can't find some
-libraries.
+You'll need to run this any time the libraries or versions of these libraries
+that crates.io uses change. Usually you'll know they've changed because you'll
+run the next step and it will fail saying it can't find some libraries.
 
-To build and serve the frontend assets, use the command `pnpm start`. There
-are variations on this command that change which backend your frontend tries to
-talk to:
+To build and serve the frontend assets, change into the `svelte/` directory
+and run one of the `pnpm dev:*` scripts. They differ in which backend the dev
+server proxies to:
 
-| Command                                   | Backend                                   | Use case                                                |
-| ----------------------------------------- | ----------------------------------------- | ------------------------------------------------------- |
-| `pnpm start:live`                         | <https://crates.io>                       | Testing UI changes with the full live site's data       |
-| `pnpm start:staging`                      | <https://staging-crates-io.herokuapp.com> | Testing UI changes with a smaller set of realistic data |
-| `pnpm start:local`                        | Backend server running locally            | See the Working on the backend section for setup        |
-| `pnpm start -- --proxy https://crates.io` | Whatever is specified in `--proxy` arg    | If your use case is not covered here                    |
+| Command (from `svelte/`)                          | Backend                                   | Use case                                                |
+| ------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------- |
+| `pnpm dev:live`                                   | <https://crates.io>                       | Testing UI changes with the full live site's data       |
+| `pnpm dev:staging`                                | <https://staging.crates.io>               | Testing UI changes with a smaller set of realistic data |
+| `pnpm dev:local`                                  | Backend server running locally            | See the "Working on the backend" section for setup      |
+| `pnpm dev:msw`                                    | MSW handlers from `/packages/crates-io-msw/` | Testing UI changes against a fully-mocked backend       |
+| `API_HOST=https://crates.io pnpm dev`             | Whatever is in `API_HOST`                 | If your use case is not covered here                    |
+
+The dev server listens on <http://localhost:5173>.
 
 ### Running the frontend tests
 
-You can run the frontend tests with:
+The Svelte app's Vitest unit and component tests:
 
 ```console
-pnpm test
+pnpm --filter crates.io-svelte test
+```
+
+The MSW package's tests:
+
+```console
+pnpm --filter "@crates-io/msw" test
+```
+
+Playwright tests (run from the repo root):
+
+```console
+pnpm e2e:svelte
 ```
 
 ## Working on the Backend
@@ -401,15 +415,15 @@ example:
 RUST_LOG=debug cargo run --bin background-worker
 ```
 Then start a frontend that uses this backend by running this command in another
-terminal session (the frontend picks up frontend changes using live reload
-without a restart needed, and you can leave the frontend running while you
-restart the server):
+terminal session (the dev server picks up frontend changes via Vite HMR
+without a restart needed, and you can leave it running while you restart the
+backend):
 
 ```console
-pnpm start:local
+cd svelte && pnpm dev:local
 ```
 
-And then you should be able to visit <http://localhost:4200>!
+And then you should be able to visit <http://localhost:5173>!
 
 #### Using Mailgun to Send Emails
 
@@ -433,7 +447,7 @@ https://crates.io/confirm/RiphVyFo31wuKQhpyTw7RF2LIf
 ```
 
 When verifying the email, you need to change the prefix to your frontend host.
-For example, change the above link to `http://localhost:4200/confirm/RiphVyFo31wuKQhpyTw7RF2LIf`.
+For example, change the above link to `http://localhost:5173/confirm/RiphVyFo31wuKQhpyTw7RF2LIf`.
 
 If you want to test sending real emails, you will have to either set the
 Mailgun environment variables in `.env` manually or run your app instance
@@ -483,7 +497,7 @@ cargo test
 
 ### Using your local crates.io with cargo
 
-Once you have a local instance of crates.io running at <http://localhost:4200> by
+Once you have a local instance of crates.io running at <http://localhost:5173> by
 following the instructions in the "Working on the Backend" section, you can go
 to another Rust project and tell cargo to use your local crates.io instead of
 production.
@@ -500,8 +514,8 @@ OAuth Applications](https://github.com/settings/developers) and click on the
 "Register a new application" button. Fill in the form as follows:
 
 - Application name: name your application whatever you'd like.
-- Homepage URL: `http://localhost:4200/`
-- Authorization callback URL: `http://localhost:4200/github-redirect.html`
+- Homepage URL: `http://localhost:5173/`
+- Authorization callback URL: `http://localhost:5173/github-redirect.html`
 
 Create the application, then take the Client ID ad Client Secret values and use
 them as the values of the `GH_CLIENT_ID` and `GH_CLIENT_SECRET` in your `.env`.
@@ -509,7 +523,7 @@ them as the values of the `GH_CLIENT_ID` and `GH_CLIENT_SECRET` in your `.env`.
 Then restart your backend, and you should be able to log in to your local
 crates.io with your GitHub account.
 
-Go to <http://localhost:4200/me> to get your API token and run the `cargo login`
+Go to <http://localhost:5173/me> to get your API token and run the `cargo login`
 command as directed.
 
 Now you should be able to go to the directory of a crate that has no
@@ -600,7 +614,7 @@ By default, the services will be exposed on their normal ports:
 
 - `5432` for Postgres
 - `8888` for the crates.io backend
-- `4200` for the crates.io frontend
+- `5173` for the crates.io frontend (the SvelteKit dev server)
 
 These can be changed with the `docker-compose.override.yml` file.
 
@@ -615,10 +629,11 @@ cargo publish --index http://localhost:8888/git/index --token $YOUR_TOKEN
 
 ### Changing code
 
-The `app/` directory is mounted directly into the frontend Docker container,
-which means that the Ember live-reload server will still just work. If
-anything outside of `app/` is changed, the base Docker image will have to be
-rebuilt:
+The `svelte/src/` and `svelte/static/` directories are mounted directly into
+the frontend Docker container, so Vite's HMR picks up changes without a
+restart. If anything outside of those (e.g. `svelte/package.json`,
+`svelte/svelte.config.js`, `svelte/vite.config.ts`) is changed, the base
+Docker image has to be rebuilt:
 
 ```console
 # Rebuild frontend Docker image

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,5 +1,10 @@
 # E2E Overview
 
-This directory is in the process of porting our current frontend test suite to a more generic system, [Playwright](https://playwright.dev/).
+End-to-end tests for the SvelteKit frontend, written with [Playwright](https://playwright.dev/).
 
-This will allow us to explore and prototype with various technologies while potentially keeping the current system in place for now. We can then incrementally port our frontend to a different technology in the future.
+The tests live alongside their fixtures and helpers in this directory and are wired to the
+Svelte preview server via `playwright.config.ts` at the repo root. Run them with `pnpm e2e:svelte`
+from the repo root, or `pnpm e2e:svelte <spec_file>` to run a single spec.
+
+The MSW handlers in `/packages/crates-io-msw/` provide a mocked backend for these tests, so they
+do not need a running crates.io backend.


### PR DESCRIPTION
`AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/CONTRIBUTING.md`, `e2e/README.md`, and the project `README.md` were still describing the Ember.js setup, which was removed in https://github.com/rust-lang/crates.io/pull/13579. Rewrite the layout, dev, test, and deploy sections to match what the repo actually looks like now: a SvelteKit app under `svelte/`, Vite dev server on port 5173, Vitest + Playwright + the MSW package for tests, and the workspace scripts the rest of the tooling uses.

### Related

- https://github.com/rust-lang/crates.io/issues/12515