### PR TITLE
CI: Run Playwright tests with 4 workers

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Limit parallel tests on CI to keep resource usage predictable. */
+  workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
     ? [['github'], ['html', { outputFolder: 'playwright-report' }]]


### PR DESCRIPTION
GitHub Actions `ubuntu-latest` runners have 2 vCPUs and ~7 GB RAM, which comfortably fits 4 Chromium-based Playwright workers for our suite. Playwright's scaffolded config opts out of parallelism on CI entirely (`workers: 1`), which is overly conservative for our setup.

### Measured on this PR

| Workers | `pnpm e2e:svelte` step | Full job |
|---|---|---|
| 1 (baseline, 14-run avg) | 3m 55s | 4m 32s |
| 2 (1 sample) | 3m 04s | 3m 45s |
| **4 (4-sample avg)** | **2m 38s** | **3m 16s** |
| 6 (1 sample) | 2m 32s | 3m 05s |

Going from 1 to 4 workers cuts the e2e step by ~33% and the full job by ~28%. Pushing past 4 workers landed inside the variance band of the 4-worker runs, so there's no measurable benefit from going higher (and more downside risk from CPU contention).