### PR TITLE
e2e: Use `expect.poll` to fix MSW DB read races

### DIFF
--- a/e2e/acceptance/api-token.spec.ts
+++ b/e2e/acceptance/api-token.spec.ts
@@ -79,7 +79,7 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-api-token]')).toHaveCount(3);
 
     await page.click('[data-test-api-token="1"] [data-test-revoke-token-button]');
-    expect(msw.db.apiToken.findMany().length, 'API token has been deleted from the backend database').toBe(2);
+    await expect.poll(() => msw.db.apiToken.findMany().length).toBe(2);
 
     await expect(page.locator('[data-test-api-token]')).toHaveCount(2);
     await expect(page.locator('[data-test-api-token="2"]')).toBeVisible();
@@ -134,8 +134,9 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
 
     await page.click('[data-test-generate]');
 
+    await expect.poll(() => msw.db.apiToken.findFirst(q => q.where({ name: 'the new token' }))).toBeTruthy();
+
     let token = msw.db.apiToken.findFirst(q => q.where({ name: 'the new token' }))?.token;
-    expect(token, 'API token has been created in the backend database').toBeTruthy();
 
     await expect(page.locator('[data-test-api-token="4"] [data-test-name]')).toHaveText('the new token');
     await expect(page.locator('[data-test-api-token="4"] [data-test-save-token-button]')).toHaveCount(0);
@@ -154,6 +155,8 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
     await page.fill('[data-test-name]', 'the new token');
     await page.click('[data-test-scope="publish-update"]');
     await page.click('[data-test-generate]');
+
+    await expect.poll(() => msw.db.apiToken.findFirst(q => q.where({ name: 'the new token' }))).toBeTruthy();
 
     let token = msw.db.apiToken.findFirst(q => q.where({ name: 'the new token' }))?.token;
     await expect(page.locator('[data-test-token]')).toHaveText(token);

--- a/e2e/acceptance/publish-notifications.spec.ts
+++ b/e2e/acceptance/publish-notifications.spec.ts
@@ -15,15 +15,17 @@ test.describe('Acceptance | publish notifications', { tag: '@acceptance' }, () =
     await expect(page.locator('[data-test-notifications] input[type=checkbox]')).not.toBeChecked();
 
     await page.click('[data-test-notifications] button');
-    user = msw.db.user.findFirst(q => q.where({ id: user.id }));
-    expect(user.publishNotifications).toBe(false);
+    await expect
+      .poll(() => msw.db.user.findFirst(q => q.where({ id: user.id })))
+      .toMatchObject({ publishNotifications: false });
 
     await page.click('[data-test-notifications] input[type=checkbox]');
     await expect(page.locator('[data-test-notifications] input[type=checkbox]')).toBeChecked();
 
     await page.click('[data-test-notifications] button');
-    user = msw.db.user.findFirst(q => q.where({ id: user.id }));
-    expect(user.publishNotifications).toBe(true);
+    await expect
+      .poll(() => msw.db.user.findFirst(q => q.where({ id: user.id })))
+      .toMatchObject({ publishNotifications: true });
   });
 
   test('persists updated setting after navigation', async ({ page, msw }) => {

--- a/e2e/acceptance/sudo.spec.ts
+++ b/e2e/acceptance/sudo.spec.ts
@@ -115,15 +115,15 @@ test.describe('Acceptance | sudo', { tag: '@acceptance' }, () => {
     await yankButton.click();
 
     // Verify backend state after yanking
-    version = msw.db.version.findFirst(q => q.where({ id: version.id }));
-    expect(version.yanked, 'The version should be yanked').toBe(true);
+    await expect.poll(() => msw.db.version.findFirst(q => q.where({ id: version.id }))).toMatchObject({ yanked: true });
 
     await expect(unyankButton).toBeVisible();
     await unyankButton.click();
 
     // Verify backend state after unyanking
-    version = msw.db.version.findFirst(q => q.where({ id: version.id }));
-    expect(version.yanked, 'The version should be unyanked').toBe(false);
+    await expect
+      .poll(() => msw.db.version.findFirst(q => q.where({ id: version.id })))
+      .toMatchObject({ yanked: false });
 
     await expect(yankButton).toBeVisible();
   });

--- a/e2e/routes/settings/tokens/new.spec.ts
+++ b/e2e/routes/settings/tokens/new.spec.ts
@@ -44,12 +44,16 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     await page.click('[data-test-scope="publish-update"]');
     await page.click('[data-test-generate]');
 
+    await expect
+      .poll(() => msw.db.apiToken.findFirst(q => q.where({ name: 'token-name' })))
+      .toMatchObject({
+        name: 'token-name',
+        expiredAt: null,
+        crateScopes: null,
+        endpointScopes: ['publish-update'],
+      });
+
     let token = msw.db.apiToken.findFirst(q => q.where({ name: 'token-name' }));
-    expect(token, 'API token has been created in the backend database').toBeTruthy();
-    expect(token.name).toBe('token-name');
-    expect(token.expiredAt).toBe(null);
-    expect(token.crateScopes).toBe(null);
-    expect(token.endpointScopes).toEqual(['publish-update']);
 
     await expect(page).toHaveURL('/settings/tokens');
     await expect(page.locator('[data-test-api-token="1"] [data-test-name]')).toHaveText('token-name');
@@ -133,11 +137,15 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
 
     await page.click('[data-test-generate]');
 
+    await expect
+      .poll(() => msw.db.apiToken.findFirst(q => q.where({ name: 'token-name' })))
+      .toMatchObject({
+        name: 'token-name',
+        crateScopes: ['serde-*', 'serde'],
+        endpointScopes: ['publish-update', 'yank'],
+      });
+
     let token = msw.db.apiToken.findFirst(q => q.where({ name: 'token-name' }));
-    expect(token, 'API token has been created in the backend database').toBeTruthy();
-    expect(token.name).toBe('token-name');
-    expect(token.crateScopes).toEqual(['serde-*', 'serde']);
-    expect(token.endpointScopes).toEqual(['publish-update', 'yank']);
 
     await expect(page).toHaveURL('/settings/tokens');
     await expect(page.locator('[data-test-api-token="1"] [data-test-name]')).toHaveText('token-name');
@@ -172,12 +180,16 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     await page.click('[data-test-scope="publish-update"]');
     await page.click('[data-test-generate]');
 
+    await expect
+      .poll(() => msw.db.apiToken.findFirst(q => q.where({ name: 'token-name' })))
+      .toMatchObject({
+        name: 'token-name',
+        expiredAt: expect.stringMatching(/^2017-12-20/),
+        crateScopes: null,
+        endpointScopes: ['publish-update'],
+      });
+
     let token = msw.db.apiToken.findFirst(q => q.where({ name: 'token-name' }));
-    expect(token, 'API token has been created in the backend database').toBeTruthy();
-    expect(token.name).toBe('token-name');
-    expect(token.expiredAt.slice(0, 10)).toBe('2017-12-20');
-    expect(token.crateScopes).toBe(null);
-    expect(token.endpointScopes).toEqual(['publish-update']);
 
     await expect(page).toHaveURL('/settings/tokens');
     await expect(page.locator('[data-test-api-token="1"] [data-test-name]')).toHaveText('token-name');
@@ -212,12 +224,16 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
 
     await page.click('[data-test-generate]');
 
+    await expect
+      .poll(() => msw.db.apiToken.findFirst(q => q.where({ name: 'token-name' })))
+      .toMatchObject({
+        name: 'token-name',
+        expiredAt: expect.stringMatching(/^2024-05-04/),
+        crateScopes: null,
+        endpointScopes: ['publish-update'],
+      });
+
     let token = msw.db.apiToken.findFirst(q => q.where({ name: 'token-name' }));
-    expect(token, 'API token has been created in the backend database').toBeTruthy();
-    expect(token.name).toBe('token-name');
-    expect(token.expiredAt.slice(0, 10)).toBe('2024-05-04');
-    expect(token.crateScopes).toBe(null);
-    expect(token.endpointScopes).toEqual(['publish-update']);
 
     await expect(page).toHaveURL('/settings/tokens');
     await expect(page.locator('[data-test-api-token="1"] [data-test-name]')).toHaveText('token-name');
@@ -320,8 +336,7 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     );
     await page.click('[data-test-generate]');
 
-    let newToken = msw.db.apiToken.findFirst(q => q.where({ name: 'foo' }));
-    expect(newToken, 'New API token has been created in the backend database').toBeTruthy();
+    await expect.poll(() => msw.db.apiToken.findFirst(q => q.where({ name: 'foo' }))).toBeTruthy();
 
     await expect(page).toHaveURL('/settings/tokens');
     await page.click('[data-test-new-token-button]');
@@ -348,12 +363,16 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     await page.click('[data-test-scope="trusted-publishing"]');
     await page.click('[data-test-generate]');
 
+    await expect
+      .poll(() => msw.db.apiToken.findFirst(q => q.where({ name: 'trusted-publishing-token' })))
+      .toMatchObject({
+        name: 'trusted-publishing-token',
+        expiredAt: null,
+        crateScopes: null,
+        endpointScopes: ['trusted-publishing'],
+      });
+
     let token = msw.db.apiToken.findFirst(q => q.where({ name: 'trusted-publishing-token' }));
-    expect(token, 'API token has been created in the backend database').toBeTruthy();
-    expect(token.name).toBe('trusted-publishing-token');
-    expect(token.expiredAt).toBe(null);
-    expect(token.crateScopes).toBe(null);
-    expect(token.endpointScopes).toEqual(['trusted-publishing']);
 
     await expect(page).toHaveURL('/settings/tokens');
     await expect(page.locator('[data-test-api-token="1"] [data-test-name]')).toHaveText('trusted-publishing-token');


### PR DESCRIPTION
Several e2e tests read from `msw.db` synchronously right after a `page.click(...)` that triggers a network request. The lookup can fire before MSW has finished handling the request and updating its in-memory database, which makes the assertions intermittently flaky.

Each commit wraps the affected lookup in `expect.poll(...)` so the assertion retries until the database reflects the new state.

- `tokens/new`: token creation across six tests
- `publish-notifications`: subscribe/unsubscribe save
- `sudo`: yank/unyank
- `api-token`: token revoke and generate

All four files were verified locally with `--repeat-each=10`.