### PR TITLE
e2e: Replace `defer()` helper with native `Promise.withResolvers()`

### DIFF
--- a/e2e/acceptance/crate-following.spec.ts
+++ b/e2e/acceptance/crate-following.spec.ts
@@ -1,4 +1,3 @@
-import { defer } from '@/e2e/deferred';
 import { expect, test } from '@/e2e/helper';
 import { http, HttpResponse } from 'msw';
 
@@ -25,7 +24,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
   test('authenticated users see a loading spinner and can follow/unfollow crates', async ({ page, msw }) => {
     await prepare(msw);
 
-    let followingDeferred = defer();
+    let followingDeferred = Promise.withResolvers<Response>();
     msw.worker.use(http.get('/api/v1/crates/:crate_id/following', () => followingDeferred.promise));
 
     await page.goto('/crates/nanomsg');
@@ -41,7 +40,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     await expect(followButton).toBeEnabled();
     await expect(spinner).toHaveCount(0);
 
-    let followDeferred = defer();
+    let followDeferred = Promise.withResolvers<Response>();
     msw.worker.use(http.put('/api/v1/crates/:crate_id/follow', () => followDeferred.promise));
     await followButton.click();
     await expect(followButton).toHaveText('Loading…');
@@ -53,7 +52,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     await expect(followButton).toBeEnabled();
     await expect(spinner).toHaveCount(0);
 
-    let unfollowDeferred = defer();
+    let unfollowDeferred = Promise.withResolvers<Response>();
     msw.worker.use(http.delete('/api/v1/crates/:crate_id/follow', () => unfollowDeferred.promise));
     await followButton.click();
     await expect(followButton).toHaveText('Loading…');

--- a/e2e/acceptance/front-page.spec.ts
+++ b/e2e/acceptance/front-page.spec.ts
@@ -1,4 +1,3 @@
-import { defer } from '@/e2e/deferred';
 import { expect, test } from '@/e2e/helper';
 import { loadFixtures } from '@crates-io/msw/fixtures';
 import { http, HttpResponse } from 'msw';
@@ -52,7 +51,7 @@ test.describe('Acceptance | front page', { tag: '@acceptance' }, () => {
 
     await msw.worker.resetHandlers();
 
-    let deferred = defer();
+    let deferred = Promise.withResolvers<void>();
     msw.worker.use(http.get('/api/v1/summary', () => deferred.promise));
 
     const button = page.locator('[data-test-try-again-button]');

--- a/e2e/acceptance/publish-notifications.spec.ts
+++ b/e2e/acceptance/publish-notifications.spec.ts
@@ -1,4 +1,3 @@
-import { defer } from '@/e2e/deferred';
 import { expect, test } from '@/e2e/helper';
 import { http, HttpResponse } from 'msw';
 
@@ -56,7 +55,7 @@ test.describe('Acceptance | publish notifications', { tag: '@acceptance' }, () =
     let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 
-    let deferred = defer();
+    let deferred = Promise.withResolvers<void>();
     msw.worker.use(http.put('/api/v1/users/:user_id', () => deferred.promise));
 
     await page.goto('/settings/profile');

--- a/e2e/acceptance/search.spec.ts
+++ b/e2e/acceptance/search.spec.ts
@@ -1,4 +1,3 @@
-import { defer } from '@/e2e/deferred';
 import { expect, test } from '@/e2e/helper';
 import { loadFixtures } from '@crates-io/msw/fixtures';
 import { http, HttpResponse } from 'msw';
@@ -140,7 +139,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-try-again-button]')).toBeEnabled();
 
     await msw.worker.resetHandlers();
-    let deferred = defer();
+    let deferred = Promise.withResolvers<void>();
     msw.worker.use(http.get('/api/v1/crates', () => deferred.promise));
 
     await page.click('[data-test-try-again-button]');
@@ -174,7 +173,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-try-again-button]')).toBeEnabled();
 
     await msw.worker.resetHandlers();
-    let deferred = defer();
+    let deferred = Promise.withResolvers<void>();
     msw.worker.use(http.get('/api/v1/crates', () => deferred.promise));
 
     await page.click('[data-test-try-again-button]');

--- a/e2e/deferred.ts
+++ b/e2e/deferred.ts
@@ -1,8 +1,0 @@
-export function defer<T = undefined>(): { resolve: (any?) => T; reject: (reason: any) => void; promise: Promise<T> } {
-  let resolve, reject;
-  let promise = new Promise((res, rej) => {
-    resolve = res;
-    reject = rej;
-  }) as Promise<T>;
-  return { resolve, reject, promise };
-}

--- a/e2e/routes/crate/delete.spec.ts
+++ b/e2e/routes/crate/delete.spec.ts
@@ -1,4 +1,3 @@
-import { defer } from '@/e2e/deferred';
 import { expect, test } from '@/e2e/helper';
 import { http, HttpResponse } from 'msw';
 
@@ -64,7 +63,7 @@ test.describe('Route: crate.delete', { tag: '@routes' }, () => {
   test('loading state', async ({ page, msw }) => {
     await prepare(msw);
 
-    let deferred = defer();
+    let deferred = Promise.withResolvers<void>();
     msw.worker.use(http.delete('/api/v1/crates/:name', () => deferred.promise));
 
     await page.goto('/crates/foo/delete');

--- a/e2e/routes/crate/settings.spec.ts
+++ b/e2e/routes/crate/settings.spec.ts
@@ -1,4 +1,3 @@
-import { defer } from '@/e2e/deferred';
 import { expect, test } from '@/e2e/helper';
 import { http, HttpResponse } from 'msw';
 
@@ -523,7 +522,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
           workflow_filename: 'ci.yml',
         });
 
-        let deferred = defer();
+        let deferred = Promise.withResolvers<Response>();
         msw.worker.use(http.patch('/api/v1/crates/:name', () => deferred.promise));
 
         await page.goto('/crates/foo/settings');

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
@@ -1,4 +1,3 @@
-import { defer } from '@/e2e/deferred';
 import { expect, test } from '@/e2e/helper';
 import { http, HttpResponse } from 'msw';
 
@@ -262,7 +261,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
       let { crate } = await prepare(msw);
 
       // Mock the server to return an error
-      let deferred = defer();
+      let deferred = Promise.withResolvers<Response>();
       msw.worker.use(http.post('/api/v1/trusted_publishing/github_configs', () => deferred.promise));
 
       await page.goto(`/crates/${crate.name}/settings/new-trusted-publisher`);
@@ -489,7 +488,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
       let { crate } = await prepare(msw);
 
       // Mock the server to return an error
-      let deferred = defer();
+      let deferred = Promise.withResolvers<Response>();
       msw.worker.use(http.post('/api/v1/trusted_publishing/gitlab_configs', () => deferred.promise));
 
       await page.goto(`/crates/${crate.name}/settings/new-trusted-publisher`);

--- a/e2e/routes/settings/tokens/new.spec.ts
+++ b/e2e/routes/settings/tokens/new.spec.ts
@@ -1,4 +1,3 @@
-import { defer } from '@/e2e/deferred';
 import { expect, test } from '@/e2e/helper';
 import { http, HttpResponse } from 'msw';
 
@@ -250,7 +249,7 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
   test('loading and error state', async ({ page, msw }) => {
     await prepare(msw);
 
-    let deferred = defer();
+    let deferred = Promise.withResolvers<Response>();
     msw.worker.use(http.put('/api/v1/me/tokens', () => deferred.promise));
 
     await page.goto('/settings/tokens/new');


### PR DESCRIPTION
`Promise.withResolvers()` has been part of the standard library since ES2024 and Node 22, so the hand-rolled `defer()` helper no longer earns its keep. Each callsite now passes an explicit type argument (`<void>` for no-body resolvers, `<Response>` for ones that pass an `HttpResponse`), which also tightens the types compared to the wrapper's `(any?)` parameter trick that previously hid mismatches.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers