### PR TITLE
e2e: Replace `any` types in test helpers

### DIFF
--- a/e2e/bugs/11772.spec.ts
+++ b/e2e/bugs/11772.spec.ts
@@ -1,7 +1,7 @@
-import { expect, test } from '@/e2e/helper';
+import { expect, test, type AppFixtures } from '@/e2e/helper';
 
 test.describe('Bug #11772', { tag: '@bugs' }, () => {
-  async function prepare(msw: any) {
+  async function prepare(msw: AppFixtures['msw']) {
     // Create a crate that will appear in "New Crates" section
     let newCrate = await msw.db.crate.create({ name: 'test-crate' });
     await msw.db.version.create({ crate: newCrate, num: '1.2.3' });

--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -16,7 +16,7 @@ export interface AppFixtures {
   msw: {
     worker: NetworkFixture;
     db: typeof db;
-    authenticateAs: (user: any) => Promise<void>;
+    authenticateAs: (user: Awaited<ReturnType<typeof db.user.create>>) => Promise<void>;
   };
   percy: PercyPage;
   a11y: A11yPage;

--- a/e2e/routes/user/yanked-crates.spec.ts
+++ b/e2e/routes/user/yanked-crates.spec.ts
@@ -1,7 +1,7 @@
-import { expect, test } from '@/e2e/helper';
+import { expect, test, type AppFixtures } from '@/e2e/helper';
 
 test.describe('Route | user | yanked crates visibility', { tag: '@routes' }, () => {
-  async function prepare(msw: any) {
+  async function prepare(msw: AppFixtures['msw']) {
     let user1 = await msw.db.user.create({ login: 'alice', name: 'Alice' });
     let user2 = await msw.db.user.create({ login: 'bob', name: 'Bob' });
 


### PR DESCRIPTION
A few `any` annotations had snuck into the e2e test helpers, which meant the helper bodies and their callers were untyped under the hood.

Two `prepare(msw: any)` helpers (in `bugs/11772.spec.ts` and `routes/user/yanked-crates.spec.ts`) now use `AppFixtures['msw']` from `helper.ts`, and `authenticateAs(user: any)` in `helper.ts` derives its parameter type from `db.user.create()`.