### PR TITLE
e2e: Replace `const` with `let` outside top-level scope

### DIFF
--- a/e2e/acceptance/crate-following.spec.ts
+++ b/e2e/acceptance/crate-following.spec.ts
@@ -30,8 +30,8 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
 
     await page.goto('/crates/nanomsg');
 
-    const followButton = page.locator('[data-test-follow-button]');
-    const spinner = followButton.locator('[data-test-spinner]');
+    let followButton = page.locator('[data-test-follow-button]');
+    let spinner = followButton.locator('[data-test-spinner]');
     await expect(followButton).toHaveText('Loading…');
     await expect(followButton).toBeDisabled();
     await expect(spinner).toBeVisible();
@@ -73,7 +73,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     msw.worker.use(http.get('/api/v1/crates/:crate_id/following', () => error));
 
     await page.goto('/crates/nanomsg');
-    const followButton = page.locator('[data-test-follow-button]');
+    let followButton = page.locator('[data-test-follow-button]');
     await expect(followButton).toHaveText('Follow');
     await expect(followButton).toBeDisabled();
     await expect(page.locator('[data-test-notification-message="error"]')).toHaveText(

--- a/e2e/acceptance/crate-navtabs.spec.ts
+++ b/e2e/acceptance/crate-navtabs.spec.ts
@@ -6,24 +6,24 @@ test.describe('Acceptance | crate navigation tabs', { tag: '@acceptance' }, () =
     let crate = await msw.db.crate.create({ name: 'nanomsg' });
     await msw.db.version.create({ crate, num: '0.6.1' });
 
-    const tabReadme = page.locator('[data-test-readme-tab] a');
-    const tabVersions = page.locator('[data-test-versions-tab] a');
-    const tabDeps = page.locator('[data-test-deps-tab] a');
-    const tabRevDeps = page.locator('[data-test-rev-deps-tab] a');
-    const tabSettings = page.locator('[data-test-settings-tab] a');
+    let tabReadme = page.locator('[data-test-readme-tab] a');
+    let tabVersions = page.locator('[data-test-versions-tab] a');
+    let tabDeps = page.locator('[data-test-deps-tab] a');
+    let tabRevDeps = page.locator('[data-test-rev-deps-tab] a');
+    let tabSettings = page.locator('[data-test-settings-tab] a');
 
     async function checkLinks(version: string = '') {
-      const readmeLink = version ? `/crates/nanomsg/${version}` : '/crates/nanomsg';
+      let readmeLink = version ? `/crates/nanomsg/${version}` : '/crates/nanomsg';
       await expect(tabReadme).toHaveAttribute('href', readmeLink);
       await expect(tabVersions).toHaveAttribute('href', '/crates/nanomsg/versions');
-      const depsLink = version ? `/crates/nanomsg/${version}/dependencies` : '/crates/nanomsg/dependencies';
+      let depsLink = version ? `/crates/nanomsg/${version}/dependencies` : '/crates/nanomsg/dependencies';
       await expect(tabDeps).toHaveAttribute('href', depsLink);
       await expect(tabRevDeps).toHaveAttribute('href', '/crates/nanomsg/reverse_dependencies');
     }
 
     async function checkTabActiveState(currentTab: Locator) {
       await expect(currentTab).toHaveAttribute('data-test-active');
-      const otherTabs = [tabReadme, tabVersions, tabDeps, tabRevDeps].filter(tab => tab !== currentTab);
+      let otherTabs = [tabReadme, tabVersions, tabDeps, tabRevDeps].filter(tab => tab !== currentTab);
       for (let tab of otherTabs) {
         await expect(tab).not.toHaveAttribute('data-test-active');
       }

--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -243,12 +243,12 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await msw.authenticateAs(user);
 
     await page.goto('/crates/nanomsg/0.5.0');
-    const yankButton = page.locator('[data-test-version-yank-button="0.5.0"]');
+    let yankButton = page.locator('[data-test-version-yank-button="0.5.0"]');
     await yankButton.click();
     await expect(yankButton).toHaveText('Yanking...');
     await expect(yankButton).toBeDisabled();
 
-    const unyankButton = page.locator('[data-test-version-unyank-button="0.5.0"]');
+    let unyankButton = page.locator('[data-test-version-unyank-button="0.5.0"]');
     await unyankButton.click();
     await expect(unyankButton).toHaveText('Unyanking...');
     await expect(unyankButton).toBeDisabled();

--- a/e2e/acceptance/crates.spec.ts
+++ b/e2e/acceptance/crates.spec.ts
@@ -30,7 +30,7 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
   });
 
   test('listing crates', async ({ page, msw }) => {
-    const per_page = 50;
+    let per_page = 50;
     for (let i = 1; i <= per_page; i++) {
       let crate = await msw.db.crate.create({});
       await msw.db.version.create({ crate });
@@ -43,13 +43,13 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
   });
 
   test('navigating to next page of crates', async ({ page, msw }) => {
-    const per_page = 50;
+    let per_page = 50;
     for (let i = 1; i <= per_page + 2; i++) {
       let crate = await msw.db.crate.create({});
       await msw.db.version.create({ crate });
     }
-    const page_start = per_page + 1;
-    const total = per_page + 2;
+    let page_start = per_page + 1;
+    let total = per_page + 2;
 
     await page.goto('/crates');
     await page.click('[data-test-pagination-next]');

--- a/e2e/acceptance/email-change.spec.ts
+++ b/e2e/acceptance/email-change.spec.ts
@@ -8,7 +8,7 @@ test.describe('Acceptance | Email Change', { tag: '@acceptance' }, () => {
 
     await page.goto('/settings/profile');
     await expect(page).toHaveURL('/settings/profile');
-    const emailInput = page.locator('[data-test-email-input]');
+    let emailInput = page.locator('[data-test-email-input]');
     await expect(emailInput).toBeVisible();
     await expect(emailInput.locator('[data-test-no-email]')).toHaveCount(0);
     await expect(emailInput.locator('[data-test-email-address]')).toContainText('old@email.com');
@@ -49,7 +49,7 @@ test.describe('Acceptance | Email Change', { tag: '@acceptance' }, () => {
 
     await page.goto('/settings/profile');
     await expect(page).toHaveURL('/settings/profile');
-    const emailInput = page.locator('[data-test-email-input]');
+    let emailInput = page.locator('[data-test-email-input]');
     await expect(emailInput).toBeVisible();
     await expect(emailInput.locator('[data-test-no-email]')).toBeVisible();
     await expect(emailInput.locator('[data-test-email-address]')).toHaveText('');
@@ -85,7 +85,7 @@ test.describe('Acceptance | Email Change', { tag: '@acceptance' }, () => {
     await msw.authenticateAs(user);
 
     await page.goto('/settings/profile');
-    const emailInput = page.locator('[data-test-email-input]');
+    let emailInput = page.locator('[data-test-email-input]');
     await emailInput.locator('[data-test-edit-button]').click();
     await emailInput.locator('[data-test-input]').fill('new@email.com');
     await expect(emailInput.locator('[data-test-invalid-email-warning]')).toHaveCount(0);
@@ -110,7 +110,7 @@ test.describe('Acceptance | Email Change', { tag: '@acceptance' }, () => {
     msw.worker.use(http.put('/api/v1/users/:user_id', () => error));
 
     await page.goto('/settings/profile');
-    const emailInput = page.locator('[data-test-email-input]');
+    let emailInput = page.locator('[data-test-email-input]');
     await emailInput.locator('[data-test-edit-button]').click();
     await emailInput.locator('[data-test-input]').fill('new@email.com');
 
@@ -134,13 +134,13 @@ test.describe('Acceptance | Email Change', { tag: '@acceptance' }, () => {
 
       await page.goto('/settings/profile');
       await expect(page).toHaveURL('/settings/profile');
-      const emailInput = page.locator('[data-test-email-input]');
+      let emailInput = page.locator('[data-test-email-input]');
       await expect(emailInput).toBeVisible();
       await expect(emailInput.locator('[data-test-email-address]')).toContainText('john@doe.com');
       await expect(emailInput.locator('[data-test-verified]')).toHaveCount(0);
       await expect(emailInput.locator('[data-test-not-verified]')).toBeVisible();
       await expect(emailInput.locator('[data-test-verification-sent]')).toBeVisible();
-      const button = emailInput.locator('[data-test-resend-button]');
+      let button = emailInput.locator('[data-test-resend-button]');
       await expect(button).toBeEnabled();
       await expect(button).toHaveText('Resend');
 
@@ -158,13 +158,13 @@ test.describe('Acceptance | Email Change', { tag: '@acceptance' }, () => {
 
       await page.goto('/settings/profile');
       await expect(page).toHaveURL('/settings/profile');
-      const emailInput = page.locator('[data-test-email-input]');
+      let emailInput = page.locator('[data-test-email-input]');
       await expect(emailInput).toBeVisible();
       await expect(emailInput.locator('[data-test-email-address]')).toContainText('john@doe.com');
       await expect(emailInput.locator('[data-test-verified]')).toHaveCount(0);
       await expect(emailInput.locator('[data-test-not-verified]')).toBeVisible();
       await expect(emailInput.locator('[data-test-verification-sent]')).toBeVisible();
-      const button = emailInput.locator('[data-test-resend-button]');
+      let button = emailInput.locator('[data-test-resend-button]');
       await expect(button).toBeEnabled();
       await expect(button).toHaveText('Resend');
 

--- a/e2e/acceptance/front-page.spec.ts
+++ b/e2e/acceptance/front-page.spec.ts
@@ -55,7 +55,7 @@ test.describe('Acceptance | front page', { tag: '@acceptance' }, () => {
     let deferred = defer();
     msw.worker.use(http.get('/api/v1/summary', () => deferred.promise));
 
-    const button = page.locator('[data-test-try-again-button]');
+    let button = page.locator('[data-test-try-again-button]');
     await button.click();
     await expect(button.locator('[data-test-spinner]')).toBeVisible();
     await expect(page.locator('[data-test-lists]')).toHaveCount(0);

--- a/e2e/acceptance/invites.spec.ts
+++ b/e2e/acceptance/invites.spec.ts
@@ -45,13 +45,13 @@ test.describe('Acceptance | /me/pending-invites', { tag: '@acceptance' }, () => 
     await expect(page).toHaveURL('/me/pending-invites');
     await expect(page.locator('[data-test-invite]')).toHaveCount(2);
 
-    const nanomsg = page.locator('[data-test-invite="nanomsg"]');
+    let nanomsg = page.locator('[data-test-invite="nanomsg"]');
     await expect(nanomsg).toBeVisible();
     await expect(nanomsg.locator('[data-test-date]')).toHaveText('11 months ago');
     await expect(nanomsg.locator('[data-test-accept-button]')).toBeVisible();
     await expect(nanomsg.locator('[data-test-decline-button]')).toBeVisible();
 
-    const emberRs = page.locator('[data-test-invite="ember-rs"]');
+    let emberRs = page.locator('[data-test-invite="ember-rs"]');
     await expect(emberRs).toBeVisible();
     await expect(emberRs.locator('[data-test-crate-link]')).toHaveText('ember-rs');
     await expect(emberRs.locator('[data-test-crate-link]')).toHaveAttribute('href', '/crates/ember-rs');
@@ -92,7 +92,7 @@ test.describe('Acceptance | /me/pending-invites', { tag: '@acceptance' }, () => 
     await page.goto('/me/pending-invites');
     await expect(page).toHaveURL('/me/pending-invites');
 
-    const nanomsgL = page.locator('[data-test-invite="nanomsg"]');
+    let nanomsgL = page.locator('[data-test-invite="nanomsg"]');
     await nanomsgL.locator('[data-test-decline-button]').click();
     await expect(nanomsgL.and(page.locator('[data-test-declined-message]'))).toHaveText(
       'Declined. You have not been added as an owner of crate nanomsg.',

--- a/e2e/acceptance/login.spec.ts
+++ b/e2e/acceptance/login.spec.ts
@@ -104,11 +104,11 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
 
     await page.goto('/');
 
-    const popupPromise = page.waitForEvent('popup');
+    let popupPromise = page.waitForEvent('popup');
 
     await page.click('[data-test-login-button]');
 
-    const popup = await popupPromise;
+    let popup = await popupPromise;
     await popup.close();
 
     await expect(page.locator('[data-test-notification-message]')).toHaveText(

--- a/e2e/acceptance/logout.spec.ts
+++ b/e2e/acceptance/logout.spec.ts
@@ -8,7 +8,7 @@ test.describe('Acceptance | Logout', { tag: '@acceptance' }, () => {
     await page.goto('/crates');
     await expect(page).toHaveURL('/crates');
 
-    const menu = page.locator('[data-test-user-menu]');
+    let menu = page.locator('[data-test-user-menu]');
     await expect(menu.locator('[data-test-toggle]')).toHaveText('John Doe');
 
     await menu.locator('[data-test-toggle]').click();

--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -123,7 +123,7 @@ test.describe('Acceptance | README rendering', { tag: '@acceptance' }, () => {
     await msw.db.version.create({ crate, num: '1.0.0', readme: README_HTML });
 
     await page.goto('/crates/serde');
-    const readme = page.locator('[data-test-readme]');
+    let readme = page.locator('[data-test-readme]');
     await expect(readme).toBeVisible();
     await expect(readme.locator('ul > li')).toHaveCount(7);
     await expect(readme.locator('pre > code.language-rust.hljs')).toHaveCount(2);

--- a/e2e/acceptance/reverse-dependencies.spec.ts
+++ b/e2e/acceptance/reverse-dependencies.spec.ts
@@ -25,10 +25,10 @@ test.describe('Acceptance | /crates/:crate_id/reverse_dependencies', { tag: '@ac
     await expect(page).toHaveURL(`/crates/${foo.name}/reverse_dependencies`);
 
     await expect(page.locator('[data-test-row]')).toHaveCount(2);
-    const row0 = page.locator('[data-test-row="0"]');
+    let row0 = page.locator('[data-test-row="0"]');
     await expect(row0.locator('[data-test-crate-name]')).toHaveText(baz.name);
     await expect(row0.locator('[data-test-description]')).toHaveText(baz.description);
-    const row1 = page.locator('[data-test-row="1"]');
+    let row1 = page.locator('[data-test-row="1"]');
     await expect(row1.locator('[data-test-crate-name]')).toHaveText(bar.name);
     await expect(row1.locator('[data-test-description]')).toHaveText(bar.description);
   });
@@ -42,9 +42,9 @@ test.describe('Acceptance | /crates/:crate_id/reverse_dependencies', { tag: '@ac
       await msw.db.dependency.create({ crate: foo, version });
     }
 
-    const row = page.locator('[data-test-row]');
-    const currentRows = page.locator('[data-test-current-rows]');
-    const totalRows = page.locator('[data-test-total-rows]');
+    let row = page.locator('[data-test-row]');
+    let currentRows = page.locator('[data-test-current-rows]');
+    let totalRows = page.locator('[data-test-total-rows]');
 
     await page.goto(`/crates/${foo.name}/reverse_dependencies`);
     await expect(page).toHaveURL(`/crates/${foo.name}/reverse_dependencies`);

--- a/e2e/acceptance/search.spec.ts
+++ b/e2e/acceptance/search.spec.ts
@@ -65,7 +65,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
 
       await page.goto('/');
 
-      const searchInput = page.locator('[data-test-search-input]');
+      let searchInput = page.locator('[data-test-search-input]');
       await searchInput.blur();
       await page.keyboard.press('a');
       await expect(searchInput).not.toBeFocused();

--- a/e2e/acceptance/sudo.spec.ts
+++ b/e2e/acceptance/sudo.spec.ts
@@ -78,12 +78,12 @@ test.describe('Acceptance | sudo', { tag: '@acceptance' }, () => {
 
     // Test that the expiry time is sensible. We'll allow a minute either way in
     // case of slow tests or slightly wonky clocks.
-    const disable = page.locator('[data-test-disable-admin-actions] > div');
-    const seen = await disable.evaluate(async disable => {
-      const untilAbout = Date.now() + 6 * 60 * 60 * 1000;
+    let disable = page.locator('[data-test-disable-admin-actions] > div');
+    let seen = await disable.evaluate(async disable => {
+      let untilAbout = Date.now() + 6 * 60 * 60 * 1000;
       let seen = 0;
-      for (const ts of [untilAbout - 60 * 1000, untilAbout, untilAbout + 60 * 1000]) {
-        const time = await globalThis.format(new Date(ts), 'HH:mm');
+      for (let ts of [untilAbout - 60 * 1000, untilAbout, untilAbout + 60 * 1000]) {
+        let time = await globalThis.format(new Date(ts), 'HH:mm');
         if (disable.textContent.includes(time)) {
           seen += 1;
         }
@@ -109,8 +109,8 @@ test.describe('Acceptance | sudo', { tag: '@acceptance' }, () => {
 
     await page.locator('[data-test-actions-toggle]').click();
 
-    const yankButton = page.locator('[data-test-version-yank-button="0.1.0"]');
-    const unyankButton = page.locator('[data-test-version-unyank-button="0.1.0"]');
+    let yankButton = page.locator('[data-test-version-yank-button="0.1.0"]');
+    let unyankButton = page.locator('[data-test-version-unyank-button="0.1.0"]');
 
     await yankButton.click();
 

--- a/e2e/acceptance/support.spec.ts
+++ b/e2e/acceptance/support.spec.ts
@@ -20,7 +20,7 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
 
     await expect(page.getByTestId('support-main-content').locator('section')).toHaveCount(1);
     await expect(page.getByTestId('inquire-list-section')).toBeVisible();
-    const inquireList = page.getByTestId('inquire-list');
+    let inquireList = page.getByTestId('inquire-list');
     await expect(inquireList).toBeVisible();
     await expect(inquireList.locator(page.getByRole('listitem'))).toHaveText(
       ['Report a crate that violates policies'].concat(['For all other cases: help@crates.io']),
@@ -36,7 +36,7 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
 
     await expect(page.getByTestId('support-main-content').locator('section')).toHaveCount(1);
     await expect(page.getByTestId('inquire-list-section')).toBeVisible();
-    const inquireList = page.getByTestId('inquire-list');
+    let inquireList = page.getByTestId('inquire-list');
     await expect(inquireList).toBeVisible();
     await expect(inquireList.locator(page.getByRole('listitem'))).toHaveText(
       ['Report a crate that violates policies'].concat(['For all other cases: help@crates.io']),
@@ -73,9 +73,9 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
     });
 
     test('empty crate should shows errors', async ({ page }) => {
-      const crateInput = page.getByTestId('crate-input');
+      let crateInput = page.getByTestId('crate-input');
       await expect(crateInput).toHaveValue('');
-      const reportButton = page.getByTestId('report-button');
+      let reportButton = page.getByTestId('report-button');
       await reportButton.click();
 
       await expect(page.getByTestId('crate-invalid')).toBeVisible();
@@ -86,19 +86,19 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
     });
 
     test('other reason selected without given detail shows an error', async ({ page }) => {
-      const crateInput = page.getByTestId('crate-input');
+      let crateInput = page.getByTestId('crate-input');
       await crateInput.fill('nanomsg');
       await expect(crateInput).toHaveValue('nanomsg');
 
-      const spam = page.getByTestId('spam-checkbox');
+      let spam = page.getByTestId('spam-checkbox');
       await spam.check();
       await expect(spam).toBeChecked();
-      const other = page.getByTestId('other-checkbox');
+      let other = page.getByTestId('other-checkbox');
       await other.check();
       await expect(other).toBeChecked();
-      const detailInput = page.getByTestId('detail-input');
+      let detailInput = page.getByTestId('detail-input');
       await expect(detailInput).toHaveValue('');
-      const reportButton = page.getByTestId('report-button');
+      let reportButton = page.getByTestId('report-button');
       await reportButton.click();
 
       await expect(page.getByTestId('crate-invalid')).not.toBeVisible();
@@ -109,18 +109,18 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
     });
 
     test('valid form without detail', async ({ page }) => {
-      const crateInput = page.getByTestId('crate-input');
+      let crateInput = page.getByTestId('crate-input');
       await crateInput.fill('nanomsg');
       await expect(crateInput).toHaveValue('nanomsg');
 
-      const spam = page.getByTestId('spam-checkbox');
+      let spam = page.getByTestId('spam-checkbox');
       await spam.check();
       await expect(spam).toBeChecked();
-      const detailInput = page.getByTestId('detail-input');
+      let detailInput = page.getByTestId('detail-input');
       await expect(detailInput).toHaveValue('');
 
       await page.waitForFunction(() => globalThis.openKwargs === undefined);
-      const reportButton = page.getByTestId('report-button');
+      let reportButton = page.getByTestId('report-button');
       await reportButton.click();
 
       await expect(page.getByTestId('crate-invalid')).not.toBeVisible();
@@ -150,22 +150,22 @@ Additional details:
     });
 
     test('valid form with required detail', async ({ page }) => {
-      const crateInput = page.getByTestId('crate-input');
+      let crateInput = page.getByTestId('crate-input');
       await crateInput.fill('nanomsg');
       await expect(crateInput).toHaveValue('nanomsg');
 
-      const spam = page.getByTestId('spam-checkbox');
+      let spam = page.getByTestId('spam-checkbox');
       await spam.check();
       await expect(spam).toBeChecked();
-      const other = page.getByTestId('other-checkbox');
+      let other = page.getByTestId('other-checkbox');
       await other.check();
       await expect(other).toBeChecked();
-      const detailInput = page.getByTestId('detail-input');
+      let detailInput = page.getByTestId('detail-input');
       await detailInput.fill('test detail');
       await expect(detailInput).toHaveValue('test detail');
 
       await page.waitForFunction(() => globalThis.openKwargs === undefined);
-      const reportButton = page.getByTestId('report-button');
+      let reportButton = page.getByTestId('report-button');
       await reportButton.click();
 
       await expect(page.getByTestId('crate-invalid')).not.toBeVisible();
@@ -204,10 +204,10 @@ test detail
     });
 
     test('empty crate should shows errors', async ({ page }) => {
-      const crateInput = page.getByTestId('crate-input');
+      let crateInput = page.getByTestId('crate-input');
       await crateInput.fill('');
       await expect(crateInput).toHaveValue('');
-      const reportButton = page.getByTestId('report-button');
+      let reportButton = page.getByTestId('report-button');
       await reportButton.click();
 
       await expect(page.getByTestId('crate-invalid')).toBeVisible();
@@ -218,15 +218,15 @@ test detail
     });
 
     test('other reason selected without given detail shows an error', async ({ page }) => {
-      const spam = page.getByTestId('spam-checkbox');
+      let spam = page.getByTestId('spam-checkbox');
       await spam.check();
       await expect(spam).toBeChecked();
-      const other = page.getByTestId('other-checkbox');
+      let other = page.getByTestId('other-checkbox');
       await other.check();
       await expect(other).toBeChecked();
-      const detailInput = page.getByTestId('detail-input');
+      let detailInput = page.getByTestId('detail-input');
       await expect(detailInput).toHaveValue('');
-      const reportButton = page.getByTestId('report-button');
+      let reportButton = page.getByTestId('report-button');
       await reportButton.click();
 
       await expect(page.getByTestId('crate-invalid')).not.toBeVisible();
@@ -237,14 +237,14 @@ test detail
     });
 
     test('valid form without detail', async ({ page }) => {
-      const spam = page.getByTestId('spam-checkbox');
+      let spam = page.getByTestId('spam-checkbox');
       await spam.check();
       await expect(spam).toBeChecked();
-      const detailInput = page.getByTestId('detail-input');
+      let detailInput = page.getByTestId('detail-input');
       await expect(detailInput).toHaveValue('');
 
       await page.waitForFunction(() => globalThis.openKwargs === undefined);
-      const reportButton = page.getByTestId('report-button');
+      let reportButton = page.getByTestId('report-button');
       await reportButton.click();
 
       await expect(page.getByTestId('crate-invalid')).not.toBeVisible();
@@ -274,18 +274,18 @@ Additional details:
     });
 
     test('valid form with required detail', async ({ page }) => {
-      const spam = page.getByTestId('spam-checkbox');
+      let spam = page.getByTestId('spam-checkbox');
       await spam.check();
       await expect(spam).toBeChecked();
-      const other = page.getByTestId('other-checkbox');
+      let other = page.getByTestId('other-checkbox');
       await other.check();
       await expect(other).toBeChecked();
-      const detailInput = page.getByTestId('detail-input');
+      let detailInput = page.getByTestId('detail-input');
       await detailInput.fill('test detail');
       await expect(detailInput).toHaveValue('test detail');
 
       await page.waitForFunction(() => globalThis.openKwargs === undefined);
-      const reportButton = page.getByTestId('report-button');
+      let reportButton = page.getByTestId('report-button');
       await reportButton.click();
 
       await expect(page.getByTestId('crate-invalid')).not.toBeVisible();
@@ -320,18 +320,18 @@ test detail
     await page.getByTestId('link-crate-violation').click();
     await expect(page).toHaveURL('/support?inquire=crate-violation');
 
-    const crateInput = page.getByTestId('crate-input');
+    let crateInput = page.getByTestId('crate-input');
     await crateInput.fill('nanomsg');
     await expect(crateInput).toHaveValue('nanomsg');
-    const checkbox = page.getByTestId('malicious-code-checkbox');
+    let checkbox = page.getByTestId('malicious-code-checkbox');
     await checkbox.check();
     await expect(checkbox).toBeChecked();
-    const detailInput = page.getByTestId('detail-input');
+    let detailInput = page.getByTestId('detail-input');
     await detailInput.fill('test detail');
     await expect(detailInput).toHaveValue('test detail');
 
     await page.waitForFunction(() => globalThis.openKwargs === undefined);
-    const reportButton = page.getByTestId('report-button');
+    let reportButton = page.getByTestId('report-button');
     await reportButton.click();
 
     await expect(page.getByTestId('crate-invalid')).not.toBeVisible();
@@ -365,12 +365,12 @@ test detail
     await page.getByTestId('link-crate-violation').click();
     await expect(page).toHaveURL('/support?inquire=crate-violation');
 
-    const crateInput = page.getByTestId('crate-input');
+    let crateInput = page.getByTestId('crate-input');
     await crateInput.fill('nanomsg');
     await expect(crateInput).toHaveValue('nanomsg');
     await expect(page.getByTestId('vulnerability-report')).not.toBeVisible();
 
-    const checkbox = page.getByTestId('vulnerability-checkbox');
+    let checkbox = page.getByTestId('vulnerability-checkbox');
     await checkbox.check();
     await expect(checkbox).toBeChecked();
     await expect(page.getByTestId('vulnerability-report')).toBeVisible();

--- a/e2e/fixtures/a11y.ts
+++ b/e2e/fixtures/a11y.ts
@@ -16,7 +16,7 @@ export class A11yPage {
   }
 
   async audit() {
-    const result = await this.builder.analyze();
+    let result = await this.builder.analyze();
     this._check(result);
   }
 
@@ -25,7 +25,7 @@ export class A11yPage {
     if (options) {
       builder = builder.options(options);
     }
-    const result = await builder.analyze();
+    let result = await builder.analyze();
     this._check(result);
   }
 

--- a/e2e/fixtures/percy.ts
+++ b/e2e/fixtures/percy.ts
@@ -13,7 +13,7 @@ export class PercyPage {
   // This implementation maintains the title format used by @percy/ember
   private title(): string {
     // Skip the filename
-    const paths = this.testInfo.titlePath.slice(1);
+    let paths = this.testInfo.titlePath.slice(1);
     // Add an "e2e" prefix to differentiate the snapshots from the QUnit tests.
     // This address the visual changes caused by the font not loading in QUnit tests (#9052).
     return ['e2e'].concat(paths).join(' | ');

--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -48,7 +48,7 @@ export const test = base.extend<AppOptions & AppFixtures>({
   ],
   msw: [
     async ({ context, page }, use) => {
-      const worker = defineNetworkFixture({
+      let worker = defineNetworkFixture({
         context,
         handlers,
         // Without this, requests for `foo.json` cannot be intercepted, which causes some tests to fail.
@@ -56,7 +56,7 @@ export const test = base.extend<AppOptions & AppFixtures>({
       });
       await worker.enable();
 
-      const authenticateAs = async function (user) {
+      let authenticateAs = async function (user) {
         await db.mswSession.create({ user });
         await page.addInitScript("globalThis.localStorage.setItem('isLoggedIn', '1')");
       };

--- a/e2e/routes/category.spec.ts
+++ b/e2e/routes/category.spec.ts
@@ -25,7 +25,7 @@ test.describe('Route | category', { tag: '@routes' }, () => {
   test('updates the search field when the categories route is accessed', async ({ page, msw }) => {
     await msw.db.category.create({ category: 'foo' });
 
-    const searchInput = page.locator('[data-test-search-input]');
+    let searchInput = page.locator('[data-test-search-input]');
     await page.goto('/');
     await page.waitForURL('/');
     await expect(searchInput).toHaveValue('');

--- a/e2e/routes/crate/settings.spec.ts
+++ b/e2e/routes/crate/settings.spec.ts
@@ -78,7 +78,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
 
   test.describe('Trusted Publishing', () => {
     test('mixed GitHub and GitLab configs', async ({ msw, page, percy }) => {
-      const { crate } = await prepare(msw);
+      let { crate } = await prepare(msw);
 
       // Create GitHub config
       await msw.db.trustpubGithubConfig.create({
@@ -128,7 +128,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
 
     test.describe('GitHub', () => {
       test('happy path', async ({ msw, page, percy }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
 
         // Create two GitHub configs for the crate
         await msw.db.trustpubGithubConfig.create({
@@ -211,7 +211,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
 
     test.describe('GitLab', () => {
       test('happy path', async ({ msw, page, percy }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
 
         // Create two GitLab configs for the crate
         await msw.db.trustpubGitlabConfig.create({
@@ -306,7 +306,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('hidden when flag is true and configs exist', async ({ msw, page }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
         await msw.db.crate.update(q => q.where({ id: crate.id }), {
           data(c) {
             c.trustpubOnly = true;
@@ -326,7 +326,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('shown when flag is true but no configs exist', async ({ msw, page, percy }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
         await msw.db.crate.update(q => q.where({ id: crate.id }), {
           data(c) {
             c.trustpubOnly = true;
@@ -344,7 +344,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('disappears when checkbox is unchecked', async ({ msw, page }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
         await msw.db.crate.update(q => q.where({ id: crate.id }), {
           data(c) {
             c.trustpubOnly = true;
@@ -361,7 +361,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('appears when last config is removed', async ({ msw, page }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
         await msw.db.crate.update(q => q.where({ id: crate.id }), {
           data(c) {
             c.trustpubOnly = true;
@@ -395,7 +395,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('visible when GitHub configs exist', async ({ msw, page }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
 
         await msw.db.trustpubGithubConfig.create({
           crate,
@@ -411,7 +411,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('visible when GitLab configs exist', async ({ msw, page }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
 
         await msw.db.trustpubGitlabConfig.create({
           crate,
@@ -427,7 +427,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('visible when flag is true but no configs', async ({ msw, page }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
         await msw.db.crate.update(q => q.where({ id: crate.id }), {
           data(c) {
             c.trustpubOnly = true;
@@ -441,7 +441,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('stays visible after disabling when no configs exist', async ({ msw, page }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
         await msw.db.crate.update(q => q.where({ id: crate.id }), {
           data(c) {
             c.trustpubOnly = true;
@@ -467,7 +467,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('enabling trustpub_only', async ({ msw, page }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
 
         await msw.db.trustpubGithubConfig.create({
           crate,
@@ -488,7 +488,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('disabling trustpub_only', async ({ msw, page }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
         await msw.db.crate.update(q => q.where({ id: crate.id }), {
           data(c) {
             c.trustpubOnly = true;
@@ -514,7 +514,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       });
 
       test('loading and error state', async ({ msw, page }) => {
-        const { crate } = await prepare(msw);
+        let { crate } = await prepare(msw);
 
         await msw.db.trustpubGithubConfig.create({
           crate,

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
@@ -60,7 +60,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
   });
 
   test.describe('prefill', () => {
-    const testCases = [
+    let testCases = [
       {
         name: 'GitHub: simple https',
         url: 'https://github.com/rust-lang/crates.io',
@@ -140,7 +140,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
       },
     ];
 
-    for (const { name, url, publisher, owner, repo } of testCases) {
+    for (let { name, url, publisher, owner, repo } of testCases) {
       test(name, async ({ msw, page }) => {
         let { crate } = await prepare(msw);
 

--- a/e2e/routes/crate/version/crate-links.spec.ts
+++ b/e2e/routes/crate/version/crate-links.spec.ts
@@ -12,9 +12,9 @@ test.describe('Route | crate.version | crate links', { tag: '@routes' }, () => {
 
     await page.goto('/crates/foo');
 
-    const homepageLink = page.locator('[data-test-homepage-link] a');
-    const docsLink = page.locator('[data-test-docs-link] a');
-    const repositoryLink = page.locator('[data-test-repository-link] a');
+    let homepageLink = page.locator('[data-test-homepage-link] a');
+    let docsLink = page.locator('[data-test-docs-link] a');
+    let repositoryLink = page.locator('[data-test-repository-link] a');
 
     await expect(homepageLink).toHaveText('crates.io');
     await expect(homepageLink).toHaveAttribute('href', 'https://crates.io/');
@@ -50,7 +50,7 @@ test.describe('Route | crate.version | crate links', { tag: '@routes' }, () => {
     await expect(page.locator('[data-test-homepage-link]')).toHaveCount(0);
     await expect(page.locator('[data-test-docs-link]')).toHaveCount(0);
 
-    const repositoryLink = page.locator('[data-test-repository-link] a');
+    let repositoryLink = page.locator('[data-test-repository-link] a');
     await expect(repositoryLink).toHaveText('github.com/rust-lang/crates.io');
     await expect(repositoryLink).toHaveAttribute('href', 'https://github.com/rust-lang/crates.io');
   });
@@ -68,7 +68,7 @@ test.describe('Route | crate.version | crate links', { tag: '@routes' }, () => {
     await expect(page.locator('[data-test-homepage-link]')).toHaveCount(0);
     await expect(page.locator('[data-test-docs-link]')).toHaveCount(0);
 
-    const repositoryLink = page.locator('[data-test-repository-link] a');
+    let repositoryLink = page.locator('[data-test-repository-link] a');
     await expect(repositoryLink).toHaveText('github.com/rust-lang/crates.io');
     await expect(repositoryLink).toHaveAttribute('href', 'https://github.com/rust-lang/crates.io.git');
   });


### PR DESCRIPTION
The TypeScript files under `e2e/` still use `const` for non-top-level declarations, while the rest of the codebase has long followed the `prefer-let/prefer-let` style for those. This brings the e2e tests in line with everything else.

Mechanical `eslint --fix` output, no behaviour changes.