### PR TITLE
ESLint: Lint TypeScript files in the root config

### DIFF
--- a/e2e/acceptance/crates.spec.ts
+++ b/e2e/acceptance/crates.spec.ts
@@ -3,9 +3,6 @@ import { loadFixtures } from '@crates-io/msw/fixtures';
 import { http, HttpResponse } from 'msw';
 
 test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
-  // should match the default set in the crates controller
-  const per_page = 50;
-
   test('visiting the crates page from the front page', async ({ page, msw, percy, a11y }) => {
     await loadFixtures(msw.db);
 

--- a/e2e/acceptance/support.spec.ts
+++ b/e2e/acceptance/support.spec.ts
@@ -44,7 +44,7 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
   });
 
   test.describe('reporting a crate from support page', () => {
-    test.beforeEach(async ({ page, msw }) => {
+    test.beforeEach(async ({ page }) => {
       await page.goto('/support');
       await page.getByTestId('link-crate-violation').click();
       await expect(page).toHaveURL('/support?inquire=crate-violation');
@@ -196,7 +196,7 @@ test detail
   });
 
   test.describe('reporting a crate from crate page', () => {
-    test.beforeEach(async ({ page, msw }) => {
+    test.beforeEach(async ({ page }) => {
       await page.goto('/crates/nanomsg');
       await page.getByTestId('link-crate-report').click();
       await expect(page).toHaveURL('/support?crate=nanomsg&inquire=crate-violation');

--- a/e2e/acceptance/support.spec.ts
+++ b/e2e/acceptance/support.spec.ts
@@ -22,9 +22,10 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
     await expect(page.getByTestId('inquire-list-section')).toBeVisible();
     let inquireList = page.getByTestId('inquire-list');
     await expect(inquireList).toBeVisible();
-    await expect(inquireList.locator(page.getByRole('listitem'))).toHaveText(
-      ['Report a crate that violates policies'].concat(['For all other cases: help@crates.io']),
-    );
+    await expect(inquireList.locator(page.getByRole('listitem'))).toHaveText([
+      'Report a crate that violates policies',
+      'For all other cases: help@crates.io',
+    ]);
 
     await percy.snapshot();
     await a11y.audit();
@@ -38,9 +39,10 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
     await expect(page.getByTestId('inquire-list-section')).toBeVisible();
     let inquireList = page.getByTestId('inquire-list');
     await expect(inquireList).toBeVisible();
-    await expect(inquireList.locator(page.getByRole('listitem'))).toHaveText(
-      ['Report a crate that violates policies'].concat(['For all other cases: help@crates.io']),
-    );
+    await expect(inquireList.locator(page.getByRole('listitem'))).toHaveText([
+      'Report a crate that violates policies',
+      'For all other cases: help@crates.io',
+    ]);
   });
 
   test.describe('reporting a crate from support page', () => {

--- a/e2e/acceptance/versions.spec.ts
+++ b/e2e/acceptance/versions.spec.ts
@@ -34,7 +34,7 @@ test.describe('Acceptance | crate versions page', { tag: '@acceptance' }, () => 
     expect(versions).toEqual(['0.3.0', '0.2.1', '0.2.0', '0.1.0']);
   });
 
-  test('shows correct release tracks label after yanking/unyanking', async ({ page, msw, percy }) => {
+  test('shows correct release tracks label after yanking/unyanking', async ({ page, msw }) => {
     let user = await msw.db.user.create({});
     await msw.authenticateAs(user);
 

--- a/e2e/fixtures/percy.ts
+++ b/e2e/fixtures/percy.ts
@@ -16,7 +16,7 @@ export class PercyPage {
     let paths = this.testInfo.titlePath.slice(1);
     // Add an "e2e" prefix to differentiate the snapshots from the QUnit tests.
     // This address the visual changes caused by the font not loading in QUnit tests (#9052).
-    return ['e2e'].concat(paths).join(' | ');
+    return ['e2e', ...paths].join(' | ');
   }
 
   async snapshot(options?: Parameters<typeof percySnapshot>[2]) {

--- a/e2e/fixtures/percy.ts
+++ b/e2e/fixtures/percy.ts
@@ -1,4 +1,4 @@
-import { default as percySnapshot } from '@percy/playwright';
+import percySnapshot from '@percy/playwright';
 import { Page, TestInfo } from '@playwright/test';
 
 export class PercyPage {

--- a/e2e/routes/crate/settings.spec.ts
+++ b/e2e/routes/crate/settings.spec.ts
@@ -126,7 +126,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
     });
 
     test.describe('GitHub', () => {
-      test('happy path', async ({ msw, page, percy }) => {
+      test('happy path', async ({ msw, page }) => {
         let { crate } = await prepare(msw);
 
         // Create two GitHub configs for the crate
@@ -177,7 +177,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
         );
       });
 
-      test('deletion failure', async ({ msw, page, percy }) => {
+      test('deletion failure', async ({ msw, page }) => {
         let { crate } = await prepare(msw);
 
         // Create a GitHub config for the crate
@@ -209,7 +209,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
     });
 
     test.describe('GitLab', () => {
-      test('happy path', async ({ msw, page, percy }) => {
+      test('happy path', async ({ msw, page }) => {
         let { crate } = await prepare(msw);
 
         // Create two GitLab configs for the crate
@@ -263,7 +263,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
         );
       });
 
-      test('deletion failure', async ({ msw, page, percy }) => {
+      test('deletion failure', async ({ msw, page }) => {
         let { crate } = await prepare(msw);
 
         // Create a GitLab config for the crate

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,7 @@ export default [
     ],
   },
   ...compat.extends('eslint:recommended', 'plugin:prettier/recommended'),
+  ...ts.configs.recommended,
   {
     plugins: {
       'prefer-let': preferLet,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,11 +3,11 @@ import { fileURLToPath } from 'node:url';
 
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
-import emberEslintParser from 'ember-eslint-parser';
 import preferLet from 'eslint-plugin-prefer-let';
 import prettier from 'eslint-plugin-prettier';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 import globals from 'globals';
+import ts from 'typescript-eslint';
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -47,7 +47,7 @@ export default [
         ...globals.browser,
       },
 
-      parser: emberEslintParser,
+      parser: ts.parser,
       ecmaVersion: 2018,
       sourceType: 'module',
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@sinonjs/fake-timers": "15.3.2",
     "@types/node": "24.12.2",
     "@types/sinonjs__fake-timers": "15.0.1",
-    "ember-eslint-parser": "0.11.3",
     "eslint": "10.3.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prefer-let": "4.2.2",
@@ -74,7 +73,8 @@
     "globals": "17.6.0",
     "msw": "2.14.2",
     "prettier": "3.8.3",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.59.1"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/packages/crates-io-api-client/index.ts
+++ b/packages/crates-io-api-client/index.ts
@@ -1,8 +1,8 @@
 import createOpenAPIClient, { type ClientOptions } from 'openapi-fetch';
 
-import type { components, operations, paths } from './schema';
+import type { paths } from './schema';
 
-export type { components, operations, paths };
+export type { components, operations, paths } from './schema';
 
 export function createClient(options?: ClientOptions) {
   return createOpenAPIClient<paths>(options);

--- a/packages/crates-io-api-client/schema.test.ts
+++ b/packages/crates-io-api-client/schema.test.ts
@@ -1,5 +1,5 @@
 import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
+import path from 'node:path';
 
 import openapiTS, { astToString } from 'openapi-typescript';
 import { expect, test } from 'vitest';

--- a/packages/crates-io-msw/models/api-token.test.js
+++ b/packages/crates-io-msw/models/api-token.test.js
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `user` is not set', async ({ expect }) => {
-  // @ts-expect-error
+  // @ts-expect-error: missing required field
   await expect(() => db.apiToken.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/crate-owner-invitation.test.js
+++ b/packages/crates-io-msw/models/crate-owner-invitation.test.js
@@ -5,7 +5,7 @@ import { db } from '../index.js';
 test('throws if `crate` is not set', async ({ expect }) => {
   let inviter = await db.user.create({});
   let invitee = await db.user.create({});
-  // @ts-expect-error
+  // @ts-expect-error: missing required field
   await expect(() => db.crateOwnerInvitation.create({ inviter, invitee })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );
@@ -14,7 +14,7 @@ test('throws if `crate` is not set', async ({ expect }) => {
 test('throws if `inviter` is not set', async ({ expect }) => {
   let crate = await db.crate.create({});
   let invitee = await db.user.create({});
-  // @ts-expect-error
+  // @ts-expect-error: missing required field
   await expect(() => db.crateOwnerInvitation.create({ crate, invitee })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );
@@ -23,7 +23,7 @@ test('throws if `inviter` is not set', async ({ expect }) => {
 test('throws if `invitee` is not set', async ({ expect }) => {
   let crate = await db.crate.create({});
   let inviter = await db.user.create({});
-  // @ts-expect-error
+  // @ts-expect-error: missing required field
   await expect(() => db.crateOwnerInvitation.create({ crate, inviter })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/crate-ownership.test.js
+++ b/packages/crates-io-msw/models/crate-ownership.test.js
@@ -4,7 +4,7 @@ import { db } from '../index.js';
 
 test('throws if `crate` is not set', async ({ expect }) => {
   let user = await db.user.create({});
-  // @ts-expect-error
+  // @ts-expect-error: missing required field
   await expect(() => db.crateOwnership.create({ user })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/dependency.test.js
+++ b/packages/crates-io-msw/models/dependency.test.js
@@ -4,7 +4,7 @@ import { db } from '../index.js';
 
 test('throws if `crate` is not set', async ({ expect }) => {
   let version = await db.version.create({ crate: await db.crate.create({}) });
-  // @ts-expect-error
+  // @ts-expect-error: missing required field
   await expect(() => db.dependency.create({ version })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );
@@ -12,7 +12,7 @@ test('throws if `crate` is not set', async ({ expect }) => {
 
 test('throws if `version` is not set', async ({ expect }) => {
   let crate = await db.crate.create({});
-  // @ts-expect-error
+  // @ts-expect-error: missing required field
   await expect(() => db.dependency.create({ crate })).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/msw-session.test.js
+++ b/packages/crates-io-msw/models/msw-session.test.js
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `user` is not set', async ({ expect }) => {
-  // @ts-expect-error
+  // @ts-expect-error: missing required field
   await expect(() => db.mswSession.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/version-download.test.js
+++ b/packages/crates-io-msw/models/version-download.test.js
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `version` is not set', async ({ expect }) => {
-  // @ts-expect-error
+  // @ts-expect-error: missing required field
   await expect(() => db.versionDownload.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/packages/crates-io-msw/models/version.test.js
+++ b/packages/crates-io-msw/models/version.test.js
@@ -3,7 +3,7 @@ import { test } from 'vitest';
 import { db } from '../index.js';
 
 test('throws if `crate` is not set', async ({ expect }) => {
-  // @ts-expect-error
+  // @ts-expect-error: missing required field
   await expect(() => db.version.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
     `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       '@types/sinonjs__fake-timers':
         specifier: 15.0.1
         version: 15.0.1
-      ember-eslint-parser:
-        specifier: 0.11.3
-        version: 0.11.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(typescript@6.0.3)
       eslint:
         specifier: 10.3.0
         version: 10.3.0(jiti@2.6.1)
@@ -78,6 +75,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      typescript-eslint:
+        specifier: 8.59.1
+        version: 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
 
   packages/crates-io-api-client:
     dependencies:
@@ -616,25 +616,6 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@glimmer/env@0.1.7':
-    resolution: {integrity: sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==}
-
-  '@glimmer/interfaces@0.94.6':
-    resolution: {integrity: sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==}
-
-  '@glimmer/syntax@0.95.0':
-    resolution: {integrity: sha512-W/PHdODnpONsXjbbdY9nedgIHpglMfOzncf/moLVrKIcCfeQhw2vG07Rs/YW8KeJCgJRCLkQsi+Ix7XvrurGAg==}
-
-  '@glimmer/util@0.94.8':
-    resolution: {integrity: sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==}
-
-  '@glimmer/wire-format@0.94.8':
-    resolution: {integrity: sha512-A+Cp5m6vZMAEu0Kg/YwU2dJZXyYxVJs2zI57d3CP6NctmX7FsT8WjViiRUmt5abVmMmRH5b8BUovqY6GSMAdrw==}
-
-  '@handlebars/parser@2.2.2':
-    resolution: {integrity: sha512-n/SZW+12rwikx/f8YcSv9JCi5p9vn1Bnts9ZtVvfErG4h0gbjHI1H1ZMhVUnaOC7yzFc6PtsCKIK8XeTnL90Gw==}
-    engines: {node: ^18 || ^20 || ^22 || >=24}
-
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -790,136 +771,6 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
-
-  '@oxc-parser/binding-android-arm-eabi@0.119.0':
-    resolution: {integrity: sha512-e0ii/Tqwk5pAHZRY+ZyXOdKHNRNmE+dvTGQZ7xQ5XPH2Am59aktD30QvfcfwItGhNTLCj/5TYGH5RHvmvqaILQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxc-parser/binding-android-arm64@0.119.0':
-    resolution: {integrity: sha512-ha0xQpiStuoBv7HGazNKQWa6IRxri2+PpeojdAyBGnHGzfioA1GcStNGEGOyXvF+OxDfWvPuw5QiRYRUMtmgbQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-parser/binding-darwin-arm64@0.119.0':
-    resolution: {integrity: sha512-h/AIi5jfQz9WQUJJkkkHeXNYMhPtR72qnYZt0ZpM/LvlH/wpI5QkCPi7MWjjyY+m0JDorIXJyfOfccn8SbNSxQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-x64@0.119.0':
-    resolution: {integrity: sha512-15RwS/AawrgognvWsonI2eLKI5BqO0FzrpYXnzROysSR0x5RYsCc3UMFBwB1ph0UFFQzJy3ZbHHxfxp8RGr5Xg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-parser/binding-freebsd-x64@0.119.0':
-    resolution: {integrity: sha512-iKaayTIDqEj0yyNPL+0t/spNAxMv7O32uY4eu/ir8BvFNgavoRmN8uqxRj8sxQDle89N/1Iw0dgRjS3tiWrqlA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.119.0':
-    resolution: {integrity: sha512-PDoOaOx8YWoxy19WNeMs6kOE0uFSb5EtA64Ye0wSp6sQpe+l8Gd+yjX2L+yNwd5MpDOvOy8KToa2bqCV4pf6iQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.119.0':
-    resolution: {integrity: sha512-AVxZ5Eo5squsUhpjnkCYuH20t5FCGV3HAP9UOKLxJQkmZW3kJvBGbfpH75ABxRrE2kGqmJW5FmS980u8v9Cepw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.119.0':
-    resolution: {integrity: sha512-9vfdyT9gczSeSwsEkBHVjigI8SWo3iB9zxEzL+YMBUrN0ftCUkKQr27DaDZK4/cQ80t6KRB+g9sUmT2T2AGnOQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-arm64-musl@0.119.0':
-    resolution: {integrity: sha512-7BOq/tjSrtnp/ihw615uGcxMY3iya2qvVtwm15h2NvBZ6Jje+PC1GSUBOLfqGKJbUr9riSVV//a4iNhHI48Qdw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.119.0':
-    resolution: {integrity: sha512-PQIrLJwoAaNyNSWBF+2SSgv44Jp+xpKVUA+8+PuoMhyBQ6lFSbQdaxewdn11i3heTFMYd2xF339HWax4S6MPVA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.119.0':
-    resolution: {integrity: sha512-spNh4YhT9K+Ya5hr6NmI1MazKSKORD8u5/06hFbzTslLnmmxiGaLqJXhNKIYUH39ne/JD5rkoRkUcOB2/LpC3A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.119.0':
-    resolution: {integrity: sha512-hFoCTRxSJAcrNBYVlgNDDQq6LyJLYyhnJDlPtK/mWrPYS3x5/fUR9jc6wo5VyxKIL/0dDJBBWp19v81q9heU/A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.119.0':
-    resolution: {integrity: sha512-bl7jHJZq3W5tYEvKG3yWZTUKTNb0/BtyYSnfMIrQ7t8hajCH4i1g0q+14s0KmQQl1UHxIX/Gx/Ps6e92qJQJmQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-x64-gnu@0.119.0':
-    resolution: {integrity: sha512-m+DE7NhJIEGp4efSJnNfRf3swT25rbZ1FTIihV+pOLTI+k5yNguxvqT338mNu61OVSx0BfpV8QlO2nz43GR/Zg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-x64-musl@0.119.0':
-    resolution: {integrity: sha512-pHhnXZHUfd5pYzFLQfvx1DH2HY+L8DPZeh6SsQrsmoaODm1+j8VPeWLwGSrXQSz5f1kfT/mnzm1iNLVOGIeuaw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-openharmony-arm64@0.119.0':
-    resolution: {integrity: sha512-8Fthv9nOec0hQLX16yjYyYIU+u8ZFuQojdQ3vNgXN+PcqI/bDohGgCATrxO69gLf0IzkyOmKmurXOQCYK8BYpQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-parser/binding-wasm32-wasi@0.119.0':
-    resolution: {integrity: sha512-KpOU6fLqevFDP6ndkgE4BPoceELM4bOsEsAXjpe+FKYuUyEzHssYPBmxouGpXDQeAeWTBIjosw5yElLMRPuccw==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.119.0':
-    resolution: {integrity: sha512-omtTgAKIl6GQ40nG+wAWN8xMJLNtfmTdd0+wMIcrw1shX9y5TntAVIuiay3Du0wvUK9sgMpL07HYNphgHeZS0A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.119.0':
-    resolution: {integrity: sha512-+0kqoCfv4WFP3e4BqcVEtf1moUuG9Zv5lo1aKcw1JakqJo008TGG+C2LnVM4QucGSZVQ/Ii/H5XCvrRbkeLQfA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-x64-msvc@0.119.0':
-    resolution: {integrity: sha512-5kaKmBHD+OQjZzGAQQ9n8jWNvCRxu3MjElAjkCqsS3i2wiN3hqHlOPKwGDydYiB1gKdeYGlTjRYtuF4gBLDSxQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxc-project/types@0.119.0':
-    resolution: {integrity: sha512-9SCGhodOxEicD2kblitu34fGHcpmqgI3beYw/E22ehVLHzccHRFH91NmKt0MhZEaAwLpei6OOA9aB6Vuks9qAg==}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -1137,9 +988,6 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
-
-  '@simple-dom/interface@1.4.0':
-    resolution: {integrity: sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==}
 
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
@@ -2277,21 +2125,6 @@ packages:
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
-  ember-eslint-parser@0.11.3:
-    resolution: {integrity: sha512-tGLDVyemseglpXyt3MMnggWL2ROYglRGoL0lKVy+GySFcrD4YQbt5iyvrY9hcEnN62gmkFLIFRinIq5niqYKXg==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@babel/eslint-parser': ^7.28.6
-      '@typescript-eslint/parser': '*'
-    peerDependenciesMeta:
-      '@babel/eslint-parser':
-        optional: true
-      '@typescript-eslint/parser':
-        optional: true
-
-  ember-estree@0.6.3:
-    resolution: {integrity: sha512-76NgApjUCvGHd6eC5BueOSwDdXtyO/+zSrZuKaWdRm3EyIbtE9ysvCOsm1cft8zl6dxdqeJpNpTJ5a1ljVIFMg==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2687,10 +2520,6 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  html-tags@5.1.0:
-    resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
-    engines: {node: '>=20.10'}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -3024,9 +2853,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mathml-tag-names@4.0.0:
-    resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
-
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
@@ -3243,10 +3069,6 @@ packages:
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
-
-  oxc-parser@0.119.0:
-    resolution: {integrity: sha512-fNiKvO0ZHSUmINQlVY2It+vGbHxCvhpqJi0rZYFFOESoOy3fs5E4erKYGZtB/J1aULkjtY06aWNil4JxMsKXGg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -3575,9 +3397,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-html-tokenizer@0.5.11:
-    resolution: {integrity: sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==}
-
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -3701,9 +3520,6 @@ packages:
   svelte@5.55.5:
     resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
     engines: {node: '>=18'}
-
-  svg-tags@1.0.0:
-    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
@@ -4445,31 +4261,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@glimmer/env@0.1.7': {}
-
-  '@glimmer/interfaces@0.94.6':
-    dependencies:
-      '@simple-dom/interface': 1.4.0
-      type-fest: 4.41.0
-
-  '@glimmer/syntax@0.95.0':
-    dependencies:
-      '@glimmer/interfaces': 0.94.6
-      '@glimmer/util': 0.94.8
-      '@glimmer/wire-format': 0.94.8
-      '@handlebars/parser': 2.2.2
-      simple-html-tokenizer: 0.5.11
-
-  '@glimmer/util@0.94.8':
-    dependencies:
-      '@glimmer/interfaces': 0.94.6
-
-  '@glimmer/wire-format@0.94.8':
-    dependencies:
-      '@glimmer/interfaces': 0.94.6
-
-  '@handlebars/parser@2.2.2': {}
-
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -4626,73 +4417,6 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
-
-  '@oxc-parser/binding-android-arm-eabi@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-android-arm64@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-arm64@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-x64@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-freebsd-x64@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-musl@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-wasm32-wasi@0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.119.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.119.0':
-    optional: true
-
-  '@oxc-project/types@0.119.0': {}
 
   '@oxc-project/types@0.127.0': {}
 
@@ -4982,8 +4706,6 @@ snapshots:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
-
-  '@simple-dom/interface@1.4.0': {}
 
   '@sinonjs/commons@3.0.1':
     dependencies:
@@ -5914,7 +5636,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  content-tag@4.1.1: {}
+  content-tag@4.1.1:
+    optional: true
 
   convert-source-map@2.0.0: {}
 
@@ -6270,33 +5993,6 @@ snapshots:
     optional: true
 
   electron-to-chromium@1.5.344: {}
-
-  ember-eslint-parser@0.11.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(typescript@6.0.3):
-    dependencies:
-      '@glimmer/syntax': 0.95.0
-      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@6.0.3)
-      content-tag: 4.1.1
-      ember-estree: 0.6.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      eslint-scope: 9.1.2
-      html-tags: 5.1.0
-      mathml-tag-names: 4.0.0
-      svg-tags: 1.0.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - typescript
-
-  ember-estree@0.6.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
-    dependencies:
-      '@glimmer/env': 0.1.7
-      '@glimmer/syntax': 0.95.0
-      content-tag: 4.1.1
-      oxc-parser: 0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
   emoji-regex@8.0.0: {}
 
@@ -6761,8 +6457,6 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-tags@5.1.0: {}
-
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -7053,8 +6747,6 @@ snapshots:
 
   math-intrinsics@1.1.0:
     optional: true
-
-  mathml-tag-names@4.0.0: {}
 
   mdn-data@2.0.28: {}
 
@@ -7405,34 +7097,6 @@ snapshots:
 
   outvariant@1.4.3: {}
 
-  oxc-parser@0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
-    dependencies:
-      '@oxc-project/types': 0.119.0
-    optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.119.0
-      '@oxc-parser/binding-android-arm64': 0.119.0
-      '@oxc-parser/binding-darwin-arm64': 0.119.0
-      '@oxc-parser/binding-darwin-x64': 0.119.0
-      '@oxc-parser/binding-freebsd-x64': 0.119.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.119.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.119.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.119.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.119.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.119.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.119.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.119.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.119.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.119.0
-      '@oxc-parser/binding-linux-x64-musl': 0.119.0
-      '@oxc-parser/binding-openharmony-arm64': 0.119.0
-      '@oxc-parser/binding-wasm32-wasi': 0.119.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@oxc-parser/binding-win32-arm64-msvc': 0.119.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.119.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.119.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -7740,8 +7404,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-html-tokenizer@0.5.11: {}
-
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -7897,8 +7559,6 @@ snapshots:
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
-
-  svg-tags@1.0.0: {}
 
   svgo@4.0.1:
     dependencies:


### PR DESCRIPTION
The root ESLint config has never actually linted TypeScript files. It inherited `ember-eslint-parser` from the Ember era and never grew a TS file selector, so anything under `e2e/` or `packages/` skipped past `eslint .` entirely. This PR fixes that.

Most of the commits are small cleanups for issues that surface once TS files are included in scope: unused fixture destructures, leftover `Array#concat()` calls, missing `@ts-expect-error` descriptions, and so on. The last two commits do the actual config work, by swapping the parser out for `typescript-eslint` and pulling in its `recommended` preset (which brings the `**/*.{ts,tsx,mts,cts}` selector along with the rules).

The Svelte sub-config has been on this setup for a while, so the root config now matches.