### PR TITLE
svelte: Drop `_`-prefix unused-binding workarounds

### DIFF
--- a/svelte/eslint.config.js
+++ b/svelte/eslint.config.js
@@ -36,16 +36,6 @@ export default defineConfig(
       // typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
       // see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
       'no-undef': 'off',
-
-      '@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-          argsIgnorePattern: '^_',
-          caughtErrorsIgnorePattern: '^_',
-          destructuredArrayIgnorePattern: '^_',
-          varsIgnorePattern: '^_',
-        },
-      ],
     },
   },
   {

--- a/svelte/src/lib/components/ReadmePlaceholder.svelte
+++ b/svelte/src/lib/components/ReadmePlaceholder.svelte
@@ -9,12 +9,12 @@
   <!-- eslint-disable svelte/require-each-key -->
 
   <Placeholder width="30%" height="25px" {radius} opacity={0.6} style="margin: var(--space-s) 0 var(--space-m)" />
-  {#each { length: 5 } as _}
+  {#each { length: 5 }}
     <Placeholder {...text} {radius} />
   {/each}
 
   <Placeholder width="50%" height="20px" {radius} opacity={0.6} style="margin: var(--space-l) 0 var(--space-m)" />
-  {#each { length: 3 } as _}
+  {#each { length: 3 }}
     <Placeholder {...text} {radius} />
   {/each}
 </div>

--- a/svelte/src/lib/components/frontpage/ListSection.svelte
+++ b/svelte/src/lib/components/frontpage/ListSection.svelte
@@ -21,7 +21,7 @@
   <h2><a {href}>{title}</a></h2>
   <svelte:element this={ordered ? 'ol' : 'ul'} class="list" aria-busy={!items}>
     {#if !items}
-      {#each { length: 10 } as _, i (i)}
+      {#each { length: 10 }, i (i)}
         <li><ListItemPlaceholder {withSubtitle} /></li>
       {/each}
     {:else}

--- a/svelte/src/routes/+page.svelte
+++ b/svelte/src/routes/+page.svelte
@@ -32,6 +32,7 @@
 {:then summary}
   <IntroBlurb {summary} />
   <CrateLists {summary} />
+  <!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
 {:catch _error}
   <IntroBlurb />
   <ErrorState isLoading={false} onRetry={retry} />

--- a/svelte/src/routes/+page.ts
+++ b/svelte/src/routes/+page.ts
@@ -33,7 +33,7 @@ async function loadSummary(client: ReturnType<typeof createClient>): Promise<Sum
   let response;
   try {
     response = await client.GET('/api/v1/summary');
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadSummaryError(504);
   }

--- a/svelte/src/routes/categories/+page.ts
+++ b/svelte/src/routes/categories/+page.ts
@@ -27,7 +27,7 @@ async function loadCategories(
   let response;
   try {
     response = await client.GET('/api/v1/categories', { params: { query } });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadCategoriesError(504);
   }

--- a/svelte/src/routes/categories/[category_id]/+page.ts
+++ b/svelte/src/routes/categories/[category_id]/+page.ts
@@ -37,7 +37,7 @@ async function loadCategory(client: ReturnType<typeof createClient>, slug: strin
   let response;
   try {
     response = await client.GET('/api/v1/categories/{category}', { params: { path: { category: slug } } });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadCategoryError(slug, 504);
   }
@@ -58,7 +58,7 @@ async function loadCrates(
   let response;
   try {
     response = await client.GET('/api/v1/crates', { params: { query } });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadCategoryError(slug, 504);
   }

--- a/svelte/src/routes/category_slugs/+page.ts
+++ b/svelte/src/routes/category_slugs/+page.ts
@@ -17,7 +17,7 @@ async function loadCategorySlugs(client: ReturnType<typeof createClient>) {
   let response;
   try {
     response = await client.GET('/api/v1/category_slugs');
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadCategorySlugsError(504);
   }

--- a/svelte/src/routes/crates/+page.ts
+++ b/svelte/src/routes/crates/+page.ts
@@ -28,7 +28,7 @@ async function loadCrates(
   let response;
   try {
     response = await client.GET('/api/v1/crates', { params: { query } });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadCratesError(504);
   }

--- a/svelte/src/routes/crates/[crate_id]/+layout.ts
+++ b/svelte/src/routes/crates/[crate_id]/+layout.ts
@@ -24,7 +24,7 @@ async function loadOwners(client: ReturnType<typeof createClient>, name: string)
     response = await client.GET('/api/v1/crates/{name}/owners', {
       params: { path: { name } },
     });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadCrateError(name, 504);
   }
@@ -54,7 +54,7 @@ async function loadCrate(client: ReturnType<typeof createClient>, name: string) 
         query: { include: 'keywords,categories,downloads,default_version' },
       },
     });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadCrateError(name, 504);
   }

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+layout.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+layout.ts
@@ -16,7 +16,7 @@ async function loadVersion(client: ReturnType<typeof createClient>, name: string
   let response;
   try {
     response = await client.GET('/api/v1/crates/{name}/{version}', { params: { path: { name, version } } });
-  } catch (_error) {
+  } catch {
     loadVersionError(name, version, 504);
   }
 

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.ts
@@ -25,7 +25,7 @@ async function loadDependencies(client: ReturnType<typeof createClient>, name: s
     response = await client.GET('/api/v1/crates/{name}/{version}/dependencies', {
       params: { path: { name, version } },
     });
-  } catch (_error) {
+  } catch {
     loadDependenciesError(name, 504);
   }
 

--- a/svelte/src/routes/crates/[crate_id]/reverse_dependencies/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/reverse_dependencies/+page.ts
@@ -47,7 +47,7 @@ async function loadReverseDependencies(client: ReturnType<typeof createClient>, 
     response = await client.GET('/api/v1/crates/{name}/reverse_dependencies', {
       params: { path: { name }, query: { page, per_page: PER_PAGE } },
     });
-  } catch (_error) {
+  } catch {
     loadError(name, 504);
   }
 

--- a/svelte/src/routes/crates/[crate_id]/settings/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/settings/+page.ts
@@ -26,7 +26,7 @@ async function loadGitHubConfigs(client: ReturnType<typeof createClient>, crateN
     response = await client.GET('/api/v1/trusted_publishing/github_configs', {
       params: { query: { crate: crateName } },
     });
-  } catch (_error) {
+  } catch {
     loadError(504);
   }
 
@@ -44,7 +44,7 @@ async function loadGitLabConfigs(client: ReturnType<typeof createClient>, crateN
     response = await client.GET('/api/v1/trusted_publishing/gitlab_configs', {
       params: { query: { crate: crateName } },
     });
-  } catch (_error) {
+  } catch {
     loadError(504);
   }
 

--- a/svelte/src/routes/crates/[crate_id]/versions/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/versions/+page.ts
@@ -20,7 +20,7 @@ export async function load({ fetch, params, url, depends }) {
         query: { sort, per_page: perPage, include: 'release_tracks' },
       },
     });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadVersionsError(504);
   }

--- a/svelte/src/routes/dashboard/+page.ts
+++ b/svelte/src/routes/dashboard/+page.ts
@@ -37,7 +37,7 @@ async function loadCrates(client: Client, query: { user_id?: number; following?:
   let response;
   try {
     response = await client.GET('/api/v1/crates', { params: { query } });
-  } catch (_error) {
+  } catch {
     loadError(504);
   }
 
@@ -53,7 +53,7 @@ async function loadStats(client: Client, userId: number) {
   let response;
   try {
     response = await client.GET('/api/v1/users/{id}/stats', { params: { path: { id: userId } } });
-  } catch (_error) {
+  } catch {
     loadError(504);
   }
 
@@ -69,7 +69,7 @@ async function loadUpdates(client: Client) {
   let response;
   try {
     response = await client.GET('/api/v1/me/updates');
-  } catch (_error) {
+  } catch {
     loadError(504);
   }
 

--- a/svelte/src/routes/keywords/+page.ts
+++ b/svelte/src/routes/keywords/+page.ts
@@ -27,7 +27,7 @@ async function loadKeywords(
   let response;
   try {
     response = await client.GET('/api/v1/keywords', { params: { query } });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadKeywordsError(504);
   }

--- a/svelte/src/routes/keywords/[keyword_id]/+page.ts
+++ b/svelte/src/routes/keywords/[keyword_id]/+page.ts
@@ -30,7 +30,7 @@ async function loadCrates(
   let response;
   try {
     response = await client.GET('/api/v1/crates', { params: { query } });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadCratesError(keyword, 504);
   }

--- a/svelte/src/routes/me/following/+page.ts
+++ b/svelte/src/routes/me/following/+page.ts
@@ -33,7 +33,7 @@ async function loadCrates(
   let response;
   try {
     response = await client.GET('/api/v1/crates', { params: { query } });
-  } catch (_error) {
+  } catch {
     loadCratesError(504);
   }
 

--- a/svelte/src/routes/teams/[team_id]/+page.ts
+++ b/svelte/src/routes/teams/[team_id]/+page.ts
@@ -36,7 +36,7 @@ async function loadTeam(client: ReturnType<typeof createClient>, login: string) 
   let response;
   try {
     response = await client.GET('/api/v1/teams/{team}', { params: { path: { team: login } } });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadTeamError(login, 504);
   }
@@ -57,7 +57,7 @@ async function loadCrates(
   let response;
   try {
     response = await client.GET('/api/v1/crates', { params: { query } });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadTeamError(login, 504);
   }

--- a/svelte/src/routes/users/[user_id]/+page.ts
+++ b/svelte/src/routes/users/[user_id]/+page.ts
@@ -53,7 +53,7 @@ async function loadUser(client: ReturnType<typeof createClient>, login: string) 
   let response;
   try {
     response = await client.GET('/api/v1/users/{user}', { params: { path: { user: login } } });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadUserError(login, 504);
   }
@@ -74,7 +74,7 @@ async function loadCrates(
   let response;
   try {
     response = await client.GET('/api/v1/crates', { params: { query } });
-  } catch (_error) {
+  } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadUserError(login, 504);
   }


### PR DESCRIPTION
The `@typescript-eslint/no-unused-vars` override in `svelte/eslint.config.js` allowed unused bindings whose name starts with `_`, which the codebase used in three patterns:

* `try { ... } catch (_error) { ... }` in route `load` functions. The error is never inspected before the relevant `loadXxxError(504)` call, so the binding can be omitted with the ES2019 optional-catch syntax `} catch { ... }`.

* `{#each { length: N } as _}` (and `{#each ... as _, i (i)}`) placeholders for "render N times" loops. Svelte 5 allows omitting the item binding in each blocks entirely: `{#each { length: N }}` / `{#each ..., i (i)}`.

* `{:catch _error}` in `+page.svelte`. Svelte's `{:catch}` syntax requires a binding name, so this one keeps its `_error` and uses an `eslint-disable-next-line` comment instead.

With those three sites cleaned up, the only remaining underscore binding (`_mswWorker` in the Vitest fixture) is actually used, which means the `_`-prefix ignore options no longer affect any code in the tree. Drop the rule override and let
`@typescript-eslint/no-unused-vars` run with its defaults.