### PR TITLE
svelte: Declare `__TEST__` as a global instead of disabling `no-undef`

### DIFF
--- a/svelte/eslint.config.js
+++ b/svelte/eslint.config.js
@@ -27,15 +27,20 @@ export default defineConfig(
       'prefer-let': preferLet,
     },
 
-    languageOptions: { globals: { ...globals.browser, ...globals.node } },
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        // Defined at build time by Vite (see `vite.config.ts`) and declared
+        // ambiently in `src/app.d.ts`. ESLint's `no-undef` rule does not see
+        // ambient `.d.ts` declarations, so we have to spell it out here.
+        __TEST__: 'readonly',
+      },
+    },
 
     rules: {
       'prefer-const': 'off',
       'prefer-let/prefer-let': 'error',
-
-      // typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
-      // see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
-      'no-undef': 'off',
     },
   },
   {


### PR DESCRIPTION
`__TEST__` is the only build-time constant referenced by the codebase that ESLint can't otherwise see: it is defined by Vite's `define` config and declared ambiently in `src/app.d.ts`. ESLint's `no-undef` rule does not read ambient `.d.ts` declarations, which forced a blanket `'no-undef': 'off'` to keep `+layout.svelte` from erroring on the reference.

For `.ts`/`.tsx`/etc. files the rule was already off via `ts.configs.recommended` (which scopes its `no-undef: off` to those extensions), so the global override only mattered for `.svelte` files and a couple of plain `.js` config files.

Listing `__TEST__` as a `readonly` global narrows the override to exactly what's missing from ESLint's view of the world, lets `no-undef` keep guarding the plain-JS surface, and matches the shape of the root config (which never disables `no-undef` either).