### PR TITLE
eslint: Use `defineConfig` for the root config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,10 +2,11 @@ import js from '@eslint/js';
 import preferLet from 'eslint-plugin-prefer-let';
 import prettierRecommended from 'eslint-plugin-prettier/recommended';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
+import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 import ts from 'typescript-eslint';
 
-export default [
+export default defineConfig(
   eslintPluginUnicorn.configs.recommended,
   {
     ignores: [
@@ -95,4 +96,4 @@ export default [
       sourceType: 'script',
     },
   },
-];
+);


### PR DESCRIPTION
`defineConfig` from `eslint/config` is the recommended way to author flat configs in ESLint v9+: it provides better type inference for the config array, surfaces validation errors against the schema at load time, and makes the file structurally identical to `svelte/eslint.config.js` (which already uses `defineConfig`).

Pure structural change: same array of config objects, same rules, same plugins. No new dependencies.