### PR TITLE
eslint: Use `includeIgnoreFile` to derive root ignores from `.gitignore`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,6 @@
+import { fileURLToPath } from 'node:url';
+
+import { includeIgnoreFile } from '@eslint/compat';
 import js from '@eslint/js';
 import preferLet from 'eslint-plugin-prefer-let';
 import prettierRecommended from 'eslint-plugin-prettier/recommended';
@@ -6,24 +9,15 @@ import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 import ts from 'typescript-eslint';
 
+const gitignorePath = fileURLToPath(new URL('.gitignore', import.meta.url));
+
 export default defineConfig(
   eslintPluginUnicorn.configs.recommended,
-  {
-    ignores: [
-      '.git/**/*',
-      'crates/',
-      'playwright-report/',
-      'svelte/',
-      'target/',
-      'test-results/',
-      'tmp/',
-      // dependencies
-      'node_modules/',
-      // misc
-      'coverage/',
-      '!**/.*',
-    ],
-  },
+  includeIgnoreFile(gitignorePath),
+  // `crates/` (Rust workspace crates) and `svelte/` (SvelteKit app with its
+  // own ESLint config) are not in `.gitignore`, but the root ESLint config
+  // should not try to lint either of them.
+  { ignores: ['crates/', 'svelte/'] },
   js.configs.recommended,
   prettierRecommended,
   ...ts.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@axe-core/playwright": "4.11.3",
     "@crates-io/msw": "workspace:*",
+    "@eslint/compat": "2.0.5",
     "@eslint/js": "10.0.1",
     "@ianvs/prettier-plugin-sort-imports": "4.7.1",
     "@msw/playwright": "0.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@crates-io/msw':
         specifier: workspace:*
         version: link:packages/crates-io-msw
+      '@eslint/compat':
+        specifier: 2.0.5
+        version: 2.0.5(eslint@10.3.0(jiti@2.6.1))
       '@eslint/js':
         specifier: 10.0.1
         version: 10.0.1(eslint@10.3.0(jiti@2.6.1))
@@ -4396,13 +4399,19 @@ snapshots:
       '@percy/cli-command': 1.31.13(typescript@6.0.3)
       '@percy/cli-exec': 1.31.13(typescript@6.0.3)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-build@1.31.13(typescript@6.0.3)':
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@6.0.3)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-command@1.31.13(typescript@6.0.3)':
     dependencies:
@@ -4419,7 +4428,10 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@6.0.3)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-doctor@1.31.13(typescript@6.0.3)':
     dependencies:
@@ -4445,14 +4457,20 @@ snapshots:
       cross-spawn: 7.0.6
       which: 2.0.2
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-snapshot@1.31.13(typescript@6.0.3)':
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@6.0.3)
       yaml: 2.8.3
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-upload@1.31.13(typescript@6.0.3)':
     dependencies:
@@ -4460,7 +4478,10 @@ snapshots:
       fast-glob: 3.3.3
       image-size: 1.2.1
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli@1.31.13(typescript@6.0.3)':
     dependencies:


### PR DESCRIPTION
The hand-maintained `ignores` list at the root duplicated most of `.gitignore` (`target/`, `node_modules/`, `tmp/`, `test-results/`, `playwright-report/`, `coverage/`). Sourcing those from `.gitignore` via `includeIgnoreFile` from `@eslint/compat` removes the duplication and keeps the two lists from drifting.

Two patterns can't be derived from `.gitignore` and stay as a small explicit `ignores` block:

* `crates/` (Rust workspace crates) is checked into the repo, so it isn't in `.gitignore`, but the root ESLint config should not try to lint it.
* `svelte/` is the SvelteKit app, which has its own ESLint config and is linted separately for now.

The previous list also contained `.git/**/*` (ESLint already skips the `.git` directory) and `!**/.*` (a re-include for dotfiles that matched no JS-extension files in the repo). Both had no effect and are dropped.

This matches the structure of `svelte/eslint.config.js`, which already uses `includeIgnoreFile`.