### PR TITLE
docs/CONTRIBUTING: Link 'Working on the Backend' from `pnpm dev:local` row

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -147,7 +147,7 @@ server proxies to:
 | ------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------- |
 | `pnpm dev:live`                                   | <https://crates.io>                       | Testing UI changes with the full live site's data       |
 | `pnpm dev:staging`                                | <https://staging.crates.io>               | Testing UI changes with a smaller set of realistic data |
-| `pnpm dev:local`                                  | Backend server running locally            | See the "Working on the backend" section for setup      |
+| `pnpm dev:local`                                  | Backend server running locally            | See ["Working on the Backend"](#working-on-the-backend) for setup |
 | `pnpm dev:msw`                                    | MSW handlers from `/packages/crates-io-msw/` | Testing UI changes against a fully-mocked backend       |
 | `API_HOST=https://crates.io pnpm dev`             | Whatever is in `API_HOST`                 | If your use case is not covered here                    |
 


### PR DESCRIPTION
The `pnpm dev:local` row in the dev-server variants table reads
"See the 'Working on the backend' section for setup" as plain text.
Make it a markdown link to the existing "Working on the Backend"
heading so readers can jump there directly.