### PR TITLE
Add svelte paths to root `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,33 +1,43 @@
-/target
-.cargo
-
-# dependencies
-node_modules/
-/bower_components
-package-lock.json
-yarn.lock
-
-# misc
-/.eslintcache
-/.sass-cache
-/connect.lock
-/coverage/*
-/coverage_*
+# crates.io
 /local_uploads
-/libpeerconnection.log
 /tmp
-npm-debug.log
-yarn-error.log
-.env
 docker-compose.override.yml
-*~
 src/schema.rs.orig
 
-# insta
-*.pending-snap
+# Env
+.env
+.env.*
+!.env.example
+!.env.test
 
-# playwright
+# JS
+/coverage/*
+/coverage_*
+node_modules/
+.eslintcache
+
+# Svelte
+.output
+/svelte/.svelte-kit
+/svelte/build
+
+# Vite
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+
+# Storybook
+*storybook.log
+storybook-static
+
+# Playwright
 /test-results/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Rust
+/target
+.cargo
+
+# insta
+*.pending-snap


### PR DESCRIPTION
Add the svelte-specific entries (`/svelte/.svelte-kit`, `/svelte/build`, Vite timestamps, Storybook artifacts, env file patterns) from `svelte/.gitignore` to the root file so root-level tools that only read the top-level `.gitignore` (i.e. `prettier`) see them.

Also reorganize entries into per-stack sections and drop stale entries (`/bower_components`, `package-lock.json`, `yarn.lock`, `/.sass-cache`, `/connect.lock`, `/libpeerconnection.log`, `npm-debug.log`, `yarn-error.log`, `*~`).

The `svelte/.gitignore` file stays around for now until we have merged the two `prettier` setups.