### PR TITLE
Remove unused `.nycrc`

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,3 +1,0 @@
-{
-    "temp-directory": "coverage"
-}


### PR DESCRIPTION
Leftover from the Ember.js frontend (removed in #13579). Nothing in
the workspace runs `nyc` anymore.