### PR TITLE
eslint: Apply `unicorn` recommended config to svelte config

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       eslint-plugin-svelte:
         specifier: 3.17.1
         version: 3.17.1(eslint@10.3.0(jiti@2.6.1))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+      eslint-plugin-unicorn:
+        specifier: 64.0.0
+        version: 64.0.0(eslint@10.3.0(jiti@2.6.1))
       globals:
         specifier: 17.6.0
         version: 17.6.0

--- a/svelte/eslint.config.js
+++ b/svelte/eslint.config.js
@@ -6,6 +6,7 @@ import prettier from 'eslint-config-prettier';
 import preferLet from 'eslint-plugin-prefer-let';
 import storybook from 'eslint-plugin-storybook';
 import svelte from 'eslint-plugin-svelte';
+import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 import ts from 'typescript-eslint';
@@ -16,7 +17,11 @@ const gitignorePath = fileURLToPath(new URL('../.gitignore', import.meta.url));
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 
 export default defineConfig(
+  eslintPluginUnicorn.configs.recommended,
   { ...includeIgnoreFile(gitignorePath), basePath: repoRoot },
+  // Static assets contain vendored files like `mockServiceWorker.js` that
+  // we should not lint.
+  { ignores: ['static/'] },
   js.configs.recommended,
   ...ts.configs.recommended,
   ...svelte.configs.recommended,
@@ -40,8 +45,56 @@ export default defineConfig(
     },
 
     rules: {
+      // it's fine to use `return` without a value and rely on the implicit `undefined` return value
+      'getter-return': 'off',
+
       'prefer-const': 'off',
       'prefer-let/prefer-let': 'error',
+
+      // disabled because it seems unnecessary
+      'unicorn/consistent-function-scoping': 'off',
+      // disabled because TypeScript already catches arity mismatches that
+      // this rule is designed to flag (e.g. `arr.map(parseInt)`)
+      'unicorn/no-array-callback-reference': 'off',
+      'unicorn/explicit-length-check': ['error', { 'non-zero': 'not-equal' }],
+      // disabled because `toReversed` is not "widely supported" yet
+      'unicorn/no-array-reverse': 'off',
+      // disabled because `toSorted` is not "widely supported" yet
+      'unicorn/no-array-sort': 'off',
+      // disabled because it is annoying in some cases...
+      'unicorn/no-await-expression-member': 'off',
+      // disabled because we need `null` since JSON has no `undefined`
+      'unicorn/no-null': 'off',
+      // disabled because this rule conflicts with prettier
+      'unicorn/no-nested-ternary': 'off',
+      // disabled because of unfixable false positives
+      'unicorn/prevent-abbreviations': 'off',
+      // disabled because we are targeting only browsers at the moment
+      'unicorn/prefer-global-this': 'off',
+      // disabled because we don't want to go all-in on ES6 modules for Node.js code yet
+      'unicorn/prefer-module': 'off',
+      // disabled because it seems unnecessary
+      'unicorn/prefer-number-properties': 'off',
+      // disabled because it seems unnecessary
+      'unicorn/prefer-reflect-apply': 'off',
+      // disabled because it seems unnecessary
+      'unicorn/prefer-string-raw': 'off',
+      // disabled because of Sentry issues
+      'unicorn/prefer-string-replace-all': 'off',
+      // disabled because `getElementById()` is faster than `querySelector("#id")`
+      // and expresses intent more clearly
+      'unicorn/prefer-query-selector': 'off',
+      // disabled because of false positives on non-array `push()` methods
+      'unicorn/prefer-single-call': 'off',
+      // disabled because switch statements in JS are quite error-prone
+      'unicorn/prefer-switch': 'off',
+      // disabled because Svelte component `<script>` blocks instantiate
+      // synchronously, so top-level await is not appropriate there
+      'unicorn/prefer-top-level-await': 'off',
+      // disabled because of false positives
+      'unicorn/consistent-destructuring': 'off',
+      // disabled because it does not play well with Svelte component naming conventions
+      'unicorn/filename-case': 'off',
     },
   },
   {

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-prefer-let": "4.2.2",
     "eslint-plugin-storybook": "10.3.6",
     "eslint-plugin-svelte": "3.17.1",
+    "eslint-plugin-unicorn": "64.0.0",
     "globals": "17.6.0",
     "magic-string": "0.30.21",
     "msw": "2.14.2",

--- a/svelte/src/hooks.client.ts
+++ b/svelte/src/hooks.client.ts
@@ -1,6 +1,7 @@
 export async function init() {
   // Clear the bootstrap error handlers set in `app.html`; the app has loaded
   // successfully, so the load-failure fallback is no longer needed.
+  // eslint-disable-next-line unicorn/prefer-add-event-listener
   window.onerror = null;
   window.onunhandledrejection = null;
 


### PR DESCRIPTION
Adds `eslint-plugin-unicorn` to the svelte-side ESLint config, mirroring the rule overrides used by the root config so behavior matches when the root config is later extended to cover this directory.