### PR TITLE
e2e/readme-rendering: Wait for fully-rendered mermaid SVG before snapshot

### DIFF
--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -127,8 +127,7 @@ test.describe('Acceptance | README rendering', { tag: '@acceptance' }, () => {
     await expect(readme).toBeVisible();
     await expect(readme.locator('ul > li')).toHaveCount(7);
     await expect(readme.locator('pre > code.language-rust.hljs')).toHaveCount(2);
-    await expect(readme.locator('pre > code.language-mermaid svg')).toBeVisible();
-    await expect(readme.locator('pre > code.language-mermaid')).toHaveAttribute('data-processed', 'true');
+    await expect(readme.locator('pre > code.language-mermaid svg.flowchart')).toBeVisible();
 
     await percy.snapshot();
   });


### PR DESCRIPTION
The Percy snapshot for this test occasionally renders the mermaid diagram as an empty grey box. Comparing the captured DOM of a flaky run against a passing one shows the flaky one with a leftover `<div id="dmermaid-...">` wrapper around the SVG, an empty `<g>`, and no `viewBox` or `class` on the `<svg>`, despite `data-processed='true'` already being set on the `<code>` element. That looks like Percy captured the DOM while mermaid was still mid-render.

Replace the visibility + `data-processed` checks with a single assertion on `svg.flowchart`. The passing snapshot has that class on the SVG and the flaky one does not, so gating on it should give Percy more time to wait before snapshotting. Whether this actually eliminates the flake remains to be seen.