### PR TITLE
e2e/percy: Remove `e2e` snapshot title prefix

### DIFF
--- a/e2e/fixtures/percy.ts
+++ b/e2e/fixtures/percy.ts
@@ -13,10 +13,7 @@ export class PercyPage {
   // This implementation maintains the title format used by @percy/ember
   private title(): string {
     // Skip the filename
-    let paths = this.testInfo.titlePath.slice(1);
-    // Add an "e2e" prefix to differentiate the snapshots from the QUnit tests.
-    // This address the visual changes caused by the font not loading in QUnit tests (#9052).
-    return ['e2e', ...paths].join(' | ');
+    return this.testInfo.titlePath.slice(1).join(' | ');
   }
 
   async snapshot(options?: Parameters<typeof percySnapshot>[2]) {


### PR DESCRIPTION
The prefix was added to differentiate Playwright snapshots from the QUnit ones (#9052), but we no longer have QUnit tests, so the prefix serves no purpose anymore.