### PR TITLE
svelte: Rewrite `README.md` with frontend overview

### DIFF
--- a/svelte/README.md
+++ b/svelte/README.md
@@ -1,38 +1,27 @@
-# sv
+# crates.io frontend
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+SvelteKit application that powers the [crates.io](https://crates.io) web UI. Pages consume the JSON API exposed by the Rust backend in `/src/`.
 
-## Creating a project
+## Quick start
 
-If you're seeing this, you've probably already done this step. Congrats!
+Run `pnpm install` from the repo root, then run `pnpm dev:live` from this folder to start the dev server against the production backend. See [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md#building-and-serving-the-frontend) for other backends and full setup.
 
-```sh
-# create a new project in the current directory
-npx sv create
+## Layout
 
-# create a new project in my-app
-npx sv create my-app
-```
+- `src/routes/` - page routes and data loaders
+- `src/lib/` - shared components, stores, and utilities
+- `static/` - static assets served at `/`
 
-## Developing
+## Testing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+- **Vitest** runs unit and component tests colocated with the code under `src/`.
+- **Playwright** runs full-app browser tests in [`/e2e/`](../e2e/). The backend is mocked by [`packages/crates-io-msw/`](../packages/crates-io-msw/) instead of using a live Rust backend. [Percy](https://percy.io/) captures page snapshots from this suite on every PR for visual regression testing.
+- **Storybook and Chromatic** handle component development and visual regression testing. Stories (`*.stories.svelte`) live alongside their components, and `pnpm storybook` from this folder opens them locally. [Chromatic](https://www.chromatic.com/) renders and checks the same stories on every PR.
 
-```sh
-npm run dev
+See [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md#running-the-frontend-tests) for commands.
 
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
-```
+## Related documentation
 
-## Building
-
-To create a production version of your app:
-
-```sh
-npm run build
-```
-
-You can preview the production build with `npm run preview`.
-
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+- [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md#working-on-the-frontend) - setup, dev commands, testing
+- [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) - system design
+- [`AGENTS.md`](../AGENTS.md) - command summary for AI agents


### PR DESCRIPTION
The previous file was the default `sv create` boilerplate. Replace it with a short signpost covering what the folder is, a quick-start hint, the directory layout, the testing tools (Vitest, Playwright with MSW plus Percy, Storybook with Chromatic), and pointers to the canonical docs in `docs/CONTRIBUTING.md`, `docs/ARCHITECTURE.md`, and `AGENTS.md`.

Setup, dev commands, and full test instructions remain in `docs/CONTRIBUTING.md` to avoid duplication.