### PR TITLE
percy: Wait for spinners to disappear before snapshotting

### DIFF
--- a/e2e/acceptance/api-token.spec.ts
+++ b/e2e/acceptance/api-token.spec.ts
@@ -48,7 +48,7 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
     await expect(row1.locator('[data-test-expired-at]')).toHaveText('Expires in 29 days');
     await expect(row1.locator('[data-test-save-token-button]')).toHaveCount(0);
     await expect(row1.locator('[data-test-revoke-token-button]')).toBeVisible();
-    await expect(row1.locator('[data-test-saving-spinner]')).toHaveCount(0);
+    await expect(row1.locator('[data-test-spinner]')).toHaveCount(0);
     await expect(row1.locator('[data-test-error]')).toHaveCount(0);
     await expect(row1.locator('[data-test-token]')).toHaveCount(0);
 
@@ -58,7 +58,7 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
     await expect(row2.locator('[data-test-expired-at]')).toHaveCount(0);
     await expect(row2.locator('[data-test-save-token-button]')).toHaveCount(0);
     await expect(row2.locator('[data-test-revoke-token-button]')).toBeVisible();
-    await expect(row2.locator('[data-test-saving-spinner]')).toHaveCount(0);
+    await expect(row2.locator('[data-test-spinner]')).toHaveCount(0);
     await expect(row2.locator('[data-test-error]')).toHaveCount(0);
     await expect(row2.locator('[data-test-token]')).toHaveCount(0);
 
@@ -68,7 +68,7 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
     await expect(row3.locator('[data-test-expired-at]')).toHaveText('Expired about 18 hours ago');
     await expect(row3.locator('[data-test-save-token-button]')).toHaveCount(0);
     await expect(row3.locator('[data-test-revoke-token-button]')).toHaveCount(0);
-    await expect(row3.locator('[data-test-saving-spinner]')).toHaveCount(0);
+    await expect(row3.locator('[data-test-spinner]')).toHaveCount(0);
     await expect(row3.locator('[data-test-error]')).toHaveCount(0);
     await expect(row3.locator('[data-test-token]')).toHaveCount(0);
   });
@@ -141,7 +141,7 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-api-token="4"] [data-test-name]')).toHaveText('the new token');
     await expect(page.locator('[data-test-api-token="4"] [data-test-save-token-button]')).toHaveCount(0);
     await expect(page.locator('[data-test-api-token="4"] [data-test-revoke-token-button]')).toBeVisible();
-    await expect(page.locator('[data-test-api-token="4"] [data-test-saving-spinner]')).toHaveCount(0);
+    await expect(page.locator('[data-test-api-token="4"] [data-test-spinner]')).toHaveCount(0);
     await expect(page.locator('[data-test-api-token="4"] [data-test-error]')).toHaveCount(0);
     await expect(page.locator('[data-test-token]')).toHaveText(token);
   });

--- a/e2e/fixtures/percy.ts
+++ b/e2e/fixtures/percy.ts
@@ -1,5 +1,5 @@
 import percySnapshot from '@percy/playwright';
-import { Page, TestInfo } from '@playwright/test';
+import { expect, Page, TestInfo } from '@playwright/test';
 
 export class PercyPage {
   constructor(
@@ -17,6 +17,11 @@ export class PercyPage {
   }
 
   async snapshot(options?: Parameters<typeof percySnapshot>[2]) {
+    // Wait for any in-flight loading state to settle before snapshotting,
+    // otherwise spinners can leak into the captured image and produce flaky
+    // visual diffs.
+    await expect(this.page.locator('[data-test-spinner]')).toHaveCount(0);
+
     await percySnapshot(this.page, this.title(), options);
   }
 }

--- a/svelte/src/lib/components/FollowButton.svelte
+++ b/svelte/src/lib/components/FollowButton.svelte
@@ -83,7 +83,7 @@
   onclick={toggleFollow}
 >
   {#if isLoading}
-    <LoadingSpinner theme="light" data-test-spinner />
+    <LoadingSpinner theme="light" />
   {:else if following}
     Unfollow
   {:else}

--- a/svelte/src/lib/components/LoadingSpinner.svelte
+++ b/svelte/src/lib/components/LoadingSpinner.svelte
@@ -8,7 +8,7 @@
   let { theme, class: className, ...restProps }: Props = $props();
 </script>
 
-<div class={['spinner', theme, className]} {...restProps}>
+<div class={['spinner', theme, className]} data-test-spinner {...restProps}>
   <span class="sr-only">Loading…</span>
 </div>
 

--- a/svelte/src/lib/components/PageHeader.svelte
+++ b/svelte/src/lib/components/PageHeader.svelte
@@ -24,7 +24,7 @@
         <small class="suffix">{suffix}</small>
       {/if}
       {#if showSpinner}
-        <LoadingSpinner style="margin-left: var(--space-2xs)" data-test-spinner />
+        <LoadingSpinner style="margin-left: var(--space-2xs)" />
       {/if}
     </h1>
   {/if}

--- a/svelte/src/lib/components/download-chart/DownloadChart.svelte
+++ b/svelte/src/lib/components/download-chart/DownloadChart.svelte
@@ -111,7 +111,7 @@
 
 <div data-test-download-graph class="wrapper">
   {#await chartPromise}
-    <LoadingSpinner class="spinner" data-test-spinner />
+    <LoadingSpinner class="spinner" />
   {:then}
     <canvas bind:this={canvasRef}></canvas>
   {:catch}

--- a/svelte/src/lib/components/frontpage/ErrorState.svelte
+++ b/svelte/src/lib/components/frontpage/ErrorState.svelte
@@ -18,7 +18,7 @@
 <button type="button" disabled={isLoading} class="try-again-button button" onclick={onRetry} data-test-try-again-button>
   Try Again
   {#if isLoading}
-    <LoadingSpinner theme="light" class="spinner" data-test-spinner />
+    <LoadingSpinner theme="light" class="spinner" />
   {/if}
 </button>
 

--- a/svelte/src/routes/crates/[crate_id]/delete/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/delete/+page.svelte
@@ -113,7 +113,7 @@
       </button>
       {#if isDeleting}
         <div class="spinner-wrapper">
-          <LoadingSpinner class="spinner" data-test-spinner />
+          <LoadingSpinner class="spinner" />
         </div>
       {/if}
     </div>

--- a/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
@@ -422,7 +422,7 @@
     <label class="trustpub-only-checkbox" data-test-trustpub-only-checkbox>
       <div class="checkbox">
         {#if trustpubOnlyLoading}
-          <LoadingSpinner data-test-spinner />
+          <LoadingSpinner />
         {:else}
           <input type="checkbox" checked={trustpubOnly} data-test-checkbox onchange={toggleTrustpubOnly} />
         {/if}

--- a/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
@@ -409,7 +409,7 @@
       Add
 
       {#if isSaving}
-        <LoadingSpinner theme="light" class="spinner" data-test-spinner />
+        <LoadingSpinner theme="light" class="spinner" />
       {/if}
     </button>
 

--- a/svelte/src/routes/settings/profile/+page.svelte
+++ b/svelte/src/routes/settings/profile/+page.svelte
@@ -89,7 +89,7 @@
         Update preferences
       </button>
       {#if isUpdating}
-        <LoadingSpinner data-test-spinner />
+        <LoadingSpinner />
       {/if}
     </div>
   </div>

--- a/svelte/src/routes/settings/tokens/+page.svelte
+++ b/svelte/src/routes/settings/tokens/+page.svelte
@@ -222,7 +222,7 @@
                 Revoke
               </button>
               {#if revokingTokenIds.has(token.id)}
-                <LoadingSpinner class="spinner" data-test-saving-spinner />
+                <LoadingSpinner class="spinner" />
               {/if}
             {/if}
           </div>

--- a/svelte/src/routes/settings/tokens/new/+page.svelte
+++ b/svelte/src/routes/settings/tokens/new/+page.svelte
@@ -346,7 +346,7 @@
         Generate Token
 
         {#if isSaving}
-          <LoadingSpinner theme="light" class="spinner" data-test-spinner />
+          <LoadingSpinner theme="light" class="spinner" />
         {/if}
       </button>
 


### PR DESCRIPTION
The "trustpub_only warning banner" Percy snapshot was flaky because the `FollowButton` queries `/api/v1/crates/{name}/following` on mount. If the snapshot ran before the request resolved, Percy captured the loading spinner instead of the final state.

To fix this generically, this PR:

1. moves the `data-test-spinner` marker into `LoadingSpinner.svelte` so every spinner on the page carries it uniformly,
2. drops the now-redundant `data-test-saving-spinner` marker on the token-revoke spinner, and
3. gates `percy.snapshot()` on `[data-test-spinner]` count being 0.

No existing test snapshots a loading state, so the new gate plugs the class of flake without breaking anything.