### PR TITLE
Heroku: Update buildpack for pnpm v11 deploys

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/heroku/heroku-buildpack-apt
-https://github.com/Turbo87/heroku-buildpack-crates-io#76b621d6189070f88dbf0f90879c4843fcbf3e08
+https://github.com/Turbo87/heroku-buildpack-crates-io#5cf07e63f02d69537ecb02fe58fc45a7d5f0353d


### PR DESCRIPTION
Picks up three buildpack fixes that together unbreak deploys after the bump to pnpm 11.0.9:

- Unvendor the pnpm install script. The vendored copy stopped matching pnpm's release-asset layout after v11.0.0-rc.3 (bare binaries replaced with tarballs; `macos`/`win` renamed to `darwin`/`win32`), and the original reason for vendoring is fixed upstream.
- Use `$PNPM_HOME/bin` in PATH. Starting with pnpm v11, `pnpm setup` installs the binary at `$PNPM_HOME/bin/pnpm` (pnpm/pnpm#10986).
- Always run `pnpm env use --global` so the Node.js symlink at `$PNPM_HOME/bin/node` is recreated on cache-hit builds; without it postinstall scripts spawned by `pnpm install` fail with `command not found: node`.