### PR TITLE
test_db: Use `STRATEGY = FILE_COPY` for test database creation

### DIFF
--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -197,7 +197,17 @@ fn create_database_from_template(
     conn: &mut PgConnection,
 ) -> QueryResult<()> {
     debug!("Creating new test database from template…");
-    sql_query(format!("CREATE DATABASE {name} TEMPLATE {template_name}")).execute(conn)?;
+    // `STRATEGY = FILE_COPY` copies the template at the filesystem level
+    // instead of streaming each block through WAL (the default `WAL_LOG`).
+    // It forces a checkpoint before and after the copy, but writes far less
+    // WAL in total. Under the parallel `CREATE DATABASE` load a test suite
+    // generates this is a clear win, since `WAL_LOG` serializes heavily on
+    // WAL flushing across concurrent calls.
+    // See https://www.postgresql.org/docs/16/sql-createdatabase.html
+    sql_query(format!(
+        "CREATE DATABASE {name} TEMPLATE {template_name} STRATEGY = FILE_COPY"
+    ))
+    .execute(conn)?;
     Ok(())
 }
 


### PR DESCRIPTION
The default `WAL_LOG` strategy streams every block of the template database through WAL, which serializes heavily across concurrent `CREATE DATABASE` calls. `FILE_COPY` copies at the filesystem level and pays two checkpoints per call, but writes far less WAL and scales much better when many tests race to spin up test databases in parallel.

Cuts `cargo test --workspace` wall-clock by roughly a third on local runs.