### PR TITLE
Retire old `SquashIndex` job in favor of GitHub-API squash

### DIFF
--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -323,26 +323,6 @@ impl Repository {
         Ok(())
     }
 
-    /// Rewrite the `master` branch to a single parentless commit wrapping the
-    /// current HEAD tree.
-    ///
-    /// The tree is reused by OID, so no blobs are read and no files are
-    /// touched. This stays cheap regardless of index size.
-    #[instrument(skip_all)]
-    pub fn squash_to_single_commit(&self, msg: &str) -> anyhow::Result<()> {
-        let repo = &self.repository;
-        let tree = repo.find_commit(self.head_oid()?)?.tree()?;
-        let sig = repo.signature()?;
-
-        // `repo.commit(Some("HEAD"), ...)` would reject a parentless commit
-        // when HEAD is not itself parentless. Create the commit detached,
-        // then force-update `refs/heads/master` to point at it.
-        let commit = repo.commit(None, &sig, &sig, msg, &tree, &[])?;
-        repo.reference("refs/heads/master", commit, true, msg)?;
-
-        Ok(())
-    }
-
     /// Runs the specified `git` command in the working directory of the local
     /// crate index repository.
     ///

--- a/src/bin/crates-admin/enqueue_job.rs
+++ b/src/bin/crates-admin/enqueue_job.rs
@@ -46,7 +46,6 @@ pub enum Command {
     },
     ProcessCdnLogQueue(jobs::ProcessCdnLogQueue),
     SendTokenExpiryNotifications,
-    SquashIndex,
     SquashIndexViaApi,
     SyncAdmins {
         /// Force a sync even if one is already in progress
@@ -115,9 +114,6 @@ pub async fn run(command: Command) -> Result<()> {
         }
         Command::SendTokenExpiryNotifications => {
             jobs::SendTokenExpiryNotifications.enqueue(&conn).await?;
-        }
-        Command::SquashIndex => {
-            jobs::SquashIndex.enqueue(&conn).await?;
         }
         Command::SquashIndexViaApi => {
             jobs::SquashIndexViaApi.enqueue(&conn).await?;

--- a/src/bin/crates-admin/enqueue_job.rs
+++ b/src/bin/crates-admin/enqueue_job.rs
@@ -46,7 +46,7 @@ pub enum Command {
     },
     ProcessCdnLogQueue(jobs::ProcessCdnLogQueue),
     SendTokenExpiryNotifications,
-    SquashIndexViaApi,
+    SquashIndex,
     SyncAdmins {
         /// Force a sync even if one is already in progress
         #[arg(long)]
@@ -115,8 +115,8 @@ pub async fn run(command: Command) -> Result<()> {
         Command::SendTokenExpiryNotifications => {
             jobs::SendTokenExpiryNotifications.enqueue(&conn).await?;
         }
-        Command::SquashIndexViaApi => {
-            jobs::SquashIndexViaApi.enqueue(&conn).await?;
+        Command::SquashIndex => {
+            jobs::SquashIndex.enqueue(&conn).await?;
         }
         Command::SyncAdmins { force } => {
             if !force {

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -423,7 +423,7 @@ impl TestAppBuilder {
 
     /// Override the `index_location` URL used for the worker
     /// [`RepositoryConfig`]. Used by tests that exercise jobs which
-    /// parse the URL (e.g. [`crates_io::worker::jobs::SquashIndexViaApi`])
+    /// parse the URL (e.g. [`crates_io::worker::jobs::SquashIndex`])
     /// but do not touch the local bare repo.
     pub fn with_index_location(mut self, url: Url) -> Self {
         self.index_location = Some(url);

--- a/src/tests/worker/squash_index.rs
+++ b/src/tests/worker/squash_index.rs
@@ -1,5 +1,4 @@
 use crate::util::TestApp;
-use chrono::Utc;
 use claims::assert_ok;
 use crates_io::schema::background_jobs;
 use crates_io::worker::jobs;
@@ -26,55 +25,6 @@ fn master_ref(sha: &str) -> GitRef {
         ref_name: MASTER_REF.into(),
         object: GitObject { sha: sha.into() },
     }
-}
-
-/// `SquashIndex` should collapse the upstream index into a single parentless
-/// commit on `master`, while preserving tree content and archiving the previous
-/// HEAD on a `snapshot-<date>` branch.
-#[tokio::test(flavor = "multi_thread")]
-async fn squash_index() {
-    let (app, _) = TestApp::full().empty().await;
-    let conn = app.db_conn().await;
-    let upstream = app.upstream_index();
-
-    // Seed a couple of entries so the squash has real content to collapse.
-    upstream.write_file("1/a", "a\n").unwrap();
-    upstream.write_file("se/rd/serde", "serde\n").unwrap();
-
-    // Capture upstream `master` state before the squash.
-    let (original_head, original_tree) = {
-        let repo = upstream.repository.lock().unwrap();
-        let head = repo.find_reference("refs/heads/master").unwrap();
-        let commit = head.peel_to_commit().unwrap();
-        (commit.id(), commit.tree().unwrap().id())
-    };
-
-    let now = Utc::now().format("%F");
-
-    assert_ok!(jobs::SquashIndex.enqueue(&conn).await);
-    app.run_pending_background_jobs().await;
-
-    let repo = upstream.repository.lock().unwrap();
-
-    // `master` now points to a parentless commit with the squash message.
-    let master = repo.find_reference("refs/heads/master").unwrap();
-    let squashed = master.peel_to_commit().unwrap();
-    assert_eq!(squashed.parent_count(), 0);
-    assert!(
-        squashed
-            .message()
-            .unwrap()
-            .starts_with("Collapse index into one commit")
-    );
-
-    // Tree content is preserved — the squashed commit references the exact
-    // same tree as the pre-squash HEAD.
-    assert_eq!(squashed.tree().unwrap().id(), original_tree);
-
-    // The archive branch captures the previous HEAD.
-    let snapshot_ref = format!("refs/heads/snapshot-{now}");
-    let snapshot = repo.find_reference(&snapshot_ref).unwrap();
-    assert_eq!(snapshot.peel_to_commit().unwrap().id(), original_head);
 }
 
 /// Queue a one-shot `get_ref(refs/heads/master)` that returns `sha`.

--- a/src/tests/worker/squash_index.rs
+++ b/src/tests/worker/squash_index.rs
@@ -116,12 +116,12 @@ fn expect_update_master(mock: &mut MockGitHubClient, new_sha: &'static str) {
         });
 }
 
-/// `SquashIndexViaApi` should drive the squash entirely via the GitHub REST
+/// `SquashIndex` should drive the squash entirely via the GitHub REST
 /// API: read master, read its tree, create a parentless commit on the same
 /// tree, create the snapshot ref, re-read master to guard against drift, and
 /// fast-forward master to the new commit.
 #[tokio::test(flavor = "multi_thread")]
-async fn squash_index_via_api() {
+async fn squash_index() {
     let mut github = MockGitHubClient::new();
     expect_get_master(&mut github, ORIGINAL_SHA);
     expect_get_commit(&mut github, ORIGINAL_SHA, TREE_SHA);
@@ -138,7 +138,7 @@ async fn squash_index_via_api() {
         .await;
 
     let conn = app.db_conn().await;
-    assert_ok!(jobs::SquashIndexViaApi.enqueue(&conn).await);
+    assert_ok!(jobs::SquashIndex.enqueue(&conn).await);
     app.run_pending_background_jobs().await;
 }
 
@@ -147,7 +147,7 @@ async fn squash_index_via_api() {
 /// on the remote. The snapshot ref created earlier remains as a harmless
 /// pointer to the pre-squash HEAD.
 #[tokio::test(flavor = "multi_thread")]
-async fn squash_index_via_api_bails_on_master_drift() {
+async fn squash_index_bails_on_master_drift() {
     const DRIFTED_SHA: &str = "cccccccccccccccccccccccccccccccccccccccc";
 
     let mut github = MockGitHubClient::new();
@@ -168,7 +168,7 @@ async fn squash_index_via_api_bails_on_master_drift() {
         .await;
 
     let mut conn = app.db_conn().await;
-    assert_ok!(jobs::SquashIndexViaApi.enqueue(&conn).await);
+    assert_ok!(jobs::SquashIndex.enqueue(&conn).await);
     let err = app.try_run_pending_background_jobs().await.unwrap_err();
     assert_eq!(err.to_string(), "1 jobs failed");
 

--- a/src/worker/jobs/index/mod.rs
+++ b/src/worker/jobs/index/mod.rs
@@ -8,5 +8,5 @@ mod sync;
 
 pub use archive::ArchiveIndexBranch;
 pub use normalize::NormalizeIndex;
-pub use squash::SquashIndexViaApi;
+pub use squash::SquashIndex;
 pub use sync::{BulkSyncToGitIndex, SyncToGitIndex, SyncToSparseIndex};

--- a/src/worker/jobs/index/mod.rs
+++ b/src/worker/jobs/index/mod.rs
@@ -8,5 +8,5 @@ mod sync;
 
 pub use archive::ArchiveIndexBranch;
 pub use normalize::NormalizeIndex;
-pub use squash::{SquashIndex, SquashIndexViaApi};
+pub use squash::SquashIndexViaApi;
 pub use sync::{BulkSyncToGitIndex, SyncToGitIndex, SyncToSparseIndex};

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -40,14 +40,14 @@ async fn enqueue_archive_job(env: &Environment, branch: &str) -> anyhow::Result<
 /// reference, and we just hand it a tiny new commit object and move
 /// `master` to point at it.
 #[derive(Serialize, Deserialize)]
-pub struct SquashIndexViaApi;
+pub struct SquashIndex;
 
-impl BackgroundJob for SquashIndexViaApi {
-    const JOB_NAME: &'static str = "squash_index_via_api";
+impl BackgroundJob for SquashIndex {
+    const JOB_NAME: &'static str = "squash_index";
     const DEDUPLICATED: bool = true;
-    // Same queue as `SquashIndex`, `SyncToGitIndex`, etc. so index-writing
-    // jobs serialize against each other, even though this job does not
-    // touch the local bare repo.
+    // Same queue as `SyncToGitIndex`, etc. so index-writing jobs serialize
+    // against each other, even though this job does not touch the local
+    // bare repo.
     const QUEUE: &'static str = "repository";
 
     type Context = Arc<Environment>;

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -1,4 +1,3 @@
-use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
 use crate::worker::jobs::ArchiveIndexBranch;
 use anyhow::{Context, anyhow};
@@ -9,80 +8,11 @@ use oauth2::AccessToken;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::process::Command;
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::{info, instrument, warn};
 
 const MASTER_REF: &str = "refs/heads/master";
-
-#[derive(Serialize, Deserialize)]
-pub struct SquashIndex;
-
-impl BackgroundJob for SquashIndex {
-    const JOB_NAME: &'static str = "squash_index";
-    const DEDUPLICATED: bool = true;
-    const QUEUE: &'static str = "repository";
-
-    type Context = Arc<Environment>;
-
-    /// Collapse the index into a single commit, archiving the current history in a snapshot branch.
-    #[instrument(skip_all)]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
-        info!("Squashing the index into a single commit");
-
-        let env_for_blocking = env.clone();
-        let snapshot_branch = spawn_blocking(move || {
-            let repo = env_for_blocking.lock_index()?;
-
-            let snapshot_branch = snapshot_branch_name();
-
-            let original_head = repo.head_oid()?;
-            info!("Read original HEAD: {original_head}");
-
-            let msg = squash_commit_message(original_head, &snapshot_branch);
-
-            let squash_start = Instant::now();
-            repo.squash_to_single_commit(&msg)?;
-            let new_head = repo.head_oid()?;
-            info!(
-                duration = squash_start.elapsed().as_nanos(),
-                "Squash commit created: {new_head}",
-            );
-
-            // Shell out to git because libgit2 does not currently support push leases
-
-            info!("Pushing squashed index to origin");
-            let push_start = Instant::now();
-            repo.run_command(Command::new("git").args([
-                "push",
-                // Both updates should succeed or fail together
-                "--atomic",
-                "origin",
-                // Overwrite master, but only if it server matches the expected value
-                &format!("--force-with-lease=refs/heads/master:{original_head}"),
-                // The new squashed commit is pushed to master
-                "HEAD:refs/heads/master",
-                // The previous value of HEAD is pushed to a snapshot branch
-                &format!("{original_head}:refs/heads/{snapshot_branch}"),
-            ]))?;
-            info!(
-                duration = push_start.elapsed().as_nanos(),
-                "Squashed index pushed to origin",
-            );
-
-            info!("The index has been successfully squashed.");
-            Ok::<_, anyhow::Error>(snapshot_branch)
-        })
-        .await??;
-
-        if let Err(error) = enqueue_archive_job(&env, &snapshot_branch).await {
-            warn!("Failed to enqueue `ArchiveIndexBranch` job for `{snapshot_branch}`: {error}");
-        }
-
-        Ok(())
-    }
-}
 
 async fn enqueue_archive_job(env: &Environment, branch: &str) -> anyhow::Result<()> {
     let conn = env.deadpool.get().await?;

--- a/src/worker/jobs/mod.rs
+++ b/src/worker/jobs/mod.rs
@@ -31,7 +31,7 @@ pub use self::dump_db::DumpDb;
 pub use self::expiry_notification::SendTokenExpiryNotifications;
 pub use self::generate_og_image::GenerateOgImage;
 pub use self::index::{
-    ArchiveIndexBranch, BulkSyncToGitIndex, NormalizeIndex, SquashIndexViaApi, SyncToGitIndex,
+    ArchiveIndexBranch, BulkSyncToGitIndex, NormalizeIndex, SquashIndex, SyncToGitIndex,
     SyncToSparseIndex,
 };
 pub use self::index_version_downloads_archive::IndexVersionDownloadsArchive;

--- a/src/worker/jobs/mod.rs
+++ b/src/worker/jobs/mod.rs
@@ -31,8 +31,8 @@ pub use self::dump_db::DumpDb;
 pub use self::expiry_notification::SendTokenExpiryNotifications;
 pub use self::generate_og_image::GenerateOgImage;
 pub use self::index::{
-    ArchiveIndexBranch, BulkSyncToGitIndex, NormalizeIndex, SquashIndex, SquashIndexViaApi,
-    SyncToGitIndex, SyncToSparseIndex,
+    ArchiveIndexBranch, BulkSyncToGitIndex, NormalizeIndex, SquashIndexViaApi, SyncToGitIndex,
+    SyncToSparseIndex,
 };
 pub use self::index_version_downloads_archive::IndexVersionDownloadsArchive;
 pub use self::invalidate_cdns::InvalidateCdns;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -37,7 +37,6 @@ impl RunnerExt for Runner<Arc<Environment>> {
             .register_job_type::<jobs::ProcessCdnLogQueue>()
             .register_job_type::<jobs::ProcessCloudfrontInvalidationQueue>()
             .register_job_type::<jobs::RenderAndUploadReadme>()
-            .register_job_type::<jobs::SquashIndex>()
             .register_job_type::<jobs::SquashIndexViaApi>()
             .register_job_type::<jobs::SyncAdmins>()
             .register_job_type::<jobs::SyncToGitIndex>()

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -37,7 +37,7 @@ impl RunnerExt for Runner<Arc<Environment>> {
             .register_job_type::<jobs::ProcessCdnLogQueue>()
             .register_job_type::<jobs::ProcessCloudfrontInvalidationQueue>()
             .register_job_type::<jobs::RenderAndUploadReadme>()
-            .register_job_type::<jobs::SquashIndexViaApi>()
+            .register_job_type::<jobs::SquashIndex>()
             .register_job_type::<jobs::SyncAdmins>()
             .register_job_type::<jobs::SyncToGitIndex>()
             .register_job_type::<jobs::SyncToSparseIndex>()


### PR DESCRIPTION
The `SquashIndexViaApi` job (#13517) has been validated in production, so the original git-CLI-based `SquashIndex` job is no longer needed.

The three commits in this PR:

1. Remove the old `SquashIndex` job, its admin CLI subcommand, worker registration, re-exports, and test.
2. Remove the now-unused `Repository::squash_to_single_commit()` helper from `crates_io_index`.
3. Rename `SquashIndexViaApi` to `SquashIndex` and `JOB_NAME` from `"squash_index_via_api"` back to `"squash_index"`. Tests and admin CLI subcommand follow.

Renaming `JOB_NAME` is technically dangerous since any queued row referencing the old name would be orphaned, but we only enqueue this job manually via the admin CLI, so as long as nothing is queued at deploy time this is fine.

### Related

- https://github.com/rust-lang/crates.io/pull/13517