### PR TITLE
Block ncollide.org; domain expired

### DIFF
--- a/crates/crates_io_api_types/src/external_urls.rs
+++ b/crates/crates_io_api_types/src/external_urls.rs
@@ -8,6 +8,7 @@ const DOMAIN_BLOCKLIST: &[&str] = &[
     "ironframework.io",
     "nebulanet.cc",
     "esp-rs.org",
+    "ncollide.org",
 ];
 
 /// Return `None` if the documentation URL host matches a blocked host


### PR DESCRIPTION
It used to host the homepage and documentation for the ncollide2d crate; now it's ads.

We got a support email letting us know about this (4204).