### PR TITLE
Add `POSTGRES_BIN_DIR` env var to override `pg_dump`/`psql` location

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,6 +22,12 @@ export SESSION_KEY=badkeyabcdefghijklmnopqrstuvwxyzabcdef
 # If you don't plan on running the tests, you can leave this blank.
 export TEST_DATABASE_URL=
 
+# Optional directory containing the `pg_dump` and `psql` binaries to use
+# for the database-dump job and its tests. If unset, the binaries are looked
+# up via `PATH`. Set this when your `PATH` defaults are a different major
+# version than the database server.
+# export POSTGRES_BIN_DIR=/Applications/Postgres.app/Contents/Versions/16/bin
+
 # Credentials for AWS.
 # export AWS_ACCESS_KEY=
 # export AWS_SECRET_KEY=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,6 +1574,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "crates_io_env_vars",
  "crates_io_test_db",
  "crates_io_version",
  "diesel",

--- a/crates/crates_io_database_dump/Cargo.toml
+++ b/crates/crates_io_database_dump/Cargo.toml
@@ -22,6 +22,7 @@ tracing = "=0.1.44"
 zip = { version = "=8.6.0", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
+crates_io_env_vars = { path = "../crates_io_env_vars" }
 crates_io_test_db = { path = "../crates_io_test_db" }
 diesel = "=2.3.9"
 diesel-async = { version = "=0.9.0", features = ["postgres"] }

--- a/crates/crates_io_database_dump/src/lib.rs
+++ b/crates/crates_io_database_dump/src/lib.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use std::fs;
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use tracing::debug;
 use zip::write::SimpleFileOptions;
 
@@ -23,19 +24,36 @@ pub struct DumpDirectory {
     /// The temporary directory that contains the export directory.
     tempdir: tempfile::TempDir,
     pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Optional directory containing the `pg_dump` and `psql` binaries to use.
+    /// When `None`, the binaries are resolved via `PATH`.
+    postgres_bin_dir: Option<PathBuf>,
 }
 
 impl DumpDirectory {
-    pub fn create() -> anyhow::Result<Self> {
+    pub fn create(postgres_bin_dir: Option<PathBuf>) -> anyhow::Result<Self> {
         debug!("Creating database dump folder…");
         let tempdir = tempfile::tempdir()?;
         let timestamp = chrono::Utc::now();
 
-        Ok(Self { tempdir, timestamp })
+        Ok(Self {
+            tempdir,
+            timestamp,
+            postgres_bin_dir,
+        })
     }
 
     pub fn path(&self) -> &Path {
         self.tempdir.path()
+    }
+
+    /// Resolve the path of a PostgreSQL client binary, honoring the configured
+    /// [`Self::postgres_bin_dir`] override. When no override is set the bare
+    /// name is returned, which `Command::new` will resolve via `PATH`.
+    fn pg_program(&self, name: &str) -> PathBuf {
+        match &self.postgres_bin_dir {
+            Some(dir) => dir.join(name),
+            None => PathBuf::from(name),
+        }
     }
 
     pub fn populate(&self, database_url: &str) -> anyhow::Result<()> {
@@ -88,16 +106,17 @@ impl DumpDirectory {
         let schema_sql =
             File::create(&path).with_context(|| format!("Failed to create {}", path.display()))?;
 
-        let status = std::process::Command::new("pg_dump")
+        let program = self.pg_program("pg_dump");
+        let status = Command::new(&program)
             .arg("--schema-only")
             .arg("--no-owner")
             .arg("--no-acl")
             .arg(database_url)
             .stdout(schema_sql)
             .spawn()
-            .context("Failed to run `pg_dump` command")?
+            .with_context(|| format!("Failed to run `{}` command", program.display()))?
             .wait()
-            .context("Failed to wait for `pg_dump` to exit")?;
+            .with_context(|| format!("Failed to wait for `{}` to exit", program.display()))?;
 
         if !status.success() {
             return Err(anyhow!(
@@ -119,37 +138,38 @@ impl DumpDirectory {
         debug!("Filling data folder…");
         fs::create_dir(self.path().join("data")).context("Failed to create `data` directory")?;
 
-        run_psql(&export_script, database_url)
+        self.run_psql(&export_script, database_url)
     }
-}
 
-pub fn run_psql(script: &Path, database_url: &str) -> anyhow::Result<()> {
-    debug!(?script, "Running psql script…");
-    let psql_script =
-        File::open(script).with_context(|| format!("Failed to open {}", script.display()))?;
+    pub fn run_psql(&self, script: &Path, database_url: &str) -> anyhow::Result<()> {
+        debug!(?script, "Running psql script…");
+        let psql_script =
+            File::open(script).with_context(|| format!("Failed to open {}", script.display()))?;
 
-    let psql = std::process::Command::new("psql")
-        .arg("--no-psqlrc")
-        .arg(database_url)
-        .current_dir(script.parent().unwrap())
-        .stdin(psql_script)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .context("Failed to run psql command")?;
+        let program = self.pg_program("psql");
+        let psql = Command::new(&program)
+            .arg("--no-psqlrc")
+            .arg(database_url)
+            .current_dir(script.parent().unwrap())
+            .stdin(psql_script)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .with_context(|| format!("Failed to run `{}` command", program.display()))?;
 
-    let output = psql
-        .wait_with_output()
-        .context("Failed to wait for psql command to exit")?;
+        let output = psql.wait_with_output().with_context(|| {
+            format!("Failed to wait for `{}` command to exit", program.display())
+        })?;
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    if stderr.contains("ERROR") {
-        return Err(anyhow!("Error while executing psql: {stderr}"));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("ERROR") {
+            return Err(anyhow!("Error while executing psql: {stderr}"));
+        }
+        if !output.status.success() {
+            return Err(anyhow!("psql did not finish successfully."));
+        }
+        Ok(())
     }
-    if !output.status.success() {
-        return Err(anyhow!("psql did not finish successfully."));
-    }
-    Ok(())
 }
 
 pub struct Archives {
@@ -235,11 +255,16 @@ pub fn create_archives(export_dir: &Path, tarball_prefix: &Path) -> anyhow::Resu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crates_io_env_vars::var_parsed;
     use crates_io_test_db::TestDatabase;
     use flate2::read::GzDecoder;
     use insta::{assert_debug_snapshot, assert_snapshot};
     use std::io::BufReader;
     use tar::Archive;
+
+    fn postgres_bin_dir() -> Option<PathBuf> {
+        var_parsed("POSTGRES_BIN_DIR").unwrap()
+    }
 
     #[test]
     fn test_dump_tarball() {
@@ -297,16 +322,16 @@ mod tests {
 
         // TODO prefill database with some data
 
-        let directory = DumpDirectory::create().unwrap();
+        let directory = DumpDirectory::create(postgres_bin_dir()).unwrap();
         directory.populate(db_one.url()).unwrap();
 
         let db_two = TestDatabase::empty();
 
         let schema_script = directory.path().join("schema.sql");
-        run_psql(&schema_script, db_two.url()).unwrap();
+        directory.run_psql(&schema_script, db_two.url()).unwrap();
 
         let import_script = directory.path().join("import.sql");
-        run_psql(&import_script, db_two.url()).unwrap();
+        directory.run_psql(&import_script, db_two.url()).unwrap();
 
         // TODO: Consistency checks on the re-imported data?
     }
@@ -315,7 +340,7 @@ mod tests {
     fn test_sql_scripts() {
         let db = TestDatabase::new();
 
-        let directory = DumpDirectory::create().unwrap();
+        let directory = DumpDirectory::create(postgres_bin_dir()).unwrap();
         directory.populate(db.url()).unwrap();
 
         insta::glob!(directory.path(), "{import,export}.sql", |path| {

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -16,6 +16,7 @@ use http::HeaderValue;
 use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::net::IpAddr;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 use tracing::warn;
@@ -106,6 +107,11 @@ pub struct Server {
     /// to. When set, the `ArchiveIndexBranch` background job pushes snapshot
     /// branches to this remote; when unset the job is a no-op.
     pub index_archive_url: Option<Url>,
+
+    /// Optional directory containing the `pg_dump` and `psql` binaries to use
+    /// for database dump generation. When unset, the binaries are resolved via
+    /// `PATH`.
+    pub postgres_bin_dir: Option<PathBuf>,
 }
 
 impl Server {
@@ -141,6 +147,8 @@ impl Server {
     ///   repository to mirror the crate index's snapshot branches to. Must be HTTPS because the
     ///   `ArchiveIndexBranch` job authenticates via a GitHub App installation token; SSH remotes
     ///   are not supported. If unset the job is a no-op.
+    /// - `POSTGRES_BIN_DIR`: Optional directory containing `pg_dump` and `psql` binaries to use
+    ///   for database dump generation. If unset, the binaries are looked up via `PATH`.
     ///
     /// # Panics
     ///
@@ -244,6 +252,7 @@ impl Server {
             sparse_index_fastly_enabled: var_parsed("SPARSE_INDEX_FASTLY_ENABLED")?
                 .unwrap_or(false),
             index_archive_url: var_parsed("GIT_ARCHIVE_REPO_URL")?,
+            postgres_bin_dir: var_parsed("POSTGRES_BIN_DIR")?,
         })
     }
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -571,6 +571,7 @@ fn simple_config() -> config::Server {
         index_include_pubtime: false,
         sparse_index_fastly_enabled: true,
         index_archive_url: None,
+        postgres_bin_dir: None,
     }
 }
 

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -27,9 +27,10 @@ impl BackgroundJob for DumpDb {
         let db_config = &env.config.db;
         let db_pool_config = db_config.replica.as_ref().unwrap_or(&db_config.primary);
         let database_url = db_pool_config.url.clone();
+        let postgres_bin_dir = env.config.postgres_bin_dir.clone();
 
         let archives = spawn_blocking(move || {
-            let directory = DumpDirectory::create()?;
+            let directory = DumpDirectory::create(postgres_bin_dir)?;
 
             info!("Exporting database…");
             directory.populate(database_url.expose_secret())?;


### PR DESCRIPTION
When set, `DumpDirectory` resolves `pg_dump` and `psql` from this directory instead of `PATH`. This lets developers point the dump and re-import test at a matched-version client toolchain, avoiding mismatches between the system `libpq` and a locally installed Postgres server.

The variable is loaded into `Server::postgres_bin_dir` and threaded into the `dump_db` background job. The dump crate's tests read it directly via `crates_io_env_vars::var_parsed`.

This fixes the `dump_db_and_reimport_dump()` test for me locally, that was failing due to a Postgres server / `pg_dump` version mismatch.