### PR TITLE
test_db: Switch from per-database to per-schema isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,6 +1844,7 @@ dependencies = [
 name = "crates_io_test_db"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "crates_io_env_vars",
  "diesel",
  "diesel-async",

--- a/crates/crates_io_database_dump/src/gen_scripts.rs
+++ b/crates/crates_io_database_dump/src/gen_scripts.rs
@@ -131,7 +131,8 @@ mod tests {
         let test_db = TestDatabase::new();
         let mut conn = test_db.async_connect().await;
 
-        let db_columns = HashSet::<Column>::from_iter(get_db_columns(&mut conn, "public").await);
+        let db_columns =
+            HashSet::<Column>::from_iter(get_db_columns(&mut conn, test_db.schema()).await);
         let vis_columns = VisibilityConfig::get()
             .0
             .iter()

--- a/crates/crates_io_database_dump/src/gen_scripts.rs
+++ b/crates/crates_io_database_dump/src/gen_scripts.rs
@@ -131,7 +131,7 @@ mod tests {
         let test_db = TestDatabase::new();
         let mut conn = test_db.async_connect().await;
 
-        let db_columns = HashSet::<Column>::from_iter(get_db_columns(&mut conn).await);
+        let db_columns = HashSet::<Column>::from_iter(get_db_columns(&mut conn, "public").await);
         let vis_columns = VisibilityConfig::get()
             .0
             .iter()
@@ -187,11 +187,11 @@ mod tests {
         column_name: String,
     }
 
-    async fn get_db_columns(conn: &mut AsyncPgConnection) -> Vec<Column> {
+    async fn get_db_columns(conn: &mut AsyncPgConnection, schema: &str) -> Vec<Column> {
         use information_schema::columns;
         columns::table
             .select((columns::table_name, columns::column_name))
-            .filter(columns::table_schema.eq("public"))
+            .filter(columns::table_schema.eq(schema))
             .order_by((columns::table_name, columns::ordinal_position))
             .load(conn)
             .await

--- a/crates/crates_io_database_dump/src/lib.rs
+++ b/crates/crates_io_database_dump/src/lib.rs
@@ -332,20 +332,33 @@ mod tests {
 
     #[test]
     fn dump_db_and_reimport_dump() {
-        let db_one = TestDatabase::new();
+        use diesel::RunQueryDsl;
+        use diesel::sql_query;
+
+        let test_db = TestDatabase::new();
 
         // TODO prefill database with some data
 
         let directory = DumpDirectory::create(postgres_bin_dir()).unwrap();
-        directory.populate(db_one.url(), None).unwrap();
+        directory
+            .populate(test_db.url(), Some(test_db.schema()))
+            .unwrap();
 
-        let db_two = TestDatabase::empty();
+        // Clear the schema so the dump's `CREATE SCHEMA` and `CREATE TABLE`
+        // statements (qualified with `test_db.schema()`) have a fresh target.
+        // The schema name in the URL's `search_path` resolves again as soon
+        // as the dump recreates it. `test_db`'s `Drop` cleans up the
+        // recreated schema at the end of the test.
+        let mut conn = test_db.connect();
+        sql_query(format!("DROP SCHEMA \"{}\" CASCADE", test_db.schema()))
+            .execute(&mut conn)
+            .unwrap();
 
         let schema_script = directory.path().join("schema.sql");
-        directory.run_psql(&schema_script, db_two.url()).unwrap();
+        directory.run_psql(&schema_script, test_db.url()).unwrap();
 
         let import_script = directory.path().join("import.sql");
-        directory.run_psql(&import_script, db_two.url()).unwrap();
+        directory.run_psql(&import_script, test_db.url()).unwrap();
 
         // TODO: Consistency checks on the re-imported data?
     }
@@ -355,7 +368,7 @@ mod tests {
         let db = TestDatabase::new();
 
         let directory = DumpDirectory::create(postgres_bin_dir()).unwrap();
-        directory.populate(db.url(), None).unwrap();
+        directory.populate(db.url(), Some(db.schema())).unwrap();
 
         insta::glob!(directory.path(), "{import,export}.sql", |path| {
             let content = fs::read_to_string(path).unwrap();

--- a/crates/crates_io_database_dump/src/lib.rs
+++ b/crates/crates_io_database_dump/src/lib.rs
@@ -56,14 +56,20 @@ impl DumpDirectory {
         }
     }
 
-    pub fn populate(&self, database_url: &str) -> anyhow::Result<()> {
+    /// Generate the full export directory (README, metadata, `schema.sql`,
+    /// `export.sql`/`import.sql`, and CSV data files) from the database at
+    /// `database_url`. When `schema` is `Some`, the dump is restricted to that
+    /// Postgres schema; when `None`, every schema in the database is dumped.
+    /// Production callers pass `None`; the test harness passes the test schema
+    /// so its `pg_dump` doesn't race with concurrent test schemas.
+    pub fn populate(&self, database_url: &str, schema: Option<&str>) -> anyhow::Result<()> {
         self.add_readme()
             .context("Failed to write README.md file")?;
 
         self.add_metadata()
             .context("Failed to write metadata.json file")?;
 
-        self.dump_schema(database_url)
+        self.dump_schema(database_url, schema)
             .context("Failed to generate schema.sql file")?;
 
         self.dump_db(database_url)
@@ -100,17 +106,25 @@ impl DumpDirectory {
         Ok(())
     }
 
-    pub fn dump_schema(&self, database_url: &str) -> anyhow::Result<()> {
+    pub fn dump_schema(&self, database_url: &str, schema: Option<&str>) -> anyhow::Result<()> {
         let path = self.path().join("schema.sql");
         debug!(?path, "Writing schema.sql file…");
         let schema_sql =
             File::create(&path).with_context(|| format!("Failed to create {}", path.display()))?;
 
         let program = self.pg_program("pg_dump");
-        let status = Command::new(&program)
+
+        let mut command = Command::new(&program);
+        command
             .arg("--schema-only")
             .arg("--no-owner")
-            .arg("--no-acl")
+            .arg("--no-acl");
+
+        if let Some(schema) = schema {
+            command.arg(format!("--schema={schema}"));
+        }
+
+        let status = command
             .arg(database_url)
             .stdout(schema_sql)
             .spawn()
@@ -323,7 +337,7 @@ mod tests {
         // TODO prefill database with some data
 
         let directory = DumpDirectory::create(postgres_bin_dir()).unwrap();
-        directory.populate(db_one.url()).unwrap();
+        directory.populate(db_one.url(), None).unwrap();
 
         let db_two = TestDatabase::empty();
 
@@ -341,7 +355,7 @@ mod tests {
         let db = TestDatabase::new();
 
         let directory = DumpDirectory::create(postgres_bin_dir()).unwrap();
-        directory.populate(db.url()).unwrap();
+        directory.populate(db.url(), None).unwrap();
 
         insta::glob!(directory.path(), "{import,export}.sql", |path| {
             let content = fs::read_to_string(path).unwrap();

--- a/crates/crates_io_test_db/Cargo.toml
+++ b/crates/crates_io_test_db/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 workspace = true
 
 [dependencies]
+anyhow = "=1.0.102"
 crates_io_env_vars = { path = "../crates_io_env_vars" }
 diesel = { version = "=2.3.9", features = ["postgres", "r2d2"] }
 diesel-async = { version = "=0.9.0", features = ["postgres"] }

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -1,12 +1,15 @@
 #![doc = include_str!("../README.md")]
 
-use crates_io_env_vars::required_var_parsed;
+use crates_io_env_vars::{required_var_parsed, var_parsed};
+use diesel::connection::SimpleConnection;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel::sql_query;
 use diesel_async::{AsyncConnection, AsyncPgConnection};
 use diesel_migrations::{FileBasedMigrations, MigrationHarness};
 use rand::RngExt;
+use std::path::PathBuf;
+use std::process::Command;
 use std::sync::LazyLock;
 use std::time::Duration;
 use tracing::{debug, instrument};
@@ -14,17 +17,35 @@ use url::Url;
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 
-struct TemplateDatabase {
+/// Prefix for per-test schemas, followed by a 16-character random suffix.
+/// Used both when allocating new schemas and when sweeping up leftovers from
+/// crashed prior runs.
+const TEST_SCHEMA_PREFIX: &str = "test";
+
+/// Schema that holds the migrated structure all per-test schemas are cloned
+/// from. Created once per process.
+const TEMPLATE_SCHEMA: &str = "test_template";
+
+/// Management state shared by every `TestDatabase` in the process.
+///
+/// On first use we ensure the `test_template` schema exists, run all pending
+/// migrations into it, and capture the resulting DDL via `pg_dump`. Each
+/// subsequent `TestDatabase::new()` creates a fresh schema and replays that
+/// captured DDL with the template schema name rewritten to the test schema
+/// name, sidestepping the per-test migration-framework overhead.
+struct Management {
     base_url: Url,
     pool: Pool<ConnectionManager<PgConnection>>,
-    template_name: String,
-    prefix: String,
+    /// DDL captured from the template schema, with the template schema's
+    /// own qualified references intact (e.g. `test_template.crates`). Per-test
+    /// replay substitutes the template name for the test schema name.
+    template_ddl: String,
 }
 
-impl TemplateDatabase {
+impl Management {
     #[instrument]
     pub fn instance() -> &'static Self {
-        static INSTANCE: LazyLock<TemplateDatabase> = LazyLock::new(TemplateDatabase::new);
+        static INSTANCE: LazyLock<Management> = LazyLock::new(Management::new);
         &INSTANCE
     }
 
@@ -32,39 +53,42 @@ impl TemplateDatabase {
     fn new() -> Self {
         let base_url: Url = required_var_parsed("TEST_DATABASE_URL").unwrap();
 
-        let prefix = base_url.path().strip_prefix('/');
-        let prefix = prefix.expect("failed to parse database name").to_string();
-
-        // Having only a single database management connection was causing
-        // contention, so this is using a connection pool to reduce unnecessary
-        // waiting times for the tests.
         let pool = Pool::builder()
             .connection_timeout(CONNECTION_TIMEOUT)
             .max_size(10)
             .min_idle(Some(0))
             .build_unchecked(ConnectionManager::new(base_url.as_ref()));
 
-        // Get a connection from the pool, and create the template database
         let mut conn = pool.get().expect("failed to connect to the database");
 
-        let template_name = format!("{prefix}_template");
-        create_template_database(&template_name, &mut conn)
-            .expect("failed to create template database");
+        // Drop any leftover test schemas from previous runs that crashed
+        // without dropping their schema. This also drops any extensions
+        // that were installed inside those schemas, freeing their
+        // database-level registration so the migrations can re-install
+        // them in `public`.
+        cleanup_leftover_schemas(&mut conn).expect("failed to clean up leftover test schemas");
 
-        let mut template_url = base_url.clone();
-        template_url.set_path(&format!("/{template_name}"));
+        sql_query(format!("CREATE SCHEMA IF NOT EXISTS \"{TEMPLATE_SCHEMA}\""))
+            .execute(&mut conn)
+            .expect("failed to ensure template schema exists");
 
-        // Connect to the template database and run the migrations
+        // Apply any pending migrations to the template schema. Diesel skips
+        // already-applied migrations, so subsequent process starts only pay
+        // for newly-added migrations.
+        let template_url = url_with_search_path(&base_url, TEMPLATE_SCHEMA);
         let mut template_conn =
-            connect(template_url.as_ref()).expect("failed to connect to the template database");
+            connect(template_url.as_ref()).expect("failed to connect to template schema");
         run_migrations(&mut template_conn)
-            .expect("failed to run migrations on the template database");
+            .expect("failed to run migrations on the template schema");
+        drop(template_conn);
 
-        TemplateDatabase {
+        let template_ddl =
+            capture_template_ddl(&base_url).expect("failed to capture template schema DDL");
+
+        Management {
             base_url,
             pool,
-            template_name,
-            prefix,
+            template_ddl,
         }
     }
 
@@ -72,65 +96,78 @@ impl TemplateDatabase {
     fn get_connection(&self) -> PooledConnection<ConnectionManager<PgConnection>> {
         self.pool.get().expect("Failed to get database connection")
     }
+
+    /// Generates a random schema name and builds the `TestDatabase` struct
+    /// around it. The schema itself is not created here; callers are
+    /// responsible for either issuing `CREATE SCHEMA` (see
+    /// [`TestDatabase::empty`]) or replaying DDL that contains a `CREATE
+    /// SCHEMA` statement (see [`TestDatabase::new`]).
+    fn allocate(&self) -> TestDatabase {
+        let schema = format!("{TEST_SCHEMA_PREFIX}_{}", generate_name().to_lowercase());
+        let url = url_with_search_path(&self.base_url, &schema);
+
+        TestDatabase { schema, url }
+    }
 }
 
 pub struct TestDatabase {
-    name: String,
+    schema: String,
+    /// Base URL for the test database with `options=--search_path=<schema>,public`
+    /// appended, so any pool or one-shot connection opened against this URL
+    /// is automatically scoped to the test's schema.
     url: Url,
-    pool: Option<Pool<ConnectionManager<PgConnection>>>,
 }
 
 impl TestDatabase {
-    /// Creates a new Postgres database based on a template with all of the
-    /// migrations already applied. Once the `TestDatabase` instance is dropped,
-    /// the database is automatically deleted.
+    /// Creates a new schema inside the test database, populated by replaying
+    /// the captured template DDL. The schema (and everything in it) is
+    /// dropped when this `TestDatabase` is dropped.
     #[allow(clippy::new_without_default)]
     #[instrument]
     pub fn new() -> TestDatabase {
-        Self::new_inner(|name, conn| {
-            let template = TemplateDatabase::instance();
-            create_database_from_template(name, &template.template_name, conn)
-        })
+        let management = Management::instance();
+        let test_db = management.allocate();
+
+        let ddl = management
+            .template_ddl
+            .replace(TEMPLATE_SCHEMA, &test_db.schema);
+
+        let mut conn = management.get_connection();
+        conn.batch_execute(&ddl)
+            .expect("failed to replay template DDL into test schema");
+
+        test_db
     }
 
-    /// Creates a new Postgres database. Once the `TestDatabase` instance is
-    /// dropped, the database is automatically deleted.
+    /// Creates a new schema inside the test database without populating it.
+    /// The schema is dropped when this `TestDatabase` is dropped.
     #[instrument]
     pub fn empty() -> TestDatabase {
-        Self::new_inner(create_database)
+        let management = Management::instance();
+        let test_db = management.allocate();
+
+        let mut conn = management.get_connection();
+        create_schema(&test_db.schema, &mut conn).expect("Failed to create test schema");
+
+        test_db
     }
 
-    fn new_inner(f: impl Fn(&str, &mut PgConnection) -> QueryResult<()>) -> TestDatabase {
-        let template = TemplateDatabase::instance();
-
-        let name = format!("{}_{}", template.prefix, generate_name().to_lowercase());
-
-        let mut conn = template.get_connection();
-        f(&name, &mut conn).expect("Failed to create test database");
-
-        let mut url = template.base_url.clone();
-        url.set_path(&format!("/{name}"));
-
-        let pool = Pool::builder()
-            .connection_timeout(CONNECTION_TIMEOUT)
-            .min_idle(Some(0))
-            .build_unchecked(ConnectionManager::new(url.as_ref()));
-
-        let pool = Some(pool);
-        TestDatabase { name, url, pool }
-    }
-
+    /// URL pointing at the test database, with the test schema baked in as a
+    /// connection option (`options=--search_path=<schema>,public`). Any pool
+    /// or one-shot connection opened against this URL is automatically scoped
+    /// to the test's schema.
     pub fn url(&self) -> &str {
         self.url.as_ref()
     }
 
+    /// Name of the schema this `TestDatabase` owns.
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
     #[instrument(skip(self))]
-    pub fn connect(&self) -> PooledConnection<ConnectionManager<PgConnection>> {
-        self.pool
-            .as_ref()
-            .unwrap()
-            .get()
-            .expect("Failed to get database connection")
+    pub fn connect(&self) -> PgConnection {
+        PgConnection::establish(self.url()).expect("Failed to connect to database")
     }
 
     #[instrument(skip(self))]
@@ -144,14 +181,35 @@ impl TestDatabase {
 impl Drop for TestDatabase {
     #[instrument(skip(self))]
     fn drop(&mut self) {
-        // Essentially `drop(self.pool)` to make sure any connections to the
-        // test database have been disconnected before dropping the database
-        // itself.
-        self.pool = None;
-
-        let mut conn = TemplateDatabase::instance().get_connection();
-        drop_database(&self.name, &mut conn).expect("failed to drop test database");
+        let mut conn = Management::instance().get_connection();
+        drop_schema(&self.schema, &mut conn).expect("failed to drop test schema");
     }
+}
+
+/// Drops any schema whose name matches `test_<16-alphanumeric-chars>`. These
+/// are leftover test schemas from a prior run that crashed before its `Drop`
+/// impl could clean up. Each `DROP SCHEMA … CASCADE` also drops any extension
+/// that happened to be installed inside the leftover schema.
+#[instrument(skip(conn))]
+fn cleanup_leftover_schemas(conn: &mut PgConnection) -> QueryResult<()> {
+    let leftovers: Vec<Schema> = diesel::sql_query(
+        "SELECT schema_name FROM information_schema.schemata \
+         WHERE schema_name ~ '^test_[a-z0-9]{16}$'",
+    )
+    .load(conn)?;
+
+    for Schema { schema_name } in leftovers {
+        debug!(name = %schema_name, "Dropping leftover test schema");
+        sql_query(format!("DROP SCHEMA \"{schema_name}\" CASCADE")).execute(conn)?;
+    }
+
+    Ok(())
+}
+
+#[derive(diesel::QueryableByName)]
+struct Schema {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    schema_name: String,
 }
 
 #[instrument]
@@ -161,60 +219,18 @@ fn connect(database_url: &str) -> ConnectionResult<PgConnection> {
 }
 
 #[instrument(skip(conn))]
-fn create_database(name: &str, conn: &mut PgConnection) -> QueryResult<()> {
-    debug!("Creating new database…");
-    sql_query(format!("CREATE DATABASE {name}")).execute(conn)?;
+fn create_schema(name: &str, conn: &mut PgConnection) -> QueryResult<()> {
+    debug!("Creating new test schema…");
+    sql_query(format!("CREATE SCHEMA \"{name}\"")).execute(conn)?;
     Ok(())
 }
 
 #[instrument(skip(conn))]
-fn create_template_database(name: &str, conn: &mut PgConnection) -> QueryResult<()> {
-    table! {
-        pg_database (datname) {
-            datname -> Text,
-        }
-    }
-
-    debug!("Checking if template database already exists…");
-    let count: i64 = pg_database::table
-        .count()
-        .filter(pg_database::datname.eq(name))
-        .get_result(conn)?;
-
-    if count == 0 {
-        create_database(name, conn)?;
-    } else {
-        debug!(%count, "Skipping template database creation");
-    }
-
-    Ok(())
-}
-
-#[instrument(skip(conn))]
-fn create_database_from_template(
-    name: &str,
-    template_name: &str,
-    conn: &mut PgConnection,
-) -> QueryResult<()> {
-    debug!("Creating new test database from template…");
-    // `STRATEGY = FILE_COPY` copies the template at the filesystem level
-    // instead of streaming each block through WAL (the default `WAL_LOG`).
-    // It forces a checkpoint before and after the copy, but writes far less
-    // WAL in total. Under the parallel `CREATE DATABASE` load a test suite
-    // generates this is a clear win, since `WAL_LOG` serializes heavily on
-    // WAL flushing across concurrent calls.
-    // See https://www.postgresql.org/docs/16/sql-createdatabase.html
-    sql_query(format!(
-        "CREATE DATABASE {name} TEMPLATE {template_name} STRATEGY = FILE_COPY"
-    ))
-    .execute(conn)?;
-    Ok(())
-}
-
-#[instrument(skip(conn))]
-fn drop_database(name: &str, conn: &mut PgConnection) -> QueryResult<()> {
-    debug!("Dropping database…");
-    sql_query(format!("DROP DATABASE {name} WITH (FORCE)")).execute(conn)?;
+fn drop_schema(name: &str, conn: &mut PgConnection) -> QueryResult<()> {
+    debug!("Dropping test schema…");
+    // `IF EXISTS` so that a `TestDatabase` whose `new()` panicked partway
+    // through the DDL replay (before `CREATE SCHEMA` ran) still drops cleanly.
+    sql_query(format!("DROP SCHEMA IF EXISTS \"{name}\" CASCADE")).execute(conn)?;
     Ok(())
 }
 
@@ -224,6 +240,76 @@ fn run_migrations(conn: &mut PgConnection) -> diesel::migration::Result<()> {
     let migrations = FileBasedMigrations::find_migrations_directory()?;
     conn.run_pending_migrations(migrations)?;
     Ok(())
+}
+
+/// Shells out to `pg_dump --schema=<template>` and returns the captured DDL
+/// as SQL ready for `batch_execute`.
+///
+/// `pg_dump`'s plain-text output targets `psql`, not the backend. To make
+/// it backend-safe:
+///
+/// - `--inserts` avoids the `COPY … FROM stdin … \.` data framing that
+///   `batch_execute` can't run.
+/// - Lines starting with `\` (psql meta-commands like `\restrict`/
+///   `\unrestrict`, emitted by `pg_dump` 17+) are stripped.
+/// - A trailing `RESET ALL` clears any session state the preamble's
+///   `SET` / `set_config('search_path', …)` calls left behind so it
+///   doesn't leak to the next checkout of the pooled connection.
+#[instrument]
+fn capture_template_ddl(base_url: &Url) -> anyhow::Result<String> {
+    let pg_dump = match var_parsed::<PathBuf>("POSTGRES_BIN_DIR")? {
+        Some(dir) => dir.join("pg_dump"),
+        None => PathBuf::from("pg_dump"),
+    };
+    debug!(pg_dump = %pg_dump.display(), "Capturing template schema DDL via pg_dump…");
+    let output = Command::new(&pg_dump)
+        .arg("--no-owner")
+        .arg("--no-acl")
+        .arg("--inserts")
+        .arg(format!("--schema={TEMPLATE_SCHEMA}"))
+        .arg(base_url.as_ref())
+        .output()
+        .map_err(|err| anyhow::anyhow!("failed to run `pg_dump`: {err}"))?;
+
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "pg_dump did not finish successfully (exit code: {}). stderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let raw = String::from_utf8(output.stdout)
+        .map_err(|err| anyhow::anyhow!("pg_dump produced non-UTF-8 output: {err}"))?;
+
+    let mut ddl = String::with_capacity(raw.len());
+    for line in raw.lines() {
+        if line.starts_with('\\') {
+            continue;
+        }
+        ddl.push_str(line);
+        ddl.push('\n');
+    }
+
+    ddl.push_str("\nRESET ALL;\n");
+
+    Ok(ddl)
+}
+
+/// Returns a copy of `base_url` with `options=--search_path=<schema>,public`
+/// appended to its query string. Postgres honors this `options` parameter when
+/// the connection is established, so every connection through the resulting
+/// URL starts with the test schema active.
+///
+/// The `--name=value` form (rather than the more common `-c name=value`) keeps
+/// the value space-free, which lets `url`'s form-encoding `append_pair()` do
+/// the right thing — libpq does not accept `+` as a space in URL query
+/// strings.
+fn url_with_search_path(base_url: &Url, schema: &str) -> Url {
+    let mut url = base_url.clone();
+    url.query_pairs_mut()
+        .append_pair("options", &format!("--search_path={schema},public"));
+    url
 }
 
 fn generate_name() -> String {

--- a/migrations/2017-10-08-193512_category_trees/up.sql
+++ b/migrations/2017-10-08-193512_category_trees/up.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS ltree;
+CREATE EXTENSION IF NOT EXISTS ltree SCHEMA public;
 
 -- Create the new column which will represent our category tree.
 -- Fill it with values from `slug` column and then set to non-null

--- a/migrations/20170308140537_create_to_semver_no_prerelease/up.sql
+++ b/migrations/20170308140537_create_to_semver_no_prerelease/up.sql
@@ -12,6 +12,7 @@ CREATE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE AS
   )::semver_triple
   WHERE strpos($1, '-') = 0
   $$ LANGUAGE SQL
+  SET search_path FROM CURRENT
 ;
 
 CREATE INDEX versions_to_semver_no_prerelease_idx ON versions (crate_id, to_semver_no_prerelease(num) DESC NULLS LAST) WHERE NOT yanked;

--- a/migrations/20170308140537_create_to_semver_no_prerelease/up.sql
+++ b/migrations/20170308140537_create_to_semver_no_prerelease/up.sql
@@ -9,7 +9,7 @@ CREATE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE AS
     split_part($1, '.', 1)::int4,
     split_part($1, '.', 2)::int4,
     split_part(split_part($1, '+', 1), '.', 3)::int4
-  )::public.semver_triple
+  )::semver_triple
   WHERE strpos($1, '-') = 0
   $$ LANGUAGE SQL
 ;

--- a/migrations/2019-05-14-165316_index_crate_name_for_like/up.sql
+++ b/migrations/2019-05-14-165316_index_crate_name_for_like/up.sql
@@ -1,2 +1,2 @@
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS pg_trgm SCHEMA public;
 CREATE INDEX index_crates_name_tgrm ON crates USING gin (canon_crate_name(name) gin_trgm_ops);

--- a/migrations/2020-07-14-113112_change_api_token_to_bytea/up.sql
+++ b/migrations/2020-07-14-113112_change_api_token_to_bytea/up.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA public;
 ALTER TABLE api_tokens
   ALTER COLUMN token
   TYPE bytea USING decode(token, 'escape');

--- a/migrations/2023-08-13-175220_to_semver_no_prerelease_parallel_safe/up.sql
+++ b/migrations/2023-08-13-175220_to_semver_no_prerelease_parallel_safe/up.sql
@@ -1,10 +1,10 @@
 DROP FUNCTION to_semver_no_prerelease(text);
 
-CREATE FUNCTION to_semver_no_prerelease(text) RETURNS public.semver_triple IMMUTABLE PARALLEL SAFE AS $$
+CREATE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE PARALLEL SAFE AS $$
   SELECT (
     split_part($1, '.', 1)::numeric,
     split_part($1, '.', 2)::numeric,
     split_part(split_part($1, '+', 1), '.', 3)::numeric
-  )::public.semver_triple
+  )::semver_triple
   WHERE strpos($1, '-') = 0
   $$ LANGUAGE SQL;

--- a/migrations/2023-08-13-175221_faster_reverse_dependencies_query/up.sql
+++ b/migrations/2023-08-13-175221_faster_reverse_dependencies_query/up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE versions ADD COLUMN IF NOT EXISTS semver_no_prerelease public.semver_triple GENERATED ALWAYS AS (to_semver_no_prerelease(num)) STORED;
+ALTER TABLE versions ADD COLUMN IF NOT EXISTS semver_no_prerelease semver_triple GENERATED ALWAYS AS (to_semver_no_prerelease(num)) STORED;

--- a/migrations/2023-10-19-092709_fix_semver_no_prerelease_fn/down.sql
+++ b/migrations/2023-10-19-092709_fix_semver_no_prerelease_fn/down.sql
@@ -1,8 +1,8 @@
-CREATE OR REPLACE FUNCTION to_semver_no_prerelease(text) RETURNS public.semver_triple IMMUTABLE PARALLEL SAFE AS $$
+CREATE OR REPLACE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE PARALLEL SAFE AS $$
   SELECT (
     split_part($1, '.', 1)::numeric,
     split_part($1, '.', 2)::numeric,
     split_part(split_part($1, '+', 1), '.', 3)::numeric
-  )::public.semver_triple
+  )::semver_triple
   WHERE strpos($1, '-') = 0
   $$ LANGUAGE SQL;

--- a/migrations/2023-10-19-092709_fix_semver_no_prerelease_fn/up.sql
+++ b/migrations/2023-10-19-092709_fix_semver_no_prerelease_fn/up.sql
@@ -1,8 +1,8 @@
-CREATE OR REPLACE FUNCTION to_semver_no_prerelease(text) RETURNS public.semver_triple IMMUTABLE PARALLEL SAFE AS $$
+CREATE OR REPLACE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE PARALLEL SAFE AS $$
   SELECT (
     split_part($1, '.', 1)::numeric,
     split_part($1, '.', 2)::numeric,
     split_part(split_part($1, '+', 1), '.', 3)::numeric
-  )::public.semver_triple
+  )::semver_triple
   WHERE strpos(split_part($1, '+', 1), '-') = 0
   $$ LANGUAGE SQL;

--- a/migrations/2025-02-11-122509_add-expires-at-column/up.sql
+++ b/migrations/2025-02-11-122509_add-expires-at-column/up.sql
@@ -1,6 +1,6 @@
 alter table crate_owner_invitations add column expires_at timestamptz;
 
-comment on column public.crate_owner_invitations.expires_at is 'Point in time at which the invitation expires/expired.'
+comment on column crate_owner_invitations.expires_at is 'Point in time at which the invitation expires/expired.'
 
 -- to be performed manually after the migration:
 --

--- a/src/bin/crates-admin/enqueue_job.rs
+++ b/src/bin/crates-admin/enqueue_job.rs
@@ -96,7 +96,7 @@ pub async fn run(command: Command) -> Result<()> {
             jobs::DailyDbMaintenance.enqueue(&conn).await?;
         }
         Command::DumpDb => {
-            jobs::DumpDb.enqueue(&conn).await?;
+            jobs::DumpDb::default().enqueue(&conn).await?;
         }
         Command::GenerateOgImage { names } => {
             for name in names {

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -23,7 +23,7 @@ async fn test_dump_db_job() -> anyhow::Result<()> {
         .expect_build(&mut conn)
         .await;
 
-    DumpDb.enqueue(&conn).await?;
+    DumpDb::default().enqueue(&conn).await?;
 
     app.run_pending_background_jobs().await;
 

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -23,7 +23,7 @@ async fn test_dump_db_job() -> anyhow::Result<()> {
         .expect_build(&mut conn)
         .await;
 
-    DumpDb::default().enqueue(&conn).await?;
+    DumpDb::for_schema(app.db_schema()).enqueue(&conn).await?;
 
     app.run_pending_background_jobs().await;
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -248,6 +248,13 @@ impl TestApp {
         &self.0.app
     }
 
+    /// Name of the per-test Postgres schema backing this `TestApp`. Pass this
+    /// to jobs or helpers that need to scope SQL operations to the test's
+    /// schema (e.g. `pg_dump --schema=<x>`).
+    pub fn db_schema(&self) -> &str {
+        self.0.test_database.schema()
+    }
+
     /// Obtain a reference to the axum Router
     pub fn router(&self) -> &axum::Router {
         &self.0.router

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -348,8 +348,7 @@ mod tests {
         let (_, version) = crate_and_version(&mut conn, user.id).await;
 
         // Wrap the test body in a transaction so `now` resolves to the same
-        // value across every query inside it. Committing at the end is fine:
-        // the test schema is dropped when the test finishes.
+        // value across every query inside it.
         conn.transaction(async |conn| {
             update(versions::table)
                 .set(versions::updated_at.eq(now.into_sql::<Timestamptz>() - 2.days()))

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -347,43 +347,44 @@ mod tests {
         let user = user(&mut conn).await;
         let (_, version) = crate_and_version(&mut conn, user.id).await;
 
-        // This test is using a transaction to ensure `now` is the same for all
-        // queries within this test.
-        conn.begin_test_transaction().await.unwrap();
+        // Wrap the test body in a transaction so `now` resolves to the same
+        // value across every query inside it. Committing at the end is fine:
+        // the test schema is dropped when the test finishes.
+        conn.transaction(async |conn| {
+            update(versions::table)
+                .set(versions::updated_at.eq(now.into_sql::<Timestamptz>() - 2.days()))
+                .execute(conn)
+                .await?;
+            update(crates::table)
+                .set(crates::updated_at.eq(now.into_sql::<Timestamptz>() - 2.days()))
+                .execute(conn)
+                .await?;
+            insert_into(version_downloads::table)
+                .values((
+                    version_downloads::version_id.eq(version.id),
+                    version_downloads::downloads.eq(2),
+                    version_downloads::counted.eq(2),
+                    version_downloads::date.eq(date(now - 2.days())),
+                    version_downloads::processed.eq(false),
+                ))
+                .execute(conn)
+                .await?;
 
-        update(versions::table)
-            .set(versions::updated_at.eq(now.into_sql::<Timestamptz>() - 2.days()))
-            .execute(&mut conn)
-            .await
-            .unwrap();
-        update(crates::table)
-            .set(crates::updated_at.eq(now.into_sql::<Timestamptz>() - 2.days()))
-            .execute(&mut conn)
-            .await
-            .unwrap();
-        insert_into(version_downloads::table)
-            .values((
-                version_downloads::version_id.eq(version.id),
-                version_downloads::downloads.eq(2),
-                version_downloads::counted.eq(2),
-                version_downloads::date.eq(date(now - 2.days())),
-                version_downloads::processed.eq(false),
-            ))
-            .execute(&mut conn)
-            .await
-            .unwrap();
+            super::update(conn).await?;
 
-        super::update(&mut conn).await.unwrap();
-
-        let versions_changed = versions::table
-            .select(versions::updated_at.ne(now.into_sql::<Timestamptz>() - 2.days()))
-            .get_result(&mut conn)
-            .await;
-        let crates_changed = crates::table
-            .select(crates::updated_at.ne(now.into_sql::<Timestamptz>() - 2.days()))
-            .get_result(&mut conn)
-            .await;
-        assert_eq!(versions_changed, Ok(false));
-        assert_eq!(crates_changed, Ok(false));
+            let versions_changed: bool = versions::table
+                .select(versions::updated_at.ne(now.into_sql::<Timestamptz>() - 2.days()))
+                .get_result(conn)
+                .await?;
+            let crates_changed: bool = crates::table
+                .select(crates::updated_at.ne(now.into_sql::<Timestamptz>() - 2.days()))
+                .get_result(conn)
+                .await?;
+            assert!(!versions_changed);
+            assert!(!crates_changed);
+            Ok::<_, diesel::result::Error>(())
+        })
+        .await
+        .unwrap();
     }
 }

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -9,8 +9,25 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{info, warn};
 
-#[derive(Clone, Serialize, Deserialize)]
-pub struct DumpDb;
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct DumpDb {
+    /// Optional Postgres schema to restrict the dump to. `None` (the
+    /// production default) dumps every schema in the database. The test
+    /// harness sets this to the per-test schema so `pg_dump` doesn't race
+    /// with concurrent test schemas.
+    #[serde(default)]
+    schema: Option<String>,
+}
+
+impl DumpDb {
+    /// Convenience constructor that scopes the dump to a single Postgres
+    /// schema.
+    pub fn for_schema(schema: impl Into<String>) -> Self {
+        Self {
+            schema: Some(schema.into()),
+        }
+    }
+}
 
 impl BackgroundJob for DumpDb {
     const JOB_NAME: &'static str = "dump_db";
@@ -28,12 +45,13 @@ impl BackgroundJob for DumpDb {
         let db_pool_config = db_config.replica.as_ref().unwrap_or(&db_config.primary);
         let database_url = db_pool_config.url.clone();
         let postgres_bin_dir = env.config.postgres_bin_dir.clone();
+        let schema = self.schema.clone();
 
         let archives = spawn_blocking(move || {
             let directory = DumpDirectory::create(postgres_bin_dir)?;
 
             info!("Exporting database…");
-            directory.populate(database_url.expose_secret())?;
+            directory.populate(database_url.expose_secret(), schema.as_deref())?;
 
             let export_dir = directory.path();
             info!(path = ?export_dir, "Creating tarball…");


### PR DESCRIPTION
The integration test suite isolates each test in its own Postgres database via `CREATE DATABASE <name> TEMPLATE <template>`. That call takes a cluster-wide lock that serializes under parallelism, costing up to ~2s per test under contention.

This PR replaces per-test databases with per-test **schemas** inside a single shared test database (`TEST_DATABASE_URL`). The cluster-wide lock is gone, and the suite gets roughly twice as fast on my machine.

Reviewing this commit-by-commit is recommended for your own sanity :D

## Local benchmark

613 tests, default parallelism, 3 runs each, fresh test database:

| Variant | median | mean |
|---|---|---|
| `CREATE DATABASE … TEMPLATE` (baseline) | 73.3s | 72.5s |
| Schema + captured DDL replay | **35.8s** | **36.4s** |

These numbers are from local runs only. CI performance has not been measured yet; merging this PR is what will let us see whether CI sees a similar improvement.

## How

1. Once per process, `Management::new()` ensures a `test_template` schema exists with all Diesel migrations applied, then captures its structure with `pg_dump --schema=test_template --inserts` and caches the SQL in memory.
2. For each `TestDatabase::new()`, the cached SQL is replayed (with the template schema name rewritten to a fresh `test_<rand16>`) via a single `batch_execute()`.
3. Per-test scoping rides on the connection URL itself as `options=--search_path=<schema>,public`. Anything that opens a connection from `TestDatabase::url()` (diesel pools, worker test pools, shelled-out `pg_dump`, ChaosProxy-rewritten URLs) is automatically scoped, with no changes to `DbPoolConfig` / `ConnectionConfig`.
4. On `Drop`: `DROP SCHEMA <name> CASCADE`. On startup: a sweep removes any `test_<rand16>` schemas left behind by crashed prior runs.

## Migration changes (no-ops on production, where they're already applied)

- Strip `public.` qualifiers from references to user-defined types/tables (`public.semver_triple`, `public.crate_owner_invitations`). The explicit qualifier would defeat the per-test schema rewrite.
- Add `SCHEMA public` to the three `CREATE EXTENSION IF NOT EXISTS …` calls so extensions consistently install in `public` regardless of the active `search_path`.

These edits are syntactically equivalent against an already-migrated database, so production is unaffected.

## Tests that shell out to `pg_dump`

Two tests run `pg_dump` against the test DB themselves and would otherwise race with concurrent tests' `CREATE`/`DROP SCHEMA`:

- `test_dump_db_job()` now enqueues `DumpDb::for_schema(app.db_schema())`, so the job's `pg_dump` runs with `--schema=<x>`.
- `dump_db_and_reimport_dump()` dumps with `Some(test_db.schema())`, drops the source schema mid-test, then replays the dump against the same URL. The `search_path` resolves again as soon as the dump's `CREATE SCHEMA` recreates it. No second `TestDatabase` is needed.

The job-side mechanism is a new optional `DumpDb::schema: Option<String>` field (`#[serde(default)]` so queued payloads still deserialize after deploy). Production callers use `DumpDb::default()` and continue to dump every schema as before.
