### PR TITLE
Add a quantum computing category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -618,6 +618,14 @@ description = """
 Crates for processing biological sequences, including alignment, assembly, and annotation.
 """
 
+[science.categories.quantum-computing]
+name = "Quantum Computing"
+description = """
+Crates for quantum computing, including circuit construction,
+simulation, quantum algorithms, intermediate representations, and
+interfaces to quantum hardware backends.
+"""
+
 [security]
 name = "Security"
 description = """


### PR DESCRIPTION
The need arises from a project I am working on within the quantum space. Given quantum computing's increasing Rust ecosystem, adding this as a category would be beneficial to discovery. ~~If a more analytical look at a rough estimate of the number of packages that fall into this category is needed to warrant this change, I can gather that information.~~

---
The main motivation for adding this is that the quantum tooling ecosystem has started to take its own unique identity. It has robust simulations for quantum circuits, intermediate representations and parsers, client crates for interaction with the quantum devices, the list goes on. Quantum computing differs from existing categories as it represents a different way of thinking about and interacting programmatically with the hardware. Easier grouping and discoverability of the tools with a subcategory will allow better differentiation of the field. With more active areas of research, such as error correction, an increase of novel tools would be benefited by this aided discoverability.

There are over 250 crates that appear with the `#quantum-computing` or `#quantum` tag.
* http://crates.io/keywords/quantum
* http://crates.io/keywords/quantum-computing

Some of the more popular packages within those:
* https://crates.io/crates/quil-rs - more than 500,000 downloads. Used for parsing a quantum instruction language
* https://crates.io/crates/hugr - more than 145,000 downloads. A representation package for quantum circuits
