### PR TITLE
e2e: Add ARIA tree snapshots

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,9 @@ packages/crates-io-api-client/schema.d.ts
 # Test fixtures keep their on-disk shape.
 **/fixtures/*.json
 
+# Playwright manages the format of these snapshot files.
+/e2e/**/*-snapshots/
+
 # pnpm manages this file's formatting.
 pnpm-lock.yaml
 

--- a/e2e/acceptance/404.spec.ts
+++ b/e2e/acceptance/404.spec.ts
@@ -9,5 +9,6 @@ test.describe('Acceptance | 404', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-go-back]')).toBeVisible();
     await expect(page.locator('[data-test-try-again]')).toHaveCount(0);
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
   });
 });

--- a/e2e/acceptance/404.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/404.spec.ts-snapshots/aria.yml
@@ -1,0 +1,86 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "Page not found" [level=1]
+  - button "Go Back"
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/api-token.spec.ts
+++ b/e2e/acceptance/api-token.spec.ts
@@ -131,6 +131,7 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
     await page.fill('[data-test-name]', 'the new token');
     await page.click('[data-test-scope="publish-update"]');
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
 
     await page.click('[data-test-generate]');
 

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -1,0 +1,140 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "John Doe (johnnydee) John Doe ▼":
+      - img "John Doe (johnnydee)"
+      - text: ""
+- main:
+  - heading "Account Settings" [level=1]
+  - list:
+    - listitem:
+      - link "Profile":
+        - /url: /settings/profile
+    - listitem:
+      - link "API Tokens":
+        - /url: /settings/tokens
+  - heading "New API Token" [level=2]
+  - text: Name
+  - textbox "Name": the new token
+  - text: Expiration
+  - combobox "Expiration":
+    - option "No expiration"
+    - option "7 days"
+    - option /\d+ days/
+    - option /\d+ days/
+    - option /\d+ days/ [selected]
+    - option /\d+ days/
+    - option "Custom..."
+  - text: /The token will expire on February \d+, \d+ Scopes/
+  - link "Help":
+    - /url: https://rust-lang.github.io/rfcs/2947-crates-io-token-scopes.html
+    - text: ""
+    - img
+  - list:
+    - listitem:
+      - checkbox "change-owners Invite new crate owners or remove existing ones"
+      - text: change-owners Invite new crate owners or remove existing ones
+    - listitem:
+      - checkbox "publish-new Publish new crates"
+      - text: publish-new Publish new crates
+    - listitem:
+      - checkbox "publish-update Publish new versions of existing crates" [checked]
+      - text: publish-update Publish new versions of existing crates
+    - listitem:
+      - checkbox "trusted-publishing Manage trusted publishing configurations"
+      - text: trusted-publishing Manage trusted publishing configurations
+    - listitem:
+      - checkbox "yank Yank and unyank crate versions"
+      - text: yank Yank and unyank crate versions
+  - text: Crates
+  - link "Help":
+    - /url: https://rust-lang.github.io/rfcs/2947-crates-io-token-scopes.html
+    - text: ""
+    - img
+  - list:
+    - listitem:
+      - strong: Unrestricted
+      - text: – This token can be used for all of your crates.
+    - listitem:
+      - button "Add pattern"
+  - button "Generate Token"
+  - link "Cancel":
+    - /url: /settings/tokens
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""
+- text: "Settings - crates.io: Rust Package Registry"

--- a/e2e/acceptance/categories.spec.ts
+++ b/e2e/acceptance/categories.spec.ts
@@ -19,6 +19,7 @@ test.describe('Acceptance | categories', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-category="everything"] [data-test-crate-count]')).toHaveText('1,234 crates');
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria-list.yml' });
     await a11y.audit();
   });
 
@@ -29,6 +30,7 @@ test.describe('Acceptance | categories', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-category-sort] [data-test-current-order]')).toHaveText('Recent Downloads');
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria-detail.yml' });
     await a11y.audit();
   });
 

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -1,0 +1,100 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+      - text: category:algorithms
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "Algorithms" [level=1]
+  - paragraph: This is the description for the category called "Algorithms"
+  - heading "Crates" [level=2]
+  - text: Displaying 0-0 of 0 total results Sort by
+  - button "Recent Downloads ▼":
+    - img
+    - text: ""
+  - list
+  - navigation "Pagination navigation":
+    - img
+    - list:
+      - listitem:
+        - link "1":
+          - /url: "?page=1"
+    - img
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -1,0 +1,111 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "All Categories" [level=1]
+  - text: Displaying 1-4 of 4 total results Sort by
+  - button "Alphabetical ▼":
+    - img
+    - text: ""
+  - link "API bindings":
+    - /url: /categories/api-bindings
+  - text: 0 crates This is the description for the category called "API bindings"
+  - link "Algorithms":
+    - /url: /categories/algorithms
+  - text: 1 crate This is the description for the category called "Algorithms"
+  - link "Asynchronous":
+    - /url: /categories/asynchronous
+  - text: /\d+ crates This is the description for the category called "Asynchronous"/
+  - link "Everything":
+    - /url: /categories/everything
+  - text: /\d+,\d+ crates This is the description for the category called "Everything"/
+  - navigation "Pagination navigation":
+    - img
+    - list:
+      - listitem:
+        - link "1":
+          - /url: "?page=1"
+    - img
+  - text: Want to categorize your crate?
+  - link "Add metadata!":
+    - /url: https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/crate-dependencies.spec.ts
+++ b/e2e/acceptance/crate-dependencies.spec.ts
@@ -15,6 +15,7 @@ test.describe('Acceptance | crate dependencies page', { tag: '@acceptance' }, ()
     await expect(page.locator('[data-test-dev-dependencies] li')).toHaveCount(1);
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
     await a11y.audit();
   });
 

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -1,0 +1,133 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "nanomsg v0.6.1" [level=1]
+  - text: A high-level, Rust idiomatic wrapper around nanomsg.
+  - list:
+    - listitem:
+      - link "#network":
+        - /url: /keywords/network
+  - navigation "nanomsg crate subpages":
+    - list:
+      - listitem:
+        - link "Readme":
+          - /url: /crates/nanomsg/0.6.1
+      - listitem:
+        - link /\d+ Versions/:
+          - /url: /crates/nanomsg/versions
+      - listitem:
+        - link "Dependencies":
+          - /url: /crates/nanomsg/0.6.1/dependencies
+      - listitem:
+        - link "Dependents":
+          - /url: /crates/nanomsg/reverse_dependencies
+      - listitem:
+        - link "Security":
+          - /url: /crates/nanomsg/security
+  - heading "Dependencies" [level=2]
+  - list:
+    - listitem:
+      - text: /\^0\.\d+\.\d+/
+      - link "libc":
+        - /url: /crates/libc/range/^0.2.18
+      - text: This is the description for the crate called "libc"
+    - listitem:
+      - text: ^0.6.1
+      - link "nanomsg-sys":
+        - /url: /crates/nanomsg-sys/range/^0.6.1
+      - text: This is the description for the crate called "nanomsg-sys"
+  - heading "Build-Dependencies" [level=2]
+  - list:
+    - listitem:
+      - text: ^0.6.1
+      - link "mock-build-deps":
+        - /url: /crates/mock-build-deps/range/^0.6.1
+      - text: This is the description for the crate called "mock-build-deps"
+  - heading "Dev-Dependencies" [level=2]
+  - list:
+    - listitem:
+      - text: ^0.6.1
+      - link "mock-dev-deps":
+        - /url: /crates/mock-dev-deps/range/^0.6.1
+      - text: optional This is the description for the crate called "mock-dev-deps"
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -33,6 +33,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-msrv]')).toContainText('v1.69.0');
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria-latest.yml' });
     await a11y.audit();
   });
 
@@ -66,6 +67,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-crate-stats-label]')).toHaveText('Stats Overview for 0.6.0 (see all)');
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria-version.yml' });
     await a11y.audit();
   });
 

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -1,0 +1,146 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "nanomsg v0.6.1" [level=1]
+  - text: This is the description for the crate called "nanomsg"
+  - navigation "nanomsg crate subpages":
+    - list:
+      - listitem:
+        - link "Readme":
+          - /url: /crates/nanomsg
+      - listitem:
+        - link "2 Versions":
+          - /url: /crates/nanomsg/versions
+      - listitem:
+        - link "Dependencies":
+          - /url: /crates/nanomsg/dependencies
+      - listitem:
+        - link "Dependents":
+          - /url: /crates/nanomsg/reverse_dependencies
+      - listitem:
+        - link "Security":
+          - /url: /crates/nanomsg/security
+  - text: nanomsg v0.6.1 appears to have no
+  - code: README.md
+  - text: file
+  - region "Crate metadata":
+    - heading "Metadata" [level=2]
+    - time:
+      - img
+      - text: over 7 years ago
+    - img
+    - text: /v1\.\d+\.\d+/
+    - img
+    - link "Apache-2.0":
+      - /url: https://choosealicense.com/licenses/apache-2.0
+    - img
+    - text: /\d+,\d+ SLoC/
+    - img
+    - text: /\d+ KiB/
+    - img
+    - button "pkg:cargo/nanomsg@0.6.1?repository_url=https%3A%2F%2Flocalhost%3A4173%2F"
+    - link "Learn more":
+      - /url: https://github.com/package-url/purl-spec
+      - img
+    - heading "Install" [level=2]
+    - paragraph: "Run the following Cargo command in your project directory:"
+    - button "cargo add nanomsg"
+    - paragraph: "Or add the following line to your Cargo.toml:"
+    - button "nanomsg = \"0.6.1\""
+    - heading "Browse source" [level=2]
+    - img
+    - link "docs.rs/crate/nanomsg/0.6.1/source":
+      - /url: https://docs.rs/crate/nanomsg/0.6.1/source/
+    - heading "Owners" [level=2]
+    - list
+    - link "Report crate":
+      - /url: /support?crate=nanomsg&inquire=crate-violation
+  - heading "Stats Overview" [level=3]
+  - img
+  - text: /\d+,\d+ Downloads all time/
+  - img
+  - text: 2 Versions published
+  - heading /Downloads over the last \d+ days/ [level=4]
+  - text: Display as
+  - button "Stacked ▼"
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -1,0 +1,147 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "nanomsg v0.6.0" [level=1]
+  - text: This is the description for the crate called "nanomsg"
+  - navigation "nanomsg crate subpages":
+    - list:
+      - listitem:
+        - link "Readme":
+          - /url: /crates/nanomsg/0.6.0
+      - listitem:
+        - link "2 Versions":
+          - /url: /crates/nanomsg/versions
+      - listitem:
+        - link "Dependencies":
+          - /url: /crates/nanomsg/0.6.0/dependencies
+      - listitem:
+        - link "Dependents":
+          - /url: /crates/nanomsg/reverse_dependencies
+      - listitem:
+        - link "Security":
+          - /url: /crates/nanomsg/security
+  - text: nanomsg v0.6.0 appears to have no
+  - code: README.md
+  - text: file
+  - region "Crate metadata":
+    - heading "Metadata" [level=2]
+    - time:
+      - img
+      - text: over 7 years ago
+    - img
+    - link "MIT":
+      - /url: https://choosealicense.com/licenses/mit
+    - img
+    - text: /\d+ SLoC/
+    - img
+    - text: /\d+ KiB/
+    - img
+    - button "pkg:cargo/nanomsg@0.6.0?repository_url=https%3A%2F%2Flocalhost%3A4173%2F"
+    - link "Learn more":
+      - /url: https://github.com/package-url/purl-spec
+      - img
+    - heading "Install" [level=2]
+    - paragraph: "Run the following Cargo command in your project directory:"
+    - button "cargo add nanomsg@=0.6.0"
+    - paragraph: "Or add the following line to your Cargo.toml:"
+    - button "nanomsg = \"=0.6.0\""
+    - heading "Browse source" [level=2]
+    - img
+    - link "docs.rs/crate/nanomsg/0.6.0/source":
+      - /url: https://docs.rs/crate/nanomsg/0.6.0/source/
+    - heading "Owners" [level=2]
+    - list
+    - link "Report crate":
+      - /url: /support?crate=nanomsg&inquire=crate-violation
+  - heading "Stats Overview for 0.6.0 (see all)" [level=3]:
+    - text: ""
+    - link "(see all)":
+      - /url: /crates/nanomsg
+  - img
+  - text: /\d+,\d+ Downloads all time/
+  - img
+  - text: 2 Versions published
+  - heading /Downloads over the last \d+ days/ [level=4]
+  - text: Display as
+  - button "Stacked ▼"
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/crates.spec.ts
+++ b/e2e/acceptance/crates.spec.ts
@@ -13,6 +13,7 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
     await expect(page).toHaveTitle('Crates - crates.io: Rust Package Registry');
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
     await a11y.audit();
   });
 

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -1,0 +1,593 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "All Crates" [level=1]
+  - text: /Displaying 1-\d+ of \d+ total results Sort by/
+  - button "Recent Downloads ▼":
+    - img
+    - text: ""
+  - list:
+    - listitem:
+      - heading "rust-crypto v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rust-crypto":
+          - /url: /crates/rust-crypto
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A (mostly) pure-Rust implementation of various common cryptographic algorithms.
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+,\\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/DaGenix/rust-crypto/
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/DaGenix/rust-crypto/
+    - listitem:
+      - heading "serde v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "serde":
+          - /url: /crates/serde
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A generic serialization/deserialization framework
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Documentation":
+            - /url: https://serde-rs.github.io/serde/serde/serde/index.html
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/serde-rs/serde
+    - listitem:
+      - heading "nanomsg v0.6.1 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "nanomsg":
+          - /url: /crates/nanomsg
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A high-level, Rust idiomatic wrapper around nanomsg.
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: /\d+ months ago/
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/thehydroimpulse/nanomsg.rs
+        - listitem:
+          - link "Documentation":
+            - /url: https://github.com/thehydroimpulse/nanomsg.rs
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/thehydroimpulse/nanomsg.rs
+    - listitem:
+      - heading "quickcheck_macros v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "quickcheck_macros":
+          - /url: /crates/quickcheck_macros
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A macro attribute for quickcheck.
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/BurntSushi/quickcheck
+        - listitem:
+          - link "Documentation":
+            - /url: http://burntsushi.net/rustdoc/quickcheck/
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/BurntSushi/quickcheck
+    - listitem:
+      - heading "rustless v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rustless":
+          - /url: /crates/rustless
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: Rustless is a REST-like API micro-framework for Rust.
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/rustless/rustless
+        - listitem:
+          - link "Repository":
+            - /url: https://crates.io/crates/rustless
+    - listitem:
+      - heading "external_mixin v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "external_mixin":
+          - /url: /crates/external_mixin
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: "Use your favourite interpreted language to generate your Rust, right in your Rust. Supports Python, Ruby and shell (`sh`) out of the box, with an extensible macro to support any others. (See `rust_mix …"
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: over 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/huonw/external_mixin
+        - listitem:
+          - link "Documentation":
+            - /url: https://github.com/huonw/external_mixin#external_mixin
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/huonw/external_mixin
+    - listitem:
+      - heading "quickcheck v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "quickcheck":
+          - /url: /crates/quickcheck
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: Automatic property based testing with shrinking.
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/BurntSushi/quickcheck
+        - listitem:
+          - link "Documentation":
+            - /url: http://burntsushi.net/rustdoc/quickcheck/
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/BurntSushi/quickcheck
+    - listitem:
+      - heading /kinetic-rust v0\.\d+\.\d+ Copy Cargo\.toml snippet to clipboard/ [level=2]:
+        - link "kinetic-rust":
+          - /url: /crates/kinetic-rust
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A Kinetic protocol library written in Rust
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: over 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://icorderi.github.io/icorderi/kinetic-rust
+        - listitem:
+          - link "Documentation":
+            - /url: https://icorderi.github.io/kinetic-rust/doc/kinetic/
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/icorderi/kinetic-rust/
+    - listitem:
+      - heading "rust_mixin v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rust_mixin":
+          - /url: /crates/rust_mixin
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: "Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)"
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: over 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/huonw/external_mixin
+        - listitem:
+          - link "Documentation":
+            - /url: https://github.com/huonw/external_mixin#rust_mixin
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/huonw/external_mixin
+    - listitem:
+      - heading "rust-htslib v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rust-htslib":
+          - /url: /crates/rust-htslib
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files.
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/rust-bio/rust-htslib.git
+    - listitem:
+      - heading "rustful v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rustful":
+          - /url: /crates/rustful
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive.
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Documentation":
+            - /url: http://ogeon.github.io/docs/rustful/master/rustful/index.html
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/Ogeon/rustful
+    - listitem:
+      - heading "nom v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "nom":
+          - /url: /crates/nom
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A byte-oriented, zero-copy, parser combinators library
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: almost 2 years ago
+      - list:
+        - listitem:
+          - link "Documentation":
+            - /url: http://rust.unhandledexpression.com/nom/
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/Geal/nom
+    - listitem:
+      - heading "libc v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "libc":
+          - /url: /crates/libc
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: This is the description for the crate called "libc"
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: over 2 years ago
+    - listitem:
+      - heading "nanomsg-sys v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "nanomsg-sys":
+          - /url: /crates/nanomsg-sys
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: This is the description for the crate called "nanomsg-sys"
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: over 2 years ago
+    - listitem:
+      - heading "mock-build-deps v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "mock-build-deps":
+          - /url: /crates/mock-build-deps
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: This is the description for the crate called "mock-build-deps"
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: over 2 years ago
+    - listitem:
+      - heading "mock-dev-deps v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "mock-dev-deps":
+          - /url: /crates/mock-dev-deps
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: This is the description for the crate called "mock-dev-deps"
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: over 2 years ago
+    - listitem:
+      - heading "rusted_cypher v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rusted_cypher":
+          - /url: /crates/rusted_cypher
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: Send cypher queries to a neo4j database
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/livioribeiro/rusted-cypher
+        - listitem:
+          - link "Documentation":
+            - /url: http://livioribeiro.github.io/rusted_cypher/rusted_cypher/
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/livioribeiro/rusted-cypher
+    - listitem:
+      - heading "zlib v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "zlib":
+          - /url: /crates/zlib
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: An (incomplete) port of zlib to Rust. The decompressor works, but the compressor has not yet been ported.
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: almost 3 years ago
+    - listitem:
+      - heading "rs-es v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rs-es":
+          - /url: /crates/rs-es
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: Client for the ElasticSearch REST API
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Documentation":
+            - /url: http://benashford.github.io/rs-es/rs_es/index.html
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/benashford/rs-es
+    - listitem:
+      - heading "postgres v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "postgres":
+          - /url: /crates/postgres
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A native PostgreSQL driver
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Documentation":
+            - /url: https://sfackler.github.io/rust-postgres/doc/v0.10.1/postgres
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/sfackler/rust-postgres
+    - listitem:
+      - heading "Inflector v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "Inflector":
+          - /url: /crates/Inflector
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, title, upper, and lower cases as well as ordinalize, deordinalize, demodulize, and foreign key are supported as both trait …
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "Recent: 1"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/whatisinternet/inflector
+        - listitem:
+          - link "Documentation":
+            - /url: http://whatisinternet.github.io/inflector/doc/inflector/
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/whatisinternet/inflector
+    - listitem:
+      - heading "external_mixin_umbrella v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "external_mixin_umbrella":
+          - /url: /crates/external_mixin_umbrella
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: "Backing library for `rust_mixin` and `external_mixin` to keep them DRY."
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "Recent: 0"
+      - img
+      - text: "Updated:"
+      - time: over 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/huonw/external_mixin
+        - listitem:
+          - link "Documentation":
+            - /url: https://github.com/huonw/external_mixin#external_mixin_base
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/huonw/external_mixin
+    - listitem:
+      - heading "unicorn-rpc v0.2.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "unicorn-rpc":
+          - /url: /crates/unicorn-rpc
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: Lexical analysers generator for Rust, written in Rust (crate dedicated to rumblebars, divergences written by Nicolas Cherel)
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "Recent: 0"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/nicolas-cherel/rustlex
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/nicolas-cherel/rustlex
+  - navigation "Pagination navigation":
+    - img
+    - list:
+      - listitem:
+        - link "1":
+          - /url: "?page=1"
+    - img
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""
+- text: "Crates - crates.io: Rust Package Registry"

--- a/e2e/acceptance/dashboard.spec.ts
+++ b/e2e/acceptance/dashboard.spec.ts
@@ -53,5 +53,6 @@ test.describe('Acceptance | Dashboard', { tag: '@acceptance' }, () => {
     await expect(page).toHaveURL('/dashboard');
     await expect(page.locator('[data-test-feed-list]')).toBeVisible();
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
   });
 });

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -1,0 +1,158 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "John Doe (johnnydee) John Doe ▼":
+      - img "John Doe (johnnydee)"
+      - text: ""
+- main:
+  - heading "My Dashboard" [level=1]
+  - img
+  - text: /\d+,\d+ Total Downloads/
+  - heading "My Crates" [level=2]:
+    - img
+    - text: ""
+  - list:
+    - listitem:
+      - link /nanomsg \(0\.1\.0\) \d+,\d+/:
+        - /url: /crates/nanomsg
+        - text: ""
+        - img
+        - text: ""
+  - heading "Following" [level=2]:
+    - img
+    - text: ""
+  - list:
+    - listitem:
+      - link /rand \(1\.1\.0\) \d+,\d+/:
+        - /url: /crates/rand
+        - text: ""
+        - img
+        - text: ""
+    - listitem:
+      - link /nanomsg \(0\.1\.0\) \d+,\d+/:
+        - /url: /crates/nanomsg
+        - text: ""
+        - img
+        - text: ""
+  - heading "Latest Updates" [level=2]:
+    - img
+    - text: ""
+  - list:
+    - listitem:
+      - link "nanomsg 0.1.0":
+        - /url: /crates/nanomsg/0.1.0
+      - text: over 7 years ago
+    - listitem:
+      - link "rand 1.1.0":
+        - /url: /crates/rand/1.1.0
+      - text: over 7 years ago
+    - listitem:
+      - link "rand 1.0.0":
+        - /url: /crates/rand/1.0.0
+      - text: over 7 years ago
+    - listitem:
+      - link "rand 0.9.0":
+        - /url: /crates/rand/0.9.0
+      - text: over 7 years ago
+    - listitem:
+      - link "rand 0.8.1":
+        - /url: /crates/rand/0.8.1
+      - text: over 7 years ago
+    - listitem:
+      - link "rand 0.8.0":
+        - /url: /crates/rand/0.8.0
+      - text: over 7 years ago
+    - listitem:
+      - link "rand 0.7.3":
+        - /url: /crates/rand/0.7.3
+      - text: over 7 years ago
+    - listitem:
+      - link "rand 0.7.2":
+        - /url: /crates/rand/0.7.2
+      - text: over 7 years ago
+    - listitem:
+      - link "rand 0.7.1":
+        - /url: /crates/rand/0.7.1
+      - text: over 7 years ago
+    - listitem:
+      - link "rand 0.7.0":
+        - /url: /crates/rand/0.7.0
+      - text: over 7 years ago
+  - button "Load More"
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/front-page.spec.ts
+++ b/e2e/acceptance/front-page.spec.ts
@@ -38,6 +38,7 @@ test.describe('Acceptance | front page', { tag: '@acceptance' }, () => {
     );
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
     await a11y.audit();
   });
 

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -1,0 +1,383 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - heading "The Rust community’s crate registry" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - link "Install Cargo":
+    - /url: https://doc.rust-lang.org/cargo/getting-started/installation.html
+    - img
+    - text: ""
+  - link "Getting Started":
+    - /url: https://doc.rust-lang.org/cargo/guide/
+    - img
+    - text: ""
+  - text: /Instantly publish your crates and install them\. Use the API to interact and find out more information about available crates\. Become a contributor and enhance the site with your work\. \d+,\d+ Downloads \d+ Crates in stock/
+  - heading "New Crates" [level=2]:
+    - link "New Crates":
+      - /url: /crates?sort=new
+  - list:
+    - listitem:
+      - link "serde v1.0.0":
+        - /url: /crates/serde
+        - text: ""
+        - img
+    - listitem:
+      - link "rust-crypto v1.0.0":
+        - /url: /crates/rust-crypto
+        - text: ""
+        - img
+    - listitem:
+      - link "quickcheck v1.0.0":
+        - /url: /crates/quickcheck
+        - text: ""
+        - img
+    - listitem:
+      - link "postgres v1.0.0":
+        - /url: /crates/postgres
+        - text: ""
+        - img
+    - listitem:
+      - link "nom v1.0.0":
+        - /url: /crates/nom
+        - text: ""
+        - img
+    - listitem:
+      - link "libc v1.0.0":
+        - /url: /crates/libc
+        - text: ""
+        - img
+    - listitem:
+      - link "nanomsg-sys v1.0.0":
+        - /url: /crates/nanomsg-sys
+        - text: ""
+        - img
+    - listitem:
+      - link "mock-build-deps v1.0.0":
+        - /url: /crates/mock-build-deps
+        - text: ""
+        - img
+    - listitem:
+      - link "mock-dev-deps v1.0.0":
+        - /url: /crates/mock-dev-deps
+        - text: ""
+        - img
+    - listitem:
+      - link "nanomsg v0.6.1":
+        - /url: /crates/nanomsg
+        - text: ""
+        - img
+  - heading "Most Downloaded" [level=2]:
+    - link "Most Downloaded":
+      - /url: /crates?sort=downloads
+  - list:
+    - listitem:
+      - link "serde":
+        - /url: /crates/serde
+        - text: ""
+        - img
+    - listitem:
+      - link "rust-crypto":
+        - /url: /crates/rust-crypto
+        - text: ""
+        - img
+    - listitem:
+      - link "quickcheck":
+        - /url: /crates/quickcheck
+        - text: ""
+        - img
+    - listitem:
+      - link "postgres":
+        - /url: /crates/postgres
+        - text: ""
+        - img
+    - listitem:
+      - link "nom":
+        - /url: /crates/nom
+        - text: ""
+        - img
+    - listitem:
+      - link "libc":
+        - /url: /crates/libc
+        - text: ""
+        - img
+    - listitem:
+      - link "nanomsg-sys":
+        - /url: /crates/nanomsg-sys
+        - text: ""
+        - img
+    - listitem:
+      - link "mock-build-deps":
+        - /url: /crates/mock-build-deps
+        - text: ""
+        - img
+    - listitem:
+      - link "mock-dev-deps":
+        - /url: /crates/mock-dev-deps
+        - text: ""
+        - img
+    - listitem:
+      - link "nanomsg":
+        - /url: /crates/nanomsg
+        - text: ""
+        - img
+  - heading "Just Updated" [level=2]:
+    - link "Just Updated":
+      - /url: /crates?sort=recent-updates
+  - list:
+    - listitem:
+      - link "nanomsg v0.6.1":
+        - /url: /crates/nanomsg/0.6.1
+        - text: ""
+        - img
+    - listitem:
+      - link "nom v1.0.0":
+        - /url: /crates/nom/1.0.0
+        - text: ""
+        - img
+    - listitem:
+      - link "rust-htslib v1.0.0":
+        - /url: /crates/rust-htslib/1.0.0
+        - text: ""
+        - img
+    - listitem:
+      - link "postgres v1.0.0":
+        - /url: /crates/postgres/1.0.0
+        - text: ""
+        - img
+    - listitem:
+      - link "rusted_cypher v1.0.0":
+        - /url: /crates/rusted_cypher/1.0.0
+        - text: ""
+        - img
+    - listitem:
+      - link "rustless v1.0.0":
+        - /url: /crates/rustless/1.0.0
+        - text: ""
+        - img
+    - listitem:
+      - link "rust-crypto v1.0.0":
+        - /url: /crates/rust-crypto/1.0.0
+        - text: ""
+        - img
+    - listitem:
+      - link "Inflector v1.0.0":
+        - /url: /crates/Inflector/1.0.0
+        - text: ""
+        - img
+    - listitem:
+      - link "serde v1.0.0":
+        - /url: /crates/serde/1.0.0
+        - text: ""
+        - img
+    - listitem:
+      - link "quickcheck_macros v1.0.0":
+        - /url: /crates/quickcheck_macros/1.0.0
+        - text: ""
+        - img
+  - heading "Most Recent Downloads" [level=2]:
+    - link "Most Recent Downloads":
+      - /url: /crates?sort=recent-downloads
+  - list:
+    - listitem:
+      - link "rust-crypto":
+        - /url: /crates/rust-crypto
+        - text: ""
+        - img
+    - listitem:
+      - link "serde":
+        - /url: /crates/serde
+        - text: ""
+        - img
+    - listitem:
+      - link "nanomsg":
+        - /url: /crates/nanomsg
+        - text: ""
+        - img
+    - listitem:
+      - link "quickcheck_macros":
+        - /url: /crates/quickcheck_macros
+        - text: ""
+        - img
+    - listitem:
+      - link "rustless":
+        - /url: /crates/rustless
+        - text: ""
+        - img
+    - listitem:
+      - link "external_mixin":
+        - /url: /crates/external_mixin
+        - text: ""
+        - img
+    - listitem:
+      - link "quickcheck":
+        - /url: /crates/quickcheck
+        - text: ""
+        - img
+    - listitem:
+      - link "kinetic-rust":
+        - /url: /crates/kinetic-rust
+        - text: ""
+        - img
+    - listitem:
+      - link "rust_mixin":
+        - /url: /crates/rust_mixin
+        - text: ""
+        - img
+    - listitem:
+      - link "rust-htslib":
+        - /url: /crates/rust-htslib
+        - text: ""
+        - img
+  - heading "Popular Keywords" [level=2]:
+    - link "Popular Keywords":
+      - /url: /keywords
+  - list:
+    - listitem:
+      - link "network 1 crates":
+        - /url: /keywords/network
+        - text: ""
+        - img
+    - listitem:
+      - link "rust 1 crates":
+        - /url: /keywords/rust
+        - text: ""
+        - img
+    - listitem:
+      - link "plugin 3 crates":
+        - /url: /keywords/plugin
+        - text: ""
+        - img
+    - listitem:
+      - link "code-generation 3 crates":
+        - /url: /keywords/code-generation
+        - text: ""
+        - img
+    - listitem:
+      - link "python 1 crates":
+        - /url: /keywords/python
+        - text: ""
+        - img
+    - listitem:
+      - link "ruby 1 crates":
+        - /url: /keywords/ruby
+        - text: ""
+        - img
+    - listitem:
+      - link "shell 1 crates":
+        - /url: /keywords/shell
+        - text: ""
+        - img
+    - listitem:
+      - link "string 1 crates":
+        - /url: /keywords/string
+        - text: ""
+        - img
+    - listitem:
+      - link "case 1 crates":
+        - /url: /keywords/case
+        - text: ""
+        - img
+    - listitem:
+      - link "camel 1 crates":
+        - /url: /keywords/camel
+        - text: ""
+        - img
+  - heading "Popular Categories" [level=2]:
+    - link "Popular Categories":
+      - /url: /categories
+  - list:
+    - listitem:
+      - link "API bindings 0 crates":
+        - /url: /categories/api-bindings
+        - text: ""
+        - img
+    - listitem:
+      - link "Algorithms 0 crates":
+        - /url: /categories/algorithms
+        - text: ""
+        - img
+    - listitem:
+      - link "Asynchronous 0 crates":
+        - /url: /categories/asynchronous
+        - text: ""
+        - img
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/invites.spec.ts
+++ b/e2e/acceptance/invites.spec.ts
@@ -155,6 +155,7 @@ test.describe('Acceptance | /me/pending-invites', { tag: '@acceptance' }, () => 
     await expect(page.locator('[data-test-invite="nanomsg"] [data-test-inviter-link]')).toHaveCount(0);
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
 
     invites = msw.db.crateOwnerInvitation.findMany(q =>
       q.where(inv => inv.crate.id === nanomsg.id && inv.invitee.id === user.id),

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -1,0 +1,99 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "User 3 (user-3) User 3 ▼":
+      - img "User 3 (user-3)"
+      - text: ""
+- main:
+  - heading "Pending Owner Invites" [level=1]
+  - paragraph:
+    - text: Success! You've been added as an owner of crate
+    - link "nanomsg":
+      - /url: /crates/nanomsg
+    - text: .
+  - heading "ember-rs" [level=3]:
+    - link "ember-rs":
+      - /url: /crates/ember-rs
+  - text: "Invited by:"
+  - link "wycats":
+    - /url: /users/wycats
+  - text: in about 3 years
+  - button "Accept"
+  - button "Decline"
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/keyword.spec.ts
+++ b/e2e/acceptance/keyword.spec.ts
@@ -9,6 +9,7 @@ test.describe('Acceptance | keywords', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-keyword-sort] [data-test-current-order]')).toHaveText('Recent Downloads');
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
     await a11y.audit();
   });
 });

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -1,0 +1,97 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "All Crates for keyword 'network'" [level=1]
+  - text: Displaying 0-0 of 0 total results Sort by
+  - button "Recent Downloads ▼":
+    - img
+    - text: ""
+  - list
+  - navigation "Pagination navigation":
+    - img
+    - list:
+      - listitem:
+        - link "1":
+          - /url: "?page=1"
+    - img
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -130,6 +130,7 @@ test.describe('Acceptance | README rendering', { tag: '@acceptance' }, () => {
     await expect(readme.locator('pre > code.language-mermaid svg.flowchart')).toBeVisible();
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
   });
 
   test('it shows a fallback if no readme is available', async ({ page, msw }) => {

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -1,0 +1,240 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "serde v1.0.0" [level=1]
+  - text: This is the description for the crate called "serde"
+  - navigation "serde crate subpages":
+    - list:
+      - listitem:
+        - link "Readme":
+          - /url: /crates/serde
+      - listitem:
+        - link "1 Version":
+          - /url: /crates/serde/versions
+      - listitem:
+        - link "Dependencies":
+          - /url: /crates/serde/dependencies
+      - listitem:
+        - link "Dependents":
+          - /url: /crates/serde/reverse_dependencies
+      - listitem:
+        - link "Security":
+          - /url: /crates/serde/security
+  - article "Readme":
+    - paragraph: Note
+    - paragraph: Useful information that users should know, even when skimming content.
+    - paragraph: Tip
+    - paragraph: Helpful advice for doing things better or more easily.
+    - paragraph: Important
+    - paragraph: Key information users need to know to achieve their goal.
+    - paragraph: Warning
+    - paragraph: Urgent info that needs immediate user attention to avoid problems.
+    - paragraph: Caution
+    - paragraph: Advises about risks or negative outcomes of certain actions.
+    - paragraph: Note
+    - paragraph: Important
+    - paragraph: Caution
+    - paragraph: Rick roll
+    - paragraph: Never gonna give you up
+    - paragraph:
+      - strong:
+        - text: Serde is a framework for
+        - emphasis: ser
+        - text: ializing and
+        - emphasis: de
+        - text: serializing Rust data structures efficiently and generically.
+    - separator
+    - paragraph: "You may be looking for:"
+    - list:
+      - listitem:
+        - link "An overview of Serde":
+          - /url: https://serde.rs/
+      - listitem:
+        - link "Data formats supported by Serde":
+          - /url: https://serde.rs/#data-formats
+      - listitem:
+        - 'link "Setting up #[derive(Serialize, Deserialize)]"':
+          - /url: https://serde.rs/derive.html
+          - text: ""
+          - code: "#[derive(Serialize, Deserialize)]"
+      - listitem:
+        - link "Examples":
+          - /url: https://serde.rs/examples.html
+      - listitem:
+        - link "API documentation":
+          - /url: https://docs.serde.rs/serde/
+      - listitem:
+        - link "Release notes":
+          - /url: https://github.com/serde-rs/serde/releases
+    - heading "Serde in action" [level=2]:
+      - link:
+        - /url: "#serde-in-action"
+      - text: ""
+    - code: "use serde::{Serialize, Deserialize}; #[derive(Serialize, Deserialize, Debug)] struct Point { x: i32, y: i32, } fn main() { let point = Point { x: 1, y: 2 }; // Convert the Point to a JSON string. let serialized = serde_json::to_string(&point).unwrap(); // Prints serialized = {\"x\":1,\"y\":2} println!(\"serialized = {}\", serialized); // Convert the JSON string back to a Point. let deserialized: Point = serde_json::from_str(&serialized).unwrap(); // Prints deserialized = Point { x: 1, y: 2 } println!(\"deserialized = {:?}\", deserialized); }"
+    - heading "Getting help" [level=2]:
+      - link:
+        - /url: "#getting-help"
+      - text: ""
+    - paragraph:
+      - text: Serde is one of the most widely used Rust libraries so any place that Rustaceans congregate will be able to help you out. For chat, consider trying the
+      - link "#general":
+        - /url: https://discord.com/channels/273534239310479360/274215136414400513
+      - text: or
+      - link "#beginners":
+        - /url: https://discord.com/channels/273534239310479360/273541522815713281
+      - text: channels of the unofficial community Discord, the
+      - link "#rust-usage":
+        - /url: https://discord.com/channels/442252698964721669/443150878111694848
+      - text: channel of the official Rust Project Discord, or the
+      - link "#general":
+        - /url: https://rust-lang.zulipchat.com/#narrow/stream/122651-general
+      - text: stream in Zulip. For asynchronous, consider the
+      - link "[rust] tag on StackOverflow":
+        - /url: https://stackoverflow.com/questions/tagged/rust
+      - text: ", the"
+      - link "/r/rust":
+        - /url: https://www.reddit.com/r/rust
+      - text: subreddit which has a pinned weekly easy questions post, or the Rust
+      - link "Discourse forum":
+        - /url: https://users.rust-lang.org
+      - text: . It's acceptable to file a support issue in this repo but they tend not to get as many eyes as any of the above and may get closed without a response after some time.
+    - paragraph:
+      - text: Hello World!
+      - superscript:
+        - link "1":
+          - /url: "#user-content-fn-1"
+    - code:
+      - document:
+        - paragraph: A
+        - paragraph: B
+        - paragraph: C
+        - paragraph: D
+    - list:
+      - listitem:
+        - paragraph: Delegate to a method with a different name
+        - code: "struct Stack { inner: Vec<u32> } impl Stack { delegate! { to self.inner { #[call(push)] pub fn add(&mut self, value: u32); } } }"
+    - list:
+      - listitem:
+        - paragraph:
+          - text: Hello Ferris, actually!
+          - link "↩":
+            - /url: "#user-content-fnref-1"
+  - region "Crate metadata":
+    - heading "Metadata" [level=2]
+    - time:
+      - img
+      - text: over 7 years ago
+    - img
+    - link "MIT":
+      - /url: https://choosealicense.com/licenses/mit
+    - img
+    - text: /\d+ SLoC/
+    - img
+    - text: /\d+ KiB/
+    - img
+    - button "pkg:cargo/serde@1.0.0?repository_url=https%3A%2F%2Flocalhost%3A4173%2F"
+    - link "Learn more":
+      - /url: https://github.com/package-url/purl-spec
+      - img
+    - heading "Install" [level=2]
+    - paragraph: "Run the following Cargo command in your project directory:"
+    - button "cargo add serde"
+    - paragraph: "Or add the following line to your Cargo.toml:"
+    - button "serde = \"1.0.0\""
+    - heading "Browse source" [level=2]
+    - img
+    - link "docs.rs/crate/serde/1.0.0/source":
+      - /url: https://docs.rs/crate/serde/1.0.0/source/
+    - heading "Owners" [level=2]
+    - list
+    - link "Report crate":
+      - /url: /support?crate=serde&inquire=crate-violation
+  - heading "Stats Overview" [level=3]
+  - img
+  - text: /\d+,\d+ Downloads all time/
+  - img
+  - text: 1 Versions published
+  - heading /Downloads over the last \d+ days/ [level=4]
+  - text: Display as
+  - button "Stacked ▼"
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/search.spec.ts
+++ b/e2e/acceptance/search.spec.ts
@@ -27,6 +27,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-crate-row="0"] [data-test-updated-at]')).toBeVisible();
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
     await a11y.audit();
   });
 

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -1,0 +1,259 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+      - text: rust
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "Search Results for 'rust'" [level=1]
+  - text: Displaying 1-7 of 7 total results Sort by
+  - button "Relevance ▼":
+    - img
+    - text: ""
+  - list:
+    - listitem:
+      - heading /kinetic-rust v0\.\d+\.\d+ Copy Cargo\.toml snippet to clipboard/ [level=2]:
+        - link "kinetic-rust":
+          - /url: /crates/kinetic-rust
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A Kinetic protocol library written in Rust
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: over 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://icorderi.github.io/icorderi/kinetic-rust
+        - listitem:
+          - link "Documentation":
+            - /url: https://icorderi.github.io/kinetic-rust/doc/kinetic/
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/icorderi/kinetic-rust/
+    - listitem:
+      - heading "rust_mixin v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rust_mixin":
+          - /url: /crates/rust_mixin
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: "Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)"
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: over 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/huonw/external_mixin
+        - listitem:
+          - link "Documentation":
+            - /url: https://github.com/huonw/external_mixin#rust_mixin
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/huonw/external_mixin
+    - listitem:
+      - heading "rust-crypto v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rust-crypto":
+          - /url: /crates/rust-crypto
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A (mostly) pure-Rust implementation of various common cryptographic algorithms.
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+,\\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/DaGenix/rust-crypto/
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/DaGenix/rust-crypto/
+    - listitem:
+      - heading "rust-htslib v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rust-htslib":
+          - /url: /crates/rust-htslib
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files.
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/rust-bio/rust-htslib.git
+    - listitem:
+      - heading "rustless v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rustless":
+          - /url: /crates/rustless
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: Rustless is a REST-like API micro-framework for Rust.
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/rustless/rustless
+        - listitem:
+          - link "Repository":
+            - /url: https://crates.io/crates/rustless
+    - listitem:
+      - heading "rusted_cypher v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rusted_cypher":
+          - /url: /crates/rusted_cypher
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: Send cypher queries to a neo4j database
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/livioribeiro/rusted-cypher
+        - listitem:
+          - link "Documentation":
+            - /url: http://livioribeiro.github.io/rusted_cypher/rusted_cypher/
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/livioribeiro/rusted-cypher
+    - listitem:
+      - heading "rustful v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "rustful":
+          - /url: /crates/rustful
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive.
+      - img
+      - text: "/All-Time: \\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: about 2 years ago
+      - list:
+        - listitem:
+          - link "Documentation":
+            - /url: http://ogeon.github.io/docs/rustful/master/rustful/index.html
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/Ogeon/rustful
+  - navigation "Pagination navigation":
+    - img
+    - list:
+      - listitem:
+        - link "1":
+          - /url: "?q=rust&page=1"
+    - img
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""
+- text: "Search Results for 'rust' - crates.io: Rust Package Registry"

--- a/e2e/acceptance/security.spec.ts
+++ b/e2e/acceptance/security.spec.ts
@@ -86,6 +86,7 @@ test.describe('Acceptance | crate security page', { tag: '@acceptance' }, () => 
     await expect(advisory2.locator('[data-test-cvss]')).not.toBeVisible();
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
   });
 
   test('show no advisory data when none exist', async ({ page, msw }) => {

--- a/e2e/acceptance/security.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/security.spec.ts-snapshots/aria.yml
@@ -1,0 +1,133 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "foo" [level=1]
+  - text: This is the description for the crate called "foo"
+  - navigation "foo crate subpages":
+    - list:
+      - listitem:
+        - link "Readme":
+          - /url: /crates/foo
+      - listitem:
+        - link "1 Version":
+          - /url: /crates/foo/versions
+      - listitem:
+        - link "Dependencies":
+          - /url: /crates/foo/dependencies
+      - listitem:
+        - link "Dependents":
+          - /url: /crates/foo/reverse_dependencies
+      - listitem:
+        - link "Security":
+          - /url: /crates/foo/security
+  - heading "Advisories" [level=2]
+  - list:
+    - listitem:
+      - 'heading /TEST-\d+: First test advisory/ [level=3]':
+        - link /TEST-\d+/:
+          - /url: https://rustsec.org/advisories/TEST-001.html
+        - text: ""
+      - strong: "Affected versions:"
+      - text: /<0\.\d+\.\d+; >=0\.8\.0, <0\.\d+\.\d+/
+      - strong: "Aliases:"
+      - list:
+        - listitem:
+          - link /CVE-\d+-\d+/:
+            - /url: https://nvd.nist.gov/vuln/detail/CVE-2024-12345
+        - listitem:
+          - link /GHSA-abcd-\d+-efgh/:
+            - /url: https://github.com/advisories/GHSA-abcd-1234-efgh
+      - strong: "CVSS:"
+      - link "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H":
+        - /url: https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+      - paragraph:
+        - text: This is the first test advisory with
+        - strong: markdown
+        - text: support.
+    - listitem:
+      - 'heading /TEST-\d+: Second test advisory/ [level=3]':
+        - link /TEST-\d+/:
+          - /url: https://rustsec.org/advisories/TEST-002.html
+        - text: ""
+      - paragraph: This is the second test advisory with more details.
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/settings/settings.spec.ts
+++ b/e2e/acceptance/settings/settings.spec.ts
@@ -29,6 +29,7 @@ test.describe('Acceptance | Settings', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-owners] a[href="/users/blabaere"]').first()).toBeVisible();
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
     await a11y.audit();
   });
 

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -1,0 +1,151 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "blabaere (blabaere) blabaere ▼":
+      - img "blabaere (blabaere)"
+      - text: ""
+- main:
+  - heading "nanomsg" [level=1]
+  - text: This is the description for the crate called "nanomsg"
+  - button "Follow"
+  - navigation "nanomsg crate subpages":
+    - list:
+      - listitem:
+        - link "Readme":
+          - /url: /crates/nanomsg
+      - listitem:
+        - link "1 Version":
+          - /url: /crates/nanomsg/versions
+      - listitem:
+        - link "Dependencies":
+          - /url: /crates/nanomsg/dependencies
+      - listitem:
+        - link "Dependents":
+          - /url: /crates/nanomsg/reverse_dependencies
+      - listitem:
+        - link "Security":
+          - /url: /crates/nanomsg/security
+      - listitem:
+        - link "Settings":
+          - /url: /crates/nanomsg/settings
+  - heading "Owners" [level=2]
+  - button "Add Owner"
+  - link "blabaere (github:org:blabaere)":
+    - /url: /teams/github:org:blabaere
+    - img "blabaere (github:org:blabaere)"
+  - link "org/blabaere":
+    - /url: /teams/github:org:blabaere
+  - button "Remove"
+  - link "thehydroimpulse (github:org:thehydroimpulse)":
+    - /url: /teams/github:org:thehydroimpulse
+    - img "thehydroimpulse (github:org:thehydroimpulse)"
+  - link "org/thehydroimpulse":
+    - /url: /teams/github:org:thehydroimpulse
+  - button "Remove"
+  - link "blabaere (blabaere)":
+    - /url: /users/blabaere
+    - img "blabaere (blabaere)"
+  - link "blabaere":
+    - /url: /users/blabaere
+  - text: blabaere@crates.io
+  - button "Remove"
+  - link "thehydroimpulse (thehydroimpulse)":
+    - /url: /users/thehydroimpulse
+    - img "thehydroimpulse (thehydroimpulse)"
+  - link "thehydroimpulse":
+    - /url: /users/thehydroimpulse
+  - button "Remove"
+  - heading "Trusted Publishing" [level=2]
+  - link "Learn more":
+    - /url: /docs/trusted-publishing
+  - link "Add":
+    - /url: /crates/nanomsg/settings/new-trusted-publisher
+  - table:
+    - rowgroup:
+      - row "Publisher Details Actions":
+        - columnheader "Publisher"
+        - columnheader "Details"
+        - columnheader "Actions"
+    - rowgroup:
+      - row "No trusted publishers configured for this crate.":
+        - cell "No trusted publishers configured for this crate."
+  - heading "Danger Zone" [level=2]
+  - link "Delete this crate":
+    - /url: /crates/nanomsg/delete
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/support.spec.ts
+++ b/e2e/acceptance/support.spec.ts
@@ -28,6 +28,7 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
     ]);
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria-list.yml' });
     await a11y.audit();
   });
 
@@ -61,6 +62,7 @@ test.describe('Acceptance | support page', { tag: '@acceptance' }, () => {
       await expect(page.getByTestId('report-button')).toHaveText('Report to help@crates.io');
 
       await percy.snapshot();
+      await expect(page).toMatchAriaSnapshot({ name: 'aria-form.yml' });
       await a11y.audit();
     });
 

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -1,0 +1,117 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "Contact Us" [level=1]
+  - heading "Report A Crate" [level=2]
+  - group:
+    - text: Crate
+    - textbox "Crate"
+  - group:
+    - text: Reasons
+    - list:
+      - listitem:
+        - checkbox "it contains spam"
+        - text: it contains spam
+      - listitem:
+        - checkbox "it is name-squatting (reserving a crate name without content)"
+        - text: it is name-squatting (reserving a crate name without content)
+      - listitem:
+        - checkbox "it is abusive or otherwise harmful"
+        - text: it is abusive or otherwise harmful
+      - listitem:
+        - checkbox "it contains malicious code"
+        - text: it contains malicious code
+      - listitem:
+        - checkbox "it contains a vulnerability"
+        - text: it contains a vulnerability
+      - listitem:
+        - checkbox "it is violating the usage policy in some other way (please specify below)"
+        - text: it is violating the usage policy in some other way (please specify below)
+  - group:
+    - text: Detail
+    - textbox "Detail"
+  - button "Report to help@crates.io":
+    - text: ""
+    - strong: help@crates.io
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""
+- text: "crates.io: Rust Package Registry"

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
@@ -1,0 +1,95 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "Contact Us" [level=1]
+  - heading "Choose one of the these categories to continue." [level=2]
+  - list:
+    - listitem:
+      - link "Report a crate that violates policies":
+        - /url: "?inquire=crate-violation"
+    - listitem:
+      - 'link "For all other cases: help@crates.io"':
+        - /url: mailto:help@crates.io
+        - text: ""
+        - strong: help@crates.io
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/team-page.spec.ts
+++ b/e2e/acceptance/team-page.spec.ts
@@ -12,6 +12,7 @@ test.describe('Acceptance | team page', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-heading] [data-test-team-name]')).toHaveText('thehydroimpulseteam');
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
     await a11y.audit();
   });
 

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -1,0 +1,127 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - img "thehydroimpulseteam (github:org:thehydroimpulse)"
+  - heading "org" [level=1]
+  - link "GitHub profile":
+    - /url: https://github.com/org_test
+    - img "GitHub profile"
+  - heading "thehydroimpulseteam" [level=2]
+  - text: Displaying 1-1 of 1 total results Sort by
+  - button "Alphabetical ▼":
+    - img
+    - text: ""
+  - list:
+    - listitem:
+      - heading "nanomsg v0.6.1 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "nanomsg":
+          - /url: /crates/nanomsg
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A high-level, Rust idiomatic wrapper around nanomsg.
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: /\d+ months ago/
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/thehydroimpulse/nanomsg.rs
+        - listitem:
+          - link "Documentation":
+            - /url: https://github.com/thehydroimpulse/nanomsg.rs
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/thehydroimpulse/nanomsg.rs
+  - navigation "Pagination navigation":
+    - img
+    - list:
+      - listitem:
+        - link "1":
+          - /url: "?page=1"
+    - img
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/token-invites.spec.ts
+++ b/e2e/acceptance/token-invites.spec.ts
@@ -47,5 +47,6 @@ test.describe('Acceptance | /accept-invite/:token', { tag: '@acceptance' }, () =
     );
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
   });
 });

--- a/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
@@ -1,0 +1,93 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "You've been added as a crate owner!" [level=1]
+  - paragraph:
+    - text: Visit your
+    - link "dashboard":
+      - /url: /dashboard
+    - text: to view all of your crates, or
+    - link "account settings":
+      - /url: /me
+    - text: to manage email notification preferences for all of your crates.
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/user-page.spec.ts
+++ b/e2e/acceptance/user-page.spec.ts
@@ -11,6 +11,7 @@ test.describe('Acceptance | user page', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-heading] [data-test-username]')).toHaveText('thehydroimpulse');
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
     await a11y.audit();
   });
 

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -1,0 +1,126 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - img "Daniel Fagnan (thehydroimpulse)"
+  - heading "thehydroimpulse" [level=1]
+  - link "GitHub profile":
+    - /url: https://github.com/thehydroimpulse
+    - img "GitHub profile"
+  - text: Displaying 1-1 of 1 total results Sort by
+  - button "Alphabetical ▼":
+    - img
+    - text: ""
+  - list:
+    - listitem:
+      - heading "nanomsg v0.6.1 Copy Cargo.toml snippet to clipboard" [level=2]:
+        - link "nanomsg":
+          - /url: /crates/nanomsg
+        - text: ""
+        - button "Copy Cargo.toml snippet to clipboard":
+          - img "Copy Cargo.toml snippet to clipboard"
+      - text: A high-level, Rust idiomatic wrapper around nanomsg.
+      - img
+      - text: "/All-Time: \\d+,\\d+/"
+      - img
+      - text: "/Recent: \\d+/"
+      - img
+      - text: "Updated:"
+      - time: /\d+ months ago/
+      - list:
+        - listitem:
+          - link "Homepage":
+            - /url: https://github.com/thehydroimpulse/nanomsg.rs
+        - listitem:
+          - link "Documentation":
+            - /url: https://github.com/thehydroimpulse/nanomsg.rs
+        - listitem:
+          - link "Repository":
+            - /url: https://github.com/thehydroimpulse/nanomsg.rs
+  - navigation "Pagination navigation":
+    - img
+    - list:
+      - listitem:
+        - link "1":
+          - /url: "?page=1"
+    - img
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/acceptance/versions.spec.ts
+++ b/e2e/acceptance/versions.spec.ts
@@ -25,6 +25,7 @@ test.describe('Acceptance | crate versions page', { tag: '@acceptance' }, () => 
     await expect(page.locator('[data-test-version="0.3.0"]')).toContainText('v1.69.0');
 
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
 
     await page.click('[data-test-current-order]');
     await page.click('[data-test-semver-sort] a');

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -1,0 +1,170 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "Log in with GitHub":
+      - img
+      - text: ""
+- main:
+  - heading "nanomsg" [level=1]
+  - text: This is the description for the crate called "nanomsg"
+  - navigation "nanomsg crate subpages":
+    - list:
+      - listitem:
+        - link "Readme":
+          - /url: /crates/nanomsg
+      - listitem:
+        - link "4 Versions":
+          - /url: /crates/nanomsg/versions
+      - listitem:
+        - link "Dependencies":
+          - /url: /crates/nanomsg/dependencies
+      - listitem:
+        - link "Dependents":
+          - /url: /crates/nanomsg/reverse_dependencies
+      - listitem:
+        - link "Security":
+          - /url: /crates/nanomsg/security
+  - strong: "4"
+  - text: of
+  - strong: "4"
+  - strong: nanomsg
+  - text: /versions since June 16th, \d+ Sort by/
+  - button "Date ▼":
+    - img
+    - text: ""
+  - list:
+    - listitem:
+      - text: "0.2"
+      - link "0.2.1":
+        - /url: /crates/nanomsg/0.2.1
+      - text: via
+      - link "GitHub":
+        - /url: https://github.com/octo-org/octo-repo/actions/runs/1234567890
+        - img
+        - text: ""
+      - time:
+        - img
+        - text: in about 2 years
+      - img
+      - text: /\d+ KiB/
+      - img
+      - link "MIT":
+        - /url: https://choosealicense.com/licenses/mit
+    - listitem:
+      - text: "0.3"
+      - link "0.3.0":
+        - /url: /crates/nanomsg/0.3.0
+      - time:
+        - img
+        - text: in about 1 year
+      - img
+      - text: /v1\.\d+\.\d+/
+      - img
+      - text: /\d+ KiB/
+      - img
+      - link "MIT":
+        - /url: https://choosealicense.com/licenses/mit
+      - text: OR
+      - link "Apache-2.0":
+        - /url: https://choosealicense.com/licenses/apache-2.0
+    - listitem:
+      - text: "0.2"
+      - link "0.2.0":
+        - /url: /crates/nanomsg/0.2.0
+      - time:
+        - img
+        - text: in about 1 month
+      - img
+      - text: /\d+ KiB/
+      - img
+      - link "Apache-2.0":
+        - /url: https://choosealicense.com/licenses/apache-2.0
+    - listitem:
+      - text: "0.1"
+      - link "0.1.0":
+        - /url: /crates/nanomsg/0.1.0
+      - time:
+        - img
+        - text: /\d+ months ago/
+      - img
+      - text: /\d+ KiB/
+      - img
+      - link "MIT":
+        - /url: https://choosealicense.com/licenses/mit
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/routes/crate/delete.spec.ts
+++ b/e2e/routes/crate/delete.spec.ts
@@ -44,6 +44,7 @@ test.describe('Route: crate.delete', { tag: '@routes' }, () => {
     await expect(page).toHaveURL('/crates/foo/delete');
     await expect(page.locator('[data-test-title]')).toHaveText('Delete the foo crate?');
     await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
 
     await page.fill('[data-test-reason]', "I don't need this crate anymore");
     await expect(page.locator('[data-test-delete-button]')).toBeDisabled();

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -1,0 +1,113 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "User 1 (user-1) User 1 ▼":
+      - img "User 1 (user-1)"
+      - text: ""
+- main:
+  - heading "Delete the foo crate?" [level=1]
+  - paragraph: Are you sure you want to delete the crate "foo"?
+  - strong: "Important:"
+  - text: This action will permanently delete the crate and its associated versions. Deleting a crate cannot be reversed!
+  - heading "Potential Impact:" [level=3]
+  - list:
+    - listitem: Users will no longer be able to download this crate.
+    - listitem: Any dependencies or projects relying on this crate will be broken.
+    - listitem: Deleted crates cannot be restored.
+    - listitem: /Publishing a crate with the same name will be blocked for \d+ hours\./
+  - heading "Requirements:" [level=3]
+  - paragraph: A crate can only be deleted if it is not depended upon by any other crate on crates.io.
+  - paragraph: "Additionally, a crate can only be deleted if either:"
+  - list:
+    - listitem: /the crate has been published for less than \d+ hours/
+  - text: or
+  - list:
+    - listitem:
+      - list:
+        - listitem:
+          - text: the crate only has a single owner,
+          - emphasis: and
+        - listitem: /the crate has been downloaded less than \d+ times for each month it has been published\./
+  - heading "Reason:" [level=3]
+  - paragraph: "Please tell us why you are deleting this crate:"
+  - textbox "Please tell us why you are deleting this crate:"
+  - checkbox "I understand that deleting this crate is permanent and cannot be undone."
+  - text: I understand that deleting this crate is permanent and cannot be undone.
+  - button "Delete this crate" [disabled]
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/routes/crate/settings.spec.ts
+++ b/e2e/routes/crate/settings.spec.ts
@@ -123,6 +123,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
       await expect(page.locator('[data-test-no-config]')).not.toBeVisible();
 
       await percy.snapshot();
+      await expect(page).toMatchAriaSnapshot({ name: 'aria-trustpub-configs.yml' });
     });
 
     test.describe('GitHub', () => {
@@ -340,6 +341,7 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
         );
 
         await percy.snapshot();
+        await expect(page).toMatchAriaSnapshot({ name: 'aria-trustpub-warning.yml' });
       });
 
       test('disappears when checkbox is unchecked', async ({ msw, page }) => {

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -1,0 +1,159 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "User 1 (user-1) User 1 ▼":
+      - img "User 1 (user-1)"
+      - text: ""
+- main:
+  - heading "foo" [level=1]
+  - text: This is the description for the crate called "foo"
+  - button "Follow"
+  - navigation "foo crate subpages":
+    - list:
+      - listitem:
+        - link "Readme":
+          - /url: /crates/foo
+      - listitem:
+        - link "1 Version":
+          - /url: /crates/foo/versions
+      - listitem:
+        - link "Dependencies":
+          - /url: /crates/foo/dependencies
+      - listitem:
+        - link "Dependents":
+          - /url: /crates/foo/reverse_dependencies
+      - listitem:
+        - link "Security":
+          - /url: /crates/foo/security
+      - listitem:
+        - link "Settings":
+          - /url: /crates/foo/settings
+  - heading "Owners" [level=2]
+  - button "Add Owner"
+  - link "User 1 (user-1)":
+    - /url: /users/user-1
+    - img "User 1 (user-1)"
+  - link "User 1":
+    - /url: /users/user-1
+  - text: user-1@crates.io
+  - button "Remove"
+  - heading "Trusted Publishing" [level=2]
+  - link "Learn more":
+    - /url: /docs/trusted-publishing
+  - link "Add":
+    - /url: /crates/foo/settings/new-trusted-publisher
+  - table:
+    - rowgroup:
+      - row "Publisher Details Actions":
+        - columnheader "Publisher"
+        - columnheader "Details"
+        - columnheader "Actions"
+    - rowgroup:
+      - 'row /GitHub Repository: rust-lang\/crates\.io · Owner ID: \d+ Workflow: ci\.yml Remove/':
+        - cell "GitHub"
+        - 'cell /Repository: rust-lang\/crates\.io · Owner ID: \d+ Workflow: ci\.yml/':
+          - strong: "Repository:"
+          - link "rust-lang/crates.io":
+            - /url: https://github.com/rust-lang/crates.io
+          - text: ""
+          - strong: "Workflow:"
+          - link "ci.yml":
+            - /url: https://github.com/rust-lang/crates.io/blob/HEAD/.github/workflows/ci.yml
+        - cell "Remove":
+          - button "Remove"
+      - 'row /GitLab Repository: johndoe\/crates\.io · Namespace ID: \d+ Workflow: \.gitlab-ci\.yml Environment: production Remove/':
+        - cell "GitLab"
+        - 'cell /Repository: johndoe\/crates\.io · Namespace ID: \d+ Workflow: \.gitlab-ci\.yml Environment: production/':
+          - strong: "Repository:"
+          - link "johndoe/crates.io":
+            - /url: https://gitlab.com/johndoe/crates.io
+          - text: ""
+          - strong: "Workflow:"
+          - link ".gitlab-ci.yml":
+            - /url: https://gitlab.com/johndoe/crates.io/-/blob/HEAD/.gitlab-ci.yml
+          - strong: "Environment:"
+          - text: ""
+        - cell "Remove":
+          - button "Remove"
+  - checkbox "Require trusted publishing for all new versions When enabled, new versions can only be published through configured trusted publishers. Publishing with API tokens will be rejected."
+  - text: Require trusted publishing for all new versions When enabled, new versions can only be published through configured trusted publishers. Publishing with API tokens will be rejected.
+  - heading "Danger Zone" [level=2]
+  - link "Delete this crate":
+    - /url: /crates/foo/delete
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -1,0 +1,136 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "User 1 (user-1) User 1 ▼":
+      - img "User 1 (user-1)"
+      - text: ""
+- main:
+  - heading "foo" [level=1]
+  - text: This is the description for the crate called "foo"
+  - button "Follow"
+  - navigation "foo crate subpages":
+    - list:
+      - listitem:
+        - link "Readme":
+          - /url: /crates/foo
+      - listitem:
+        - link "1 Version":
+          - /url: /crates/foo/versions
+      - listitem:
+        - link "Dependencies":
+          - /url: /crates/foo/dependencies
+      - listitem:
+        - link "Dependents":
+          - /url: /crates/foo/reverse_dependencies
+      - listitem:
+        - link "Security":
+          - /url: /crates/foo/security
+      - listitem:
+        - link "Settings":
+          - /url: /crates/foo/settings
+  - heading "Owners" [level=2]
+  - button "Add Owner"
+  - link "User 1 (user-1)":
+    - /url: /users/user-1
+    - img "User 1 (user-1)"
+  - link "User 1":
+    - /url: /users/user-1
+  - text: user-1@crates.io
+  - button "Remove"
+  - heading "Trusted Publishing" [level=2]
+  - link "Learn more":
+    - /url: /docs/trusted-publishing
+  - link "Add":
+    - /url: /crates/foo/settings/new-trusted-publisher
+  - text: Trusted publishing is required but no publishers are configured. Publishing to this crate is currently blocked.
+  - table:
+    - rowgroup:
+      - row "Publisher Details Actions":
+        - columnheader "Publisher"
+        - columnheader "Details"
+        - columnheader "Actions"
+    - rowgroup:
+      - row "No trusted publishers configured for this crate.":
+        - cell "No trusted publishers configured for this crate."
+  - checkbox "Require trusted publishing for all new versions When enabled, new versions can only be published through configured trusted publishers. Publishing with API tokens will be rejected." [checked]
+  - text: Require trusted publishing for all new versions When enabled, new versions can only be published through configured trusted publishers. Publishing with API tokens will be rejected.
+  - heading "Danger Zone" [level=2]
+  - link "Delete this crate":
+    - /url: /crates/foo/delete
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts
@@ -187,6 +187,7 @@ test.describe('Route | crate.settings.new-trusted-publisher', { tag: '@routes' }
       );
 
       await percy.snapshot();
+      await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
 
       // Fill in the repository fields and confirm the note updates
       await page.fill('[data-test-namespace]', 'rust-lang');

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -1,0 +1,113 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+    - heading "crates.io" [level=1]
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Submit":
+      - text: ""
+      - img
+  - navigation:
+    - button "Change color scheme":
+      - img
+      - text: ""
+    - link "Browse All Crates":
+      - /url: /crates
+    - text: "|"
+    - button "User 1 (user-1) User 1 ▼":
+      - img "User 1 (user-1)"
+      - text: ""
+- main:
+  - heading "Add a new Trusted Publisher" [level=2]
+  - text: Publisher
+  - combobox "Publisher":
+    - option "GitHub" [selected]
+    - option "GitLab"
+  - text: Select the CI/CD platform where your publishing workflow is configured. Repository owner
+  - textbox "Repository owner"
+  - text: The GitHub organization name or GitHub username that owns the repository. Repository name
+  - textbox "Repository name"
+  - text: The name of the GitHub repository that contains the publishing workflow. Workflow filename
+  - textbox "Workflow filename"
+  - text: The filename of the publishing workflow. This file should be present in the
+  - code: .github/workflows/
+  - text: "directory of the repository configured above. For example:"
+  - code: release.yml
+  - text: or
+  - code: publish.yml
+  - text: . The workflow filename will be verified once all necessary fields are filled. Environment name (optional)
+  - textbox "Environment name (optional)"
+  - text: The name of the
+  - link "GitHub Actions environment":
+    - /url: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
+  - text: that the above workflow uses for publishing. This should be configured in the repository settings. A dedicated publishing environment is not required, but is
+  - strong: strongly recommended
+  - text: ", especially if your repository has maintainers with commit access who should not have crates.io publishing access."
+  - button "Add"
+  - link "Cancel":
+    - /url: /crates/foo/settings
+- contentinfo:
+  - heading "Rust" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=1]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=1]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=1]
+  - list:
+    - listitem:
+      - link "rust-lang/crates.io":
+        - /url: https://github.com/rust-lang/crates.io/
+        - img
+        - text: ""
+    - listitem:
+      - link "#t-crates-io":
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+        - img
+        - text: ""
+    - listitem:
+      - link "@cratesiostatus":
+        - /url: https://twitter.com/cratesiostatus
+        - img
+        - text: ""
+- text: "Add Trusted Publisher - foo - crates.io: Rust Package Registry"


### PR DESCRIPTION
This establishes baseline ARIA tree coverage on the important user-facing routes to catch silent structural and a11y regressions like role demotions, lost accessible names, or broken heading hierarchy.

The snapshots are colocated with existing `percy.snapshot()` calls, which already mark the curated UI states worth checking.

Most specs use `aria.yml`. Specs that snapshot multiple states use descriptive filenames to avoid collisions.