### PR TITLE
SearchForm: Remove unused `id` from desktop input

### DIFF
--- a/svelte/src/lib/components/SearchForm.svelte
+++ b/svelte/src/lib/components/SearchForm.svelte
@@ -71,7 +71,6 @@
     inputmode="search"
     class="input-lg"
     name="q"
-    id="cargo-desktop-search"
     placeholder="Type 'S' or '/' to search"
     autocorrect="off"
     bind:value={searchFormContext.value}


### PR DESCRIPTION
`id="cargo-desktop-search"` had no `<label for>`, JS, or CSS referencing it. Grepping the repo confirms the declaration site is the only mention.