### PR TITLE
Header: Clean up accessibility tree

### DIFF
--- a/e2e/acceptance/404.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/404.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/404.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/404.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/404.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/404.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/404.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/404.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/404.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/404.spec.ts-snapshots/aria.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "Page not found" [level=1]
   - button "Go Back"

--- a/e2e/acceptance/404.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/404.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "John Doe (johnnydee) John Doe":
       - img "John Doe (johnnydee)"
       - text: ""

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -14,9 +14,7 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - button "John Doe (johnnydee) John Doe":
-      - img "John Doe (johnnydee)"
-      - text: ""
+    - button "John Doe"
 - main:
   - heading "Account Settings" [level=1]
   - list:

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -15,7 +15,7 @@
     - link "Browse All Crates":
       - /url: /crates
     - text: "|"
-    - button "John Doe (johnnydee) John Doe ▼":
+    - button "John Doe (johnnydee) John Doe":
       - img "John Doe (johnnydee)"
       - text: ""
 - main:

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "John Doe"

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -7,9 +7,7 @@
       - text: category:algorithms
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -10,9 +10,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "Algorithms" [level=1]
   - paragraph: This is the description for the category called "Algorithms"

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -5,7 +5,7 @@
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
       - text: category:algorithms
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -24,7 +24,7 @@
   - paragraph: This is the description for the category called "Algorithms"
   - heading "Crates" [level=2]
   - text: Displaying 0-0 of 0 total results Sort by
-  - button "Recent Downloads ▼":
+  - button "Recent Downloads":
     - img
     - text: ""
   - list

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -5,9 +5,7 @@
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
       - text: category:algorithms
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -15,7 +15,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "All Categories" [level=1]
   - text: Displaying 1-4 of 4 total results Sort by

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -21,7 +21,7 @@
 - main:
   - heading "All Categories" [level=1]
   - text: Displaying 1-4 of 4 total results Sort by
-  - button "Alphabetical ▼":
+  - button "Alphabetical":
     - img
     - text: ""
   - link "API bindings":

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "nanomsg v0.6.1" [level=1]
   - text: A high-level, Rust idiomatic wrapper around nanomsg.

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -321,7 +321,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-keyword]')).toBeVisible();
 
     await page.fill('[data-test-search-input]', 'nanomsg');
-    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Submit' }).click();
+    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Search' }).click();
     await expect(page).toHaveURL('/search?q=nanomsg');
     await page.getByRole('link', { name: 'nanomsg', exact: true }).click();
 

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -80,7 +80,7 @@
   - text: 2 Versions published
   - heading /Downloads over the last \d+ days/ [level=4]
   - text: Display as
-  - button "Stacked ▼"
+  - button "Stacked"
 - contentinfo:
   - heading "Rust" [level=1]
   - list:

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "nanomsg v0.6.1" [level=1]
   - text: This is the description for the crate called "nanomsg"

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "nanomsg v0.6.0" [level=1]
   - text: This is the description for the crate called "nanomsg"

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -81,7 +81,7 @@
   - text: 2 Versions published
   - heading /Downloads over the last \d+ days/ [level=4]
   - text: Display as
-  - button "Stacked ▼"
+  - button "Stacked"
 - contentinfo:
   - heading "Rust" [level=1]
   - list:

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "All Crates" [level=1]
   - text: /Displaying 1-\d+ of \d+ total results Sort by/

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -21,7 +21,7 @@
 - main:
   - heading "All Crates" [level=1]
   - text: /Displaying 1-\d+ of \d+ total results Sort by/
-  - button "Recent Downloads ▼":
+  - button "Recent Downloads":
     - img
     - text: ""
   - list:

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "John Doe (johnnydee) John Doe":
       - img "John Doe (johnnydee)"
       - text: ""

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -14,9 +14,7 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - button "John Doe (johnnydee) John Doe":
-      - img "John Doe (johnnydee)"
-      - text: ""
+    - button "John Doe"
 - main:
   - heading "My Dashboard" [level=1]
   - img

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -15,7 +15,7 @@
     - link "Browse All Crates":
       - /url: /crates
     - text: "|"
-    - button "John Doe (johnnydee) John Doe ▼":
+    - button "John Doe (johnnydee) John Doe":
       - img "John Doe (johnnydee)"
       - text: ""
 - main:

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "John Doe"

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -10,9 +10,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - link "Install Cargo":
     - /url: https://doc.rust-lang.org/cargo/getting-started/installation.html

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - heading "The Rust community’s crate registry" [level=1]
   - search:
     - textbox "Search":

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -5,9 +5,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -5,7 +5,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -15,7 +15,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -7,9 +7,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -15,7 +15,7 @@
     - link "Browse All Crates":
       - /url: /crates
     - text: "|"
-    - button "User 3 (user-3) User 3 ▼":
+    - button "User 3 (user-3) User 3":
       - img "User 3 (user-3)"
       - text: ""
 - main:

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "User 3 (user-3) User 3":
       - img "User 3 (user-3)"
       - text: ""

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -14,9 +14,7 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - button "User 3 (user-3) User 3":
-      - img "User 3 (user-3)"
-      - text: ""
+    - button "User 3"
 - main:
   - heading "Pending Owner Invites" [level=1]
   - paragraph:

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "User 3"

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "All Crates for keyword 'network'" [level=1]
   - text: Displaying 0-0 of 0 total results Sort by

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -21,7 +21,7 @@
 - main:
   - heading "All Crates for keyword 'network'" [level=1]
   - text: Displaying 0-0 of 0 total results Sort by
-  - button "Recent Downloads ▼":
+  - button "Recent Downloads":
     - img
     - text: ""
   - list

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -174,7 +174,7 @@
   - text: 1 Versions published
   - heading /Downloads over the last \d+ days/ [level=4]
   - text: Display as
-  - button "Stacked ▼"
+  - button "Stacked"
 - contentinfo:
   - heading "Rust" [level=1]
   - list:

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "serde v1.0.0" [level=1]
   - text: This is the description for the crate called "serde"

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/search.spec.ts
+++ b/e2e/acceptance/search.spec.ts
@@ -8,7 +8,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
 
     await page.goto('/');
     await page.fill('[data-test-search-input]', 'rust');
-    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Submit' }).click();
+    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Search' }).click();
 
     await expect(page).toHaveURL('/search?q=rust');
     await expect(page).toHaveTitle("Search Results for 'rust' - crates.io: Rust Package Registry");
@@ -120,7 +120,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
 
     await page.goto('/');
     await page.fill('[data-test-search-input]', 'rust');
-    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Submit' }).click();
+    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Search' }).click();
 
     await expect(page.locator('[data-test-search-sort] [data-test-current-order]')).toHaveText('Relevance');
   });
@@ -134,7 +134,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
 
     await page.goto('/');
     await page.fill('[data-test-search-input]', 'rust');
-    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Submit' }).click();
+    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Search' }).click();
     await expect(page.locator('[data-test-crate-row]')).toHaveCount(0);
     await expect(page.locator('[data-test-error-message]')).toBeVisible();
     await expect(page.locator('[data-test-try-again-button]')).toBeEnabled();
@@ -168,7 +168,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
     msw.worker.use(http.get('/api/v1/crates', () => error));
 
     await page.fill('[data-test-search-input]', 'ru');
-    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Submit' }).click();
+    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Search' }).click();
     await expect(page.locator('[data-test-crate-row]')).toHaveCount(0);
     await expect(page.locator('[data-test-error-message]')).toBeVisible();
     await expect(page.locator('[data-test-try-again-button]')).toBeEnabled();

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -10,9 +10,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "Search Results for 'rust'" [level=1]
   - text: Displaying 1-7 of 7 total results Sort by

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -22,7 +22,7 @@
 - main:
   - heading "Search Results for 'rust'" [level=1]
   - text: Displaying 1-7 of 7 total results Sort by
-  - button "Relevance ▼":
+  - button "Relevance":
     - img
     - text: ""
   - list:

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -7,9 +7,7 @@
       - text: rust
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -5,7 +5,7 @@
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
       - text: rust
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -5,9 +5,7 @@
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
       - text: rust
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -15,7 +15,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/security.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/security.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/security.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/security.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/security.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/security.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/security.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/security.spec.ts-snapshots/aria.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "foo" [level=1]
   - text: This is the description for the crate called "foo"

--- a/e2e/acceptance/security.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/security.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/security.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/security.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -14,9 +14,7 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - button "blabaere (blabaere) blabaere":
-      - img "blabaere (blabaere)"
-      - text: ""
+    - button "blabaere"
 - main:
   - heading "nanomsg" [level=1]
   - text: This is the description for the crate called "nanomsg"

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "blabaere (blabaere) blabaere":
       - img "blabaere (blabaere)"
       - text: ""

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -15,7 +15,7 @@
     - link "Browse All Crates":
       - /url: /crates
     - text: "|"
-    - button "blabaere (blabaere) blabaere ▼":
+    - button "blabaere (blabaere) blabaere":
       - img "blabaere (blabaere)"
       - text: ""
 - main:

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "blabaere"

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "Contact Us" [level=1]
   - heading "Report A Crate" [level=2]

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "Contact Us" [level=1]
   - heading "Choose one of the these categories to continue." [level=2]

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -26,7 +26,7 @@
     - img "GitHub profile"
   - heading "thehydroimpulseteam" [level=2]
   - text: Displaying 1-1 of 1 total results Sort by
-  - button "Alphabetical ▼":
+  - button "Alphabetical":
     - img
     - text: ""
   - list:

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - img "thehydroimpulseteam (github:org:thehydroimpulse)"
   - heading "org" [level=1]

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "You've been added as a crate owner!" [level=1]
   - paragraph:

--- a/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - img "Daniel Fagnan (thehydroimpulse)"
   - heading "thehydroimpulse" [level=1]

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -25,7 +25,7 @@
     - /url: https://github.com/thehydroimpulse
     - img "GitHub profile"
   - text: Displaying 1-1 of 1 total results Sort by
-  - button "Alphabetical ▼":
+  - button "Alphabetical":
     - img
     - text: ""
   - list:

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -9,9 +9,7 @@
     - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
-    - button "Log in with GitHub":
-      - img
-      - text: ""
+    - button "Log in with GitHub"
 - main:
   - heading "nanomsg" [level=1]
   - text: This is the description for the crate called "nanomsg"

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "Log in with GitHub":
       - img
       - text: ""

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -43,7 +43,7 @@
   - strong: "4"
   - strong: nanomsg
   - text: /versions since June 16th, \d+ Sort by/
-  - button "Date ▼":
+  - button "Date":
     - img
     - text: ""
   - list:

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "Log in with GitHub":

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "User 1 (user-1) User 1":
       - img "User 1 (user-1)"
       - text: ""

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -14,9 +14,7 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - button "User 1 (user-1) User 1":
-      - img "User 1 (user-1)"
-      - text: ""
+    - button "User 1"
 - main:
   - heading "Delete the foo crate?" [level=1]
   - paragraph: Are you sure you want to delete the crate "foo"?

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "User 1"

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -15,7 +15,7 @@
     - link "Browse All Crates":
       - /url: /crates
     - text: "|"
-    - button "User 1 (user-1) User 1 ▼":
+    - button "User 1 (user-1) User 1":
       - img "User 1 (user-1)"
       - text: ""
 - main:

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "User 1 (user-1) User 1":
       - img "User 1 (user-1)"
       - text: ""

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "User 1"

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -14,9 +14,7 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - button "User 1 (user-1) User 1":
-      - img "User 1 (user-1)"
-      - text: ""
+    - button "User 1"
 - main:
   - heading "foo" [level=1]
   - text: This is the description for the crate called "foo"

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -15,7 +15,7 @@
     - link "Browse All Crates":
       - /url: /crates
     - text: "|"
-    - button "User 1 (user-1) User 1 ▼":
+    - button "User 1 (user-1) User 1":
       - img "User 1 (user-1)"
       - text: ""
 - main:

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "User 1 (user-1) User 1":
       - img "User 1 (user-1)"
       - text: ""

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "User 1"

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -14,9 +14,7 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - button "User 1 (user-1) User 1":
-      - img "User 1 (user-1)"
-      - text: ""
+    - button "User 1"
 - main:
   - heading "foo" [level=1]
   - text: This is the description for the crate called "foo"

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -15,7 +15,7 @@
     - link "Browse All Crates":
       - /url: /crates
     - text: "|"
-    - button "User 1 (user-1) User 1 ▼":
+    - button "User 1 (user-1) User 1":
       - img "User 1 (user-1)"
       - text: ""
 - main:

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -14,7 +14,6 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - text: "|"
     - button "User 1 (user-1) User 1":
       - img "User 1 (user-1)"
       - text: ""

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -4,7 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Submit":
+    - button "Search":
       - text: ""
       - img
   - navigation:

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -1,7 +1,6 @@
 - banner:
   - link "crates.io":
     - /url: /
-    - heading "crates.io" [level=1]
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -4,9 +4,7 @@
   - search:
     - textbox "Search":
       - /placeholder: Type 'S' or '/' to search
-    - button "Search":
-      - text: ""
-      - img
+    - button "Search"
   - navigation:
     - button "Change color scheme":
       - img

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -6,9 +6,7 @@
       - /placeholder: Type 'S' or '/' to search
     - button "Search"
   - navigation:
-    - button "Change color scheme":
-      - img
-      - text: ""
+    - 'button "Change color scheme. Current: system"'
     - link "Browse All Crates":
       - /url: /crates
     - button "User 1"

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -14,9 +14,7 @@
       - text: ""
     - link "Browse All Crates":
       - /url: /crates
-    - button "User 1 (user-1) User 1":
-      - img "User 1 (user-1)"
-      - text: ""
+    - button "User 1"
 - main:
   - heading "Add a new Trusted Publisher" [level=2]
   - text: Publisher

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -15,7 +15,7 @@
     - link "Browse All Crates":
       - /url: /crates
     - text: "|"
-    - button "User 1 (user-1) User 1 ▼":
+    - button "User 1 (user-1) User 1":
       - img "User 1 (user-1)"
       - text: ""
 - main:

--- a/svelte/src/lib/components/ColorSchemeMenu.svelte
+++ b/svelte/src/lib/components/ColorSchemeMenu.svelte
@@ -32,8 +32,8 @@
 <div class={['color-scheme-menu', className]} {...restProps}>
   <Dropdown.Root class="dropdown">
     <Dropdown.Trigger hideArrow class="trigger">
-      <CurrentIcon class="icon" />
-      <span class="sr-only">Change color scheme</span>
+      <CurrentIcon class="icon" aria-hidden="true" />
+      <span class="sr-only">Change color scheme. Current: {colorScheme.scheme}</span>
     </Dropdown.Trigger>
 
     <Dropdown.Menu class="menu">

--- a/svelte/src/lib/components/ColorSchemeMenu.svelte
+++ b/svelte/src/lib/components/ColorSchemeMenu.svelte
@@ -45,7 +45,7 @@
             type="button"
             onclick={() => colorScheme.setScheme(mode)}
           >
-            <Icon class="icon" />
+            <Icon class="icon" aria-hidden="true" />
             {mode}
           </button>
         </Dropdown.Item>

--- a/svelte/src/lib/components/Header.svelte
+++ b/svelte/src/lib/components/Header.svelte
@@ -132,7 +132,7 @@
           {#if isLoggingIn}
             <LoadingSpinner class="spinner" />
           {:else}
-            <LockIcon />
+            <LockIcon aria-hidden="true" />
           {/if}
           Log in with GitHub
         </button>

--- a/svelte/src/lib/components/Header.svelte
+++ b/svelte/src/lib/components/Header.svelte
@@ -53,7 +53,7 @@
       <ColorSchemeMenu class="color-scheme-menu" />
 
       <a href={resolve('/crates')} data-test-all-crates-link> Browse All Crates </a>
-      <span class="sep">|</span>
+      <span class="sep" aria-hidden="true">|</span>
 
       {#if currentUser}
         <Dropdown.Root data-test-user-menu>

--- a/svelte/src/lib/components/Header.svelte
+++ b/svelte/src/lib/components/Header.svelte
@@ -59,7 +59,8 @@
         <Dropdown.Root data-test-user-menu>
           <Dropdown.Trigger class="button-reset" data-test-toggle>
             {#if isSudoEnabled}
-              <div class="wizard-hat" data-test-wizard-hat>🧙</div>
+              <span class="sr-only">Admin mode active</span>
+              <div class="wizard-hat" aria-hidden="true" data-test-wizard-hat>🧙</div>
             {/if}
 
             <UserAvatar

--- a/svelte/src/lib/components/Header.svelte
+++ b/svelte/src/lib/components/Header.svelte
@@ -40,7 +40,7 @@
   <div class="header-inner width-limit">
     <a href={resolve('/')} class="index-link">
       <img src={logo} role="none" alt="" class="logo" />
-      <h1>crates.io</h1>
+      crates.io
     </a>
 
     <div class="search-form">
@@ -244,11 +244,9 @@
     grid-area: logo;
     display: flex;
     align-items: center;
-
-    & h1 {
-      margin: 0;
-      font-size: var(--space-m);
-    }
+    font-family: var(--font-heading);
+    font-size: var(--space-m);
+    font-weight: bold;
   }
 
   .logo {

--- a/svelte/src/lib/components/Header.svelte
+++ b/svelte/src/lib/components/Header.svelte
@@ -66,6 +66,7 @@
               user={{ ...currentUser, kind: 'user' }}
               size="small"
               style="margin-right: var(--space-2xs); margin-top: calc((22px - 1em) * -0.5)"
+              aria-hidden="true"
               data-test-avatar
             />
 

--- a/svelte/src/lib/components/SearchForm.svelte
+++ b/svelte/src/lib/components/SearchForm.svelte
@@ -95,7 +95,7 @@
 
   <button type="submit" class="submit-button button-reset">
     <span class="sr-only">Search</span>
-    <SearchIcon />
+    <SearchIcon aria-hidden="true" />
   </button>
 </form>
 

--- a/svelte/src/lib/components/SearchForm.svelte
+++ b/svelte/src/lib/components/SearchForm.svelte
@@ -94,7 +94,7 @@
   />
 
   <button type="submit" class="submit-button button-reset">
-    <span class="sr-only">Submit</span>
+    <span class="sr-only">Search</span>
     <SearchIcon />
   </button>
 </form>

--- a/svelte/src/lib/components/dropdown/Trigger.svelte
+++ b/svelte/src/lib/components/dropdown/Trigger.svelte
@@ -26,7 +26,7 @@
 >
   {@render children()}
   {#if !hideArrow}
-    <span class="arrow"></span>
+    <span class="arrow" aria-hidden="true"></span>
   {/if}
 </button>
 


### PR DESCRIPTION
Follow-up to #13692, which added ARIA tree snapshots that exposed a number of small accessibility issues across the persistent header. This PR works through them.

Changes are split into focused commits so each one is easy to review against the snapshot diff:

- `dropdown`: hide the decorative chevron glyph from the AT tree, so dropdown triggers no longer announce a trailing `▼` / `▲`.
- `Header`: hide the `|` separator, mark the redundant `<UserAvatar>` inside the user-menu trigger as decorative, replace the literally-spoken wizard emoji for sudo mode with an `sr-only` "Admin mode active" announcement, demote the global `<h1>crates.io</h1>` to plain text so each page's own `<h1>` is the sole top-level heading, and hide the decorative lock icon on the login button.
- `SearchForm`: rename the submit button's accessible name from "Submit" to "Search", and hide the decorative magnifying-glass icon.
- `ColorSchemeMenu`: hide the decorative trigger icon and include the active scheme in the trigger's `sr-only` label, and hide the per-item icons that duplicate the visible mode labels.

Every commit updates the ARIA snapshots in the same commit, so the AT-tree impact of each change is visible in the diff.

### Related

- https://github.com/rust-lang/crates.io/pull/13692