### PR TITLE
Footer: Clean up accessibility tree

### DIFF
--- a/e2e/acceptance/404.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/404.spec.ts-snapshots/aria.yml
@@ -62,17 +62,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/404.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/404.spec.ts-snapshots/aria.yml
@@ -14,7 +14,7 @@
   - heading "Page not found" [level=1]
   - button "Go Back"
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -25,7 +25,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -39,7 +39,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -59,7 +59,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -67,7 +67,7 @@
   - link "Cancel":
     - /url: /settings/tokens
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -78,7 +78,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -92,7 +92,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -112,7 +112,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -115,18 +115,12 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""
 - text: "Settings - crates.io: Rust Package Registry"

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -76,17 +76,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -28,7 +28,7 @@
           - /url: "?page=1"
     - img
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -39,7 +39,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -53,7 +53,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -73,7 +73,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -39,7 +39,7 @@
   - link "Add metadata!":
     - /url: https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -50,7 +50,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -64,7 +64,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -84,7 +84,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -87,17 +87,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -61,7 +61,7 @@
         - /url: /crates/mock-dev-deps/range/^0.6.1
       - text: optional This is the description for the crate called "mock-dev-deps"
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -72,7 +72,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -86,7 +86,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -106,7 +106,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -109,17 +109,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -122,17 +122,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -74,7 +74,7 @@
   - text: Display as
   - button "Stacked"
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -85,7 +85,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -99,7 +99,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -119,7 +119,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -75,7 +75,7 @@
   - text: Display as
   - button "Stacked"
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -86,7 +86,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -100,7 +100,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -120,7 +120,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -123,17 +123,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -520,7 +520,7 @@
           - /url: "?page=1"
     - img
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -531,7 +531,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -545,7 +545,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -565,7 +565,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -568,18 +568,12 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""
 - text: "Crates - crates.io: Rust Package Registry"

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -86,7 +86,7 @@
       - text: over 7 years ago
   - button "Load More"
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -97,7 +97,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -111,7 +111,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -131,7 +131,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -134,17 +134,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -359,17 +359,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -311,7 +311,7 @@
         - text: ""
         - img
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -322,7 +322,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -336,7 +336,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -356,7 +356,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -75,17 +75,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -27,7 +27,7 @@
   - button "Accept"
   - button "Decline"
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -38,7 +38,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -52,7 +52,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -72,7 +72,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -25,7 +25,7 @@
           - /url: "?page=1"
     - img
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -36,7 +36,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -50,7 +50,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -70,7 +70,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -73,17 +73,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -168,7 +168,7 @@
   - text: Display as
   - button "Stacked"
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -179,7 +179,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -193,7 +193,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -213,7 +213,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -216,17 +216,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -186,7 +186,7 @@
           - /url: "?q=rust&page=1"
     - img
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -197,7 +197,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -211,7 +211,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -231,7 +231,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -234,18 +234,12 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""
 - text: "Search Results for 'rust' - crates.io: Rust Package Registry"

--- a/e2e/acceptance/security.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/security.spec.ts-snapshots/aria.yml
@@ -109,17 +109,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/security.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/security.spec.ts-snapshots/aria.yml
@@ -61,7 +61,7 @@
         - text: ""
       - paragraph: This is the second test advisory with more details.
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -72,7 +72,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -86,7 +86,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -106,7 +106,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -127,17 +127,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -79,7 +79,7 @@
   - link "Delete this crate":
     - /url: /crates/nanomsg/delete
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -90,7 +90,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -104,7 +104,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -124,7 +124,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -92,18 +92,12 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""
 - text: "crates.io: Rust Package Registry"

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -44,7 +44,7 @@
     - text: ""
     - strong: help@crates.io
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -55,7 +55,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -69,7 +69,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -89,7 +89,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
@@ -23,7 +23,7 @@
         - text: ""
         - strong: help@crates.io
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -34,7 +34,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -48,7 +48,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -68,7 +68,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
@@ -71,17 +71,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -103,17 +103,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -55,7 +55,7 @@
           - /url: "?page=1"
     - img
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -66,7 +66,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -80,7 +80,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -100,7 +100,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
@@ -21,7 +21,7 @@
       - /url: /me
     - text: to manage email notification preferences for all of your crates.
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -32,7 +32,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -46,7 +46,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -66,7 +66,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
@@ -69,17 +69,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -54,7 +54,7 @@
           - /url: "?page=1"
     - img
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -65,7 +65,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -79,7 +79,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -99,7 +99,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -102,17 +102,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -146,17 +146,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -98,7 +98,7 @@
       - link "MIT":
         - /url: https://choosealicense.com/licenses/mit
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -109,7 +109,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -123,7 +123,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -143,7 +143,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -89,17 +89,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -41,7 +41,7 @@
   - text: I understand that deleting this crate is permanent and cannot be undone.
   - button "Delete this crate" [disabled]
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -52,7 +52,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -66,7 +66,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -86,7 +86,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -87,7 +87,7 @@
   - link "Delete this crate":
     - /url: /crates/foo/delete
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -98,7 +98,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -112,7 +112,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -132,7 +132,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -135,17 +135,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -112,17 +112,11 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -64,7 +64,7 @@
   - link "Delete this crate":
     - /url: /crates/foo/delete
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -75,7 +75,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -89,7 +89,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -109,7 +109,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -40,7 +40,7 @@
   - link "Cancel":
     - /url: /crates/foo/settings
 - contentinfo:
-  - heading "Rust" [level=1]
+  - heading "Rust" [level=2]
   - list:
     - listitem:
       - link "rust-lang.org":
@@ -51,7 +51,7 @@
     - listitem:
       - link "The crates.io team":
         - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
-  - heading "Get Help" [level=1]
+  - heading "Get Help" [level=2]
   - list:
     - listitem:
       - link "The Cargo Book":
@@ -65,7 +65,7 @@
     - listitem:
       - link "Report a bug":
         - /url: https://github.com/rust-lang/crates.io/issues/new/choose
-  - heading "Policies" [level=1]
+  - heading "Policies" [level=2]
   - list:
     - listitem:
       - link "Usage Policy":
@@ -85,7 +85,7 @@
     - listitem:
       - link "Rate Limits":
         - /url: /docs/rate-limits
-  - heading "Social" [level=1]
+  - heading "Social" [level=2]
   - list:
     - listitem:
       - link "rust-lang/crates.io":

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -88,18 +88,12 @@
   - heading "Social" [level=2]
   - list:
     - listitem:
-      - link "rust-lang/crates.io":
+      - 'link "GitHub: rust-lang/crates.io"':
         - /url: https://github.com/rust-lang/crates.io/
-        - img
-        - text: ""
     - listitem:
-      - link "#t-crates-io":
+      - 'link "Zulip: #t-crates-io"':
         - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
-        - img
-        - text: ""
     - listitem:
-      - link "@cratesiostatus":
+      - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-        - img
-        - text: ""
 - text: "Add Trusted Publisher - foo - crates.io: Rust Package Registry"

--- a/svelte/src/lib/components/Footer.svelte
+++ b/svelte/src/lib/components/Footer.svelte
@@ -42,9 +42,24 @@
     <div>
       <h2>Social</h2>
       <ul role="list">
-        <li><a href="https://github.com/rust-lang/crates.io/"><GitHub /> rust-lang/crates.io</a></li>
-        <li><a href="https://rust-lang.zulipchat.com/#streams/318791/t-crates-io"><Zulip /> #t-crates-io</a></li>
-        <li><a href="https://twitter.com/cratesiostatus"><Twitter /> @cratesiostatus</a></li>
+        <li>
+          <a href="https://github.com/rust-lang/crates.io/">
+            <GitHub aria-hidden="true" />
+            <span class="sr-only">GitHub: </span>rust-lang/crates.io
+          </a>
+        </li>
+        <li>
+          <a href="https://rust-lang.zulipchat.com/#streams/318791/t-crates-io">
+            <Zulip aria-hidden="true" />
+            <span class="sr-only">Zulip: </span>#t-crates-io
+          </a>
+        </li>
+        <li>
+          <a href="https://twitter.com/cratesiostatus">
+            <Twitter aria-hidden="true" />
+            <span class="sr-only">X: </span>@cratesiostatus
+          </a>
+        </li>
       </ul>
     </div>
   </div>

--- a/svelte/src/lib/components/Footer.svelte
+++ b/svelte/src/lib/components/Footer.svelte
@@ -9,7 +9,7 @@
 <footer class="footer">
   <div class="content width-limit">
     <div>
-      <h1>Rust</h1>
+      <h2>Rust</h2>
       <ul role="list">
         <li><a href="https://www.rust-lang.org/">rust-lang.org</a></li>
         <li><a href="https://foundation.rust-lang.org/">Rust Foundation</a></li>
@@ -18,7 +18,7 @@
     </div>
 
     <div>
-      <h1>Get Help</h1>
+      <h2>Get Help</h2>
       <ul role="list">
         <li><a href="https://doc.rust-lang.org/cargo/">The Cargo Book</a></li>
         <li><a href={resolve('/support')} data-test-support-link>Support</a></li>
@@ -28,7 +28,7 @@
     </div>
 
     <div>
-      <h1>Policies</h1>
+      <h2>Policies</h2>
       <ul role="list">
         <li><a href={resolve('/policies')}>Usage Policy</a></li>
         <li><a href={resolve('/policies/security')}>Security</a></li>
@@ -40,7 +40,7 @@
     </div>
 
     <div>
-      <h1>Social</h1>
+      <h2>Social</h2>
       <ul role="list">
         <li><a href="https://github.com/rust-lang/crates.io/"><GitHub /> rust-lang/crates.io</a></li>
         <li><a href="https://rust-lang.zulipchat.com/#streams/318791/t-crates-io"><Zulip /> #t-crates-io</a></li>
@@ -82,7 +82,7 @@
       grid-template-columns: repeat(4, 1fr);
     }
 
-    & h1 {
+    & h2 {
       margin: 0 0 var(--space-s);
       font-size: 20px;
       font-weight: 500;


### PR DESCRIPTION
Follow-up to #13704, applying the same kind of AT-tree cleanup to the page footer.

- `Footer`: demote the four section headings ("Rust", "Get Help", "Policies", "Social") from `<h1>` to `<h2>`, so they no longer compete with the page `<h1>` and the top-level heading count stays at one per page.
- `Footer`: prefix each social link with an `sr-only` platform name and mark the icon `aria-hidden="true"`, so accessible names read as `"GitHub: rust-lang/crates.io"`, `"Zulip: #t-crates-io"`, and `"X: @cratesiostatus"` instead of just the handle.

ARIA tree snapshots are updated in the same commits as the changes.


### Related

- https://github.com/rust-lang/crates.io/pull/13692
- https://github.com/rust-lang/crates.io/pull/13704