### PR TITLE
CrateRow: Clean up accessibility tree

### DIFF
--- a/e2e/acceptance/crates.spec.ts
+++ b/e2e/acceptance/crates.spec.ts
@@ -69,14 +69,18 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
     await loadFixtures(msw.db);
 
     await page.goto('/crates');
-    await expect(page.locator('[data-test-crate-row="0"] [data-test-downloads]')).toHaveText('All-Time: 21,573');
+    await expect(page.locator('[data-test-crate-row="0"] [data-test-downloads]')).toHaveText(
+      /All-Time\s*Downloads:\s*21,573/,
+    );
   });
 
   test('recent downloads appears for each crate on crate list', async ({ page, msw }) => {
     await loadFixtures(msw.db);
 
     await page.goto('/crates');
-    await expect(page.locator('[data-test-crate-row="0"] [data-test-recent-downloads]')).toHaveText('Recent: 2,000');
+    await expect(page.locator('[data-test-crate-row="0"] [data-test-recent-downloads]')).toHaveText(
+      /Recent\s*Downloads:\s*2,000/,
+    );
   });
 
   test('shows error message screen', async ({ page, msw }) => {

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -24,13 +24,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A (mostly) pure-Rust implementation of various common cryptographic algorithms.
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+,\\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A \\(mostly\\) pure-Rust implementation of various common cryptographic algorithms\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+,\\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -46,13 +40,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A generic serialization/deserialization framework
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A generic serialization\\/deserialization framework All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -68,13 +56,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A high-level, Rust idiomatic wrapper around nanomsg.
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A high-level, Rust idiomatic wrapper around nanomsg\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: /\d+ months ago/
       - list:
         - listitem:
@@ -93,13 +75,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A macro attribute for quickcheck.
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A macro attribute for quickcheck\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -118,13 +94,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: Rustless is a REST-like API micro-framework for Rust.
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/Rustless is a REST-like API micro-framework for Rust\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -140,13 +110,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "Use your favourite interpreted language to generate your Rust, right in your Rust. Supports Python, Ruby and shell (`sh`) out of the box, with an extensible macro to support any others. (See `rust_mix …"
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/Use your favourite interpreted language to generate your Rust, right in your Rust\\. Supports Python, Ruby and shell \\(`sh`\\) out of the box, with an extensible macro to support any others\\. \\(See `rust_mix … All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: over 2 years ago
       - list:
         - listitem:
@@ -165,13 +129,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: Automatic property based testing with shrinking.
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/Automatic property based testing with shrinking\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -190,13 +148,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A Kinetic protocol library written in Rust
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A Kinetic protocol library written in Rust All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: over 2 years ago
       - list:
         - listitem:
@@ -215,13 +167,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)"
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/Yo dawg, use Rust to generate Rust, right in your Rust\\. \\(See `external_mixin` to use scripting languages\\.\\) All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: over 2 years ago
       - list:
         - listitem:
@@ -240,13 +186,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files.
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -259,13 +199,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive.
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -281,13 +215,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A byte-oriented, zero-copy, parser combinators library
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A byte-oriented, zero-copy, parser combinators library All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: almost 2 years ago
       - list:
         - listitem:
@@ -303,13 +231,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: This is the description for the crate called "libc"
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/This is the description for the crate called \"libc\" All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: over 2 years ago
     - listitem:
       - heading "nanomsg-sys v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
@@ -318,13 +240,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: This is the description for the crate called "nanomsg-sys"
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/This is the description for the crate called \"nanomsg-sys\" All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: over 2 years ago
     - listitem:
       - heading "mock-build-deps v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
@@ -333,13 +249,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: This is the description for the crate called "mock-build-deps"
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/This is the description for the crate called \"mock-build-deps\" All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: over 2 years ago
     - listitem:
       - heading "mock-dev-deps v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
@@ -348,13 +258,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: This is the description for the crate called "mock-dev-deps"
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/This is the description for the crate called \"mock-dev-deps\" All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: over 2 years ago
     - listitem:
       - heading "rusted_cypher v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
@@ -363,13 +267,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: Send cypher queries to a neo4j database
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/Send cypher queries to a neo4j database All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -388,13 +286,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: An (incomplete) port of zlib to Rust. The decompressor works, but the compressor has not yet been ported.
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/An \\(incomplete\\) port of zlib to Rust\\. The decompressor works, but the compressor has not yet been ported\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: almost 3 years ago
     - listitem:
       - heading "rs-es v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
@@ -403,13 +295,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: Client for the ElasticSearch REST API
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/Client for the ElasticSearch REST API All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -425,13 +311,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A native PostgreSQL driver
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A native PostgreSQL driver All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -447,13 +327,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, title, upper, and lower cases as well as ordinalize, deordinalize, demodulize, and foreign key are supported as both trait …
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "Recent: 1"
-      - img
-      - text: "Updated:"
+      - text: "/Adds String based inflections for Rust\\. Snake, kebab, camel, sentence, class, title, upper, and lower cases as well as ordinalize, deordinalize, demodulize, and foreign key are supported as both trait … All-Time Downloads : \\d+ Recent Downloads : 1 Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -472,13 +346,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "Backing library for `rust_mixin` and `external_mixin` to keep them DRY."
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "Recent: 0"
-      - img
-      - text: "Updated:"
+      - text: "/Backing library for `rust_mixin` and `external_mixin` to keep them DRY\\. All-Time Downloads : \\d+ Recent Downloads : 0 Updated:/"
       - time: over 2 years ago
       - list:
         - listitem:
@@ -497,13 +365,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: Lexical analysers generator for Rust, written in Rust (crate dedicated to rumblebars, divergences written by Nicolas Cherel)
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "Recent: 0"
-      - img
-      - text: "Updated:"
+      - text: "/Lexical analysers generator for Rust, written in Rust \\(crate dedicated to rumblebars, divergences written by Nicolas Cherel\\) All-Time Downloads : \\d+ Recent Downloads : 0 Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -22,8 +22,7 @@
         - link "rust-crypto":
           - /url: /crates/rust-crypto
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A (mostly) pure-Rust implementation of various common cryptographic algorithms.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -43,8 +42,7 @@
         - link "serde":
           - /url: /crates/serde
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A generic serialization/deserialization framework
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -64,8 +62,7 @@
         - link "nanomsg":
           - /url: /crates/nanomsg
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A high-level, Rust idiomatic wrapper around nanomsg.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -88,8 +85,7 @@
         - link "quickcheck_macros":
           - /url: /crates/quickcheck_macros
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A macro attribute for quickcheck.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -112,8 +108,7 @@
         - link "rustless":
           - /url: /crates/rustless
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: Rustless is a REST-like API micro-framework for Rust.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -133,8 +128,7 @@
         - link "external_mixin":
           - /url: /crates/external_mixin
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: "Use your favourite interpreted language to generate your Rust, right in your Rust. Supports Python, Ruby and shell (`sh`) out of the box, with an extensible macro to support any others. (See `rust_mix …"
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -157,8 +151,7 @@
         - link "quickcheck":
           - /url: /crates/quickcheck
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: Automatic property based testing with shrinking.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -181,8 +174,7 @@
         - link "kinetic-rust":
           - /url: /crates/kinetic-rust
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A Kinetic protocol library written in Rust
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -205,8 +197,7 @@
         - link "rust_mixin":
           - /url: /crates/rust_mixin
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: "Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)"
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -229,8 +220,7 @@
         - link "rust-htslib":
           - /url: /crates/rust-htslib
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -247,8 +237,7 @@
         - link "rustful":
           - /url: /crates/rustful
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -268,8 +257,7 @@
         - link "nom":
           - /url: /crates/nom
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A byte-oriented, zero-copy, parser combinators library
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -289,8 +277,7 @@
         - link "libc":
           - /url: /crates/libc
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: This is the description for the crate called "libc"
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -303,8 +290,7 @@
         - link "nanomsg-sys":
           - /url: /crates/nanomsg-sys
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: This is the description for the crate called "nanomsg-sys"
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -317,8 +303,7 @@
         - link "mock-build-deps":
           - /url: /crates/mock-build-deps
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: This is the description for the crate called "mock-build-deps"
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -331,8 +316,7 @@
         - link "mock-dev-deps":
           - /url: /crates/mock-dev-deps
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: This is the description for the crate called "mock-dev-deps"
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -345,8 +329,7 @@
         - link "rusted_cypher":
           - /url: /crates/rusted_cypher
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: Send cypher queries to a neo4j database
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -369,8 +352,7 @@
         - link "zlib":
           - /url: /crates/zlib
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: An (incomplete) port of zlib to Rust. The decompressor works, but the compressor has not yet been ported.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -383,8 +365,7 @@
         - link "rs-es":
           - /url: /crates/rs-es
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: Client for the ElasticSearch REST API
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -404,8 +385,7 @@
         - link "postgres":
           - /url: /crates/postgres
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A native PostgreSQL driver
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -425,8 +405,7 @@
         - link "Inflector":
           - /url: /crates/Inflector
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, title, upper, and lower cases as well as ordinalize, deordinalize, demodulize, and foreign key are supported as both trait …
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -449,8 +428,7 @@
         - link "external_mixin_umbrella":
           - /url: /crates/external_mixin_umbrella
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: "Backing library for `rust_mixin` and `external_mixin` to keep them DRY."
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -473,8 +451,7 @@
         - link "unicorn-rpc":
           - /url: /crates/unicorn-rpc
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: Lexical analysers generator for Rust, written in Rust (crate dedicated to rumblebars, divergences written by Nicolas Cherel)
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -24,8 +24,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A \\(mostly\\) pure-Rust implementation of various common cryptographic algorithms\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+,\\d+ Updated:/"
-      - time: about 2 years ago
+      - text: A (mostly) pure-Rust implementation of various common cryptographic algorithms.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+,\\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -40,8 +45,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A generic serialization\\/deserialization framework All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: A generic serialization/deserialization framework
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Documentation":
@@ -56,8 +66,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A high-level, Rust idiomatic wrapper around nanomsg\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: /\d+ months ago/
+      - text: A high-level, Rust idiomatic wrapper around nanomsg.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: /\d+ months ago/
       - list:
         - listitem:
           - link "Homepage":
@@ -75,8 +90,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A macro attribute for quickcheck\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: A macro attribute for quickcheck.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -94,8 +114,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Rustless is a REST-like API micro-framework for Rust\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: Rustless is a REST-like API micro-framework for Rust.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -110,8 +135,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Use your favourite interpreted language to generate your Rust, right in your Rust\\. Supports Python, Ruby and shell \\(`sh`\\) out of the box, with an extensible macro to support any others\\. \\(See `rust_mix … All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: over 2 years ago
+      - text: "Use your favourite interpreted language to generate your Rust, right in your Rust. Supports Python, Ruby and shell (`sh`) out of the box, with an extensible macro to support any others. (See `rust_mix …"
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: over 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -129,8 +159,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Automatic property based testing with shrinking\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: Automatic property based testing with shrinking.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -148,8 +183,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A Kinetic protocol library written in Rust All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: over 2 years ago
+      - text: A Kinetic protocol library written in Rust
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: over 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -167,8 +207,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Yo dawg, use Rust to generate Rust, right in your Rust\\. \\(See `external_mixin` to use scripting languages\\.\\) All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: over 2 years ago
+      - text: "Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)"
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: over 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -186,8 +231,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Repository":
@@ -199,8 +249,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Documentation":
@@ -215,8 +270,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A byte-oriented, zero-copy, parser combinators library All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: almost 2 years ago
+      - text: A byte-oriented, zero-copy, parser combinators library
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: almost 2 years ago
       - list:
         - listitem:
           - link "Documentation":
@@ -231,8 +291,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/This is the description for the crate called \"libc\" All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: over 2 years ago
+      - text: This is the description for the crate called "libc"
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: over 2 years ago
     - listitem:
       - heading "nanomsg-sys v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
         - link "nanomsg-sys":
@@ -240,8 +305,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/This is the description for the crate called \"nanomsg-sys\" All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: over 2 years ago
+      - text: This is the description for the crate called "nanomsg-sys"
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: over 2 years ago
     - listitem:
       - heading "mock-build-deps v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
         - link "mock-build-deps":
@@ -249,8 +319,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/This is the description for the crate called \"mock-build-deps\" All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: over 2 years ago
+      - text: This is the description for the crate called "mock-build-deps"
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: over 2 years ago
     - listitem:
       - heading "mock-dev-deps v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
         - link "mock-dev-deps":
@@ -258,8 +333,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/This is the description for the crate called \"mock-dev-deps\" All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: over 2 years ago
+      - text: This is the description for the crate called "mock-dev-deps"
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: over 2 years ago
     - listitem:
       - heading "rusted_cypher v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
         - link "rusted_cypher":
@@ -267,8 +347,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Send cypher queries to a neo4j database All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: Send cypher queries to a neo4j database
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -286,8 +371,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/An \\(incomplete\\) port of zlib to Rust\\. The decompressor works, but the compressor has not yet been ported\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: almost 3 years ago
+      - text: An (incomplete) port of zlib to Rust. The decompressor works, but the compressor has not yet been ported.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: almost 3 years ago
     - listitem:
       - heading "rs-es v1.0.0 Copy Cargo.toml snippet to clipboard" [level=2]:
         - link "rs-es":
@@ -295,8 +385,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Client for the ElasticSearch REST API All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: Client for the ElasticSearch REST API
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Documentation":
@@ -311,8 +406,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A native PostgreSQL driver All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: A native PostgreSQL driver
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Documentation":
@@ -327,8 +427,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Adds String based inflections for Rust\\. Snake, kebab, camel, sentence, class, title, upper, and lower cases as well as ordinalize, deordinalize, demodulize, and foreign key are supported as both trait … All-Time Downloads : \\d+ Recent Downloads : 1 Updated:/"
-      - time: about 2 years ago
+      - text: Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, title, upper, and lower cases as well as ordinalize, deordinalize, demodulize, and foreign key are supported as both trait …
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "Recent Downloads : 1"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -346,8 +451,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Backing library for `rust_mixin` and `external_mixin` to keep them DRY\\. All-Time Downloads : \\d+ Recent Downloads : 0 Updated:/"
-      - time: over 2 years ago
+      - text: "Backing library for `rust_mixin` and `external_mixin` to keep them DRY."
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "Recent Downloads : 0"
+        - listitem:
+          - text: "Updated:"
+          - time: over 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -365,8 +475,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Lexical analysers generator for Rust, written in Rust \\(crate dedicated to rumblebars, divergences written by Nicolas Cherel\\) All-Time Downloads : \\d+ Recent Downloads : 0 Updated:/"
-      - time: about 2 years ago
+      - text: Lexical analysers generator for Rust, written in Rust (crate dedicated to rumblebars, divergences written by Nicolas Cherel)
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "Recent Downloads : 0"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Homepage":

--- a/e2e/acceptance/search.spec.ts
+++ b/e2e/acceptance/search.spec.ts
@@ -23,7 +23,9 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-crate-row="0"] [data-test-description]')).toHaveText(
       'A Kinetic protocol library written in Rust',
     );
-    await expect(page.locator('[data-test-crate-row="0"] [data-test-downloads]')).toHaveText('All-Time: 225');
+    await expect(page.locator('[data-test-crate-row="0"] [data-test-downloads]')).toHaveText(
+      /All-Time\s*Downloads:\s*225/,
+    );
     await expect(page.locator('[data-test-crate-row="0"] [data-test-updated-at]')).toBeVisible();
 
     await percy.snapshot();

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -25,13 +25,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A Kinetic protocol library written in Rust
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A Kinetic protocol library written in Rust All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: over 2 years ago
       - list:
         - listitem:
@@ -50,13 +44,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)"
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/Yo dawg, use Rust to generate Rust, right in your Rust\\. \\(See `external_mixin` to use scripting languages\\.\\) All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: over 2 years ago
       - list:
         - listitem:
@@ -75,13 +63,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A (mostly) pure-Rust implementation of various common cryptographic algorithms.
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+,\\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A \\(mostly\\) pure-Rust implementation of various common cryptographic algorithms\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+,\\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -97,13 +79,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files.
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -116,13 +92,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: Rustless is a REST-like API micro-framework for Rust.
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/Rustless is a REST-like API micro-framework for Rust\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -138,13 +108,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: Send cypher queries to a neo4j database
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/Send cypher queries to a neo4j database All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:
@@ -163,13 +127,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive.
-      - img
-      - text: "/All-Time: \\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
       - time: about 2 years ago
       - list:
         - listitem:

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -23,8 +23,7 @@
         - link "kinetic-rust":
           - /url: /crates/kinetic-rust
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A Kinetic protocol library written in Rust
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -47,8 +46,7 @@
         - link "rust_mixin":
           - /url: /crates/rust_mixin
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: "Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)"
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -71,8 +69,7 @@
         - link "rust-crypto":
           - /url: /crates/rust-crypto
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A (mostly) pure-Rust implementation of various common cryptographic algorithms.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"
@@ -92,8 +89,7 @@
         - link "rust-htslib":
           - /url: /crates/rust-htslib
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -110,8 +106,7 @@
         - link "rustless":
           - /url: /crates/rustless
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: Rustless is a REST-like API micro-framework for Rust.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -131,8 +126,7 @@
         - link "rusted_cypher":
           - /url: /crates/rusted_cypher
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: Send cypher queries to a neo4j database
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"
@@ -155,8 +149,7 @@
         - link "rustful":
           - /url: /crates/rustful
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+/"

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -25,8 +25,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A Kinetic protocol library written in Rust All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: over 2 years ago
+      - text: A Kinetic protocol library written in Rust
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: over 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -44,8 +49,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Yo dawg, use Rust to generate Rust, right in your Rust\\. \\(See `external_mixin` to use scripting languages\\.\\) All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: over 2 years ago
+      - text: "Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)"
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: over 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -63,8 +73,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A \\(mostly\\) pure-Rust implementation of various common cryptographic algorithms\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+,\\d+ Updated:/"
-      - time: about 2 years ago
+      - text: A (mostly) pure-Rust implementation of various common cryptographic algorithms.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+,\\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -79,8 +94,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Repository":
@@ -92,8 +112,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Rustless is a REST-like API micro-framework for Rust\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: Rustless is a REST-like API micro-framework for Rust.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -108,8 +133,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/Send cypher queries to a neo4j database All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: Send cypher queries to a neo4j database
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Homepage":
@@ -127,8 +157,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive\\. All-Time Downloads : \\d+ Recent Downloads : \\d+ Updated:/"
-      - time: about 2 years ago
+      - text: A light HTTP framework, with some REST-like features and the ambition of being simple, modular and non-intrusive.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: about 2 years ago
       - list:
         - listitem:
           - link "Documentation":

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -29,8 +29,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A high-level, Rust idiomatic wrapper around nanomsg\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: /\d+ months ago/
+      - text: A high-level, Rust idiomatic wrapper around nanomsg.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: /\d+ months ago/
       - list:
         - listitem:
           - link "Homepage":

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -29,13 +29,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A high-level, Rust idiomatic wrapper around nanomsg.
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A high-level, Rust idiomatic wrapper around nanomsg\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: /\d+ months ago/
       - list:
         - listitem:

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -27,8 +27,7 @@
         - link "nanomsg":
           - /url: /crates/nanomsg
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A high-level, Rust idiomatic wrapper around nanomsg.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -28,13 +28,7 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: A high-level, Rust idiomatic wrapper around nanomsg.
-      - img
-      - text: "/All-Time: \\d+,\\d+/"
-      - img
-      - text: "/Recent: \\d+/"
-      - img
-      - text: "Updated:"
+      - text: "/A high-level, Rust idiomatic wrapper around nanomsg\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
       - time: /\d+ months ago/
       - list:
         - listitem:

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -26,8 +26,7 @@
         - link "nanomsg":
           - /url: /crates/nanomsg
         - text: ""
-        - button "Copy Cargo.toml snippet to clipboard":
-          - img "Copy Cargo.toml snippet to clipboard"
+        - button "Copy Cargo.toml snippet to clipboard"
       - text: A high-level, Rust idiomatic wrapper around nanomsg.
       - list "Statistics":
         - listitem: "/All-Time Downloads : \\d+,\\d+/"

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -28,8 +28,13 @@
         - text: ""
         - button "Copy Cargo.toml snippet to clipboard":
           - img "Copy Cargo.toml snippet to clipboard"
-      - text: "/A high-level, Rust idiomatic wrapper around nanomsg\\. All-Time Downloads : \\d+,\\d+ Recent Downloads : \\d+ Updated:/"
-      - time: /\d+ months ago/
+      - text: A high-level, Rust idiomatic wrapper around nanomsg.
+      - list "Statistics":
+        - listitem: "/All-Time Downloads : \\d+,\\d+/"
+        - listitem: "/Recent Downloads : \\d+/"
+        - listitem:
+          - text: "Updated:"
+          - time: /\d+ months ago/
       - list:
         - listitem:
           - link "Homepage":

--- a/svelte/src/lib/components/CrateRow.svelte
+++ b/svelte/src/lib/components/CrateRow.svelte
@@ -52,27 +52,27 @@
 
   <div class="stats">
     <div class="downloads" data-test-downloads>
-      <DownloadIcon class="download-icon" />
+      <DownloadIcon class="download-icon" aria-hidden="true" />
       <span>
         <span>
-          All-Time:
+          All-Time<span class="sr-only"> Downloads</span>:
           <Tooltip text="Total number of downloads" />
         </span>
         {crate.downloads.toLocaleString()}
       </span>
     </div>
     <div class="recent-downloads" data-test-recent-downloads>
-      <DownloadIcon class="download-icon" />
+      <DownloadIcon class="download-icon" aria-hidden="true" />
       <span>
         <span>
-          Recent:
+          Recent<span class="sr-only"> Downloads</span>:
           <Tooltip text="Downloads in the last 90 days" />
         </span>
         {(crate.recent_downloads ?? 0).toLocaleString()}
       </span>
     </div>
     <div class="updated-at">
-      <LatestUpdatesIcon height="32" width="32" />
+      <LatestUpdatesIcon height="32" width="32" aria-hidden="true" />
       <span>
         <span>
           Updated:

--- a/svelte/src/lib/components/CrateRow.svelte
+++ b/svelte/src/lib/components/CrateRow.svelte
@@ -39,7 +39,7 @@
           class="copy-button button-reset"
           data-test-copy-toml-button
         >
-          <CopyIcon aria-label="Copy Cargo.toml snippet to clipboard" />
+          <CopyIcon aria-hidden="true" />
         </CopyButton>
       {/if}
     </div>

--- a/svelte/src/lib/components/CrateRow.svelte
+++ b/svelte/src/lib/components/CrateRow.svelte
@@ -50,8 +50,8 @@
     {/if}
   </div>
 
-  <div class="stats">
-    <div class="downloads" data-test-downloads>
+  <ul class="stats" role="list" aria-label="Statistics">
+    <li class="downloads" data-test-downloads>
       <DownloadIcon class="download-icon" aria-hidden="true" />
       <span>
         <span>
@@ -60,8 +60,8 @@
         </span>
         {crate.downloads.toLocaleString()}
       </span>
-    </div>
-    <div class="recent-downloads" data-test-recent-downloads>
+    </li>
+    <li class="recent-downloads" data-test-recent-downloads>
       <DownloadIcon class="download-icon" aria-hidden="true" />
       <span>
         <span>
@@ -70,8 +70,8 @@
         </span>
         {(crate.recent_downloads ?? 0).toLocaleString()}
       </span>
-    </div>
-    <div class="updated-at">
+    </li>
+    <li class="updated-at">
       <LatestUpdatesIcon height="32" width="32" aria-hidden="true" />
       <span>
         <span>
@@ -83,8 +83,8 @@
           <Tooltip text={updatedAt.toString()} />
         </time>
       </span>
-    </div>
-  </div>
+    </li>
+  </ul>
 
   {#if crate.homepage || crate.documentation || crate.repository}
     <ul class="quick-links">
@@ -185,6 +185,9 @@
   .stats {
     width: 30%;
     color: var(--main-color-light);
+    list-style: none;
+    padding: 0;
+    margin: 0;
 
     > :global(* + *) {
       margin-top: var(--space-xs);


### PR DESCRIPTION
Applies the same kind of AT-tree cleanup as the previous a11y PRs to the `CrateRow` component used on the crates list, search results, team pages, and user pages.

- Hide the decorative stat icons (`aria-hidden="true"`) and extend the ambiguous "All-Time:" / "Recent:" labels with an inline `sr-only` "Downloads" so the AT representation reads "All-Time Downloads:" and "Recent Downloads:" while the visible labels stay compact.
- Wrap the `.stats` block as `<ul aria-label="Statistics">` with one `<li>` per stat, so screen reader users get a labelled boundary, an item count, and item-by-item navigation instead of one flat run of text.
- Mark the `CopyIcon` inside the per-row Cargo.toml copy button as `aria-hidden="true"`, bringing it in line with the same icon's usage in `InstallInstructions` and the tokens page and removing the duplicate accessible name.

A handful of existing tests switch from exact `toHaveText` to regex matching, because Playwright's `innerText` includes `sr-only` content and the previous exact-string assertions would otherwise become brittle.

ARIA tree snapshots are updated in the same commits as the changes.

### Related

- https://github.com/rust-lang/crates.io/pull/13692
- https://github.com/rust-lang/crates.io/pull/13704
- https://github.com/rust-lang/crates.io/pull/13705