### PR TITLE
version-list/Row: Clean up accessibility tree

### DIFF
--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -41,7 +41,7 @@
   - list:
     - listitem:
       - text: Release track 0.2 (latest)
-      - link "0.2.1":
+      - link "Version 0.2.1":
         - /url: /crates/nanomsg/0.2.1
       - list "Version metadata":
         - listitem:
@@ -56,7 +56,7 @@
             - /url: https://choosealicense.com/licenses/mit
     - listitem:
       - text: Release track 0.3 (latest)
-      - link "0.3.0":
+      - link "Version 0.3.0":
         - /url: /crates/nanomsg/0.3.0
       - list "Version metadata":
         - listitem: in about 1 year
@@ -71,7 +71,7 @@
             - /url: https://choosealicense.com/licenses/apache-2.0
     - listitem:
       - text: Release track 0.2
-      - link "0.2.0":
+      - link "Version 0.2.0":
         - /url: /crates/nanomsg/0.2.0
       - list "Version metadata":
         - listitem: in about 1 month
@@ -82,7 +82,7 @@
             - /url: https://choosealicense.com/licenses/apache-2.0
     - listitem:
       - text: Release track 0.1 (latest)
-      - link "0.1.0":
+      - link "Version 0.1.0":
         - /url: /crates/nanomsg/0.1.0
       - list "Version metadata":
         - listitem: /\d+ months ago/

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -46,28 +46,16 @@
       - text: via
       - link "GitHub":
         - /url: https://github.com/octo-org/octo-repo/actions/runs/1234567890
-        - img
-        - text: ""
-      - time:
-        - img
-        - text: in about 2 years
-      - img
-      - text: /\d+ KiB/
-      - img
+      - time: in about 2 years
+      - text: "/Size: \\d+ KiB License:/"
       - link "MIT":
         - /url: https://choosealicense.com/licenses/mit
     - listitem:
       - text: "0.3"
       - link "0.3.0":
         - /url: /crates/nanomsg/0.3.0
-      - time:
-        - img
-        - text: in about 1 year
-      - img
-      - text: /v1\.\d+\.\d+/
-      - img
-      - text: /\d+ KiB/
-      - img
+      - time: in about 1 year
+      - text: "/Minimum Rust version: v1\\.\\d+\\.\\d+ Size: \\d+ KiB License:/"
       - link "MIT":
         - /url: https://choosealicense.com/licenses/mit
       - text: OR
@@ -77,24 +65,16 @@
       - text: "0.2"
       - link "0.2.0":
         - /url: /crates/nanomsg/0.2.0
-      - time:
-        - img
-        - text: in about 1 month
-      - img
-      - text: /\d+ KiB/
-      - img
+      - time: in about 1 month
+      - text: "/Size: \\d+ KiB License:/"
       - link "Apache-2.0":
         - /url: https://choosealicense.com/licenses/apache-2.0
     - listitem:
       - text: "0.1"
       - link "0.1.0":
         - /url: /crates/nanomsg/0.1.0
-      - time:
-        - img
-        - text: /\d+ months ago/
-      - img
-      - text: /\d+ KiB/
-      - img
+      - time: /\d+ months ago/
+      - text: "/Size: \\d+ KiB License:/"
       - link "MIT":
         - /url: https://choosealicense.com/licenses/mit
 - contentinfo:

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -40,7 +40,7 @@
     - text: ""
   - list:
     - listitem:
-      - text: "0.2"
+      - text: Release track 0.2 (latest)
       - link "0.2.1":
         - /url: /crates/nanomsg/0.2.1
       - list "Version metadata":
@@ -55,7 +55,7 @@
           - link "MIT":
             - /url: https://choosealicense.com/licenses/mit
     - listitem:
-      - text: "0.3"
+      - text: Release track 0.3 (latest)
       - link "0.3.0":
         - /url: /crates/nanomsg/0.3.0
       - list "Version metadata":
@@ -70,7 +70,7 @@
           - link "Apache-2.0":
             - /url: https://choosealicense.com/licenses/apache-2.0
     - listitem:
-      - text: "0.2"
+      - text: Release track 0.2
       - link "0.2.0":
         - /url: /crates/nanomsg/0.2.0
       - list "Version metadata":
@@ -81,7 +81,7 @@
           - link "Apache-2.0":
             - /url: https://choosealicense.com/licenses/apache-2.0
     - listitem:
-      - text: "0.1"
+      - text: Release track 0.1 (latest)
       - link "0.1.0":
         - /url: /crates/nanomsg/0.1.0
       - list "Version metadata":

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -43,40 +43,54 @@
       - text: "0.2"
       - link "0.2.1":
         - /url: /crates/nanomsg/0.2.1
-      - text: via
-      - link "GitHub":
-        - /url: https://github.com/octo-org/octo-repo/actions/runs/1234567890
-      - time: in about 2 years
-      - text: "/Size: \\d+ KiB License:/"
-      - link "MIT":
-        - /url: https://choosealicense.com/licenses/mit
+      - list "Version metadata":
+        - listitem:
+          - text: via
+          - link "GitHub":
+            - /url: https://github.com/octo-org/octo-repo/actions/runs/1234567890
+        - listitem: in about 2 years
+        - listitem: "/Size: \\d+ KiB/"
+        - listitem:
+          - text: "License:"
+          - link "MIT":
+            - /url: https://choosealicense.com/licenses/mit
     - listitem:
       - text: "0.3"
       - link "0.3.0":
         - /url: /crates/nanomsg/0.3.0
-      - time: in about 1 year
-      - text: "/Minimum Rust version: v1\\.\\d+\\.\\d+ Size: \\d+ KiB License:/"
-      - link "MIT":
-        - /url: https://choosealicense.com/licenses/mit
-      - text: OR
-      - link "Apache-2.0":
-        - /url: https://choosealicense.com/licenses/apache-2.0
+      - list "Version metadata":
+        - listitem: in about 1 year
+        - listitem: "/Minimum Rust version: v1\\.\\d+\\.\\d+/"
+        - listitem: "/Size: \\d+ KiB/"
+        - listitem:
+          - text: "License:"
+          - link "MIT":
+            - /url: https://choosealicense.com/licenses/mit
+          - text: OR
+          - link "Apache-2.0":
+            - /url: https://choosealicense.com/licenses/apache-2.0
     - listitem:
       - text: "0.2"
       - link "0.2.0":
         - /url: /crates/nanomsg/0.2.0
-      - time: in about 1 month
-      - text: "/Size: \\d+ KiB License:/"
-      - link "Apache-2.0":
-        - /url: https://choosealicense.com/licenses/apache-2.0
+      - list "Version metadata":
+        - listitem: in about 1 month
+        - listitem: "/Size: \\d+ KiB/"
+        - listitem:
+          - text: "License:"
+          - link "Apache-2.0":
+            - /url: https://choosealicense.com/licenses/apache-2.0
     - listitem:
       - text: "0.1"
       - link "0.1.0":
         - /url: /crates/nanomsg/0.1.0
-      - time: /\d+ months ago/
-      - text: "/Size: \\d+ KiB License:/"
-      - link "MIT":
-        - /url: https://choosealicense.com/licenses/mit
+      - list "Version metadata":
+        - listitem: /\d+ months ago/
+        - listitem: "/Size: \\d+ KiB/"
+        - listitem:
+          - text: "License:"
+          - link "MIT":
+            - /url: https://choosealicense.com/licenses/mit
 - contentinfo:
   - heading "Rust" [level=2]
   - list:

--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -169,10 +169,10 @@
     </a>
   </div>
 
-  <div class="metadata">
-    <div class="metadata-row">
+  <div class="metadata" role="list" aria-label="Version metadata">
+    <div class="metadata-row" role="presentation">
       {#if publishedBy}
-        <span class="publisher">
+        <span class="publisher" role="listitem">
           by
           <a href={resolve('/users/[user_id]', { user_id: publishedBy.login })}>
             <UserAvatar user={publishedBy} class="avatar" />
@@ -180,7 +180,7 @@
           </a>
         </span>
       {:else if trustpubPublisher}
-        <span class="publisher trustpub">
+        <span class="publisher trustpub" role="listitem">
           via
           {#if trustpubUrl}
             <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
@@ -203,7 +203,7 @@
         </span>
       {/if}
 
-      <time datetime={formatISO(version.created_at)} class="date" class:new={isNew}>
+      <time datetime={formatISO(version.created_at)} class="date" class:new={isNew} role="listitem">
         <CalendarIcon aria-hidden="true" />
         {formatDistanceToNow(version.created_at, { addSuffix: true })}
 
@@ -217,22 +217,22 @@
     </div>
 
     {#if version.crate_size || version.license || featureList.length !== 0}
-      <div class="metadata-row">
+      <div class="metadata-row" role="presentation">
         {#if version.rust_version}
-          <span class="msrv">
+          <span class="msrv" role="listitem">
             <RustIcon aria-hidden="true" />
             <span class="sr-only">Minimum Rust version:</span>
             <Msrv msrv={version.rust_version} edition={version.edition} />
           </span>
         {:else if version.edition}
-          <span class="edition">
+          <span class="edition" role="listitem">
             <RustIcon aria-hidden="true" />
             <Edition edition={version.edition} />
           </span>
         {/if}
 
         {#if version.crate_size}
-          <span class="bytes">
+          <span class="bytes" role="listitem">
             <WeightIcon aria-hidden="true" />
             <span class="sr-only">Size:</span>
             {prettyBytes(version.crate_size, { binary: true })}
@@ -240,7 +240,7 @@
         {/if}
 
         {#if version.license}
-          <span class="license">
+          <span class="license" role="listitem">
             <LicenseIcon aria-hidden="true" />
             <span class="sr-only">License:</span>
             <LicenseExpression license={version.license} />
@@ -248,7 +248,7 @@
         {/if}
 
         {#if featureList.length !== 0}
-          <span class="num-features" data-test-feature-list>
+          <span class="num-features" role="listitem" data-test-feature-list>
             <CheckboxIcon aria-hidden="true" />
             {featureList.length}
             {featureList.length === 1 ? 'Feature' : 'Features'}

--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -173,6 +173,7 @@
       onfocusout={() => (focused = false)}
       data-test-release-track-link
     >
+      <span class="sr-only">Version</span>
       {version.num}
     </a>
   </div>

--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -128,7 +128,8 @@
   <div class="version">
     <div class="release-track" data-test-release-track>
       {#if version.yanked}
-        <TrashIcon />
+        <TrashIcon aria-hidden="true" />
+        <span class="sr-only">Yanked</span>
       {:else if !semver}
         ?
       {:else}
@@ -185,17 +186,17 @@
             <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
             <a href={trustpubUrl} target="_blank" rel="nofollow noopener noreferrer">
               {#if trustpubProvider === 'github'}
-                <GitHubIcon />
+                <GitHubIcon aria-hidden="true" />
               {:else if trustpubProvider === 'gitlab'}
-                <GitLabIcon />
+                <GitLabIcon aria-hidden="true" />
               {/if}
               {trustpubPublisher}
             </a>
           {:else}
             {#if trustpubProvider === 'github'}
-              <GitHubIcon />
+              <GitHubIcon aria-hidden="true" />
             {:else if trustpubProvider === 'gitlab'}
-              <GitLabIcon />
+              <GitLabIcon aria-hidden="true" />
             {/if}
             {trustpubPublisher}
           {/if}
@@ -203,7 +204,7 @@
       {/if}
 
       <time datetime={formatISO(version.created_at)} class="date" class:new={isNew}>
-        <CalendarIcon />
+        <CalendarIcon aria-hidden="true" />
         {formatDistanceToNow(version.created_at, { addSuffix: true })}
 
         <Tooltip>
@@ -219,33 +220,36 @@
       <div class="metadata-row">
         {#if version.rust_version}
           <span class="msrv">
-            <RustIcon />
+            <RustIcon aria-hidden="true" />
+            <span class="sr-only">Minimum Rust version:</span>
             <Msrv msrv={version.rust_version} edition={version.edition} />
           </span>
         {:else if version.edition}
           <span class="edition">
-            <RustIcon />
+            <RustIcon aria-hidden="true" />
             <Edition edition={version.edition} />
           </span>
         {/if}
 
         {#if version.crate_size}
           <span class="bytes">
-            <WeightIcon />
+            <WeightIcon aria-hidden="true" />
+            <span class="sr-only">Size:</span>
             {prettyBytes(version.crate_size, { binary: true })}
           </span>
         {/if}
 
         {#if version.license}
           <span class="license">
-            <LicenseIcon />
+            <LicenseIcon aria-hidden="true" />
+            <span class="sr-only">License:</span>
             <LicenseExpression license={version.license} />
           </span>
         {/if}
 
         {#if featureList.length !== 0}
           <span class="num-features" data-test-feature-list>
-            <CheckboxIcon />
+            <CheckboxIcon aria-hidden="true" />
             {featureList.length}
             {featureList.length === 1 ? 'Feature' : 'Features'}
 
@@ -254,11 +258,12 @@
                 {#each features.list as feature (feature.name)}
                   <li>
                     {#if feature.isDefault}
-                      <CheckboxIcon />
+                      <CheckboxIcon aria-hidden="true" />
                     {:else}
-                      <CheckboxEmptyIcon />
+                      <CheckboxEmptyIcon aria-hidden="true" />
                     {/if}
                     {feature.name}
+                    {#if feature.isDefault}<span class="sr-only">(default)</span>{/if}
                   </li>
                 {/each}
                 {#if features.more > 0}
@@ -279,7 +284,7 @@
   <PrivilegedAction userAuthorised={isOwner} class="actions">
     <Dropdown.Root class="dropdown" data-test-actions-menu>
       <Dropdown.Trigger hideArrow class="trigger" data-test-actions-toggle>
-        <EllipsisCircleIcon class="icon" />
+        <EllipsisCircleIcon class="icon" aria-hidden="true" />
         <span class="sr-only">Actions</span>
       </Dropdown.Trigger>
 

--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -131,9 +131,17 @@
         <TrashIcon aria-hidden="true" />
         <span class="sr-only">Yanked</span>
       {:else if !semver}
-        ?
+        <span aria-hidden="true">?</span>
+        <span class="sr-only">Unable to parse version</span>
       {:else}
-        {releaseTrack}
+        <span aria-hidden="true">{releaseTrack}</span>
+        <span class="sr-only">
+          Release track {releaseTrack}
+          {#if isPrerelease || isHighestOfReleaseTrack}
+            ({#if isPrerelease}prerelease{/if}{#if isPrerelease && isHighestOfReleaseTrack},
+            {/if}{#if isHighestOfReleaseTrack}latest{/if})
+          {/if}
+        </span>
       {/if}
 
       <Tooltip side="right">

--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -184,7 +184,7 @@
         <span class="publisher" role="listitem">
           by
           <a href={resolve('/users/[user_id]', { user_id: publishedBy.login })}>
-            <UserAvatar user={publishedBy} class="avatar" />
+            <UserAvatar user={publishedBy} class="avatar" aria-hidden="true" />
             {publishedBy.name ?? publishedBy.login}
           </a>
         </span>


### PR DESCRIPTION
Applies the same kind of AT-tree cleanup as the previous a11y PRs to the version-list `Row` component used on the per-crate versions list and the front page recent releases.

- Hide the many decorative icons (release date, trustpub provider, license, MSRV, size, features, default-feature marker, actions menu) that surfaced as unnamed `img` nodes. Where the icon carried unique information, replace it with `sr-only` text: "Yanked", "Minimum Rust version:", "Size:", "License:", and a "(default)" suffix on default feature names.
- Wrap the metadata block as a labelled list via `role="list"` + `aria-label="Version metadata"` on the outer container and `role="listitem"` on each leaf, with `role="presentation"` on the two `.metadata-row` wrappers. ARIA roles are used instead of native `<ul>`/`<li>` so the existing two-row visual layout can stay intact.
- Announce the release-track glyph (the styled circle on the left) via an `sr-only` sibling reading e.g. "Release track 0.2 (latest)", "Release track 1.0 (prerelease)", or "Unable to parse version", matching what the hover tooltip already says.
- Add an `sr-only` "Version" prefix to the version number link so its accessible name reads "Version 0.2.1" instead of a bare number.
- Mark the publisher avatar `aria-hidden="true"` so the publisher link's accessible name no longer doubles the username.

ARIA tree snapshots are updated in the same commits as the changes.

### Related

- https://github.com/rust-lang/crates.io/pull/13692
- https://github.com/rust-lang/crates.io/pull/13704
- https://github.com/rust-lang/crates.io/pull/13705
- https://github.com/rust-lang/crates.io/pull/13706