### PR TITLE
version-list/RowTestWrapper: Set up tooltip context

### DIFF
--- a/svelte/src/lib/components/version-list/RowTestWrapper.svelte
+++ b/svelte/src/lib/components/version-list/RowTestWrapper.svelte
@@ -3,6 +3,8 @@
 
   import { createClient } from '@crates-io/api-client';
 
+  import TooltipContainer from '$lib/components/TooltipContainer.svelte';
+  import { setTooltipContext } from '$lib/tooltip.svelte';
   import { SessionState, setSession } from '$lib/utils/session.svelte';
   import Row from './Row.svelte';
 
@@ -14,10 +16,15 @@
   }
 
   let { version, crateName }: Props = $props();
+  let propsId = $props.id();
 
   // Row uses PrivilegedAction, which requires a session context.
   let session = new SessionState(createClient({ fetch }));
   setSession(session);
+
+  // Row uses Tooltip, which requires a tooltip context.
+  setTooltipContext({ containerId: `tooltip-container-${propsId}` });
 </script>
 
 <Row {version} {crateName} />
+<TooltipContainer />


### PR DESCRIPTION
`Row` renders three `Tooltip` instances (release-track, date, features). `Tooltip` reads its container id from a tooltip context that is set up at the layout level for the live app, but the test wrapper did not provide one. When a `Tooltip` became visible during a test (focus or hover on its anchor), the missing context surfaced as an unhandled `missing_context` error.

The same wrapper already sets up a session context for `PrivilegedAction`. Mirroring that pattern, set up a tooltip context and render a `TooltipContainer` so any tooltip activated during the test has its container to mount into.

This should hopefully unblock the failing `Frontend / Test` CI job on #13707.

### Related

- https://github.com/rust-lang/crates.io/pull/13707