### PR TITLE
Clean up accessibility tree for the crate detail page

### DIFF
--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -220,10 +220,10 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await loadFixtures(msw.db);
 
     await page.goto('/crates/nanomsg');
-    await expect(page.locator('[data-test-license]')).toHaveText('Apache-2.0');
+    await expect(page.locator('[data-test-license]')).toHaveText(/License:\s*Apache-2\.0/);
 
     await page.goto('/crates/nanomsg/0.5.0');
-    await expect(page.locator('[data-test-license]')).toHaveText('MIT OR Apache-2.0');
+    await expect(page.locator('[data-test-license]')).toHaveText(/License:\s*MIT OR Apache-2\.0/);
   });
 
   test('sidebar shows correct information', async ({ page, msw }) => {

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -35,23 +35,14 @@
   - text: file
   - region "Crate metadata":
     - heading "Metadata" [level=2]
-    - time:
-      - img
-      - text: over 7 years ago
-    - img
-    - text: /v1\.\d+\.\d+/
-    - img
+    - time: "Release date: over 7 years ago"
+    - text: "/Minimum Rust version: v1\\.\\d+\\.\\d+ License:/"
     - link "Apache-2.0":
       - /url: https://choosealicense.com/licenses/apache-2.0
-    - img
-    - text: /\d+,\d+ SLoC/
-    - img
-    - text: /\d+ KiB/
-    - img
+    - text: "/\\d+,\\d+ SLoC Size: \\d+ KiB Package URL:/"
     - button "pkg:cargo/nanomsg@0.6.1?repository_url=https%3A%2F%2Flocalhost%3A4173%2F"
     - link "Learn more":
       - /url: https://github.com/package-url/purl-spec
-      - img
     - heading "Install" [level=2]
     - paragraph: "Run the following Cargo command in your project directory:"
     - button "cargo add nanomsg"

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -49,7 +49,6 @@
     - paragraph: "Or add the following line to your Cargo.toml:"
     - button "nanomsg = \"0.6.1\""
     - heading "Browse source" [level=2]
-    - img
     - link "docs.rs/crate/nanomsg/0.6.1/source":
       - /url: https://docs.rs/crate/nanomsg/0.6.1/source/
     - heading "Owners" [level=2]

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -56,10 +56,7 @@
     - link "Report crate":
       - /url: /support?crate=nanomsg&inquire=crate-violation
   - heading "Stats Overview" [level=3]
-  - img
-  - text: /\d+,\d+ Downloads all time/
-  - img
-  - text: 2 Versions published
+  - text: /\d+,\d+ Downloads all time 2 Versions published/
   - heading /Downloads over the last \d+ days/ [level=4]
   - text: Display as
   - button "Stacked"

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -59,10 +59,7 @@
     - text: ""
     - link "(see all)":
       - /url: /crates/nanomsg
-  - img
-  - text: /\d+,\d+ Downloads all time/
-  - img
-  - text: 2 Versions published
+  - text: /\d+,\d+ Downloads all time 2 Versions published/
   - heading /Downloads over the last \d+ days/ [level=4]
   - text: Display as
   - button "Stacked"

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -49,7 +49,6 @@
     - paragraph: "Or add the following line to your Cargo.toml:"
     - button "nanomsg = \"=0.6.0\""
     - heading "Browse source" [level=2]
-    - img
     - link "docs.rs/crate/nanomsg/0.6.0/source":
       - /url: https://docs.rs/crate/nanomsg/0.6.0/source/
     - heading "Owners" [level=2]

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -35,21 +35,14 @@
   - text: file
   - region "Crate metadata":
     - heading "Metadata" [level=2]
-    - time:
-      - img
-      - text: over 7 years ago
-    - img
+    - time: "Release date: over 7 years ago"
+    - text: "License:"
     - link "MIT":
       - /url: https://choosealicense.com/licenses/mit
-    - img
-    - text: /\d+ SLoC/
-    - img
-    - text: /\d+ KiB/
-    - img
+    - text: "/\\d+ SLoC Size: \\d+ KiB Package URL:/"
     - button "pkg:cargo/nanomsg@0.6.0?repository_url=https%3A%2F%2Flocalhost%3A4173%2F"
     - link "Learn more":
       - /url: https://github.com/package-url/purl-spec
-      - img
     - heading "Install" [level=2]
     - paragraph: "Run the following Cargo command in your project directory:"
     - button "cargo add nanomsg@=0.6.0"

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -131,21 +131,14 @@
             - /url: "#user-content-fnref-1"
   - region "Crate metadata":
     - heading "Metadata" [level=2]
-    - time:
-      - img
-      - text: over 7 years ago
-    - img
+    - time: "Release date: over 7 years ago"
+    - text: "License:"
     - link "MIT":
       - /url: https://choosealicense.com/licenses/mit
-    - img
-    - text: /\d+ SLoC/
-    - img
-    - text: /\d+ KiB/
-    - img
+    - text: "/\\d+ SLoC Size: \\d+ KiB Package URL:/"
     - button "pkg:cargo/serde@1.0.0?repository_url=https%3A%2F%2Flocalhost%3A4173%2F"
     - link "Learn more":
       - /url: https://github.com/package-url/purl-spec
-      - img
     - heading "Install" [level=2]
     - paragraph: "Run the following Cargo command in your project directory:"
     - button "cargo add serde"

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -152,10 +152,7 @@
     - link "Report crate":
       - /url: /support?crate=serde&inquire=crate-violation
   - heading "Stats Overview" [level=3]
-  - img
-  - text: /\d+,\d+ Downloads all time/
-  - img
-  - text: 1 Versions published
+  - text: /\d+,\d+ Downloads all time 1 Versions published/
   - heading /Downloads over the last \d+ days/ [level=4]
   - text: Display as
   - button "Stacked"

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -145,7 +145,6 @@
     - paragraph: "Or add the following line to your Cargo.toml:"
     - button "serde = \"1.0.0\""
     - heading "Browse source" [level=2]
-    - img
     - link "docs.rs/crate/serde/1.0.0/source":
       - /url: https://docs.rs/crate/serde/1.0.0/source/
     - heading "Owners" [level=2]

--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -128,7 +128,7 @@
 
     <div class="stat">
       <span class="num">
-        <DownloadIcon />
+        <DownloadIcon aria-hidden="true" />
         <span class="num__align">{numberFormat.format(downloadsContext.downloads)}</span>
       </span>
       <span class="text--small">Downloads all time</span>
@@ -136,7 +136,7 @@
 
     <div class="stat">
       <span class="num">
-        <CrateIcon />
+        <CrateIcon aria-hidden="true" />
         <span class="num__align">{crate.num_versions}</span>
       </span>
       <span class="text--small">Versions published</span>

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
@@ -107,7 +107,8 @@
     <h2 class="heading">Metadata</h2>
 
     <time datetime={formatISO(version.created_at)} class="date">
-      <CalendarIcon />
+      <CalendarIcon aria-hidden="true" />
+      <span class="sr-only">Release date:</span>
       <span>
         {formatDistanceToNow(version.created_at, { addSuffix: true })}
         <Tooltip>
@@ -119,19 +120,21 @@
 
     {#if version.rust_version}
       <div class="msrv" data-test-msrv>
-        <RustIcon />
+        <RustIcon aria-hidden="true" />
+        <span class="sr-only">Minimum Rust version:</span>
         <Msrv msrv={version.rust_version} edition={version.edition ?? undefined} />
       </div>
     {:else if version.edition}
       <div class="edition" data-test-edition>
-        <RustIcon />
+        <RustIcon aria-hidden="true" />
         <Edition edition={version.edition} />
       </div>
     {/if}
 
     {#if version.license}
       <div class="license" data-test-license>
-        <LicenseIcon />
+        <LicenseIcon aria-hidden="true" />
+        <span class="sr-only">License:</span>
         <span>
           <LicenseExpression license={version.license} />
         </span>
@@ -140,7 +143,7 @@
 
     {#if version.linecounts?.total_code_lines}
       <div class="linecount" data-test-linecounts>
-        <CodeIcon />
+        <CodeIcon aria-hidden="true" />
         <span>
           {formatShortNum(Number(version.linecounts.total_code_lines))} SLoC
           <Tooltip>
@@ -153,7 +156,8 @@
 
     {#if version.crate_size}
       <div class="bytes">
-        <WeightIcon />
+        <WeightIcon aria-hidden="true" />
+        <span class="sr-only">Size:</span>
         <span>
           {prettyBytes(version.crate_size, { binary: true })}
           <Tooltip text="Compressed package size" />
@@ -162,7 +166,8 @@
     {/if}
 
     <div class="purl" data-test-purl>
-      <LinkIcon />
+      <LinkIcon aria-hidden="true" />
+      <span class="sr-only">Package URL:</span>
       <CopyButton copyText={purl} class="button-reset purl-copy-button">
         <span class="purl-text">{purl}</span>
         <Tooltip>
@@ -180,7 +185,7 @@
         class="purl-help-link"
         aria-label="Learn more"
       >
-        <CircleQuestionIcon />
+        <CircleQuestionIcon aria-hidden="true" />
         <Tooltip text="Learn more about Package URLs" />
       </a>
     </div>

--- a/svelte/src/lib/components/crate-sidebar/Link.svelte
+++ b/svelte/src/lib/components/crate-sidebar/Link.svelte
@@ -40,15 +40,15 @@
   <h2 class="title" data-test-title>{title}</h2>
   <div class="content">
     {#if text.startsWith('docs.rs/')}
-      <DocsRsIcon class="icon" data-test-icon="docs-rs" />
+      <DocsRsIcon class="icon" data-test-icon="docs-rs" aria-hidden="true" />
     {:else if text.startsWith('github.com/')}
-      <GitHubIcon class="icon" data-test-icon="github" />
+      <GitHubIcon class="icon" data-test-icon="github" aria-hidden="true" />
     {:else if text.startsWith('gitlab.com/')}
-      <GitLabIcon class="icon" data-test-icon="gitlab" />
+      <GitLabIcon class="icon" data-test-icon="gitlab" aria-hidden="true" />
     {:else if text.startsWith('codeberg.org/')}
-      <CodebergIcon class="icon" data-test-icon="codeberg" />
+      <CodebergIcon class="icon" data-test-icon="codeberg" aria-hidden="true" />
     {:else}
-      <LinkIcon class="icon" data-test-icon="link" />
+      <LinkIcon class="icon" data-test-icon="link" aria-hidden="true" />
     {/if}
 
     <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->


### PR DESCRIPTION
Applies the same kind of AT-tree cleanup as the previous a11y PRs to the per-crate detail page (`CrateSidebar`, its `Link` sub-component, and the `CrateVersionPage` Stats Overview section).

- `CrateSidebar`: hide the metadata icons (`aria-hidden="true"`) and replace the visual-only cues with `sr-only` text where the icon was the sole source of context: "Release date:", "Minimum Rust version:", "License:", "Size:", and "Package URL:". Icons that pair with already-named text (edition, SLoC, "Learn more") are simply hidden. Two license-test assertions switch from exact `toHaveText` to regex matching to absorb the new `sr-only` prefix.
- `crate-sidebar/Link`: hide the platform icon (docs.rs / GitHub / GitLab / Codeberg / fallback). The surrounding `<h2>` already names the section and the link text contains the platform's domain.
- `CrateVersionPage`: hide the download and crate icons in the Stats Overview block. The companion small-text label ("Downloads all time", "Versions published") already names each stat.

ARIA tree snapshots are updated in the same commits as the changes.

### Related

- https://github.com/rust-lang/crates.io/pull/13692
- https://github.com/rust-lang/crates.io/pull/13704
- https://github.com/rust-lang/crates.io/pull/13705
- https://github.com/rust-lang/crates.io/pull/13706
- https://github.com/rust-lang/crates.io/pull/13707
- https://github.com/rust-lang/crates.io/pull/13709