### PR TITLE
a11y: Promote section headings to fix heading hierarchy

### DIFF
--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -15,13 +15,13 @@
   - paragraph: Are you sure you want to delete the crate "foo"?
   - strong: "Important:"
   - text: This action will permanently delete the crate and its associated versions. Deleting a crate cannot be reversed!
-  - heading "Potential Impact:" [level=3]
+  - heading "Potential Impact:" [level=2]
   - list:
     - listitem: Users will no longer be able to download this crate.
     - listitem: Any dependencies or projects relying on this crate will be broken.
     - listitem: Deleted crates cannot be restored.
     - listitem: /Publishing a crate with the same name will be blocked for \d+ hours\./
-  - heading "Requirements:" [level=3]
+  - heading "Requirements:" [level=2]
   - paragraph: A crate can only be deleted if it is not depended upon by any other crate on crates.io.
   - paragraph: "Additionally, a crate can only be deleted if either:"
   - list:
@@ -34,7 +34,7 @@
           - text: the crate only has a single owner,
           - emphasis: and
         - listitem: /the crate has been downloaded less than \d+ times for each month it has been published\./
-  - heading "Reason:" [level=3]
+  - heading "Reason:" [level=2]
   - paragraph: "Please tell us why you are deleting this crate:"
   - textbox "Please tell us why you are deleting this crate:"
   - checkbox "I understand that deleting this crate is permanent and cannot be undone."

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -11,7 +11,7 @@
       - /url: /crates
     - button "User 1"
 - main:
-  - heading "Add a new Trusted Publisher" [level=2]
+  - heading "Add a new Trusted Publisher" [level=1]
   - text: Publisher
   - combobox "Publisher":
     - option "GitHub" [selected]

--- a/svelte/src/routes/crates/[crate_id]/delete/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/delete/+page.svelte
@@ -65,7 +65,7 @@
     </Alert>
 
     <div class="impact">
-      <h3>Potential Impact:</h3>
+      <h2>Potential Impact:</h2>
       <ul>
         <li>Users will no longer be able to download this crate.</li>
         <li>Any dependencies or projects relying on this crate will be broken.</li>
@@ -75,7 +75,7 @@
     </div>
 
     <div class="requirements">
-      <h3>Requirements:</h3>
+      <h2>Requirements:</h2>
       <p>A crate can only be deleted if it is not depended upon by any other crate on crates.io.</p>
       <p>Additionally, a crate can only be deleted if either:</p>
       <ol class="first">
@@ -93,7 +93,7 @@
     </div>
 
     <div class="reason">
-      <h3>Reason:</h3>
+      <h2>Reason:</h2>
       <label>
         <p>Please tell us why you are deleting this crate:</p>
         <input type="text" bind:value={reason} required class="reason-input base-input" data-test-reason />
@@ -135,6 +135,11 @@
 
   .title {
     margin-top: 0;
+  }
+
+  h2 {
+    font-size: 1.17em;
+    margin: 1em 0;
   }
 
   .impact,

--- a/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/new-trusted-publisher/+page.svelte
@@ -160,7 +160,7 @@
 <PageTitle title="Add Trusted Publisher" />
 
 <form class="form" onsubmit={handleSubmit}>
-  <h2>Add a new Trusted Publisher</h2>
+  <h1>Add a new Trusted Publisher</h1>
 
   <div class="form-group">
     <label for="publisher" class="form-group-name">Publisher</label>
@@ -427,6 +427,11 @@
   .form {
     max-width: 600px;
     margin: var(--space-m) auto;
+  }
+
+  h1 {
+    font-size: 1.5em;
+    margin: 0.83em 0;
   }
 
   .form-group,


### PR DESCRIPTION
Two small heading-level fixes flagged by the ARIA tree snapshots.

- `new-trusted-publisher`: the page used `<h2>` as its top heading and had no `<h1>` at all, so screen reader users navigating by heading could not identify the page's primary heading.
- `delete-crate`: the "Potential Impact", "Requirements" and "Reason" section headings were `<h3>` directly under the page `<h1>`, skipping `<h2>` (WCAG 1.3.1 failure).

In both cases the promoted headings get a scoped style that pins their rendered size and margin to the previous browser defaults, so the visual appearance is unchanged.

### Related

- https://github.com/rust-lang/crates.io/pull/13692
- https://github.com/rust-lang/crates.io/pull/13709
- https://github.com/rust-lang/crates.io/pull/13710
- https://github.com/rust-lang/crates.io/pull/13711