### PR TITLE
a11y: Restructure the pending invites list

### DIFF
--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -12,19 +12,22 @@
     - button "User 3"
 - main:
   - heading "Pending Owner Invites" [level=1]
-  - paragraph:
-    - text: Success! You've been added as an owner of crate
-    - link "nanomsg":
-      - /url: /crates/nanomsg
-    - text: .
-  - link "ember-rs":
-    - /url: /crates/ember-rs
-  - text: "Invited by:"
-  - link "wycats":
-    - /url: /users/wycats
-  - text: in about 3 years
-  - button "Accept"
-  - button "Decline"
+  - list:
+    - listitem:
+      - paragraph:
+        - text: Success! You've been added as an owner of crate
+        - link "nanomsg":
+          - /url: /crates/nanomsg
+        - text: .
+    - listitem:
+      - link "ember-rs":
+        - /url: /crates/ember-rs
+      - text: "Invited by:"
+      - link "wycats":
+        - /url: /users/wycats
+      - text: in about 3 years
+      - button "Accept"
+      - button "Decline"
 - contentinfo:
   - heading "Rust" [level=2]
   - list:

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -17,9 +17,8 @@
     - link "nanomsg":
       - /url: /crates/nanomsg
     - text: .
-  - heading "ember-rs" [level=3]:
-    - link "ember-rs":
-      - /url: /crates/ember-rs
+  - link "ember-rs":
+    - /url: /crates/ember-rs
   - text: "Invited by:"
   - link "wycats":
     - /url: /users/wycats

--- a/svelte/src/lib/components/PendingOwnerInviteRow.svelte
+++ b/svelte/src/lib/components/PendingOwnerInviteRow.svelte
@@ -65,11 +65,9 @@
 {:else}
   <div class="row" data-test-invite={invite.crate_name}>
     <div class="crate-column">
-      <h3>
-        <a href={resolve('/crates/[crate_id]', { crate_id: invite.crate_name })} data-test-crate-link>
-          {invite.crate_name}
-        </a>
-      </h3>
+      <a class="crate-link" href={resolve('/crates/[crate_id]', { crate_id: invite.crate_name })} data-test-crate-link>
+        {invite.crate_name}
+      </a>
     </div>
     <div>
       Invited by:
@@ -113,9 +111,11 @@
 
   .crate-column {
     width: 200px;
+  }
 
-    h3 {
-      margin: 0;
-    }
+  .crate-link {
+    font-family: var(--font-heading);
+    font-size: 1.17em;
+    font-weight: bold;
   }
 </style>

--- a/svelte/src/routes/me/pending-invites/+page.svelte
+++ b/svelte/src/routes/me/pending-invites/+page.svelte
@@ -11,11 +11,17 @@
 <PageHeader title="Pending Owner Invites" />
 
 <div class="list">
-  {#each data.invites as invite (invite.crate_id)}
-    <PendingOwnerInviteRow {invite} />
+  {#if data.invites.length !== 0}
+    <ul>
+      {#each data.invites as invite (invite.crate_id)}
+        <li>
+          <PendingOwnerInviteRow {invite} />
+        </li>
+      {/each}
+    </ul>
   {:else}
     <p data-test-empty-state>You don't seem to have any pending invitations.</p>
-  {/each}
+  {/if}
 </div>
 
 <style>
@@ -24,13 +30,23 @@
     border-radius: var(--space-3xs);
     box-shadow: 0 1px 3px light-dark(hsla(51, 90%, 42%, 0.35), #232321);
     margin-bottom: var(--space-s);
+  }
 
-    > :global(*) {
-      padding: var(--space-s);
-    }
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 
-    > :global(* + *) {
+  li {
+    padding: var(--space-s);
+
+    & + & {
       border-top: 1px solid light-dark(hsla(51, 90%, 42%, 0.25), #232321);
     }
+  }
+
+  p {
+    padding: var(--space-s);
   }
 </style>


### PR DESCRIPTION
Two related fixes for the `/me/pending-invites` page surfaced by the ARIA tree snapshots.

- `PendingOwnerInviteRow`: the crate name link was wrapped in `<h3>`, creating a heading-level skip from the page `<h1>` directly to `<h3>`. The crate name is not a section heading, just the most prominent piece of information in the row, so the `<h3>` wrapper is replaced with a plain `<a>` carrying heading-like font styling.
- `pending-invites/+page`: the rows were bare children of a container `<div>`, with the row dividers and padding applied via `> *` selectors. The rows now sit inside a `<ul>` with one `<li>` per invite so screen reader users can tell they form a collection. The padding and divider styles move onto `<li>`, and the empty-state paragraph stays as a sibling of the list.

The visual layout is unchanged in both cases.

### Related

- https://github.com/rust-lang/crates.io/pull/13692
- https://github.com/rust-lang/crates.io/pull/13709
- https://github.com/rust-lang/crates.io/pull/13710
- https://github.com/rust-lang/crates.io/pull/13711
- https://github.com/rust-lang/crates.io/pull/13716