### PR TITLE
a11y: Fix fieldset usage in the report-a-crate form

### DIFF
--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -13,9 +13,8 @@
 - main:
   - heading "Contact Us" [level=1]
   - heading "Report A Crate" [level=2]
-  - group:
-    - text: Crate
-    - textbox "Crate"
+  - text: Crate
+  - textbox "Crate"
   - group "Reasons":
     - list:
       - listitem:
@@ -36,9 +35,8 @@
       - listitem:
         - checkbox "it is violating the usage policy in some other way (please specify below)"
         - text: it is violating the usage policy in some other way (please specify below)
-  - group:
-    - text: Detail
-    - textbox "Detail"
+  - text: Detail
+  - textbox "Detail"
   - button "Report to help@crates.io":
     - text: ""
     - strong: help@crates.io

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -16,8 +16,7 @@
   - group:
     - text: Crate
     - textbox "Crate"
-  - group:
-    - text: Reasons
+  - group "Reasons":
     - list:
       - listitem:
         - checkbox "it contains spam"

--- a/svelte/src/lib/components/support/CrateReportForm.svelte
+++ b/svelte/src/lib/components/support/CrateReportForm.svelte
@@ -130,7 +130,7 @@ ${detail}
   </fieldset>
 
   <fieldset class="form-group" data-test-id="fieldset-reasons">
-    <div class="form-group-name">Reasons</div>
+    <legend class="form-group-name">Reasons</legend>
     <ul role="list" class="reasons-list scopes-list" class:invalid={reasonsInvalid}>
       {#each REASONS as option (option.reason)}
         <li>

--- a/svelte/src/lib/components/support/CrateReportForm.svelte
+++ b/svelte/src/lib/components/support/CrateReportForm.svelte
@@ -109,7 +109,7 @@ ${detail}
 <form {...restProps} class="report-form" data-testid="crate-report-form" onsubmit={handleSubmit}>
   <h2>Report A Crate</h2>
 
-  <fieldset class="form-group" data-test-id="fieldset-crate">
+  <div class="form-group" data-test-id="fieldset-crate">
     <label for="{id}-crate" class="form-group-name">Crate</label>
     <!-- svelte-ignore a11y_autofocus -->
     <input
@@ -127,7 +127,7 @@ ${detail}
     {#if crateInvalid}
       <div class="form-group-error" data-test-id="crate-invalid">Please specify a crate.</div>
     {/if}
-  </fieldset>
+  </div>
 
   <fieldset class="form-group" data-test-id="fieldset-reasons">
     <legend class="form-group-name">Reasons</legend>
@@ -171,7 +171,7 @@ ${detail}
     </div>
   {/if}
 
-  <fieldset class="form-group" data-test-id="fieldset-detail">
+  <div class="form-group" data-test-id="fieldset-detail">
     <label for="{id}-detail" class="form-group-name">Detail</label>
     <textarea
       id="{id}-detail"
@@ -187,7 +187,7 @@ ${detail}
     {#if detailInvalid}
       <div class="form-group-error" data-test-id="detail-invalid">Please provide some detail.</div>
     {/if}
-  </fieldset>
+  </div>
 
   <div class="buttons">
     <button type="submit" class="report-button button button--small" data-test-id="report-button">


### PR DESCRIPTION
Two related fixes for `CrateReportForm` surfaced by the ARIA tree snapshot.

- The "Reasons" checkbox group used `<div class="form-group-name">` as its label inside a `<fieldset>`. Screen readers do not associate a `<div>` with the surrounding fieldset, so the group was announced without a name and the "Reasons" text appeared as an unattached node. Switched to `<legend>` so the fieldset's group name is properly associated.
- The "Crate" and "Detail" inputs were each wrapped in a `<fieldset>` with no `<legend>`, creating an unnamed `group` node in the accessibility tree. Per W3C WCAG technique [H71](https://www.w3.org/WAI/WCAG21/Techniques/html/H71), `<fieldset>` / `<legend>` is meant for grouping multiple related controls; a single input with its own `<label for>` is sufficiently described by the label alone ([H44](https://www.w3.org/WAI/WCAG21/Techniques/html/H44)). Swapped those wrappers to plain `<div>`.

The `form-group` class already explicitly zeroes the `<fieldset>` defaults (`border: none; margin: 0; padding: 0`), so the visual appearance is unchanged.

### Related

- https://github.com/rust-lang/crates.io/pull/13692
- https://github.com/rust-lang/crates.io/pull/13709
- https://github.com/rust-lang/crates.io/pull/13710
- https://github.com/rust-lang/crates.io/pull/13711
- https://github.com/rust-lang/crates.io/pull/13716
- https://github.com/rust-lang/crates.io/pull/13717