### PR TITLE
CI: Drop custom Rust toolchain Renovate preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,6 @@
     ':automergeTesters',
     'customManagers:dockerfileVersions',
     'customManagers:githubActionsVersions',
-    'github>Turbo87/renovate-config//rust/updateToolchain',
   ],
   packageRules: [
     {


### PR DESCRIPTION
Renovate now ships a native `rust-toolchain` manager (renovatebot/renovate#38554), which supersedes the external preset with proper handling of stable/beta/nightly channels and range strategies.