### PR TITLE
Replace Mozilla CDN with Fontsource packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,12 @@ importers:
       '@floating-ui/dom':
         specifier: 1.7.6
         version: 1.7.6
+      '@fontsource/fira-mono':
+        specifier: 5.2.7
+        version: 5.2.7
+      '@fontsource/fira-sans':
+        specifier: 5.2.7
+        version: 5.2.7
       chart.js:
         specifier: 4.5.1
         version: 4.5.1
@@ -544,6 +550,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/fira-mono@5.2.7':
+    resolution: {integrity: sha512-wYrAn6i3nH6luqQBZxtWUpl4UTUvs9AEbEeZxksPMwIqyjRRaxHTNW3c2VfM50gabS2IS7pT8lVWS2USB4ukYA==}
+
+  '@fontsource/fira-sans@5.2.7':
+    resolution: {integrity: sha512-5DE4AealD/VnbwdzMgnpWfCttMQBbteNiK9DCJE7cVwZEbDTPLUoFDMMvxNQ498nZc5in7Mta9c/s+3Ehh0BAg==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -3951,6 +3963,10 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/fira-mono@5.2.7': {}
+
+  '@fontsource/fira-sans@5.2.7': {}
 
   '@humanfs/core@0.19.2':
     dependencies:

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@crates-io/api-client": "workspace:*",
     "@floating-ui/dom": "1.7.6",
+    "@fontsource/fira-mono": "5.2.7",
+    "@fontsource/fira-sans": "5.2.7",
     "chart.js": "4.5.1",
     "date-fns": "4.1.0",
     "highlight.js": "11.11.1",

--- a/svelte/src/lib/css/global.css
+++ b/svelte/src/lib/css/global.css
@@ -3,7 +3,15 @@
 @import './shared/forms.css';
 @import './shared/sort-by.css';
 @import './shared/typography.css';
-@import 'https://code.cdn.mozilla.net/fonts/fira.css';
+
+@import '@fontsource/fira-sans/300.css';
+@import '@fontsource/fira-sans/400.css';
+@import '@fontsource/fira-sans/400-italic.css';
+@import '@fontsource/fira-sans/500.css';
+@import '@fontsource/fira-sans/600.css';
+@import '@fontsource/fira-sans/700.css';
+@import '@fontsource/fira-mono/400.css';
+@import '@fontsource/fira-mono/700.css';
 
 /*
  * The `normalize.css` file does not use CSS layers, so we need to vendor it

--- a/svelte/svelte.config.js
+++ b/svelte/svelte.config.js
@@ -59,9 +59,7 @@ const config = {
           // If the script content changes, regenerate this hash.
           'sha256-5Cz6+Mc7r7EqumpZ/iP8Bxa/U8yPvwbiANROmonMceg=',
         ],
-        // Fira Sans is loaded from the Mozilla CDN via `@import` in `global.css`
-        'style-src': ['self', 'unsafe-inline', 'https://code.cdn.mozilla.net'],
-        'font-src': ['https://code.cdn.mozilla.net'],
+        'style-src': ['self', 'unsafe-inline'],
         'img-src': ['*'],
         'object-src': ['none'],
       },


### PR DESCRIPTION
The `mozilla/Fira` repository was archived on 2026-05-13 and `code.cdn.mozilla.net` has uncertain long-term availability. The CDN is also only reachable over IPv4, which breaks IPv6-only clients.

This switches to `@fontsource/fira-sans` and `@fontsource/fira-mono` (both at 5.2.7) and imports the 8 weights currently used in the codebase. Vite bundles the WOFF2 and WOFF files into the static asset directory with content hashes, adding around 1.9 MB to the build output.

The `code.cdn.mozilla.net` entry is dropped from the CSP `style-src`, and the now-redundant `font-src` directive is removed since `default-src: 'self'` covers it.

Resolves #13454