### PR TITLE
Add AI tools policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,5 +221,6 @@ Before submitting:
 - `/docs/ARCHITECTURE.md` - System architecture and design decisions
 - `/docs/API-DESIGN.md` - JSON API conventions for new endpoints
 - `/docs/PR-REVIEW.md` - Guidelines for reviewing pull requests
+- `/docs/AI-TOOLS.md` - Guidelines for using AI tools when contributing
 - `/script/import-database-dump.sh` - Import production database dump for testing
 - `/.github/workflows/ci.yml` - CI pipeline definition and tool versions

--- a/docs/AI-TOOLS.md
+++ b/docs/AI-TOOLS.md
@@ -30,7 +30,6 @@ mind for the quality of your contribution:
   tests may be ensuring specific API behaviors are maintained.
 
 Pay close attention to AI generated recommendations for testing changes.
-Provide input about Python's testing principles when guiding an AI model.
 Always review the output before opening a pull request or issue,
 including proposed PR or issue titles and descriptions.
 

--- a/docs/AI-TOOLS.md
+++ b/docs/AI-TOOLS.md
@@ -1,0 +1,56 @@
+# Guidelines for using AI tools
+
+The person submitting an issue or PR is responsible for its content,
+regardless of whether AI tools were used in its creation. Generative AI
+tools can produce output quickly, but discretion, good judgment, and
+critical thinking are the foundation of all good contributions. We value
+good code, concise accurate documentation, and well scoped PRs without
+unneeded code churn.
+
+## Considerations for success
+
+Authors must review the work done by AI tooling in detail to ensure it
+actually makes sense before proposing it as a PR or filing it as an issue.
+
+We expect PR authors and those filing issues to be able to explain their
+proposed changes in their own words.
+
+Disclosure of the use of AI tools in the PR description is appreciated,
+while not required. Be prepared to explain how the tool was used and what
+changes it made.
+
+Whether you are using AI tools or not, keep the following principles in
+mind for the quality of your contribution:
+
+- Consider whether the change is necessary
+- Make minimal, focused changes
+- Follow existing coding style and patterns
+- Write tests that exercise the change
+- Keep backwards compatibility with prior releases in mind. Existing
+  tests may be ensuring specific API behaviors are maintained.
+
+Pay close attention to AI generated recommendations for testing changes.
+Provide input about Python's testing principles when guiding an AI model.
+Always review the output before opening a pull request or issue,
+including proposed PR or issue titles and descriptions.
+
+## Acceptable uses
+
+Some of the acceptable uses of generative AI include:
+
+- Assistance with writing comments, especially in a non-native language
+- Gaining understanding of existing code
+- Supplementing contributor knowledge for code, tests, and documentation
+
+## Unacceptable uses
+
+Maintainers may close issues and PRs that are not useful or productive,
+regardless of whether AI tools were used or not.
+
+If a contributor repeatedly opens unproductive issues or PRs, they may be
+blocked from contributing to the project because it is disruptive and
+disrespectful of the maintainers time.
+
+It is not acceptable to alter or bypass existing tests, or remove desired
+functionality, in order to make a failing test pass. Such changes are not
+a real fix.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to crates.io
 
 - [Attending the weekly team meetings](#attending-the-weekly-team-meetings)
+- [Using AI tools](#using-ai-tools)
 - [Finding an issue to work on](#finding-an-issue-to-work-on)
 - [Submitting a Pull Request](#submitting-a-pull-request)
 - [Reviewing Pull Requests](#reviewing-pull-requests)
@@ -16,6 +17,11 @@ on Zoom or [Zulip] (`#t-crates-io`) for our weekly team meeting, and we invite
 everyone who wants to contribute to crates.io to participate.
 
 [Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/
+
+## Using AI tools
+
+If you use AI tools to help draft issues, PRs, or comments, please
+review [`docs/AI-TOOLS.md`](AI-TOOLS.md) for our guidelines.
 
 ## Finding an issue to work on
 


### PR DESCRIPTION
This PR proposes adopting the CPython devguide's AI tools policy as crates.io's own, as `docs/AI-TOOLS.md` (with one Python-specific testing sentence dropped). It is linked from `CONTRIBUTING.md` and `AGENTS.md`.

The CPython policy puts responsibility for content on the submitter, requires contributors to be able to explain their changes, and doesn't try to ban AI tooling outright. That matches how things are already done in this project and seems a reasonable starting point.

Project-wide AI policy for rust-lang is still being debated in two open RFCs (neither close to consensus), with a separate `rust-lang/rust`-scoped policy that explicitly excludes crates.io. If a project-wide policy is later adopted, we can align with it.

Open to feedback on whether this is the right policy and whether anything should be adjusted before merging.

### Related

- https://github.com/python/devguide/pull/1778
- https://github.com/rust-lang/rfcs/pull/3950
- https://github.com/rust-lang/rfcs/pull/3959
- https://github.com/rust-lang/rust-forge/pull/1040