### PR TITLE
Add `cargo nextest` support

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+experimental = ["setup-scripts"]
+
+[scripts.setup.crates-io-template-db]
+command = 'cargo run --quiet --package crates_io_test_db --bin nextest_setup'
+
+[[profile.default.scripts]]
+filter = 'rdeps(crates_io_test_db)'
+setup = 'crates-io-template-db'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,6 +1865,7 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "rand 0.10.1",
+ "tempfile",
  "tracing",
  "url",
 ]

--- a/crates/crates_io_test_db/Cargo.toml
+++ b/crates/crates_io_test_db/Cargo.toml
@@ -14,5 +14,6 @@ diesel = { version = "=2.3.9", features = ["postgres", "r2d2"] }
 diesel-async = { version = "=0.9.0", features = ["postgres"] }
 diesel_migrations = { version = "=2.3.2", features = ["postgres"] }
 rand = "=0.10.1"
+tempfile = "=3.27.0"
 tracing = "=0.1.44"
 url = "=2.5.8"

--- a/crates/crates_io_test_db/README.md
+++ b/crates/crates_io_test_db/README.md
@@ -96,3 +96,17 @@ The crate will automatically create:
 3. **Automatic Cleanup**: Each test database is automatically dropped when the `TestDatabase` instance is dropped
 
 This approach significantly reduces test setup time by avoiding migration runs for each individual test.
+
+### `cargo nextest` integration
+
+This crate ships a `nextest_setup` binary and a workspace
+`.config/nextest.toml` that registers it as a nextest setup script
+filtered to `rdeps(crates_io_test_db)`. The script calls
+`prepare_template_db()` once before any test binary starts and writes
+the resulting DDL file path into the file at `$NEXTEST_ENV` as
+`CRATES_IO_TEST_DB_DDL_PATH=<path>`.
+
+Each test process then checks for `CRATES_IO_TEST_DB_DDL_PATH`. When
+the env var is present, the file at that path is read instead of
+re-running migrations and `pg_dump`. When the env var is unset (as
+under plain `cargo test`), each process prepares its own template.

--- a/crates/crates_io_test_db/src/bin/nextest_setup.rs
+++ b/crates/crates_io_test_db/src/bin/nextest_setup.rs
@@ -1,0 +1,24 @@
+use anyhow::Context;
+use crates_io_env_vars::required_var_parsed;
+use crates_io_test_db::prepare_template_db;
+use std::env;
+use std::fs::OpenOptions;
+use std::io::Write;
+use url::Url;
+
+/// Nextest setup script that prepares the shared `test_template` schema
+/// once per `cargo nextest run` invocation and publishes the path to the
+/// captured DDL via the `NEXTEST_ENV` file as
+/// `CRATES_IO_TEST_DB_DDL_PATH=<path>`. Test binaries that depend on
+/// `crates_io_test_db` pick up that env var and skip per-process
+/// migrations and `pg_dump`.
+fn main() -> anyhow::Result<()> {
+    let base_url: Url = required_var_parsed("TEST_DATABASE_URL")?;
+    let path = prepare_template_db(&base_url)?;
+
+    let env_file = env::var("NEXTEST_ENV")
+        .context("NEXTEST_ENV is not set (this binary must be run as a nextest setup script)")?;
+    let mut file = OpenOptions::new().append(true).open(&env_file)?;
+    writeln!(file, "CRATES_IO_TEST_DB_DDL_PATH={}", path.display())?;
+    Ok(())
+}

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -8,6 +8,7 @@ use diesel::sql_query;
 use diesel_async::{AsyncConnection, AsyncPgConnection};
 use diesel_migrations::{FileBasedMigrations, MigrationHarness};
 use rand::RngExt;
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::LazyLock;
@@ -82,8 +83,11 @@ impl Management {
             .expect("failed to run migrations on the template schema");
         drop(template_conn);
 
-        let template_ddl =
-            capture_template_ddl(&base_url).expect("failed to capture template schema DDL");
+        let mut ddl_buf = Vec::new();
+        capture_template_ddl(&base_url, &mut ddl_buf)
+            .expect("failed to capture template schema DDL");
+
+        let template_ddl = String::from_utf8(ddl_buf).expect("pg_dump produced non-UTF-8 output");
 
         Management {
             base_url,
@@ -242,8 +246,8 @@ fn run_migrations(conn: &mut PgConnection) -> diesel::migration::Result<()> {
     Ok(())
 }
 
-/// Shells out to `pg_dump --schema=<template>` and returns the captured DDL
-/// as SQL ready for `batch_execute`.
+/// Shells out to `pg_dump --schema=<template>` and writes the captured DDL
+/// as SQL ready for `batch_execute` into `out`.
 ///
 /// `pg_dump`'s plain-text output targets `psql`, not the backend. To make
 /// it backend-safe:
@@ -255,8 +259,8 @@ fn run_migrations(conn: &mut PgConnection) -> diesel::migration::Result<()> {
 /// - A trailing `RESET ALL` clears any session state the preamble's
 ///   `SET` / `set_config('search_path', …)` calls left behind so it
 ///   doesn't leak to the next checkout of the pooled connection.
-#[instrument]
-fn capture_template_ddl(base_url: &Url) -> anyhow::Result<String> {
+#[instrument(skip(out))]
+fn capture_template_ddl(base_url: &Url, out: &mut impl Write) -> anyhow::Result<()> {
     let pg_dump = match var_parsed::<PathBuf>("POSTGRES_BIN_DIR")? {
         Some(dir) => dir.join("pg_dump"),
         None => PathBuf::from("pg_dump"),
@@ -279,21 +283,19 @@ fn capture_template_ddl(base_url: &Url) -> anyhow::Result<String> {
         ));
     }
 
-    let raw = String::from_utf8(output.stdout)
+    let raw = std::str::from_utf8(&output.stdout)
         .map_err(|err| anyhow::anyhow!("pg_dump produced non-UTF-8 output: {err}"))?;
 
-    let mut ddl = String::with_capacity(raw.len());
     for line in raw.lines() {
         if line.starts_with('\\') {
             continue;
         }
-        ddl.push_str(line);
-        ddl.push('\n');
+        writeln!(out, "{line}")?;
     }
 
-    ddl.push_str("\nRESET ALL;\n");
+    writeln!(out, "\nRESET ALL;")?;
 
-    Ok(ddl)
+    Ok(())
 }
 
 /// Returns a copy of `base_url` with `options=--search_path=<schema>,public`

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -56,7 +56,16 @@ impl Management {
     fn new() -> Self {
         let base_url: Url = required_var_parsed("TEST_DATABASE_URL").unwrap();
 
-        let ddl_path = prepare_template_db(&base_url).expect("failed to prepare template DB");
+        // Under `cargo nextest`, the setup binary in this crate prepares the
+        // template schema once and publishes the DDL path via this env var.
+        // Plain `cargo test` leaves it unset and each process prepares its
+        // own.
+        let ddl_path: PathBuf = var_parsed("CRATES_IO_TEST_DB_DDL_PATH")
+            .expect("invalid CRATES_IO_TEST_DB_DDL_PATH")
+            .unwrap_or_else(|| {
+                prepare_template_db(&base_url).expect("failed to prepare template DB")
+            });
+
         let template_ddl = fs::read_to_string(&ddl_path).expect("failed to read template DDL file");
 
         let pool = Pool::builder()

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -8,11 +8,13 @@ use diesel::sql_query;
 use diesel_async::{AsyncConnection, AsyncPgConnection};
 use diesel_migrations::{FileBasedMigrations, MigrationHarness};
 use rand::RngExt;
+use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::LazyLock;
 use std::time::Duration;
+use tempfile::NamedTempFile;
 use tracing::{debug, instrument};
 use url::Url;
 
@@ -54,33 +56,8 @@ impl Management {
     fn new() -> Self {
         let base_url: Url = required_var_parsed("TEST_DATABASE_URL").unwrap();
 
-        let mut conn = connect(base_url.as_ref()).expect("failed to connect to the database");
-
-        // Drop any leftover test schemas from previous runs that crashed
-        // without dropping their schema. This also drops any extensions
-        // that were installed inside those schemas, freeing their
-        // database-level registration so the migrations can re-install
-        // them in `public`.
-        cleanup_leftover_schemas(&mut conn).expect("failed to clean up leftover test schemas");
-
-        sql_query(format!("CREATE SCHEMA IF NOT EXISTS \"{TEMPLATE_SCHEMA}\""))
-            .execute(&mut conn)
-            .expect("failed to ensure template schema exists");
-
-        // Apply any pending migrations to the template schema. Diesel skips
-        // already-applied migrations, so subsequent process starts only pay
-        // for newly-added migrations.
-        sql_query(format!("SET search_path TO \"{TEMPLATE_SCHEMA}\", public"))
-            .execute(&mut conn)
-            .expect("failed to set search_path on template connection");
-        run_migrations(&mut conn).expect("failed to run migrations on the template schema");
-        drop(conn);
-
-        let mut ddl_buf = Vec::new();
-        capture_template_ddl(&base_url, &mut ddl_buf)
-            .expect("failed to capture template schema DDL");
-
-        let template_ddl = String::from_utf8(ddl_buf).expect("pg_dump produced non-UTF-8 output");
+        let ddl_path = prepare_template_db(&base_url).expect("failed to prepare template DB");
+        let template_ddl = fs::read_to_string(&ddl_path).expect("failed to read template DDL file");
 
         let pool = Pool::builder()
             .connection_timeout(CONNECTION_TIMEOUT)
@@ -187,6 +164,44 @@ impl Drop for TestDatabase {
         let mut conn = Management::instance().get_connection();
         drop_schema(&self.schema, &mut conn).expect("failed to drop test schema");
     }
+}
+
+/// Prepares the `test_template` schema and writes its DDL to a persistent
+/// temporary file.
+///
+/// This sweeps any leftover per-test schemas from a prior crashed run,
+/// ensures `test_template` exists with all pending migrations applied, and
+/// dumps the schema via `pg_dump` into a file ready for
+/// `conn.batch_execute()`. The returned path points at a file kept past
+/// the function's lifetime via [`NamedTempFile::keep`]. Callers are
+/// responsible for reading it.
+#[instrument]
+pub fn prepare_template_db(base_url: &Url) -> anyhow::Result<PathBuf> {
+    let mut conn = connect(base_url.as_ref())?;
+
+    // Drop any leftover test schemas from previous runs that crashed
+    // without dropping their schema. This also drops any extensions
+    // that were installed inside those schemas, freeing their
+    // database-level registration so the migrations can re-install
+    // them in `public`.
+    cleanup_leftover_schemas(&mut conn)?;
+
+    sql_query(format!("CREATE SCHEMA IF NOT EXISTS \"{TEMPLATE_SCHEMA}\"")).execute(&mut conn)?;
+
+    // Apply any pending migrations to the template schema. Diesel skips
+    // already-applied migrations, so subsequent process starts only pay
+    // for newly-added migrations.
+    sql_query(format!("SET search_path TO \"{TEMPLATE_SCHEMA}\", public")).execute(&mut conn)?;
+
+    run_migrations(&mut conn).map_err(anyhow::Error::msg)?;
+
+    drop(conn);
+
+    let mut tempfile = NamedTempFile::new()?;
+    capture_template_ddl(base_url, &mut tempfile)?;
+    let (_, path) = tempfile.keep()?;
+
+    Ok(path)
 }
 
 /// Drops any schema whose name matches `test_<16-alphanumeric-chars>`. These

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -54,13 +54,7 @@ impl Management {
     fn new() -> Self {
         let base_url: Url = required_var_parsed("TEST_DATABASE_URL").unwrap();
 
-        let pool = Pool::builder()
-            .connection_timeout(CONNECTION_TIMEOUT)
-            .max_size(10)
-            .min_idle(Some(0))
-            .build_unchecked(ConnectionManager::new(base_url.as_ref()));
-
-        let mut conn = pool.get().expect("failed to connect to the database");
+        let mut conn = connect(base_url.as_ref()).expect("failed to connect to the database");
 
         // Drop any leftover test schemas from previous runs that crashed
         // without dropping their schema. This also drops any extensions
@@ -76,18 +70,23 @@ impl Management {
         // Apply any pending migrations to the template schema. Diesel skips
         // already-applied migrations, so subsequent process starts only pay
         // for newly-added migrations.
-        let template_url = url_with_search_path(&base_url, TEMPLATE_SCHEMA);
-        let mut template_conn =
-            connect(template_url.as_ref()).expect("failed to connect to template schema");
-        run_migrations(&mut template_conn)
-            .expect("failed to run migrations on the template schema");
-        drop(template_conn);
+        sql_query(format!("SET search_path TO \"{TEMPLATE_SCHEMA}\", public"))
+            .execute(&mut conn)
+            .expect("failed to set search_path on template connection");
+        run_migrations(&mut conn).expect("failed to run migrations on the template schema");
+        drop(conn);
 
         let mut ddl_buf = Vec::new();
         capture_template_ddl(&base_url, &mut ddl_buf)
             .expect("failed to capture template schema DDL");
 
         let template_ddl = String::from_utf8(ddl_buf).expect("pg_dump produced non-UTF-8 output");
+
+        let pool = Pool::builder()
+            .connection_timeout(CONNECTION_TIMEOUT)
+            .max_size(10)
+            .min_idle(Some(0))
+            .build_unchecked(ConnectionManager::new(base_url.as_ref()));
 
         Management {
             base_url,


### PR DESCRIPTION
Adds a `cargo nextest` setup script that prepares the shared `test_template` schema once before any test binary starts, instead of each binary running the prep in its own `LazyLock`.

The new `nextest_setup` binary in `crates_io_test_db` is registered in a workspace-level `.config/nextest.toml`, filtered to `rdeps(crates_io_test_db)`. It calls `prepare_template_db()` and writes the resulting DDL path into `$NEXTEST_ENV` as `CRATES_IO_TEST_DB_DDL_PATH`. `Management::new()` reads from that path when the env var is set. When unset (as under plain `cargo test`), each process prepares its own template as before.

The previous two-connection setup is collapsed into a single one-shot connection with `SET search_path` applied directly, since the pool now only serves `TestDatabase` operations.

In local timings against this workspace, `cargo nextest` is not faster than `cargo test`, possibly slightly slower. The setup is in place for contributors who prefer nextest's UX.


### Related

- https://github.com/rust-lang/crates.io/pull/13668