### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# The Rust Code of Conduct
+
+The Code of Conduct for this repository [can be found online](https://www.rust-lang.org/conduct.html).


### PR DESCRIPTION
The file is not present in the repository but it is linked on the website so I'm just aligning the two. The file is sort of a "link" to the authoritative place for the policy (I am following what `rust-lang/rust` does) .

I *think* this should be enough for GH to pick it and show it in the git repo properties tab

thanks