### PR TITLE
CI: Scope `update-cdn-ip-ranges` token to `contents: write`

### DIFF
--- a/.github/workflows/update-cdn-ip-ranges.yml
+++ b/.github/workflows/update-cdn-ip-ranges.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           app-id: ${{ vars.WORKFLOWS_CRATES_IO_APP_ID }}
           private-key: ${{ secrets.WORKFLOWS_CRATES_IO_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] repository write access is already the effective boundary; an environment adds no meaningful protection
+          permission-contents: write
 
       - name: Get GitHub App User ID
         id: get-user-id


### PR DESCRIPTION
By default `actions/create-github-app-token` issues a token with all permissions the GitHub App possesses. This workflow only needs `contents: write` to push the updated CDN IP ranges back to `main`, so request only that permission. Addresses zizmor's [`github-app`](https://docs.zizmor.sh/audits/#github-app) audit recommendation to apply least privilege to the issued installation token.