### PR TITLE
Remove unused `vendor/qunit.css`

### DIFF
--- a/vendor/qunit.css
+++ b/vendor/qunit.css
@@ -1,3 +1,0 @@
-[data-app-test] .ember-application {
-  background-color: var(--header-bg-color);
-}


### PR DESCRIPTION
Leftover from the old QUnit/Ember test setup. The frontend has since migrated to SvelteKit with Vitest and Playwright, and nothing in the tree references this file anymore.