### PR TITLE
Require `C` database collation for `semver_ord`

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,6 +24,10 @@ services:
     image: postgres:16
     environment:
       POSTGRES_DB: cargo_registry
+      # `semver_ord` stores prerelease identifiers as JSONB strings and
+      # relies on byte-wise ordering. Force `C` collation so JSONB string
+      # comparison matches the SemVer spec's ASCII sort order.
+      POSTGRES_INITDB_ARGS: '--lc-collate=C --lc-ctype=C'
       # Trust auth is fine because Postgres is only reachable on the
       # internal Docker network; no port is published to the host.
       POSTGRES_HOST_AUTH_METHOD: trust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
     env:
       RUST_BACKTRACE: 1
-      TEST_DATABASE_URL: postgres://postgres:postgres@localhost/postgres
+      TEST_DATABASE_URL: postgres://postgres:postgres@localhost/cargo_registry_test
       RUSTFLAGS: '-D warnings -Cinstrument-coverage'
       MALLOC_CONF: 'background_thread:true,abort_conf:true,abort:true,junk:true'
 
@@ -178,6 +178,7 @@ jobs:
 
       - run: sudo systemctl start postgresql.service
       - run: sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'postgres'"
+      - run: sudo -u postgres createdb --lc-collate=C --lc-ctype=C -T template0 cargo_registry_test
 
       - run: cargo fetch --locked
       - run: cargo build --tests --workspace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ cargo fmt --all --check                                # Formatting
 cargo clippy --all-targets --all-features --workspace  # Linting
 ```
 
-Test database setup: Set `TEST_DATABASE_URL` in `.env` to a separate database (e.g., `postgres://postgres@localhost/cargo_registry_test`). The test harness creates isolated databases and runs migrations automatically. Create the base test database once with `createdb cargo_registry_test`.
+Test database setup: Set `TEST_DATABASE_URL` in `.env` to a separate database (e.g., `postgres://postgres@localhost/cargo_registry_test`). The test harness creates isolated databases and runs migrations automatically. Create the base test database once with `createdb --lc-collate=C --lc-ctype=C -T template0 cargo_registry_test`. The `C` collation is required by the `semver_ord()` function.
 
 ### Architecture and Conventions
 

--- a/crates/crates_io_database/tests/semver_ord.rs
+++ b/crates/crates_io_database/tests/semver_ord.rs
@@ -1,3 +1,4 @@
+use claims::assert_matches;
 use crates_io_test_db::TestDatabase;
 use diesel::prelude::*;
 use diesel::sql_types::{Nullable, Text};
@@ -75,7 +76,8 @@ async fn test_spec_order() {
                     '1.0.0-beta.2',
                     '1.0.0-alpha.1',
                     '1.0.0-alpha.beta',
-                    '1.0.0-beta.11'
+                    '1.0.0-beta.11',
+                    '1.0.0-B'
                 ]) as num
             )
             select num
@@ -92,6 +94,7 @@ async fn test_spec_order() {
 
     insta::assert_debug_snapshot!(check("asc").await, @r"
     [
+        1.0.0-B,
         1.0.0-alpha,
         1.0.0-alpha.1,
         1.0.0-alpha.beta,
@@ -113,6 +116,42 @@ async fn test_spec_order() {
         1.0.0-alpha.beta,
         1.0.0-alpha.1,
         1.0.0-alpha,
+        1.0.0-B,
     ]
     ");
+}
+
+/// `semver_ord` stores prerelease identifiers as JSONB strings and relies on
+/// byte-wise comparison to match the SemVer spec's ASCII sort order. PostgreSQL
+/// compares JSONB strings using the database's default collation, so this only
+/// works when the database was created with `C` (or `POSIX`) collation.
+///
+/// This test catches a mis-configured test database early with an actionable
+/// error, rather than letting `test_spec_order` fail with a confusing snapshot
+/// diff.
+#[tokio::test]
+async fn test_database_collation_is_c() {
+    let test_db = TestDatabase::new();
+    let mut conn = test_db.async_connect().await;
+
+    #[derive(QueryableByName)]
+    struct Row {
+        #[diesel(sql_type = Text)]
+        datcollate: String,
+    }
+
+    let query = "select datcollate from pg_database where datname = current_database()";
+    let row = diesel::sql_query(query)
+        .get_result::<Row>(&mut conn)
+        .await
+        .unwrap();
+
+    assert_matches!(
+        row.datcollate.as_str(),
+        "C" | "POSIX",
+        "test database collation is `{}`, but `semver_ord` requires `C` (or `POSIX`). \
+         Recreate the test database with:\n    \
+         dropdb cargo_registry_test && createdb --lc-collate=C --lc-ctype=C -T template0 cargo_registry_test",
+        row.datcollate,
+    );
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -317,7 +317,7 @@ Another option is to use a standalone Docker container for Postgres:
 
 ```sh
 # example using postgres 16
-docker run -e POSTGRES_PASSWORD=password -p 5432:5432 postgres:16
+docker run -e POSTGRES_PASSWORD=password -e POSTGRES_INITDB_ARGS='--lc-collate=C --lc-ctype=C' -p 5432:5432 postgres:16
 # database URL will be
 # DATABASE_URL=postgres://postgres:password@localhost:5432/cargo_registry
 ```
@@ -398,8 +398,13 @@ named `cargo_registry`.
 Create a new database by running:
 
 ```console
-createdb cargo_registry
+createdb --lc-collate=C --lc-ctype=C -T template0 cargo_registry
 ```
+
+The `C` collation is required because the `semver_ord` function stores
+prerelease identifiers as JSONB strings and relies on byte-wise comparison
+to match the SemVer spec's ASCII sort order. The same applies to
+`cargo_registry_test` below.
 
 Then run the migrations:
 
@@ -515,7 +520,7 @@ Example: `postgres://postgres@localhost/cargo_registry_test`.
 Create the test database by running:
 
 ```console
-createdb cargo_registry_test
+createdb --lc-collate=C --lc-ctype=C -T template0 cargo_registry_test
 ```
 
 The test harness will ensure that migrations are run.


### PR DESCRIPTION
The `semver_ord()` function encodes prerelease identifiers as JSONB strings and orders versions via JSONB comparison. PostgreSQL compares JSONB strings using the database's default collation, so on any non-`C` collation (for example the `en_US.UTF-8` default of the official postgres image) the ASCII sort order required by SemVer spec item 11 is violated and e.g. `1.0.0-B` sorts after `1.0.0-alpha` instead of before it.

Production already runs on `C` collation, so this is currently invisible there, but local dev, the devcontainer, and contributors using the default postgres locale all hit it.

This pins the devcontainer's postgres to `C`, adds an uppercase identifier to `test_spec_order` so the bug surfaces in tests, adds `test_database_collation_is_c` which reports a misconfigured database with the exact `createdb` invocation to recreate it, and documents the requirement in `docs/CONTRIBUTING.md` and `AGENTS.md`.

/cc @danilobuerger

### Related

- Resolves https://github.com/rust-lang/crates.io/issues/13749