### PR TITLE
frontend: Show markdown alerts in `RenderedHtml` storybook

### DIFF
--- a/svelte/src/lib/components/RenderedHtml.stories.svelte
+++ b/svelte/src/lib/components/RenderedHtml.stories.svelte
@@ -18,6 +18,40 @@
 }</code></pre>
     <p>Here's another code block without a language:</p>
     <pre><code>some generic code</code></pre>
+
+    <h2>Alerts</h2>
+    <div class="markdown-alert markdown-alert-note">
+      <p class="markdown-alert-title">Note</p>
+      <p>Useful information that users should know, even when skimming content.</p>
+    </div>
+    <div class="markdown-alert markdown-alert-tip">
+      <p class="markdown-alert-title">Tip</p>
+      <p>Helpful advice for doing things better or more easily.</p>
+    </div>
+    <div class="markdown-alert markdown-alert-important">
+      <p class="markdown-alert-title">Important</p>
+      <p>Key information users need to know to achieve their goal.</p>
+    </div>
+    <div class="markdown-alert markdown-alert-warning">
+      <p class="markdown-alert-title">Warning</p>
+      <p>Urgent info that needs immediate user attention to avoid problems.</p>
+    </div>
+    <div class="markdown-alert markdown-alert-caution">
+      <p class="markdown-alert-title">Caution</p>
+      <p>Advises about risks or negative outcomes of certain actions.</p>
+    </div>
+
+    <div class="markdown-alert markdown-alert-note">
+      <p class="markdown-alert-title">Note</p>
+      <div class="markdown-alert markdown-alert-important">
+        <p class="markdown-alert-title">Important</p>
+        <div class="markdown-alert markdown-alert-caution">
+          <p class="markdown-alert-title">Caution</p>
+          <p>Rick roll</p>
+          <p>Never gonna give you up</p>
+        </div>
+      </div>
+    </div>
   `;
 
   const MERMAID_HTML = `


### PR DESCRIPTION
Adds the five alert variants (note, tip, important, warning, caution) plus the nested-alert example from the e2e readme rendering tests to the default `RenderedHtml` story. This gives a single Storybook view that exercises every alert variant the backend can produce, useful for visual regression checks.