### PR TITLE
Switch default_version sort key to `semver_ord_v2` and require it

### DIFF
--- a/crates/crates_io_database/src/models/default_versions.rs
+++ b/crates/crates_io_database/src/models/default_versions.rs
@@ -1,7 +1,8 @@
 use crate::schema::{default_versions, versions};
 use crates_io_diesel_helpers::SemverVersion;
-use diesel::dsl::jsonb_typeof;
+use diesel::dsl::sql;
 use diesel::prelude::*;
+use diesel::sql_types::Bool;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use tracing::{debug, instrument, warn};
 
@@ -126,10 +127,13 @@ async fn calculate_default_version(
         .order((
             // 1. Non-yanked first
             versions::yanked,
-            // 2. Non-prerelease first
-            jsonb_typeof(versions::semver_ord.retrieve_as_object(3)).eq("array"),
+            // 2. Non-prerelease first. The post-patch byte of `semver_ord_v2`
+            // is 0x03 for releases and 0x00 for prereleases.
+            sql::<Bool>(
+                "get_byte(versions.semver_ord_v2, octet_length(versions.semver_ord_v2) - 1) <> 3",
+            ),
             // 3. Higher semver first
-            versions::semver_ord.desc(),
+            versions::semver_ord_v2.desc(),
             // 4. Higher ID first as tie-breaker
             versions::id.desc(),
         ))
@@ -295,6 +299,7 @@ mod tests {
 
         create_version(crate_id, "1.1.0", &*conn).await;
         create_version(crate_id, "1.0.1", &*conn).await;
+        create_version(crate_id, "2.0.0-beta.1", &*conn).await;
         assert_eq!(get_default_version(crate_id, &*conn).await, "1.0.0");
 
         update_default_version(crate_id, &*conn).await.unwrap();

--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -1207,6 +1207,8 @@ diesel::table! {
         rust_version -> Nullable<Varchar>,
         /// JSONB representation of the version number for sorting purposes.
         semver_ord -> Nullable<Jsonb>,
+        /// Order-preserving bytea representation of the version number for sorting purposes.
+        semver_ord_v2 -> Bytea,
         /// JSONB data containing JWT claims from the trusted publisher (e.g., GitHub Actions context like repository, run_id, sha)
         trustpub_data -> Nullable<Jsonb>,
         /// The `updated_at` column of the `versions` table.

--- a/crates/crates_io_database_dump/src/dump-import.sql.j2
+++ b/crates/crates_io_database_dump/src/dump-import.sql.j2
@@ -19,6 +19,9 @@ BEGIN;
     -- Enable this trigger so that `crates.textsearchable_index_col` can be excluded from the export
     ALTER TABLE "crates" ENABLE TRIGGER "trigger_crates_tsvector_update";
 
+    -- Enable this trigger so that `versions.semver_ord_v2` can be excluded from the export
+    ALTER TABLE "versions" ENABLE TRIGGER "trigger_set_semver_ord_v2";
+
     -- Import the CSV data.
 {% for table in tables %}
     \copy "{{table.name}}" ({{table.columns}}) FROM 'data/{{table.name}}.csv' WITH CSV HEADER

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/crates_io_database_dump/src/lib.rs
-assertion_line: 323
 expression: content
 ---
 BEGIN;
@@ -48,6 +47,9 @@ BEGIN;
 
     -- Enable this trigger so that `crates.textsearchable_index_col` can be excluded from the export
     ALTER TABLE "crates" ENABLE TRIGGER "trigger_crates_tsvector_update";
+
+    -- Enable this trigger so that `versions.semver_ord_v2` can be excluded from the export
+    ALTER TABLE "versions" ENABLE TRIGGER "trigger_set_semver_ord_v2";
 
     -- Import the CSV data.
 

--- a/crates/crates_io_diesel_helpers/src/fns.rs
+++ b/crates/crates_io_diesel_helpers/src/fns.rs
@@ -15,3 +15,4 @@ define_sql_function!(fn greatest<T: SingleValue>(x: T, y: T) -> T);
 define_sql_function!(fn least<T: SingleValue>(x: T, y: T) -> T);
 define_sql_function!(fn split_part(string: Text, delimiter: Text, n: Integer) -> Text);
 define_sql_function!(fn semver_ord(num: Text) -> Nullable<Jsonb>);
+define_sql_function!(fn semver_ord_v2(num: Text) -> Nullable<Bytea>);

--- a/migrations/2026-05-27-120000-0000_semver_ord_v2_not_null/down.sql
+++ b/migrations/2026-05-27-120000-0000_semver_ord_v2_not_null/down.sql
@@ -1,0 +1,2 @@
+alter table versions
+    alter column semver_ord_v2 drop not null;

--- a/migrations/2026-05-27-120000-0000_semver_ord_v2_not_null/up.sql
+++ b/migrations/2026-05-27-120000-0000_semver_ord_v2_not_null/up.sql
@@ -1,0 +1,8 @@
+-- safety-assured:start
+-- A `SELECT * FROM versions WHERE semver_ord_v2 IS NULL` against prod runs in
+-- around 3 seconds, so the validation scan that `SET NOT NULL` performs under
+-- ACCESS EXCLUSIVE is expected to be at least as fast. Not worth the extra
+-- CHECK constraint work for this table size.
+alter table versions
+    alter column semver_ord_v2 set not null;
+-- safety-assured:end

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -15,7 +15,7 @@ use crate::views::release_tracks::ReleaseTracks;
 use axum::Json;
 use axum::extract::FromRequestParts;
 use axum_extra::extract::Query;
-use crates_io_diesel_helpers::semver_ord;
+use crates_io_diesel_helpers::semver_ord_v2;
 use diesel::dsl::not;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -173,10 +173,11 @@ async fn list(
             }
             Some(SeekPayload::Semver(Semver { num, id })) => {
                 query = query.filter(
-                    versions::semver_ord
-                        .eq(semver_ord(num.clone()))
+                    versions::semver_ord_v2
+                        .nullable()
+                        .eq(semver_ord_v2(num.clone()))
                         .and(versions::id.lt(id))
-                        .or(versions::semver_ord.lt(semver_ord(num))),
+                        .or(versions::semver_ord_v2.nullable().lt(semver_ord_v2(num))),
                 )
             }
             None => {}
@@ -188,7 +189,7 @@ async fn list(
     if seek == Seek::Date {
         query = query.order((versions::created_at.desc(), versions::id.desc()));
     } else {
-        query = query.order((versions::semver_ord.desc(), versions::id.desc()));
+        query = query.order((versions::semver_ord_v2.desc(), versions::id.desc()));
     }
 
     let data: Vec<(Version, Option<User>)> = query.load(&mut conn).await?;
@@ -205,7 +206,7 @@ async fn list(
                 .filter(versions::crate_id.eq(crate_id))
                 .filter(not(versions::yanked))
                 .select(versions::num)
-                .order(versions::semver_ord.desc())
+                .order(versions::semver_ord_v2.desc())
                 .load_stream::<String>(&mut conn)
                 .await?
                 .try_for_each(|num| {


### PR DESCRIPTION
In #13775 we added `semver_ord_v2` as a nullable column populated by an insert trigger. Existing rows have since been backfilled manually, so the column is now fully populated and can be marked NOT NULL.

This commit:

- Adds a migration that sets `versions.semver_ord_v2 NOT NULL`.
- Exposes the column in `schema.rs` and adds a Diesel SQL function binding `semver_ord_v2(num: Text) -> Nullable<Bytea>`. The binding stays nullable because the underlying SQL function returns NULL for unparseable input.
- Switches the readers in `calculate_default_version` and `controllers/krate/versions::list` from `semver_ord` to `semver_ord_v2`, including the seek-based pagination filter.

For the "non-prerelease first" tier in default version selection, the JSONB introspection (`jsonb_typeof(retrieve_as_object(3)) = 'array'`) is replaced by a direct check of the last byte:
`get_byte(ord, octet_length(ord) - 1) <> 3`. The encoding guarantees the trailing byte is 0x03 for releases and 0x00 (the prerelease end marker) for prereleases.

The old `semver_ord` JSONB column, its SQL function, and the `semver_ord.rs` test are intentionally left in place and will be removed in a follow up once the new path is confirmed working.

Note: The `get_byte` expression is used as the previous available `semver_no_prerelease` was removed in #8867.

**Deployment Note:**
The migration uses a direct `ALTER COLUMN ... SET NOT NULL`, which briefly takes `ACCESS EXCLUSIVE` on `versions` and scans the table to verify the constraint.