### PR TITLE
Adjust `NewUser::insert()` fns to return only user IDs

### DIFF
--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -100,7 +100,7 @@ impl NewUser<'_> {
     }
 
     /// Inserts the user into the database, or updates an existing one.
-    pub async fn insert_or_update(&self, mut conn: &AsyncPgConnection) -> QueryResult<User> {
+    pub async fn insert_or_update(&self, mut conn: &AsyncPgConnection) -> QueryResult<i32> {
         diesel::insert_into(users::table)
             .values(self)
             // We need the `WHERE gh_id > 0` condition here because `gh_id` set
@@ -119,7 +119,7 @@ impl NewUser<'_> {
                 users::gh_avatar.eq(excluded(users::gh_avatar)),
                 users::gh_encrypted_token.eq(excluded(users::gh_encrypted_token)),
             ))
-            .returning(User::as_returning())
+            .returning(users::id)
             .get_result(&mut conn)
             .await
     }

--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -91,10 +91,10 @@ pub struct NewUser<'a> {
 
 impl NewUser<'_> {
     /// Inserts the user into the database, or fails if the user already exists.
-    pub async fn insert(&self, mut conn: &AsyncPgConnection) -> QueryResult<User> {
+    pub async fn insert(&self, mut conn: &AsyncPgConnection) -> QueryResult<i32> {
         diesel::insert_into(users::table)
             .values(self)
-            .returning(User::as_returning())
+            .returning(users::id)
             .get_result(&mut conn)
             .await
     }

--- a/crates/crates_io_test_utils/src/helpers.rs
+++ b/crates/crates_io_test_utils/src/helpers.rs
@@ -1,17 +1,17 @@
-use crates_io_database::models::{Crate, CrateOwner, Team, User};
+use crates_io_database::models::{Crate, CrateOwner, Team};
 use diesel::prelude::*;
 use diesel_async::AsyncPgConnection;
 
 pub async fn add_team_to_crate(
     t: &Team,
     krate: &Crate,
-    u: &User,
+    user_id: i32,
     conn: &mut AsyncPgConnection,
 ) -> QueryResult<()> {
     CrateOwner::builder()
         .crate_id(krate.id)
         .team_id(t.id)
-        .created_by(u.id)
+        .created_by(user_id)
         .build()
         .insert(conn)
         .await

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -2,7 +2,7 @@ use crate::app::AppState;
 use crate::email::EmailMessage;
 use crate::email::Emails;
 use crate::middleware::log_request::RequestLogExt;
-use crate::models::{NewEmail, NewOauthGithub, NewUser, User};
+use crate::models::{NewEmail, NewOauthGithub, NewUser};
 use crate::schema::users;
 use crate::util::diesel::is_read_only_error;
 use crate::util::errors::{AppResult, bad_request, server_error};
@@ -162,10 +162,7 @@ pub async fn save_user_to_database(
         Err(error) if is_read_only_error(&error) => {
             // If we're in read only mode, we can't update their details
             // just look for an existing user
-            find_user_by_gh_id(conn, user.id)
-                .await?
-                .map(|u| u.id)
-                .ok_or(error)
+            find_user_by_gh_id(conn, user.id).await?.ok_or(error)
         }
         Err(error) => Err(error),
     }
@@ -232,9 +229,10 @@ async fn create_or_update_user(
     .await
 }
 
-async fn find_user_by_gh_id(mut conn: &AsyncPgConnection, gh_id: i32) -> QueryResult<Option<User>> {
-    User::query()
+async fn find_user_by_gh_id(mut conn: &AsyncPgConnection, gh_id: i32) -> QueryResult<Option<i32>> {
+    users::table
         .filter(users::gh_id.eq(gh_id))
+        .select(users::id)
         .first(&mut conn)
         .await
         .optional()

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -135,10 +135,10 @@ pub async fn authorize_session(
     let ghuser = app.github.current_user(token).await?;
 
     let mut conn = app.db_write().await?;
-    let user = save_user_to_database(&ghuser, &encrypted_token, &app.emails, &mut conn).await?;
+    let user_id = save_user_to_database(&ghuser, &encrypted_token, &app.emails, &mut conn).await?;
 
     // Log in by setting a cookie and the middleware authentication
-    session.insert("user_id".to_string(), user.id.to_string());
+    session.insert("user_id".to_string(), user_id.to_string());
 
     super::user::me::get_authenticated_user(app, req).await
 }
@@ -148,7 +148,7 @@ pub async fn save_user_to_database(
     encrypted_token: &[u8],
     emails: &Emails,
     conn: &mut AsyncPgConnection,
-) -> QueryResult<User> {
+) -> QueryResult<i32> {
     let new_user = NewUser::builder()
         .gh_id(user.id)
         .gh_login(&user.login)
@@ -158,11 +158,14 @@ pub async fn save_user_to_database(
         .build();
 
     match create_or_update_user(&new_user, user.email.as_deref(), emails, conn).await {
-        Ok(user) => Ok(user),
+        Ok(user) => Ok(user.id),
         Err(error) if is_read_only_error(&error) => {
             // If we're in read only mode, we can't update their details
             // just look for an existing user
-            find_user_by_gh_id(conn, user.id).await?.ok_or(error)
+            find_user_by_gh_id(conn, user.id)
+                .await?
+                .map(|u| u.id)
+                .ok_or(error)
         }
         Err(error) => Err(error),
     }

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -158,7 +158,7 @@ pub async fn save_user_to_database(
         .build();
 
     match create_or_update_user(&new_user, user.email.as_deref(), emails, conn).await {
-        Ok(user) => Ok(user.id),
+        Ok(id) => Ok(id),
         Err(error) if is_read_only_error(&error) => {
             // If we're in read only mode, we can't update their details
             // just look for an existing user
@@ -180,19 +180,19 @@ async fn create_or_update_user(
     email: Option<&str>,
     emails: &Emails,
     conn: &mut AsyncPgConnection,
-) -> QueryResult<User> {
+) -> QueryResult<i32> {
     conn.transaction(async |conn| {
-        let user = new_user.insert_or_update(conn).await?;
+        let user_id = new_user.insert_or_update(conn).await?.id;
 
         // To assist in eventually someday allowing OAuth with more than GitHub, also
         // write the GitHub info to the `oauth_github` table. Nothing currently reads
         // from this table. Only log errors but don't fail login if this writing fails.
         let new_oauth_github = NewOauthGithub::builder()
-            .user_id(user.id)
-            .account_id(user.gh_id as i64)
+            .user_id(user_id)
+            .account_id(new_user.gh_id as i64)
             .encrypted_token(new_user.gh_encrypted_token)
-            .login(&user.gh_login)
-            .maybe_avatar(user.gh_avatar.as_deref())
+            .login(new_user.gh_login)
+            .maybe_avatar(new_user.gh_avatar)
             .build();
         if let Err(e) = new_oauth_github.insert_or_update(conn).await {
             error!("Error inserting or updating oauth_github record: {e}");
@@ -201,7 +201,7 @@ async fn create_or_update_user(
         // To send the user an account verification email
         if let Some(user_email) = email {
             let new_email = NewEmail::builder()
-                .user_id(user.id)
+                .user_id(user_id)
                 .email(user_email)
                 .build();
 
@@ -209,7 +209,7 @@ async fn create_or_update_user(
                 let email = EmailMessage::from_template(
                     "user_confirm",
                     context! {
-                        user_name => user.gh_login,
+                        user_name => new_user.gh_login,
                         domain => emails.domain,
                         token => token.expose_secret()
                     },
@@ -227,7 +227,7 @@ async fn create_or_update_user(
             }
         }
 
-        Ok(user)
+        Ok(user_id)
     })
     .await
 }

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -179,7 +179,7 @@ async fn create_or_update_user(
     conn: &mut AsyncPgConnection,
 ) -> QueryResult<i32> {
     conn.transaction(async |conn| {
-        let user_id = new_user.insert_or_update(conn).await?.id;
+        let user_id = new_user.insert_or_update(conn).await?;
 
         // To assist in eventually someday allowing OAuth with more than GitHub, also
         // write the GitHub info to the `oauth_github` table. Nothing currently reads

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -711,7 +711,6 @@ mod tests {
             .build()
             .insert(conn)
             .await
-            .map(|user| user.id)
     }
 
     async fn new_user_bucket(

--- a/src/tests/krate/publish/github_org_restrictions.rs
+++ b/src/tests/krate/publish/github_org_restrictions.rs
@@ -44,7 +44,7 @@ async fn publish_with_org_restrictions() {
         .create_or_update(&conn)
         .await
         .unwrap();
-    add_team_to_crate(&team, &krate, owner_model, &mut conn)
+    add_team_to_crate(&team, &krate, owner_model.id, &mut conn)
         .await
         .unwrap();
 

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -286,7 +286,7 @@ async fn check_ownership_two_crates() -> anyhow::Result<()> {
     let krate_owned_by_team = CrateBuilder::new("foo", user.id)
         .expect_build(&mut conn)
         .await;
-    add_team_to_crate(&team, &krate_owned_by_team, user, &mut conn).await?;
+    add_team_to_crate(&team, &krate_owned_by_team, user.id, &mut conn).await?;
 
     let user2 = app.db_new_user("user_bar").await;
     let user2 = user2.as_model();
@@ -325,7 +325,7 @@ async fn check_ownership_one_crate() -> anyhow::Result<()> {
     let krate = CrateBuilder::new("best_crate", user.id)
         .expect_build(&mut conn)
         .await;
-    add_team_to_crate(&team, &krate, user, &mut conn).await?;
+    add_team_to_crate(&team, &krate, user.id, &mut conn).await?;
 
     let json: TeamResponse = anon
         .get("/api/v1/crates/best_crate/owner_team")
@@ -359,7 +359,7 @@ async fn add_existing_team() {
     let krate = CrateBuilder::new("best_crate", user.id)
         .expect_build(&mut conn)
         .await;
-    add_team_to_crate(&t, &krate, user, &mut conn)
+    add_team_to_crate(&t, &krate, user.id, &mut conn)
         .await
         .unwrap();
 

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -23,7 +23,7 @@ async fn index() -> anyhow::Result<()> {
         assert_eq!(json.meta.total, 0);
     }
 
-    let user_id = new_user("foo").insert(&conn).await?.id;
+    let user_id = new_user("foo").insert(&conn).await?;
 
     let krate = CrateBuilder::new("fooindex", user_id)
         .expect_build(&mut conn)

--- a/src/tests/routes/crates/versions/docs.rs
+++ b/src/tests/routes/crates/versions/docs.rs
@@ -45,7 +45,7 @@ async fn test_trigger_rebuild_permission_failed() -> anyhow::Result<()> {
 
     let mut conn = app.db_conn().await;
 
-    let other_user = NewUser::builder()
+    let other_user_id = NewUser::builder()
         .gh_id(111)
         .gh_login("other_user")
         .gh_encrypted_token(&[])
@@ -53,7 +53,7 @@ async fn test_trigger_rebuild_permission_failed() -> anyhow::Result<()> {
         .insert(&conn)
         .await?;
 
-    CrateBuilder::new("krate", other_user.id)
+    CrateBuilder::new("krate", other_user_id)
         .version(VersionBuilder::new("0.1.0"))
         .build(&mut conn)
         .await?;

--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -116,11 +116,7 @@ async fn test_update_email_notifications_not_owned() {
     let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn().await;
 
-    let user_id = new_user("arbitrary_username")
-        .insert(&conn)
-        .await
-        .unwrap()
-        .id;
+    let user_id = new_user("arbitrary_username").insert(&conn).await.unwrap();
 
     let not_my_crate = CrateBuilder::new("test_package", user_id)
         .expect_build(&mut conn)

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -466,7 +466,7 @@ async fn crates_by_team_id() -> anyhow::Result<()> {
     let krate = CrateBuilder::new("foo", user.id)
         .expect_build(&mut conn)
         .await;
-    add_team_to_crate(&t, &krate, user, &mut conn).await?;
+    add_team_to_crate(&t, &krate, user.id, &mut conn).await?;
 
     let json = anon.search(&format!("team_id={}", t.id)).await;
     assert_eq!(json.crates.len(), 1);
@@ -492,7 +492,7 @@ async fn crates_by_team_id_not_including_deleted_owners() -> anyhow::Result<()> 
     let krate = CrateBuilder::new("foo", user.id)
         .expect_build(&mut conn)
         .await;
-    add_team_to_crate(&t, &krate, user, &mut conn).await?;
+    add_team_to_crate(&t, &krate, user.id, &mut conn).await?;
     krate.owner_remove(&conn, &t.login).await.unwrap();
 
     let json = anon.search(&format!("team_id={}", t.id)).await;

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -84,7 +84,8 @@ async fn github_without_email_does_not_overwrite_email() -> anyhow::Result<()> {
         avatar_url: None,
     };
 
-    let u = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let u = User::find(&conn, user_id).await?;
 
     let user_without_github_email = MockCookieUser::new(&app, u);
 
@@ -107,7 +108,8 @@ async fn github_without_email_does_not_overwrite_email() -> anyhow::Result<()> {
         avatar_url: None,
     };
 
-    let u = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let u = User::find(&conn, user_id).await?;
 
     let again_user_without_github_email = MockCookieUser::new(&app, u);
 
@@ -148,7 +150,8 @@ async fn github_with_email_does_not_overwrite_email() -> anyhow::Result<()> {
         avatar_url: None,
     };
 
-    let u = session::save_user_to_database(&gh_user, &[], &emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(&gh_user, &[], &emails, &mut conn).await?;
+    let u = User::find(&conn, user_id).await?;
 
     let user_with_different_email_in_github = MockCookieUser::new(&app, u);
 
@@ -204,7 +207,8 @@ async fn test_confirm_user_email() -> anyhow::Result<()> {
         avatar_url: None,
     };
 
-    let u = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let u = User::find(&conn, user_id).await?;
 
     let user = MockCookieUser::new(&app, u);
     let user_model = user.as_model();
@@ -249,7 +253,8 @@ async fn test_existing_user_email() -> anyhow::Result<()> {
         avatar_url: None,
     };
 
-    let u = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let u = User::find(&conn, user_id).await?;
 
     update(Email::belonging_to(&u))
         // Users created before we added verification will have
@@ -289,7 +294,8 @@ async fn also_write_to_oauth_github() -> anyhow::Result<()> {
         avatar_url: None,
     };
     let encrypted_token = encryption.encrypt("some random token")?;
-    let u = session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await?;
+    let uid = session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await?;
+    let u = User::find(&conn, uid).await?;
 
     let oauth_github_records: Vec<OauthGithub> = oauth_github::table.load(&mut conn).await.unwrap();
     assert_eq!(oauth_github_records.len(), 1);
@@ -311,7 +317,8 @@ async fn also_write_to_oauth_github() -> anyhow::Result<()> {
         avatar_url: Some("http://example.com/icon.png".into()),
     };
     let encrypted_token = encryption.encrypt("a different token")?;
-    let u = session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await?;
+    let uid = session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await?;
+    let u = User::find(&conn, uid).await?;
 
     let oauth_github_records: Vec<OauthGithub> = oauth_github::table.load(&mut conn).await.unwrap();
     // There still should only be one `oauth_github` record that got updated, not a new insertion
@@ -337,7 +344,8 @@ async fn also_write_to_oauth_github() -> anyhow::Result<()> {
         avatar_url: None,
     };
     let encrypted_token = encryption.encrypt("a different random token")?;
-    let u = session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await?;
+    let uid = session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await?;
+    let u = User::find(&conn, uid).await?;
 
     assert_eq!(u.gh_login, "arbitrary_username");
     assert_eq!(u.gh_id, new_gh_id);

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -6,8 +6,8 @@ use crates_io::config::{
     self, Base, CdnLogQueueConfig, CdnLogStorageConfig, DatabasePools, DbPoolConfig,
 };
 use crates_io::middleware::cargo_compat::StatusCodeConfig;
-use crates_io::models::NewEmail;
 use crates_io::models::token::{CrateScope, EndpointScope};
+use crates_io::models::{NewEmail, User};
 use crates_io::rate_limiter::{LimitedAction, RateLimiterConfig};
 use crates_io::storage::StorageConfig;
 use crates_io::util::gh_token_encryption::GitHubTokenEncryption;
@@ -141,15 +141,29 @@ impl TestApp {
 
         let email = format!("{username}@example.com");
 
-        let user = crate::new_user(username).insert(&conn).await.unwrap();
+        let new_user = crate::new_user(username);
+        let id = new_user.insert(&conn).await.unwrap();
 
         let new_email = NewEmail::builder()
-            .user_id(user.id)
+            .user_id(id)
             .email(&email)
             .verified(true)
             .build();
 
         new_email.insert(&conn).await.unwrap();
+
+        let user = User {
+            id,
+            name: new_user.name.map(str::to_string),
+            gh_id: new_user.gh_id,
+            gh_login: new_user.gh_login.to_string(),
+            gh_avatar: new_user.gh_avatar.map(str::to_string),
+            gh_encrypted_token: new_user.gh_encrypted_token.to_vec(),
+            account_lock_reason: None,
+            account_lock_until: None,
+            is_admin: false,
+            publish_notifications: true,
+        };
 
         MockCookieUser {
             app: self.clone(),

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -43,13 +43,13 @@ impl UpdateTest {
         let emails = &app.as_inner().emails;
         let mut conn = app.db_conn().await;
 
-        let u =
+        let user_id =
             session::save_user_to_database(&existing_gh_user, &ENCRYPTED_TOKEN, emails, &mut conn)
                 .await
                 .unwrap();
 
         let oauth_github_before_update = oauth_github::table
-            .filter(oauth_github::user_id.eq(u.id))
+            .filter(oauth_github::user_id.eq(user_id))
             .first::<OauthGithub>(&mut conn)
             .await
             .unwrap();
@@ -63,7 +63,7 @@ impl UpdateTest {
         let job_result = app.try_run_pending_background_jobs().await;
 
         let oauth_github_after_update = oauth_github::table
-            .filter(oauth_github::user_id.eq(u.id))
+            .filter(oauth_github::user_id.eq(user_id))
             .first::<OauthGithub>(&mut conn)
             .await
             .unwrap();
@@ -75,7 +75,7 @@ impl UpdateTest {
         }
 
         // For now, we want to update the `User` record too
-        let user_after_update = User::find(&conn, u.id).await.unwrap();
+        let user_after_update = User::find(&conn, user_id).await.unwrap();
         assert_eq!(user_after_update.gh_login, expected_username);
 
         if job_result.is_err() {

--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -199,8 +199,8 @@ mod tests {
 
         // Let's set up a team that owns both b and c, but not a.
         let not_the_a_team = faker::team(&mut conn, "org", "team").await?;
-        add_team_to_crate(&not_the_a_team, &top_b, &user_b, &mut conn).await?;
-        add_team_to_crate(&not_the_a_team, &not_top_c, &user_b, &mut conn).await?;
+        add_team_to_crate(&not_the_a_team, &top_b, user_b.id, &mut conn).await?;
+        add_team_to_crate(&not_the_a_team, &not_top_c, user_b.id, &mut conn).await?;
 
         let top_crates = TopCrates::new(&mut conn, 2).await?;
 

--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -192,15 +192,14 @@ mod tests {
         let user_b = faker::user(&mut conn, "b").await?;
 
         // Set up three crates with various ownership schemes.
-        let _top_a = faker::crate_and_version(&mut conn, "a", "Hello", user_a.id, 2).await?;
-        let top_b =
-            faker::crate_and_version(&mut conn, "b", "Yes, this is dog", user_b.id, 1).await?;
-        let not_top_c = faker::crate_and_version(&mut conn, "c", "Unpopular", user_a.id, 0).await?;
+        let _top_a = faker::crate_and_version(&mut conn, "a", "Hello", user_a, 2).await?;
+        let top_b = faker::crate_and_version(&mut conn, "b", "Yes, this is dog", user_b, 1).await?;
+        let not_top_c = faker::crate_and_version(&mut conn, "c", "Unpopular", user_a, 0).await?;
 
         // Let's set up a team that owns both b and c, but not a.
         let not_the_a_team = faker::team(&mut conn, "org", "team").await?;
-        add_team_to_crate(&not_the_a_team, &top_b, user_b.id, &mut conn).await?;
-        add_team_to_crate(&not_the_a_team, &not_top_c, user_b.id, &mut conn).await?;
+        add_team_to_crate(&not_the_a_team, &top_b, user_b, &mut conn).await?;
+        add_team_to_crate(&not_the_a_team, &not_top_c, user_b, &mut conn).await?;
 
         let top_crates = TopCrates::new(&mut conn, 2).await?;
 

--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -192,10 +192,10 @@ mod tests {
         let user_b = faker::user(&mut conn, "b").await?;
 
         // Set up three crates with various ownership schemes.
-        let _top_a = faker::crate_and_version(&mut conn, "a", "Hello", &user_a, 2).await?;
+        let _top_a = faker::crate_and_version(&mut conn, "a", "Hello", user_a.id, 2).await?;
         let top_b =
-            faker::crate_and_version(&mut conn, "b", "Yes, this is dog", &user_b, 1).await?;
-        let not_top_c = faker::crate_and_version(&mut conn, "c", "Unpopular", &user_a, 0).await?;
+            faker::crate_and_version(&mut conn, "b", "Yes, this is dog", user_b.id, 1).await?;
+        let not_top_c = faker::crate_and_version(&mut conn, "c", "Unpopular", user_a.id, 0).await?;
 
         // Let's set up a team that owns both b and c, but not a.
         let not_the_a_team = faker::team(&mut conn, "org", "team").await?;

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -13,10 +13,10 @@ pub mod faker {
         conn: &mut AsyncPgConnection,
         name: &str,
         description: &str,
-        user: &User,
+        user_id: i32,
         downloads: i32,
     ) -> anyhow::Result<Crate> {
-        CrateBuilder::new(name, user.id)
+        CrateBuilder::new(name, user_id)
             .description(description)
             .downloads(downloads)
             .version("1.0.0")

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -45,6 +45,5 @@ pub mod faker {
             .build()
             .insert(conn)
             .await
-            .map(|user| user.id)
     }
 }

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -1,6 +1,6 @@
 use diesel::prelude::*;
 
-use crate::models::{Crate, NewTeam, NewUser, Team, User};
+use crate::models::{Crate, NewTeam, NewUser, Team};
 use crates_io_test_utils::github::next_gh_id;
 
 pub mod faker {
@@ -37,7 +37,7 @@ pub mod faker {
         Ok(team.create_or_update(conn).await?)
     }
 
-    pub async fn user(conn: &mut AsyncPgConnection, login: &str) -> QueryResult<User> {
+    pub async fn user(conn: &mut AsyncPgConnection, login: &str) -> QueryResult<i32> {
         NewUser::builder()
             .gh_id(next_gh_id())
             .gh_login(login)
@@ -45,5 +45,6 @@ pub mod faker {
             .build()
             .insert(conn)
             .await
+            .map(|user| user.id)
     }
 }

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -107,13 +107,13 @@ async fn batch_update(batch_size: i64, conn: &mut AsyncPgConnection) -> QueryRes
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
+    use crate::models::{Crate, NewCrate, NewUser, NewVersion, Version};
     use crate::schema::{crate_downloads, crates, versions};
     use crates_io_test_db::TestDatabase;
     use diesel::sql_types::Timestamptz;
     use diesel_async::AsyncConnection;
 
-    async fn user(conn: &mut AsyncPgConnection) -> User {
+    async fn user(conn: &mut AsyncPgConnection) -> i32 {
         NewUser::builder()
             .gh_id(2)
             .gh_login("login")
@@ -122,6 +122,7 @@ mod tests {
             .insert(conn)
             .await
             .unwrap()
+            .id
     }
 
     async fn crate_and_version(conn: &mut AsyncPgConnection, user_id: i32) -> (Crate, Version) {
@@ -150,8 +151,8 @@ mod tests {
         let test_db = TestDatabase::new();
         let mut conn = test_db.async_connect().await;
 
-        let user = user(&mut conn).await;
-        let (krate, version) = crate_and_version(&mut conn, user.id).await;
+        let user_id = user(&mut conn).await;
+        let (krate, version) = crate_and_version(&mut conn, user_id).await;
         insert_into(version_downloads::table)
             .values(version_downloads::version_id.eq(version.id))
             .execute(&mut conn)
@@ -200,8 +201,8 @@ mod tests {
         let test_db = TestDatabase::new();
         let mut conn = test_db.async_connect().await;
 
-        let user = user(&mut conn).await;
-        let (_, version) = crate_and_version(&mut conn, user.id).await;
+        let user_id = user(&mut conn).await;
+        let (_, version) = crate_and_version(&mut conn, user_id).await;
         insert_into(version_downloads::table)
             .values((
                 version_downloads::version_id.eq(version.id),
@@ -228,8 +229,8 @@ mod tests {
         let test_db = TestDatabase::new();
         let mut conn = test_db.async_connect().await;
 
-        let user = user(&mut conn).await;
-        let (_, version) = crate_and_version(&mut conn, user.id).await;
+        let user_id = user(&mut conn).await;
+        let (_, version) = crate_and_version(&mut conn, user_id).await;
         insert_into(version_downloads::table)
             .values((
                 version_downloads::version_id.eq(version.id),
@@ -258,8 +259,8 @@ mod tests {
         let test_db = TestDatabase::new();
         let mut conn = test_db.async_connect().await;
 
-        let user = user(&mut conn).await;
-        let (krate, version) = crate_and_version(&mut conn, user.id).await;
+        let user_id = user(&mut conn).await;
+        let (krate, version) = crate_and_version(&mut conn, user_id).await;
         update(versions::table)
             .set(versions::updated_at.eq(now.into_sql::<Timestamptz>() - 2.hours()))
             .execute(&mut conn)
@@ -344,8 +345,8 @@ mod tests {
         let test_db = TestDatabase::new();
         let mut conn = test_db.async_connect().await;
 
-        let user = user(&mut conn).await;
-        let (_, version) = crate_and_version(&mut conn, user.id).await;
+        let user_id = user(&mut conn).await;
+        let (_, version) = crate_and_version(&mut conn, user_id).await;
 
         // Wrap the test body in a transaction so `now` resolves to the same
         // value across every query inside it.

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -122,7 +122,6 @@ mod tests {
             .insert(conn)
             .await
             .unwrap()
-            .id
     }
 
     async fn crate_and_version(conn: &mut AsyncPgConnection, user_id: i32) -> (Crate, Version) {

--- a/src/worker/jobs/expiry_notification.rs
+++ b/src/worker/jobs/expiry_notification.rs
@@ -154,7 +154,7 @@ mod tests {
         let mut conn = test_db.async_connect().await;
 
         // Set up a user and a token that is about to expire.
-        let user = NewUser::builder()
+        let user_id = NewUser::builder()
             .gh_id(0)
             .gh_login("a")
             .gh_encrypted_token(&[])
@@ -163,7 +163,7 @@ mod tests {
             .await?;
 
         NewEmail::builder()
-            .user_id(user.id)
+            .user_id(user_id)
             .email("testuser@test.com")
             .build()
             .insert(&conn)
@@ -173,7 +173,7 @@ mod tests {
 
         let token: ApiToken = diesel::insert_into(api_tokens::table)
             .values((
-                api_tokens::user_id.eq(user.id),
+                api_tokens::user_id.eq(user_id),
                 api_tokens::name.eq("test_token"),
                 api_tokens::token.eq(token.hashed()),
                 api_tokens::expired_at.eq(now.into_sql::<Timestamptz>().nullable()
@@ -189,7 +189,7 @@ mod tests {
             let token = PlainToken::generate();
             diesel::insert_into(api_tokens::table)
                 .values((
-                    api_tokens::user_id.eq(user.id),
+                    api_tokens::user_id.eq(user_id),
                     api_tokens::name.eq(format!("test_token{i}")),
                     api_tokens::token.eq(token.hashed()),
                     api_tokens::expired_at
@@ -233,7 +233,7 @@ mod tests {
         let token = PlainToken::generate();
         diesel::insert_into(api_tokens::table)
             .values((
-                api_tokens::user_id.eq(user.id),
+                api_tokens::user_id.eq(user_id),
                 api_tokens::name.eq("expired_token"),
                 api_tokens::token.eq(token.hashed()),
                 api_tokens::expired_at.eq(now.into_sql::<Timestamptz>().nullable() - 1.day()),

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -134,7 +134,7 @@ mod tests {
 
         // Set up a user and a popular crate to match against.
         let user = faker::user(&mut conn, "a").await?;
-        faker::crate_and_version(&mut conn, "my-crate", "It's awesome", user.id, 100).await?;
+        faker::crate_and_version(&mut conn, "my-crate", "It's awesome", user, 100).await?;
 
         // Prime the cache so it only includes the crate we just created.
         let mut async_conn = test_db.async_connect().await;
@@ -147,7 +147,7 @@ mod tests {
             &mut async_conn,
             "innocent-crate",
             "I'm just a simple, innocent crate",
-            other_user.id,
+            other_user,
             0,
         )
         .await?;
@@ -155,7 +155,7 @@ mod tests {
             &mut async_conn,
             "mycrate",
             "I'm even more innocent, obviously",
-            other_user.id,
+            other_user,
             0,
         )
         .await?;

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -134,7 +134,7 @@ mod tests {
 
         // Set up a user and a popular crate to match against.
         let user = faker::user(&mut conn, "a").await?;
-        faker::crate_and_version(&mut conn, "my-crate", "It's awesome", &user, 100).await?;
+        faker::crate_and_version(&mut conn, "my-crate", "It's awesome", user.id, 100).await?;
 
         // Prime the cache so it only includes the crate we just created.
         let mut async_conn = test_db.async_connect().await;
@@ -147,7 +147,7 @@ mod tests {
             &mut async_conn,
             "innocent-crate",
             "I'm just a simple, innocent crate",
-            &other_user,
+            other_user.id,
             0,
         )
         .await?;
@@ -155,7 +155,7 @@ mod tests {
             &mut async_conn,
             "mycrate",
             "I'm even more innocent, obviously",
-            &other_user,
+            other_user.id,
             0,
         )
         .await?;


### PR DESCRIPTION
The `users.gh_*` columns are being migrated into the `oauth_github` table, which will make `User`'s selectable reference columns outside users and break `RETURNING` `User::as_returning()` from an insert against `users`. Narrowing the return type to `i32` sidesteps that without forcing the insert path to re-fetch through the joined query.

The `insert()` and `insert_or_update()` methods on `NewUser` both returned a fully populated `User`. The sole production caller (`controllers::session::create_or_update_user()`) only ever consumed `.id` from that value, and most test helpers were in the same shape: they held a `User` only to read its id. The `RETURNING` clause is now narrowed to `users::id`.

The change ripples outward through `controllers::session` and a few test helpers (`typosquat::faker::user()`, `add_team_to_crate()`, `tests::user()` in the download-metadata job). Each of those previously held a `User` only for its id, so they now take or return `i32` directly.

A few sites genuinely needed the full `User`. Test callers of `save_user_to_database()` in `src/tests/user.rs` and `src/tests/worker/update_user_from_github.rs` re-fetch the row via `User::find()`. `db_new_user()` keeps handing a `User` to `MockCookieUser` (to preserve `as_model()` for the many tests that read fields off it), synthesized from the `NewUser` builder and the returned id with database defaults for the remaining columns.

One spot worth a closer look during review: `create_or_update_user()` now sources `gh_login`, `gh_id`, and `gh_avatar` for the `NewOauthGithub` builder and the email confirmation template from the `NewUser` argument instead of the upserted `User`. The upsert's `SET` clause writes those same `excluded(...)` values, so the visible state matches.