### PR TITLE
Read user avatar from `oauth_github` table via `LEFT JOIN`

### DIFF
--- a/crates/crates_io_database/src/models/action.rs
+++ b/crates/crates_io_database/src/models/action.rs
@@ -62,7 +62,7 @@ impl VersionOwnerAction {
 
         version_owner_actions::table
             .filter(version_id.eq(version.id))
-            .inner_join(users::table)
+            .inner_join(users::table.left_join(oauth_github::table))
             .select((VersionOwnerAction::as_select(), User::as_select()))
             .order(version_owner_actions::dsl::id)
             .load(&mut conn)
@@ -74,7 +74,7 @@ impl VersionOwnerAction {
         versions: &[&Version],
     ) -> QueryResult<Vec<Vec<(Self, User)>>> {
         Ok(Self::belonging_to(versions)
-            .inner_join(users::table)
+            .inner_join(users::table.left_join(oauth_github::table))
             .select((VersionOwnerAction::as_select(), User::as_select()))
             .order(version_owner_actions::dsl::id)
             .load(&mut conn)

--- a/crates/crates_io_database/src/models/crate_owner_invitation.rs
+++ b/crates/crates_io_database/src/models/crate_owner_invitation.rs
@@ -4,7 +4,7 @@ use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use secrecy::SecretString;
 
 use crate::models::{CrateOwner, User};
-use crate::schema::{crate_owner_invitations, crates};
+use crate::schema::{crate_owner_invitations, crates, users};
 
 #[derive(Debug)]
 pub enum NewCrateOwnerInvitationOutcome {
@@ -103,7 +103,10 @@ impl CrateOwnerInvitation {
         }
 
         // Get the user and check if they have a verified email
-        let user = User::query().find(self.invited_user_id).first(conn).await?;
+        let user = User::query()
+            .filter(users::id.eq(self.invited_user_id))
+            .first(conn)
+            .await?;
 
         let verified_email = user.verified_email(conn).await?;
         if verified_email.is_none() {

--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -210,7 +210,7 @@ impl Crate {
         let users = CrateOwner::by_owner_kind(OwnerKind::User)
             .filter(crate_owners::crate_id.eq(self.id))
             .order((crate_owners::owner_id, crate_owners::owner_kind))
-            .inner_join(users::table)
+            .inner_join(users::table.left_join(oauth_github::table))
             .select(User::as_select())
             .load(&mut conn)
             .await?

--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -13,11 +13,16 @@ use crates_io_diesel_helpers::lower;
 
 /// The model representing a row in the `users` database table.
 #[derive(Clone, Debug, HasQuery, Identifiable, Serialize)]
+#[diesel(
+    table_name = users,
+    base_query = users::table.left_join(oauth_github::table),
+)]
 pub struct User {
     pub id: i32,
     pub name: Option<String>,
     pub gh_id: i32,
     pub gh_login: String,
+    #[diesel(select_expression = oauth_github::avatar.nullable())]
     pub gh_avatar: Option<String>,
     #[serde(skip)]
     pub gh_encrypted_token: Vec<u8>,
@@ -29,7 +34,10 @@ pub struct User {
 
 impl User {
     pub async fn find(mut conn: &AsyncPgConnection, id: i32) -> QueryResult<User> {
-        User::query().find(id).first(&mut conn).await
+        User::query()
+            .filter(users::id.eq(id))
+            .first(&mut conn)
+            .await
     }
 
     pub async fn find_by_login(mut conn: &AsyncPgConnection, login: &str) -> QueryResult<User> {
@@ -43,7 +51,7 @@ impl User {
 
     pub async fn owning(krate: &Crate, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Owner>> {
         let users = CrateOwner::by_owner_kind(OwnerKind::User)
-            .inner_join(users::table)
+            .inner_join(users::table.left_join(oauth_github::table))
             .select(User::as_select())
             .filter(crate_owners::crate_id.eq(krate.id))
             .load(&mut conn)

--- a/crates/crates_io_database/src/models/version.rs
+++ b/crates/crates_io_database/src/models/version.rs
@@ -8,7 +8,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::Deserialize;
 
 use crate::models::{Crate, TrustpubData, User};
-use crate::schema::{readme_renderings, versions};
+use crate::schema::{readme_renderings, users, versions};
 
 #[derive(Clone, Identifiable, Associations, Debug, HasQuery)]
 #[diesel(belongs_to(Crate), belongs_to(crate::models::download::Version, foreign_key=id))]
@@ -60,7 +60,11 @@ impl Version {
     /// Not for use when you have a group of versions you need the publishers for.
     pub async fn published_by(&self, mut conn: &AsyncPgConnection) -> QueryResult<Option<User>> {
         match self.published_by {
-            Some(pb) => User::query().find(pb).first(&mut conn).await.optional(),
+            Some(pb) => User::query()
+                .filter(users::id.eq(pb))
+                .first(&mut conn)
+                .await
+                .optional(),
             None => Ok(None),
         }
     }

--- a/src/controllers/admin.rs
+++ b/src/controllers/admin.rs
@@ -78,6 +78,7 @@ pub async fn list(
 
     let (user, verified, user_email) = users::table
         .left_join(emails::table)
+        .left_join(oauth_github::table)
         .filter(users::gh_login.eq(username))
         .select((
             User::as_select(),

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -13,7 +13,7 @@ use crate::views::{EncodableVersion, EncodableVersionDownload};
 use axum::Json;
 use axum::extract::FromRequestParts;
 use axum_extra::extract::Query;
-use crates_io_database::schema::users;
+use crates_io_database::schema::{oauth_github, users};
 use crates_io_diesel_helpers::to_char;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -171,7 +171,7 @@ async fn load_versions_and_publishers(
         return Ok(vec![]);
     }
     FullVersion::belonging_to(versions)
-        .left_outer_join(users::table)
+        .left_outer_join(users::table.left_join(oauth_github::table))
         .select(VersionsAndPublishers::as_select())
         .load(&mut conn)
         .await
@@ -186,7 +186,7 @@ async fn load_actions(
         return Ok(vec![]);
     }
     VersionOwnerAction::belonging_to(versions)
-        .inner_join(users::table)
+        .inner_join(users::table.left_join(oauth_github::table))
         .select((VersionOwnerAction::as_select(), User::as_select()))
         .order(version_owner_actions::id)
         .load(&mut conn)

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -307,7 +307,7 @@ async fn _load_versions_and_publishers(
     version_num: Option<&str>,
 ) -> AppResult<Option<Vec<VersionsAndPublishers>>> {
     let mut query = Version::belonging_to(krate)
-        .left_outer_join(users::table)
+        .left_outer_join(users::table.left_join(oauth_github::table))
         .select(<(Version, Option<User>)>::as_select())
         .order_by(versions::id.desc())
         .into_boxed();

--- a/src/controllers/krate/rev_deps.rs
+++ b/src/controllers/krate/rev_deps.rs
@@ -5,7 +5,7 @@ use crate::models::{CrateName, User, Version, VersionOwnerAction};
 use crate::util::errors::AppResult;
 use crate::views::{EncodableDependency, EncodableVersion};
 use axum::Json;
-use crates_io_database::schema::{crates, users, versions};
+use crates_io_database::schema::{crates, oauth_github, users, versions};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::request::Parts;
@@ -62,7 +62,7 @@ pub async fn list_reverse_dependencies(
     let versions_and_publishers: Vec<(Version, CrateName, Option<User>)> = versions::table
         .filter(versions::id.eq_any(version_ids))
         .inner_join(crates::table)
-        .left_outer_join(users::table)
+        .left_outer_join(users::table.left_join(oauth_github::table))
         .select(<(Version, CrateName, Option<User>)>::as_select())
         .load(&mut conn)
         .await?;

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -6,7 +6,7 @@ use crate::controllers::helpers::pagination::{
 };
 use crate::controllers::krate::CratePath;
 use crate::models::{User, Version, VersionOwnerAction};
-use crate::schema::{users, versions};
+use crate::schema::{oauth_github, users, versions};
 use crate::util::RequestUtils;
 use crate::util::errors::{AppResult, BoxedAppError, bad_request};
 use crate::util::string_excl_null::StringExclNull;
@@ -144,7 +144,7 @@ async fn list(
     let make_base_query = || {
         let mut query = versions::table
             .filter(versions::crate_id.eq(crate_id))
-            .left_outer_join(users::table)
+            .left_outer_join(users::table.left_join(oauth_github::table))
             .select(<(Version, Option<User>)>::as_select())
             .into_boxed();
 

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -4,7 +4,7 @@ use crate::controllers::helpers::Paginate;
 use crate::controllers::helpers::pagination::{Paginated, PaginationOptions};
 use crate::models::krate::CrateName;
 use crate::models::{CrateOwner, Follow, OwnerKind, User, Version, VersionOwnerAction};
-use crate::schema::{crate_owners, crates, emails, follows, users, versions};
+use crate::schema::{crate_owners, crates, emails, follows, oauth_github, users, versions};
 use crate::util::errors::AppResult;
 use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCrate};
 use axum::Json;
@@ -34,6 +34,7 @@ pub async fn get_authenticated_user(app: AppState, req: Parts) -> AppResult<Json
         users::table
             .find(user_id)
             .left_join(emails::table)
+            .left_join(oauth_github::table)
             .select((
                 User::as_select(),
                 emails::verified.nullable(),
@@ -104,7 +105,7 @@ pub async fn get_authenticated_user_updates(
     let followed_crates = Follow::belonging_to(user).select(follows::crate_id);
     let query = versions::table
         .inner_join(crates::table)
-        .left_outer_join(users::table)
+        .left_outer_join(users::table.left_join(oauth_github::table))
         .filter(crates::id.eq_any(followed_crates))
         .order(versions::created_at.desc())
         .select(<(Version, CrateName, Option<User>)>::as_select())


### PR DESCRIPTION
`User.gh_avatar` now sources from `oauth_github.avatar` via a `LEFT JOIN` in the model's `base_query`. The `users.gh_avatar` column is still written by `NewUser::insert_or_update()` but is no longer read by any of the affected query paths.

Each `User::as_select()` call site picks up an extra `.left_join(oauth_github::table)` so the selectable's reference to `oauth_github::avatar` resolves. `User::find()`, `Version::published_by()`, and the `crate_owner_invitations` accept path switched from `.find(id)` to `.filter(users::id.eq(id))` because the joined query doesn't support `find()`.

This will allow us to drop the `users.gh_avatar` column in the future.

### Related

- https://github.com/rust-lang/crates.io/issues/13758#issuecomment-4565431099
- #13792