### PR TITLE
Remove "Browse All Crates" link from `Header`

### DIFF
--- a/e2e/acceptance/404.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/404.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "Page not found" [level=1]

--- a/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/api-token.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "John Doe"
 - main:
   - heading "Account Settings" [level=1]

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-detail.yml
@@ -8,8 +8,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "Algorithms" [level=1]

--- a/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/categories.spec.ts-snapshots/aria-list.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "All Categories" [level=1]

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "nanomsg v0.6.1" [level=1]

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "nanomsg v0.6.1" [level=1]

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "nanomsg v0.6.0" [level=1]

--- a/e2e/acceptance/crates.spec.ts
+++ b/e2e/acceptance/crates.spec.ts
@@ -3,11 +3,10 @@ import { loadFixtures } from '@crates-io/msw/fixtures';
 import { http, HttpResponse } from 'msw';
 
 test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
-  test('visiting the crates page from the front page', async ({ page, msw, percy, a11y }) => {
+  test('visiting the crates page', async ({ page, msw, percy, a11y }) => {
     await loadFixtures(msw.db);
 
-    await page.goto('/');
-    await page.click('[data-test-all-crates-link]');
+    await page.goto('/crates');
 
     await expect(page).toHaveURL('/crates');
     await expect(page).toHaveTitle('Crates - crates.io: Rust Package Registry');
@@ -15,16 +14,6 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
     await percy.snapshot();
     await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
     await a11y.audit();
-  });
-
-  test('visiting the crates page directly', async ({ page, msw }) => {
-    await loadFixtures(msw.db);
-
-    await page.goto('/crates');
-    await page.click('[data-test-all-crates-link]');
-
-    await expect(page).toHaveURL('/crates');
-    await expect(page).toHaveTitle('Crates - crates.io: Rust Package Registry');
   });
 
   test('listing crates', async ({ page, msw }) => {

--- a/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crates.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "All Crates" [level=1]
@@ -526,4 +524,3 @@
     - listitem:
       - 'link "X: @cratesiostatus"':
         - /url: https://twitter.com/cratesiostatus
-- text: "Crates - crates.io: Rust Package Registry"

--- a/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/dashboard.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "John Doe"
 - main:
   - heading "My Dashboard" [level=1]

--- a/e2e/acceptance/front-page.spec.ts
+++ b/e2e/acceptance/front-page.spec.ts
@@ -13,7 +13,6 @@ test.describe('Acceptance | front page', { tag: '@acceptance' }, () => {
     await expect(page).toHaveTitle('crates.io: Rust Package Registry');
 
     await expect(page.locator('[data-test-install-cargo-link]')).toBeVisible();
-    await expect(page.locator('[data-test-all-crates-link]')).toBeVisible();
     await expect(page.locator('[data-test-login-button]')).toBeVisible();
 
     await expect(page.locator('[data-test-total-downloads] [data-test-value]')).toHaveText('143,345');

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -8,8 +8,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - link "Install Cargo":

--- a/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/invites.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "User 3"
 - main:
   - heading "Pending Owner Invites" [level=1]

--- a/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/keyword.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "All Crates for keyword 'network'" [level=1]

--- a/e2e/acceptance/publish-notifications.spec.ts
+++ b/e2e/acceptance/publish-notifications.spec.ts
@@ -41,8 +41,8 @@ test.describe('Acceptance | publish notifications', { tag: '@acceptance' }, () =
     await expect(page.locator('[data-test-notifications] input[type=checkbox]')).not.toBeChecked();
 
     // Navigate away and back via client-side links
-    await page.click('[data-test-all-crates-link]');
-    await expect(page).toHaveURL('/crates');
+    await page.locator('header').getByRole('link', { name: 'crates.io' }).click();
+    await expect(page).toHaveURL('/');
     await page.click('[data-test-user-menu] [data-test-toggle]');
     await page.click('[data-test-user-menu] [data-test-settings]');
     await expect(page).toHaveURL('/settings/profile');

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "serde v1.0.0" [level=1]

--- a/e2e/acceptance/search.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/search.spec.ts-snapshots/aria.yml
@@ -8,8 +8,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "Search Results for 'rust'" [level=1]

--- a/e2e/acceptance/security.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/security.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "foo" [level=1]

--- a/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/settings/settings.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "blabaere"
 - main:
   - heading "nanomsg" [level=1]

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-form.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "Contact Us" [level=1]
@@ -16,6 +14,7 @@
   - text: Crate
   - textbox "Crate"
   - group "Reasons":
+    - text: ""
     - list:
       - listitem:
         - checkbox "it contains spam"

--- a/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
+++ b/e2e/acceptance/support.spec.ts-snapshots/aria-list.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "Contact Us" [level=1]

--- a/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/team-page.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - img "thehydroimpulseteam (github:org:thehydroimpulse)"

--- a/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/token-invites.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "You've been added as a crate owner!" [level=1]

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - img "Daniel Fagnan (thehydroimpulse)"

--- a/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/versions.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "Log in with GitHub"
 - main:
   - heading "nanomsg" [level=1]

--- a/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/delete.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "User 1"
 - main:
   - heading "Delete the foo crate?" [level=1]

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-configs.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "User 1"
 - main:
   - heading "foo" [level=1]

--- a/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
+++ b/e2e/routes/crate/settings.spec.ts-snapshots/aria-trustpub-warning.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "User 1"
 - main:
   - heading "foo" [level=1]

--- a/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
+++ b/e2e/routes/crate/settings/new-trusted-publisher.spec.ts-snapshots/aria.yml
@@ -7,8 +7,6 @@
     - button "Search"
   - navigation:
     - 'button "Change color scheme. Current: system"'
-    - link "Browse All Crates":
-      - /url: /crates
     - button "User 1"
 - main:
   - heading "Add a new Trusted Publisher" [level=1]

--- a/svelte/src/lib/components/Header.svelte
+++ b/svelte/src/lib/components/Header.svelte
@@ -51,9 +51,6 @@
     <nav class="nav">
       <ColorSchemeMenu class="color-scheme-menu" />
 
-      <a href={resolve('/crates')} data-test-all-crates-link> Browse All Crates </a>
-      <span class="sep" aria-hidden="true">|</span>
-
       {#if currentUser}
         <Dropdown.Root data-test-user-menu>
           <Dropdown.Trigger class="button-reset" data-test-toggle>
@@ -144,7 +141,6 @@
       <Dropdown.Root>
         <Dropdown.Trigger class="button-reset">Menu</Dropdown.Trigger>
         <Dropdown.Menu class="current-user-links">
-          <Dropdown.Item><a href={resolve('/crates')}>Browse All Crates</a></Dropdown.Item>
           {#if currentUser}
             <Dropdown.Item>
               <a href={resolve('/users/[user_id]', { user_id: currentUser.login })}>Profile</a>
@@ -286,11 +282,6 @@
     .hero & {
       display: block;
     }
-  }
-
-  .sep {
-    margin: 0 var(--space-2xs);
-    opacity: 0.5;
   }
 
   .nav {


### PR DESCRIPTION
With 200k+ crates in the registry, browsing the full list is no longer a meaningful entry point, so the link no longer warrants a premium spot in the topbar. Search and the keyword listings are the practical ways to find crates now.

This drops the link from both the nav and the mobile menu, along with the now-unused `.sep` separator rule, and updates the affected end-to-end specs and ARIA snapshots accordingly.