### PR TITLE
Remove obsolete nginx `start-web.sh` script

### DIFF
--- a/script/start-web.sh
+++ b/script/start-web.sh
@@ -1,7 +1,0 @@
-#! /bin/bash
-set -ue
-
-# Since this script is launched from our app, we tell the nginx
-# buildpack (`bin/start-nginx`) that `cat` is our server.
-
-bin/start-nginx cat


### PR DESCRIPTION
This script invoked the Heroku nginx buildpack's `bin/start-nginx cat` entrypoint. The nginx buildpack and `config/nginx.conf.erb` were removed in d87c350cd (Oct 2023), so `bin/start-nging` no longer exists in the deploy.

Nothing references this script: the `Procfile` web process runs the `server` binary directly, and the backend no longer spawns it (the spawn-from-backend graceful-shutdown workaround from 0061c5fb5 is gone). It was missed during the Oct 2023 nginx cleanup.