### PR TITLE
dropdown: Keep trigger label on a single line

### DIFF
--- a/svelte/src/lib/components/dropdown/Trigger.svelte
+++ b/svelte/src/lib/components/dropdown/Trigger.svelte
@@ -36,6 +36,7 @@
     align-items: center;
     color: inherit;
     cursor: pointer;
+    white-space: nowrap;
   }
 
   .arrow {


### PR DESCRIPTION
This ensures that the text in the trigger button stays on one line instead of wrapping when inside a shrinking flexbox/grid.