### PR TITLE
Use full page width for `Header`

### DIFF
--- a/svelte/src/lib/components/Header.svelte
+++ b/svelte/src/lib/components/Header.svelte
@@ -36,7 +36,7 @@
 </script>
 
 <header class="header" class:hero>
-  <div class="header-inner width-limit">
+  <div class="header-inner">
     <a href={resolve('/')} class="index-link">
       <enhanced:img src="$lib/assets/cargo.png?w=38;76;114" role="none" alt="" class="logo" sizes="38px" />
       crates.io
@@ -193,8 +193,10 @@
     display: grid;
     grid-template:
       'logo search nav' auto /
-      auto 1fr auto;
+      1fr minmax(0, 600px) 1fr;
     align-items: center;
+    column-gap: var(--space-m);
+    width: 100%;
     padding: var(--space-xs) var(--space-m);
     color: white;
 
@@ -210,7 +212,7 @@
     @media only screen and (max-width: 900px) {
       grid-template:
         'logo search menu' auto /
-        auto 1fr auto;
+        1fr minmax(0, 600px) 1fr;
     }
 
     @media only screen and (max-width: 820px) {
@@ -258,16 +260,17 @@
 
   .search-form {
     grid-area: search;
-    margin: 0 var(--space-m);
+    width: 100%;
+    max-width: 600px;
+    /* cap the width and center within the full-width header */
+    margin: 0 auto;
 
     @media only screen and (max-width: 820px) {
-      margin: var(--space-s) 0;
+      margin: var(--space-s) auto;
     }
 
     .hero & {
-      justify-self: center;
       padding: var(--space-l) 0 var(--space-l-xl);
-      margin: 0;
     }
   }
 
@@ -313,6 +316,7 @@
   .login-button {
     display: inline-flex;
     align-items: center;
+    white-space: nowrap;
     /* negative margin for larger click target */
     margin: calc(var(--space-2xs) * -1);
     padding: var(--space-2xs);


### PR DESCRIPTION
This drops the `width-limit` so the header spans the full viewport width instead of being constrained to the central content column. It caps the search box at 600px and centers it between two flexible side columns so it no longer stretches edge to edge on wide screens, and adds a column gap so the logo, search box, and nav do not crowd each other.

It also keeps the login button on a single line, since the nav column is now flexible and would otherwise let the label wrap.

This ports the header half of #3681 to the Svelte frontend and resolves half of #1559. The grid refactor and single search form from that PR already exist on `main`, and the dropdown alignment fixes landed separately in #13725.

#3681 was previously reverted in #3696 because of #3687, where logged-out users hitting a protected route saw a flash error overlapping the header login link, which the wider header made worse. #4315 has since fixed that root cause by rendering a proper "This page requires authentication" page instead of a flash error, so dropping the `width-limit` here cannot reintroduce that regression.

<img width="1578" height="974" alt="Screen Shot 2026-06-02 at 11 06 21" src="https://github.com/user-attachments/assets/3ec017c8-c17a-4ba3-b599-a8cf0b6805a8" />

### Related

- #1559
- #3681
- #3687
- #3696
- #4315
- #13725
