### PR TITLE
Show crate descriptions and version/downloads in front-page lists

### DIFF
--- a/e2e/acceptance/front-page.spec.ts
+++ b/e2e/acceptance/front-page.spec.ts
@@ -18,23 +18,23 @@ test.describe('Acceptance | front page', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-total-downloads] [data-test-value]')).toHaveText('143,345');
     await expect(page.locator('[data-test-total-crates] [data-test-value]')).toHaveText('23');
 
-    await expect(page.locator('[data-test-new-crates] [data-test-crate-link="0"]')).toHaveText('serde v1.0.0');
-    await expect(page.locator('[data-test-new-crates] [data-test-crate-link="0"]')).toHaveAttribute(
-      'href',
-      '/crates/serde',
+    let newCrate = page.locator('[data-test-new-crates] [data-test-crate-link="0"]');
+    await expect(newCrate.locator('[data-test-title]')).toHaveText('serde');
+    await expect(newCrate.locator('[data-test-subtitle]')).toHaveText(
+      'A generic serialization/deserialization framework',
     );
+    await expect(newCrate.locator('[data-test-version]')).toHaveText('1.0.0');
+    await expect(newCrate).toHaveAttribute('href', '/crates/serde');
 
-    await expect(page.locator('[data-test-most-downloaded] [data-test-crate-link="0"]')).toHaveText('serde');
-    await expect(page.locator('[data-test-most-downloaded] [data-test-crate-link="0"]')).toHaveAttribute(
-      'href',
-      '/crates/serde',
-    );
+    let mostDownloaded = page.locator('[data-test-most-downloaded] [data-test-crate-link="0"]');
+    await expect(mostDownloaded.locator('[data-test-title]')).toHaveText('serde');
+    await expect(mostDownloaded.locator('[data-test-downloads]')).toContainText('51K');
+    await expect(mostDownloaded).toHaveAttribute('href', '/crates/serde');
 
-    await expect(page.locator('[data-test-just-updated] [data-test-crate-link="0"]')).toHaveText('nanomsg v0.6.1');
-    await expect(page.locator('[data-test-just-updated] [data-test-crate-link="0"]')).toHaveAttribute(
-      'href',
-      '/crates/nanomsg/0.6.1',
-    );
+    let justUpdated = page.locator('[data-test-just-updated] [data-test-crate-link="0"]');
+    await expect(justUpdated.locator('[data-test-title]')).toHaveText('nanomsg');
+    await expect(justUpdated.locator('[data-test-version]')).toHaveText('0.6.1');
+    await expect(justUpdated).toHaveAttribute('href', '/crates/nanomsg/0.6.1');
 
     await percy.snapshot();
     await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -22,43 +22,43 @@
     - listitem:
       - link "serde":
         - /url: /crates/serde
-        - text: serde v1.0.0
+        - text: serde A generic serialization/deserialization framework version 1.0.0
     - listitem:
       - link "rust-crypto":
         - /url: /crates/rust-crypto
-        - text: rust-crypto v1.0.0
+        - text: rust-crypto A (mostly) pure-Rust implementation of various common cryptographic algorithms. version 1.0.0
     - listitem:
       - link "quickcheck":
         - /url: /crates/quickcheck
-        - text: quickcheck v1.0.0
+        - text: quickcheck Automatic property based testing with shrinking. version 1.0.0
     - listitem:
       - link "postgres":
         - /url: /crates/postgres
-        - text: postgres v1.0.0
+        - text: postgres A native PostgreSQL driver version 1.0.0
     - listitem:
       - link "nom":
         - /url: /crates/nom
-        - text: nom v1.0.0
+        - text: nom A byte-oriented, zero-copy, parser combinators library version 1.0.0
     - listitem:
       - link "libc":
         - /url: /crates/libc
-        - text: libc v1.0.0
+        - text: libc This is the description for the crate called "libc" version 1.0.0
     - listitem:
       - link "nanomsg-sys":
         - /url: /crates/nanomsg-sys
-        - text: nanomsg-sys v1.0.0
+        - text: nanomsg-sys This is the description for the crate called "nanomsg-sys" version 1.0.0
     - listitem:
       - link "mock-build-deps":
         - /url: /crates/mock-build-deps
-        - text: mock-build-deps v1.0.0
+        - text: mock-build-deps This is the description for the crate called "mock-build-deps" version 1.0.0
     - listitem:
       - link "mock-dev-deps":
         - /url: /crates/mock-dev-deps
-        - text: mock-dev-deps v1.0.0
+        - text: mock-dev-deps This is the description for the crate called "mock-dev-deps" version 1.0.0
     - listitem:
       - link "nanomsg":
         - /url: /crates/nanomsg
-        - text: nanomsg v0.6.1
+        - text: nanomsg A high-level, Rust idiomatic wrapper around nanomsg. version 0.6.1
   - heading "Most Downloaded" [level=2]:
     - link "Most Downloaded":
       - /url: /crates?sort=downloads
@@ -66,33 +66,43 @@
     - listitem:
       - link "serde":
         - /url: /crates/serde
+        - text: /serde A generic serialization\/deserialization framework [\d,.]+[bkmBKM]+ downloads/
     - listitem:
       - link "rust-crypto":
         - /url: /crates/rust-crypto
+        - text: /rust-crypto A \(mostly\) pure-Rust implementation of various common cryptographic algorithms\. [\d,.]+[bkmBKM]+ downloads/
     - listitem:
       - link "quickcheck":
         - /url: /crates/quickcheck
+        - text: /quickcheck Automatic property based testing with shrinking\. [\d,.]+[bkmBKM]+ downloads/
     - listitem:
       - link "postgres":
         - /url: /crates/postgres
+        - text: /postgres A native PostgreSQL driver [\d,.]+[bkmBKM]+ downloads/
     - listitem:
       - link "nom":
         - /url: /crates/nom
+        - text: /nom A byte-oriented, zero-copy, parser combinators library [\d,.]+[bkmBKM]+ downloads/
     - listitem:
       - link "libc":
         - /url: /crates/libc
+        - text: /libc This is the description for the crate called "libc" [\d,.]+[bkmBKM]+ downloads/
     - listitem:
       - link "nanomsg-sys":
         - /url: /crates/nanomsg-sys
+        - text: /nanomsg-sys This is the description for the crate called "nanomsg-sys" [\d,.]+[bkmBKM]+ downloads/
     - listitem:
       - link "mock-build-deps":
         - /url: /crates/mock-build-deps
+        - text: /mock-build-deps This is the description for the crate called "mock-build-deps" [\d,.]+[bkmBKM]+ downloads/
     - listitem:
       - link "mock-dev-deps":
         - /url: /crates/mock-dev-deps
+        - text: /mock-dev-deps This is the description for the crate called "mock-dev-deps" [\d,.]+[bkmBKM]+ downloads/
     - listitem:
       - link "nanomsg":
         - /url: /crates/nanomsg
+        - text: /nanomsg A high-level, Rust idiomatic wrapper around nanomsg\. [\d,.]+[bkmBKM]+ downloads/
   - heading "Just Updated" [level=2]:
     - link "Just Updated":
       - /url: /crates?sort=recent-updates
@@ -100,43 +110,43 @@
     - listitem:
       - link "nanomsg":
         - /url: /crates/nanomsg/0.6.1
-        - text: nanomsg v0.6.1
+        - text: nanomsg A high-level, Rust idiomatic wrapper around nanomsg. version 0.6.1
     - listitem:
       - link "nom":
         - /url: /crates/nom/1.0.0
-        - text: nom v1.0.0
+        - text: nom A byte-oriented, zero-copy, parser combinators library version 1.0.0
     - listitem:
       - link "rust-htslib":
         - /url: /crates/rust-htslib/1.0.0
-        - text: rust-htslib v1.0.0
+        - text: rust-htslib This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files. version 1.0.0
     - listitem:
       - link "postgres":
         - /url: /crates/postgres/1.0.0
-        - text: postgres v1.0.0
+        - text: postgres A native PostgreSQL driver version 1.0.0
     - listitem:
       - link "rusted_cypher":
         - /url: /crates/rusted_cypher/1.0.0
-        - text: rusted_cypher v1.0.0
+        - text: rusted_cypher Send cypher queries to a neo4j database version 1.0.0
     - listitem:
       - link "rustless":
         - /url: /crates/rustless/1.0.0
-        - text: rustless v1.0.0
+        - text: rustless Rustless is a REST-like API micro-framework for Rust. version 1.0.0
     - listitem:
       - link "rust-crypto":
         - /url: /crates/rust-crypto/1.0.0
-        - text: rust-crypto v1.0.0
+        - text: rust-crypto A (mostly) pure-Rust implementation of various common cryptographic algorithms. version 1.0.0
     - listitem:
       - link "Inflector":
         - /url: /crates/Inflector/1.0.0
-        - text: Inflector v1.0.0
+        - text: Inflector Adds String based inflections for Rust. Snake, kebab, camel, sentence, class, title, upper, and lower cases as well as ordinalize, deordinalize, demodulize, and foreign key are supported as both traits and pure functions acting on String types. version 1.0.0
     - listitem:
       - link "serde":
         - /url: /crates/serde/1.0.0
-        - text: serde v1.0.0
+        - text: serde A generic serialization/deserialization framework version 1.0.0
     - listitem:
       - link "quickcheck_macros":
         - /url: /crates/quickcheck_macros/1.0.0
-        - text: quickcheck_macros v1.0.0
+        - text: quickcheck_macros A macro attribute for quickcheck. version 1.0.0
   - heading "Most Recent Downloads" [level=2]:
     - link "Most Recent Downloads":
       - /url: /crates?sort=recent-downloads
@@ -144,33 +154,43 @@
     - listitem:
       - link "rust-crypto":
         - /url: /crates/rust-crypto
+        - text: /rust-crypto A \(mostly\) pure-Rust implementation of various common cryptographic algorithms\. [\d,.]+[bkmBKM]+ downloads/
     - listitem:
       - link "serde":
         - /url: /crates/serde
+        - text: /serde A generic serialization\/deserialization framework \d+ downloads/
     - listitem:
       - link "nanomsg":
         - /url: /crates/nanomsg
+        - text: /nanomsg A high-level, Rust idiomatic wrapper around nanomsg\. \d+ downloads/
     - listitem:
       - link "quickcheck_macros":
         - /url: /crates/quickcheck_macros
+        - text: /quickcheck_macros A macro attribute for quickcheck\. \d+ downloads/
     - listitem:
       - link "rustless":
         - /url: /crates/rustless
+        - text: /rustless Rustless is a REST-like API micro-framework for Rust\. \d+ downloads/
     - listitem:
       - link "external_mixin":
         - /url: /crates/external_mixin
+        - text: "/external_mixin Use your favourite interpreted language to generate your Rust, right in your Rust\\. Supports Python, Ruby and shell \\(`sh`\\) out of the box, with an extensible macro to support any others\\. \\(See `rust_mixin` to be able to use your all-time favourite language to generate your Rust\\.\\) \\d+ downloads/"
     - listitem:
       - link "quickcheck":
         - /url: /crates/quickcheck
+        - text: /quickcheck Automatic property based testing with shrinking\. \d+ downloads/
     - listitem:
       - link "kinetic-rust":
         - /url: /crates/kinetic-rust
+        - text: /kinetic-rust A Kinetic protocol library written in Rust \d+ downloads/
     - listitem:
       - link "rust_mixin":
         - /url: /crates/rust_mixin
+        - text: "/rust_mixin Yo dawg, use Rust to generate Rust, right in your Rust\\. \\(See `external_mixin` to use scripting languages\\.\\) \\d+ downloads/"
     - listitem:
       - link "rust-htslib":
         - /url: /crates/rust-htslib
+        - text: /rust-htslib This library provides HTSlib bindings and a high level Rust API for reading and writing BAM files\. \d+ downloads/
   - heading "Popular Keywords" [level=2]:
     - link "Popular Keywords":
       - /url: /keywords

--- a/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/front-page.spec.ts-snapshots/aria.yml
@@ -20,35 +20,45 @@
       - /url: /crates?sort=new
   - list:
     - listitem:
-      - link "serde v1.0.0":
+      - link "serde":
         - /url: /crates/serde
+        - text: serde v1.0.0
     - listitem:
-      - link "rust-crypto v1.0.0":
+      - link "rust-crypto":
         - /url: /crates/rust-crypto
+        - text: rust-crypto v1.0.0
     - listitem:
-      - link "quickcheck v1.0.0":
+      - link "quickcheck":
         - /url: /crates/quickcheck
+        - text: quickcheck v1.0.0
     - listitem:
-      - link "postgres v1.0.0":
+      - link "postgres":
         - /url: /crates/postgres
+        - text: postgres v1.0.0
     - listitem:
-      - link "nom v1.0.0":
+      - link "nom":
         - /url: /crates/nom
+        - text: nom v1.0.0
     - listitem:
-      - link "libc v1.0.0":
+      - link "libc":
         - /url: /crates/libc
+        - text: libc v1.0.0
     - listitem:
-      - link "nanomsg-sys v1.0.0":
+      - link "nanomsg-sys":
         - /url: /crates/nanomsg-sys
+        - text: nanomsg-sys v1.0.0
     - listitem:
-      - link "mock-build-deps v1.0.0":
+      - link "mock-build-deps":
         - /url: /crates/mock-build-deps
+        - text: mock-build-deps v1.0.0
     - listitem:
-      - link "mock-dev-deps v1.0.0":
+      - link "mock-dev-deps":
         - /url: /crates/mock-dev-deps
+        - text: mock-dev-deps v1.0.0
     - listitem:
-      - link "nanomsg v0.6.1":
+      - link "nanomsg":
         - /url: /crates/nanomsg
+        - text: nanomsg v0.6.1
   - heading "Most Downloaded" [level=2]:
     - link "Most Downloaded":
       - /url: /crates?sort=downloads
@@ -88,35 +98,45 @@
       - /url: /crates?sort=recent-updates
   - list:
     - listitem:
-      - link "nanomsg v0.6.1":
+      - link "nanomsg":
         - /url: /crates/nanomsg/0.6.1
+        - text: nanomsg v0.6.1
     - listitem:
-      - link "nom v1.0.0":
+      - link "nom":
         - /url: /crates/nom/1.0.0
+        - text: nom v1.0.0
     - listitem:
-      - link "rust-htslib v1.0.0":
+      - link "rust-htslib":
         - /url: /crates/rust-htslib/1.0.0
+        - text: rust-htslib v1.0.0
     - listitem:
-      - link "postgres v1.0.0":
+      - link "postgres":
         - /url: /crates/postgres/1.0.0
+        - text: postgres v1.0.0
     - listitem:
-      - link "rusted_cypher v1.0.0":
+      - link "rusted_cypher":
         - /url: /crates/rusted_cypher/1.0.0
+        - text: rusted_cypher v1.0.0
     - listitem:
-      - link "rustless v1.0.0":
+      - link "rustless":
         - /url: /crates/rustless/1.0.0
+        - text: rustless v1.0.0
     - listitem:
-      - link "rust-crypto v1.0.0":
+      - link "rust-crypto":
         - /url: /crates/rust-crypto/1.0.0
+        - text: rust-crypto v1.0.0
     - listitem:
-      - link "Inflector v1.0.0":
+      - link "Inflector":
         - /url: /crates/Inflector/1.0.0
+        - text: Inflector v1.0.0
     - listitem:
-      - link "serde v1.0.0":
+      - link "serde":
         - /url: /crates/serde/1.0.0
+        - text: serde v1.0.0
     - listitem:
-      - link "quickcheck_macros v1.0.0":
+      - link "quickcheck_macros":
         - /url: /crates/quickcheck_macros/1.0.0
+        - text: quickcheck_macros v1.0.0
   - heading "Most Recent Downloads" [level=2]:
     - link "Most Recent Downloads":
       - /url: /crates?sort=recent-downloads
@@ -156,48 +176,61 @@
       - /url: /keywords
   - list:
     - listitem:
-      - link "network 1 crates":
+      - link "network":
         - /url: /keywords/network
+        - text: network 1 crates
     - listitem:
-      - link "rust 1 crates":
+      - link "rust":
         - /url: /keywords/rust
+        - text: rust 1 crates
     - listitem:
-      - link "plugin 3 crates":
+      - link "plugin":
         - /url: /keywords/plugin
+        - text: plugin 3 crates
     - listitem:
-      - link "code-generation 3 crates":
+      - link "code-generation":
         - /url: /keywords/code-generation
+        - text: code-generation 3 crates
     - listitem:
-      - link "python 1 crates":
+      - link "python":
         - /url: /keywords/python
+        - text: python 1 crates
     - listitem:
-      - link "ruby 1 crates":
+      - link "ruby":
         - /url: /keywords/ruby
+        - text: ruby 1 crates
     - listitem:
-      - link "shell 1 crates":
+      - link "shell":
         - /url: /keywords/shell
+        - text: shell 1 crates
     - listitem:
-      - link "string 1 crates":
+      - link "string":
         - /url: /keywords/string
+        - text: string 1 crates
     - listitem:
-      - link "case 1 crates":
+      - link "case":
         - /url: /keywords/case
+        - text: case 1 crates
     - listitem:
-      - link "camel 1 crates":
+      - link "camel":
         - /url: /keywords/camel
+        - text: camel 1 crates
   - heading "Popular Categories" [level=2]:
     - link "Popular Categories":
       - /url: /categories
   - list:
     - listitem:
-      - link "API bindings 0 crates":
+      - link "API bindings":
         - /url: /categories/api-bindings
+        - text: API bindings 0 crates
     - listitem:
-      - link "Algorithms 0 crates":
+      - link "Algorithms":
         - /url: /categories/algorithms
+        - text: Algorithms 0 crates
     - listitem:
-      - link "Asynchronous 0 crates":
+      - link "Asynchronous":
         - /url: /categories/asynchronous
+        - text: Asynchronous 0 crates
 - contentinfo:
   - heading "Rust" [level=2]
   - list:

--- a/e2e/bugs/11772.spec.ts
+++ b/e2e/bugs/11772.spec.ts
@@ -17,8 +17,7 @@ test.describe('Bug #11772', { tag: '@bugs' }, () => {
     await expect(page).toHaveURL('/');
 
     // Verify initial correct version displays
-    await expect(page.locator('[data-test-new-crates] [data-test-crate-link]')).toContainText('test-crate v1.2.3');
-    await expect(page.locator('[data-test-just-updated] [data-test-crate-link]')).toContainText('test-crate v1.2.3');
+    await expectVersion(page, '1.2.3');
 
     // Click on a crate to navigate to its details page
     await page.click('[data-test-new-crates] [data-test-crate-link]');
@@ -29,8 +28,7 @@ test.describe('Bug #11772', { tag: '@bugs' }, () => {
     await page.goto('/'); // Re-visit to simulate the back navigation
 
     // Versions should still be displayed correctly, not v0.0.0
-    await expect(page.locator('[data-test-new-crates] [data-test-crate-link]')).toContainText('test-crate v1.2.3');
-    await expect(page.locator('[data-test-just-updated] [data-test-crate-link]')).toContainText('test-crate v1.2.3');
+    await expectVersion(page, '1.2.3');
   });
 
   test('crates with actual v0.0.0 versions should display correctly', async ({ page, msw }) => {
@@ -42,8 +40,8 @@ test.describe('Bug #11772', { tag: '@bugs' }, () => {
     await page.goto('/');
     await expect(page).toHaveURL('/');
 
-    // Should correctly display v0.0.0 for crates that actually have that version
-    await expect(page.locator('[data-test-new-crates] [data-test-crate-link]')).toContainText('test-zero-crate v0.0.0');
+    // Should correctly display 0.0.0 for crates that actually have that version
+    await expectVersion(page, '0.0.0', 'test-zero-crate');
 
     // Click on the crate to navigate to its details page
     await page.click('[data-test-new-crates] [data-test-crate-link]');
@@ -53,7 +51,15 @@ test.describe('Bug #11772', { tag: '@bugs' }, () => {
 
     await page.goto('/'); // Re-visit to simulate the back navigation
 
-    // Should still display v0.0.0 correctly (this is the intended behavior)
-    await expect(page.locator('[data-test-new-crates] [data-test-crate-link]')).toContainText('test-zero-crate v0.0.0');
+    // Should still display 0.0.0 correctly (this is the intended behavior)
+    await expectVersion(page, '0.0.0', 'test-zero-crate');
   });
 });
+
+async function expectVersion(page: AppFixtures['page'], version: string, name = 'test-crate') {
+  for (let section of ['new-crates', 'just-updated']) {
+    let link = page.locator(`[data-test-${section}] [data-test-crate-link]`);
+    await expect(link.locator('[data-test-title]')).toHaveText(name);
+    await expect(link.locator('[data-test-version]')).toHaveText(version);
+  }
+}

--- a/e2e/routes/category.spec.ts
+++ b/e2e/routes/category.spec.ts
@@ -31,7 +31,7 @@ test.describe('Route | category', { tag: '@routes' }, () => {
     await expect(searchInput).toHaveValue('');
 
     // favor navigation via link click over page.goto
-    await page.getByRole('link', { name: 'foo 0 crates' }).click();
+    await page.getByRole('link', { name: 'foo', exact: true }).click();
     await page.waitForURL('/categories/foo');
     await expect(searchInput).toHaveValue('category:foo ');
 

--- a/svelte/src/lib/components/Tooltip.svelte
+++ b/svelte/src/lib/components/Tooltip.svelte
@@ -8,6 +8,11 @@
 
   interface BaseProps {
     side?: 'top' | 'bottom' | 'left' | 'right';
+    /**
+     * Milliseconds to wait after the pointer enters the anchor before showing
+     * the tooltip. Defaults to `0`, which shows it immediately.
+     */
+    delay?: number;
   }
 
   interface TextProps extends BaseProps {
@@ -22,10 +27,11 @@
 
   type Props = TextProps | ChildrenProps;
 
-  let { text, children, side = 'top' }: Props = $props();
+  let { text, children, side = 'top', delay = 0 }: Props = $props();
 
   let anchorElement = $state<HTMLElement | null>(null);
   let visible = $state(false);
+  let showTimeout = $state<ReturnType<typeof setTimeout> | null>(null);
   let hideTimeout = $state<ReturnType<typeof setTimeout> | null>(null);
 
   function show() {
@@ -33,10 +39,21 @@
       clearTimeout(hideTimeout);
       hideTimeout = null;
     }
-    visible = true;
+
+    if (visible || showTimeout) return;
+
+    showTimeout = setTimeout(() => {
+      showTimeout = null;
+      visible = true;
+    }, delay);
   }
 
   function hide() {
+    if (showTimeout) {
+      clearTimeout(showTimeout);
+      showTimeout = null;
+    }
+
     hideTimeout = setTimeout(() => {
       visible = false;
     }, 100);

--- a/svelte/src/lib/components/Tooltip.svelte
+++ b/svelte/src/lib/components/Tooltip.svelte
@@ -13,6 +13,12 @@
      * the tooltip. Defaults to `0`, which shows it immediately.
      */
     delay?: number;
+    /**
+     * Only show the tooltip when the anchor element's content is horizontally
+     * truncated (e.g. clipped by `text-overflow: ellipsis`). Useful to avoid a
+     * redundant tooltip that merely repeats fully visible text.
+     */
+    onlyWhenTruncated?: boolean;
   }
 
   interface TextProps extends BaseProps {
@@ -27,7 +33,7 @@
 
   type Props = TextProps | ChildrenProps;
 
-  let { text, children, side = 'top', delay = 0 }: Props = $props();
+  let { text, children, side = 'top', delay = 0, onlyWhenTruncated = false }: Props = $props();
 
   let anchorElement = $state<HTMLElement | null>(null);
   let visible = $state(false);
@@ -35,6 +41,13 @@
   let hideTimeout = $state<ReturnType<typeof setTimeout> | null>(null);
 
   function show() {
+    // Sub-pixel rounding can leave `scrollWidth` 1px above `clientWidth`
+    // without any visible clipping, so require more than that before treating
+    // the content as truncated.
+    if (onlyWhenTruncated && anchorElement && anchorElement.scrollWidth - anchorElement.clientWidth <= 1) {
+      return;
+    }
+
     if (hideTimeout) {
       clearTimeout(hideTimeout);
       hideTimeout = null;

--- a/svelte/src/lib/components/Tooltip.svelte.test.ts
+++ b/svelte/src/lib/components/Tooltip.svelte.test.ts
@@ -26,4 +26,27 @@ describe('Tooltip', () => {
       await expect.element(page.getByCSS('.tooltip')).toBeVisible();
     });
   });
+
+  describe('onlyWhenTruncated', () => {
+    it('shows the tooltip when the anchor content is truncated', async () => {
+      render(TooltipTestWrapper, {
+        text: 'A very long string that does not fit into the narrow anchor element',
+        width: '50px',
+        onlyWhenTruncated: true,
+      });
+
+      await userEvent.hover(page.getByCSS('[data-test-anchor]'));
+
+      await expect.element(page.getByCSS('.tooltip')).toBeVisible();
+    });
+
+    it('does not show the tooltip when the anchor content fits', async () => {
+      render(TooltipTestWrapper, { text: 'short', width: '500px', onlyWhenTruncated: true });
+
+      await userEvent.hover(page.getByCSS('[data-test-anchor]'));
+      await tick();
+
+      expect(document.querySelector('.tooltip')).toBeNull();
+    });
+  });
 });

--- a/svelte/src/lib/components/Tooltip.svelte.test.ts
+++ b/svelte/src/lib/components/Tooltip.svelte.test.ts
@@ -1,0 +1,29 @@
+import { tick } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page, userEvent } from 'vitest/browser';
+
+import TooltipTestWrapper from './TooltipTestWrapper.svelte';
+
+describe('Tooltip', () => {
+  it('shows the tooltip on hover', async () => {
+    render(TooltipTestWrapper, { text: 'short', width: '500px' });
+
+    await userEvent.hover(page.getByCSS('[data-test-anchor]'));
+
+    await expect.element(page.getByCSS('.tooltip')).toBeVisible();
+  });
+
+  describe('delay', () => {
+    it('waits for the configured delay before showing the tooltip', async () => {
+      render(TooltipTestWrapper, { text: 'short', width: '500px', delay: 200 });
+
+      await userEvent.hover(page.getByCSS('[data-test-anchor]'));
+      await tick();
+
+      expect(document.querySelector('.tooltip')).toBeNull();
+
+      await expect.element(page.getByCSS('.tooltip')).toBeVisible();
+    });
+  });
+});

--- a/svelte/src/lib/components/TooltipTestWrapper.svelte
+++ b/svelte/src/lib/components/TooltipTestWrapper.svelte
@@ -7,9 +7,10 @@
     text: string;
     width: string;
     delay?: number;
+    onlyWhenTruncated?: boolean;
   }
 
-  let { text, width, delay = 0 }: Props = $props();
+  let { text, width, delay = 0, onlyWhenTruncated = false }: Props = $props();
   let propsId = $props.id();
 
   setTooltipContext({ containerId: `tooltip-container-${propsId}` });
@@ -17,7 +18,7 @@
 
 <div data-test-anchor style:width style:overflow="hidden" style:white-space="nowrap" style:text-overflow="ellipsis">
   {text}
-  <Tooltip {text} {delay} />
+  <Tooltip {text} {delay} {onlyWhenTruncated} />
 </div>
 
 <TooltipContainer />

--- a/svelte/src/lib/components/TooltipTestWrapper.svelte
+++ b/svelte/src/lib/components/TooltipTestWrapper.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { setTooltipContext } from '$lib/tooltip.svelte';
+  import Tooltip from './Tooltip.svelte';
+  import TooltipContainer from './TooltipContainer.svelte';
+
+  interface Props {
+    text: string;
+    width: string;
+    delay?: number;
+  }
+
+  let { text, width, delay = 0 }: Props = $props();
+  let propsId = $props.id();
+
+  setTooltipContext({ containerId: `tooltip-container-${propsId}` });
+</script>
+
+<div data-test-anchor style:width style:overflow="hidden" style:white-space="nowrap" style:text-overflow="ellipsis">
+  {text}
+  <Tooltip {text} {delay} />
+</div>
+
+<TooltipContainer />

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
@@ -139,7 +139,8 @@
       <div class="linecount" data-test-linecounts>
         <Icon class="i-mdi:code-tags" />
         <span>
-          {formatShortNum(Number(version.linecounts.total_code_lines))} SLoC
+          <!-- Use the OpenGraph image `threshold` so the sidebar matches the generated image -->
+          {formatShortNum(Number(version.linecounts.total_code_lines), { threshold: 1500 })} SLoC
           <Tooltip>
             Source Lines of Code<br />
             <small>(excluding comments, integration tests and example code)</small>

--- a/svelte/src/lib/components/frontpage/CrateLists.stories.svelte
+++ b/svelte/src/lib/components/frontpage/CrateLists.stories.svelte
@@ -9,10 +9,11 @@
     tags: ['autodocs'],
   });
 
-  function createMockCrate(name: string, version: string) {
+  function createMockCrate(name: string, version: string, description = `${name} is a useful Rust crate`) {
     return {
       id: name,
       name,
+      description,
       newest_version: version,
       max_version: version,
       downloads: 1_000_000,

--- a/svelte/src/lib/components/frontpage/CrateLists.svelte
+++ b/svelte/src/lib/components/frontpage/CrateLists.svelte
@@ -26,12 +26,14 @@
     href={`${resolve('/crates')}?sort=new`}
     items={summary?.new_crates}
     withSubtitle
+    withTrailing
     data-test-new-crates
   >
     {#snippet item(crate: Crate, index: number)}
       <ListItem
         title={crate.name}
-        subtitle={`v${crate.newest_version}`}
+        subtitle={crate.description ?? undefined}
+        version={crate.newest_version}
         href={resolve('/crates/[crate_id]', { crate_id: crate.id })}
         data-test-crate-link={index}
       />
@@ -42,11 +44,15 @@
     title="Most Downloaded"
     href={`${resolve('/crates')}?sort=downloads`}
     items={summary?.most_downloaded}
+    withSubtitle
+    withTrailing
     data-test-most-downloaded
   >
     {#snippet item(crate: Crate, index: number)}
       <ListItem
         title={crate.name}
+        subtitle={crate.description ?? undefined}
+        downloads={crate.downloads}
         href={resolve('/crates/[crate_id]', { crate_id: crate.id })}
         data-test-crate-link={index}
       />
@@ -58,12 +64,14 @@
     href={`${resolve('/crates')}?sort=recent-updates`}
     items={summary?.just_updated}
     withSubtitle
+    withTrailing
     data-test-just-updated
   >
     {#snippet item(crate: Crate, index: number)}
       <ListItem
         title={crate.name}
-        subtitle={`v${crate.newest_version}`}
+        subtitle={crate.description ?? undefined}
+        version={crate.newest_version}
         href={resolve('/crates/[crate_id]/[version_num]', {
           crate_id: crate.id,
           version_num: crate.newest_version,
@@ -77,11 +85,15 @@
     title="Most Recent Downloads"
     href={`${resolve('/crates')}?sort=recent-downloads`}
     items={summary?.most_recently_downloaded}
+    withSubtitle
+    withTrailing
     data-test-most-recently-downloaded
   >
     {#snippet item(crate: Crate, index: number)}
       <ListItem
         title={crate.name}
+        subtitle={crate.description ?? undefined}
+        downloads={crate.recent_downloads ?? undefined}
         href={resolve('/crates/[crate_id]', { crate_id: crate.id })}
         data-test-crate-link={index}
       />

--- a/svelte/src/lib/components/frontpage/ListItem.stories.svelte
+++ b/svelte/src/lib/components/frontpage/ListItem.stories.svelte
@@ -28,6 +28,16 @@
 />
 
 <Story
+  name="With Downloads"
+  args={{
+    href: '#',
+    title: 'serde',
+    subtitle: 'A generic serialization/deserialization framework',
+    downloads: 8_200_000,
+  }}
+/>
+
+<Story
   name="Long Content"
   args={{
     href: '#',

--- a/svelte/src/lib/components/frontpage/ListItem.stories.svelte
+++ b/svelte/src/lib/components/frontpage/ListItem.stories.svelte
@@ -18,10 +18,21 @@
 />
 
 <Story
+  name="With Version"
+  args={{
+    href: '#',
+    title: 'serde',
+    subtitle: 'A generic serialization/deserialization framework',
+    version: '1.0.219',
+  }}
+/>
+
+<Story
   name="Long Content"
   args={{
     href: '#',
     title: 'some-very-long-crate-name-that-might-overflow-and-should-not-break-the-rendering',
     subtitle: 'An event-driven, non-blocking I/O platform for writing asynchronous applications',
+    version: '3.0.0-beta.1',
   }}
 />

--- a/svelte/src/lib/components/frontpage/ListItem.svelte
+++ b/svelte/src/lib/components/frontpage/ListItem.svelte
@@ -15,20 +15,34 @@
   }
 
   let { title, subtitle, href, version, downloads, class: className, ...restProps }: Props = $props();
+
+  // The accessible name is restricted to the crate name via `aria-labelledby`
+  // so the screen reader links list stays scannable; the subtitle and trailing
+  // value are exposed as a supplementary `aria-describedby` description that is
+  // announced after the name instead of being concatenated into it.
+  const uid = $props.id();
+  const titleId = `${uid}-title`;
+  const subtitleId = `${uid}-subtitle`;
+  const trailingId = `${uid}-trailing`;
+
+  let hasTrailing = $derived(Boolean(version) || downloads != null);
+  let describedBy = $derived(
+    [subtitle ? subtitleId : null, hasTrailing ? trailingId : null].filter(Boolean).join(' ') || undefined,
+  );
 </script>
 
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-<a {href} class={['box', className]} {...restProps}>
+<a {href} class={['box', className]} aria-labelledby={titleId} aria-describedby={describedBy} {...restProps}>
   <div class="left">
-    <div class="title">{title}</div>
-    {#if subtitle}<div class="subtitle">{subtitle}</div>{/if}
+    <div class="title" id={titleId} data-test-title>{title}</div>
+    {#if subtitle}<div class="subtitle" id={subtitleId} data-test-subtitle>{subtitle}</div>{/if}
   </div>
   {#if version}
-    <div class="version">
+    <div class="version" id={trailingId}>
       <span class="sr-only">version </span><span data-test-version>{version}</span>
     </div>
   {:else if downloads != null}
-    <div class="downloads" data-test-downloads>
+    <div class="downloads" id={trailingId} data-test-downloads>
       <Icon class="i-mdi:download download-icon" />
       {formatShortNum(downloads)}
       <span class="sr-only">downloads</span>

--- a/svelte/src/lib/components/frontpage/ListItem.svelte
+++ b/svelte/src/lib/components/frontpage/ListItem.svelte
@@ -2,6 +2,7 @@
   import type { HTMLAttributes } from 'svelte/elements';
 
   import Icon from '$lib/components/Icon.svelte';
+  import { formatShortNum } from '$lib/utils/format-short-num';
 
   interface Props extends HTMLAttributes<HTMLAnchorElement> {
     title: string;
@@ -9,9 +10,11 @@
     href: string;
     /** Version number shown on the trailing edge. */
     version?: string;
+    /** Download count shown on the trailing edge in compact form. */
+    downloads?: number;
   }
 
-  let { title, subtitle, href, version, class: className, ...restProps }: Props = $props();
+  let { title, subtitle, href, version, downloads, class: className, ...restProps }: Props = $props();
 </script>
 
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
@@ -23,6 +26,12 @@
   {#if version}
     <div class="version">
       <span class="sr-only">version </span><span data-test-version>{version}</span>
+    </div>
+  {:else if downloads != null}
+    <div class="downloads" data-test-downloads>
+      <Icon class="i-mdi:download download-icon" />
+      {formatShortNum(downloads)}
+      <span class="sr-only">downloads</span>
     </div>
   {:else}
     <Icon class="i-mdi:chevron-right right" />
@@ -94,14 +103,30 @@
     color: light-dark(rgb(118, 131, 138), #cccac2);
   }
 
-  .version {
+  .version,
+  .downloads {
     flex-shrink: 0;
     margin-left: var(--space-2xs);
     font-size: 13px;
     color: light-dark(rgb(118, 131, 138), #cccac2);
+  }
+
+  .version {
     max-width: 5em;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .downloads {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4xs);
+    white-space: nowrap;
+  }
+
+  .downloads :global(.download-icon) {
+    width: 1.1em;
+    height: 1.1em;
   }
 </style>

--- a/svelte/src/lib/components/frontpage/ListItem.svelte
+++ b/svelte/src/lib/components/frontpage/ListItem.svelte
@@ -27,9 +27,20 @@
   const trailingId = `${uid}-trailing`;
 
   let hasTrailing = $derived(Boolean(version) || downloads != null);
-  let describedBy = $derived(
-    [subtitle ? subtitleId : null, hasTrailing ? trailingId : null].filter(Boolean).join(' ') || undefined,
-  );
+  let describedBy = $derived.by(() => {
+    let describedByIds = [];
+
+    if (subtitle) {
+      describedByIds.push(subtitleId);
+    }
+    if (hasTrailing) {
+      describedByIds.push(trailingId);
+    }
+
+    if (describedByIds.length !== 0) {
+      return describedByIds.join(' ');
+    }
+  });
 </script>
 
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->

--- a/svelte/src/lib/components/frontpage/ListItem.svelte
+++ b/svelte/src/lib/components/frontpage/ListItem.svelte
@@ -2,6 +2,7 @@
   import type { HTMLAttributes } from 'svelte/elements';
 
   import Icon from '$lib/components/Icon.svelte';
+  import Tooltip from '$lib/components/Tooltip.svelte';
   import { formatShortNum } from '$lib/utils/format-short-num';
 
   interface Props extends HTMLAttributes<HTMLAnchorElement> {
@@ -35,7 +36,12 @@
 <a {href} class={['box', className]} aria-labelledby={titleId} aria-describedby={describedBy} {...restProps}>
   <div class="left">
     <div class="title" id={titleId} data-test-title>{title}</div>
-    {#if subtitle}<div class="subtitle" id={subtitleId} data-test-subtitle>{subtitle}</div>{/if}
+    {#if subtitle}
+      <div class="subtitle" id={subtitleId} data-test-subtitle>
+        {subtitle}
+        <Tooltip text={subtitle} onlyWhenTruncated delay={350} side="bottom" />
+      </div>
+    {/if}
   </div>
   {#if version}
     <div class="version" id={trailingId}>

--- a/svelte/src/lib/components/frontpage/ListItem.svelte
+++ b/svelte/src/lib/components/frontpage/ListItem.svelte
@@ -7,9 +7,11 @@
     title: string;
     subtitle?: string;
     href: string;
+    /** Version number shown on the trailing edge. */
+    version?: string;
   }
 
-  let { title, subtitle, href, class: className, ...restProps }: Props = $props();
+  let { title, subtitle, href, version, class: className, ...restProps }: Props = $props();
 </script>
 
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
@@ -18,7 +20,13 @@
     <div class="title">{title}</div>
     {#if subtitle}<div class="subtitle">{subtitle}</div>{/if}
   </div>
-  <Icon class="i-mdi:chevron-right right" />
+  {#if version}
+    <div class="version">
+      <span class="sr-only">version </span><span data-test-version>{version}</span>
+    </div>
+  {:else}
+    <Icon class="i-mdi:chevron-right right" />
+  {/if}
 </a>
 
 <style>
@@ -84,5 +92,16 @@
     width: var(--space-m);
     margin-right: calc(-0.8 * var(--space-2xs));
     color: light-dark(rgb(118, 131, 138), #cccac2);
+  }
+
+  .version {
+    flex-shrink: 0;
+    margin-left: var(--space-2xs);
+    font-size: 13px;
+    color: light-dark(rgb(118, 131, 138), #cccac2);
+    max-width: 5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 </style>

--- a/svelte/src/lib/components/frontpage/ListItemPlaceholder.stories.svelte
+++ b/svelte/src/lib/components/frontpage/ListItemPlaceholder.stories.svelte
@@ -13,3 +13,7 @@
 <Story name="Default" />
 
 <Story name="With Subtitle" args={{ withSubtitle: true }} />
+
+<Story name="With Trailing" args={{ withTrailing: true }} />
+
+<Story name="With Subtitle And Trailing" args={{ withSubtitle: true, withTrailing: true }} />

--- a/svelte/src/lib/components/frontpage/ListItemPlaceholder.svelte
+++ b/svelte/src/lib/components/frontpage/ListItemPlaceholder.svelte
@@ -6,9 +6,10 @@
 
   interface Props extends HTMLAttributes<HTMLDivElement> {
     withSubtitle?: boolean;
+    withTrailing?: boolean;
   }
 
-  let { withSubtitle = false, class: className, ...restProps }: Props = $props();
+  let { withSubtitle = false, withTrailing = false, class: className, ...restProps }: Props = $props();
 </script>
 
 <div class={['link', className]} {...restProps}>
@@ -25,7 +26,11 @@
       />
     {/if}
   </div>
-  <Icon class="i-mdi:chevron-right right" />
+  {#if withTrailing}
+    <Placeholder width="40px" height="13px" radius="6.5px" opacity={0.2} />
+  {:else}
+    <Icon class="i-mdi:chevron-right right" />
+  {/if}
 </div>
 
 <style>

--- a/svelte/src/lib/components/frontpage/ListSection.svelte
+++ b/svelte/src/lib/components/frontpage/ListSection.svelte
@@ -9,11 +9,21 @@
     href: string;
     items: T[] | undefined;
     withSubtitle?: boolean;
+    withTrailing?: boolean;
     ordered?: boolean;
     item: Snippet<[item: T, index: number]>;
   }
 
-  let { title, href, items, withSubtitle = false, ordered = true, item, ...restProps }: Props = $props();
+  let {
+    title,
+    href,
+    items,
+    withSubtitle = false,
+    withTrailing = false,
+    ordered = true,
+    item,
+    ...restProps
+  }: Props = $props();
 </script>
 
 <section {...restProps}>
@@ -22,7 +32,7 @@
   <svelte:element this={ordered ? 'ol' : 'ul'} class="list" aria-busy={!items}>
     {#if !items}
       {#each { length: 10 }, i (i)}
-        <li><ListItemPlaceholder {withSubtitle} /></li>
+        <li><ListItemPlaceholder {withSubtitle} {withTrailing} /></li>
       {/each}
     {:else}
       {#each items as it, index (it.id)}

--- a/svelte/src/lib/utils/format-short-num.test.ts
+++ b/svelte/src/lib/utils/format-short-num.test.ts
@@ -3,65 +3,65 @@ import { describe, expect, it } from 'vitest';
 import { formatShortNum } from './format-short-num';
 
 describe('formatShortNum()', () => {
-  describe('formats numbers without suffix (below 1500)', () => {
+  describe('formats numbers without suffix (below four digits)', () => {
     it.each([
       [0, '0'],
       [1, '1'],
-      [1000, '1,000'],
-      [1499, '1,499'],
+      [500, '500'],
+      [999, '999'],
     ])('%d → %s', (input, expected) => {
       expect(formatShortNum(input)).toBe(expected);
     });
   });
 
-  describe('formats numbers with K suffix (1500 to 1500000)', () => {
+  describe('formats numbers with K suffix', () => {
     it.each([
+      [1000, '1.0K'],
+      [1234, '1.2K'],
       [1500, '1.5K'],
-      [2000, '2.0K'],
-      [5000, '5.0K'],
       [10_000, '10K'],
       [50_000, '50K'],
       [100_000, '100K'],
       [500_000, '500K'],
-      [999_999, '1,000K'],
+      [999_499, '999K'],
     ])('%d → %s', (input, expected) => {
       expect(formatShortNum(input)).toBe(expected);
     });
   });
 
-  describe('formats numbers with M suffix (1500000 to 1500000000)', () => {
+  describe('formats numbers with M suffix', () => {
     it.each([
+      [999_500, '1.0M'],
+      [1_000_000, '1.0M'],
       [1_500_000, '1.5M'],
-      [2_000_000, '2.0M'],
-      [5_000_000, '5.0M'],
       [10_000_000, '10M'],
-      [50_000_000, '50M'],
       [100_000_000, '100M'],
-      [1_000_000_000, '1,000M'],
+      [999_499_000, '999M'],
     ])('%d → %s', (input, expected) => {
       expect(formatShortNum(input)).toBe(expected);
     });
   });
 
-  describe('formats numbers with B suffix (above 1500000000)', () => {
+  describe('formats numbers with B suffix', () => {
     it.each([
-      [1_500_000_000, '1.5B'],
-      [2_000_000_000, '2.0B'],
-      [10_000_000_000, '10B'],
+      [999_500_000, '1.0B'],
+      [1_000_000_000, '1.0B'],
+      [1_743_000_000, '1.7B'],
       [1_000_000_000_000, '1,000B'],
     ])('%d → %s', (input, expected) => {
       expect(formatShortNum(input)).toBe(expected);
     });
   });
 
-  describe('honours a custom threshold', () => {
+  describe('matches the OpenGraph image threshold of 1500', () => {
     it.each([
-      [999, '999'],
-      [1000, '1.0K'],
-      [999_499, '999K'],
-      [999_500, '1.0M'],
+      [1499, '1,499'],
+      [1500, '1.5K'],
+      [999_999, '1,000K'],
+      [1_499_999, '1,500K'],
+      [1_500_000, '1.5M'],
     ])('%d → %s', (input, expected) => {
-      expect(formatShortNum(input, { threshold: 999.5 })).toBe(expected);
+      expect(formatShortNum(input, { threshold: 1500 })).toBe(expected);
     });
   });
 });

--- a/svelte/src/lib/utils/format-short-num.test.ts
+++ b/svelte/src/lib/utils/format-short-num.test.ts
@@ -29,7 +29,7 @@ describe('formatShortNum()', () => {
     });
   });
 
-  describe('formats numbers with M suffix (above 1500000)', () => {
+  describe('formats numbers with M suffix (1500000 to 1500000000)', () => {
     it.each([
       [1_500_000, '1.5M'],
       [2_000_000, '2.0M'],
@@ -38,6 +38,17 @@ describe('formatShortNum()', () => {
       [50_000_000, '50M'],
       [100_000_000, '100M'],
       [1_000_000_000, '1,000M'],
+    ])('%d → %s', (input, expected) => {
+      expect(formatShortNum(input)).toBe(expected);
+    });
+  });
+
+  describe('formats numbers with B suffix (above 1500000000)', () => {
+    it.each([
+      [1_500_000_000, '1.5B'],
+      [2_000_000_000, '2.0B'],
+      [10_000_000_000, '10B'],
+      [1_000_000_000_000, '1,000B'],
     ])('%d → %s', (input, expected) => {
       expect(formatShortNum(input)).toBe(expected);
     });

--- a/svelte/src/lib/utils/format-short-num.test.ts
+++ b/svelte/src/lib/utils/format-short-num.test.ts
@@ -53,4 +53,15 @@ describe('formatShortNum()', () => {
       expect(formatShortNum(input)).toBe(expected);
     });
   });
+
+  describe('honours a custom threshold', () => {
+    it.each([
+      [999, '999'],
+      [1000, '1.0K'],
+      [999_499, '999K'],
+      [999_500, '1.0M'],
+    ])('%d → %s', (input, expected) => {
+      expect(formatShortNum(input, { threshold: 999.5 })).toBe(expected);
+    });
+  });
 });

--- a/svelte/src/lib/utils/format-short-num.ts
+++ b/svelte/src/lib/utils/format-short-num.ts
@@ -1,19 +1,19 @@
-const DEFAULT_THRESHOLD = 1500;
+// A four-digit mantissa rounds up to "1,000", so rolling over at this value
+// keeps the displayed number at three digits or fewer within each unit.
+const DEFAULT_THRESHOLD = 999.5;
 const UNITS = ['', 'K', 'M', 'B'];
 
 interface FormatShortNumOptions {
   /**
    * Value at or above which the number rolls over to the next unit. Defaults
-   * to {@link DEFAULT_THRESHOLD}.
+   * to {@link DEFAULT_THRESHOLD}, which rolls over as soon as a number would
+   * otherwise render with a four-digit mantissa.
    */
   threshold?: number;
 }
 
 /**
  * Formats a number in a compact form with K/M/B suffix.
- *
- * With the default threshold this matches the implementation in https://github.com/rust-lang/crates_io_og_image/blob/v0.2.1/src/formatting.rs
- * to ensure that we render roughly the same values in our user interface and the generated OpenGraph images.
  */
 export function formatShortNum(value: number, { threshold = DEFAULT_THRESHOLD }: FormatShortNumOptions = {}): string {
   let unitIndex = 0;

--- a/svelte/src/lib/utils/format-short-num.ts
+++ b/svelte/src/lib/utils/format-short-num.ts
@@ -1,8 +1,8 @@
 const THRESHOLD = 1500;
-const UNITS = ['', 'K', 'M'];
+const UNITS = ['', 'K', 'M', 'B'];
 
 /**
- * Formats a number in a compact form with K/M suffix.
+ * Formats a number in a compact form with K/M/B suffix.
  *
  * This matches the implementation in https://github.com/rust-lang/crates_io_og_image/blob/v0.2.1/src/formatting.rs
  * to ensure that we render roughly the same values in our user interface and the generated OpenGraph images.

--- a/svelte/src/lib/utils/format-short-num.ts
+++ b/svelte/src/lib/utils/format-short-num.ts
@@ -1,17 +1,25 @@
-const THRESHOLD = 1500;
+const DEFAULT_THRESHOLD = 1500;
 const UNITS = ['', 'K', 'M', 'B'];
+
+interface FormatShortNumOptions {
+  /**
+   * Value at or above which the number rolls over to the next unit. Defaults
+   * to {@link DEFAULT_THRESHOLD}.
+   */
+  threshold?: number;
+}
 
 /**
  * Formats a number in a compact form with K/M/B suffix.
  *
- * This matches the implementation in https://github.com/rust-lang/crates_io_og_image/blob/v0.2.1/src/formatting.rs
+ * With the default threshold this matches the implementation in https://github.com/rust-lang/crates_io_og_image/blob/v0.2.1/src/formatting.rs
  * to ensure that we render roughly the same values in our user interface and the generated OpenGraph images.
  */
-export function formatShortNum(value: number): string {
+export function formatShortNum(value: number, { threshold = DEFAULT_THRESHOLD }: FormatShortNumOptions = {}): string {
   let unitIndex = 0;
 
   // Keep dividing by 1000 until value is below threshold or we've reached the last unit
-  while (value >= THRESHOLD && unitIndex < UNITS.length - 1) {
+  while (value >= threshold && unitIndex < UNITS.length - 1) {
     value /= 1000;
     unitIndex += 1;
   }


### PR DESCRIPTION
This reworks the front-page crate lists so each row shows the crate's description and a more useful trailing value in place of the chevron. New Crates and Just Updated now display the newest version on the trailing edge without the `v` prefix, while Most Downloaded and Most Recent Downloads show a compact download count with a download icon, the latter using the 90-day count. The description becomes the row subtitle, and the name, description, and version all truncate with an ellipsis when they get too long.

The compact counts come from `formatShortNum()`, which gains a `threshold` option and a billions (`B`) unit and now rolls over to the next unit as soon as a number reaches four digits, so `1,000,000` reads as `1.0M` rather than `1,000K`. The crate sidebar passes the previous `1500` threshold so its source-lines-of-code figure stays consistent with the generated OpenGraph image.

Each row stays a single link, so to keep the screen-reader links list scannable its accessible name is restricted to the crate name via `aria-labelledby`, with the description and trailing value exposed through `aria-describedby` and announced after the name. Popular Keywords and Popular Categories are unchanged and keep the chevron.

<img width="938" height="498" alt="Bildschirmfoto 2026-06-02 um 12 46 13" src="https://github.com/user-attachments/assets/b61e592c-2cfb-405c-80d5-1bf4633c07e4" />
<img width="954" height="487" alt="Bildschirmfoto 2026-06-02 um 12 46 32" src="https://github.com/user-attachments/assets/1ce01039-30c9-4a8c-9fea-780b91be08cf" />
