### PR TITLE
Replace the global `Vary` header with scoped cache headers

### DIFF
--- a/src/controllers/admin.rs
+++ b/src/controllers/admin.rs
@@ -4,8 +4,11 @@ use crate::{
     models::{OwnerKind, User},
     schema::*,
     util::errors::{AppResult, custom},
+    util::no_store,
 };
 use axum::{Json, extract::Path};
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
 use chrono::{DateTime, Utc};
 use diesel::{dsl::count_star, prelude::*};
 use diesel_async::RunQueryDsl;
@@ -63,7 +66,7 @@ pub async fn list(
     state: AppState,
     Path(username): Path<String>,
     req: Parts,
-) -> AppResult<Json<AdminListResponse>> {
+) -> AppResult<(TypedHeader<CacheControl>, Json<AdminListResponse>)> {
     let mut conn = state.db_read().await?;
 
     let auth = AuthCheck::default().check(&req, &mut conn).await?;
@@ -127,11 +130,14 @@ pub async fn list(
             }
         })
         .collect();
-    Ok(Json(AdminListResponse {
-        user_email,
-        user_email_verified: verified.unwrap_or_default(),
-        crates,
-    }))
+    Ok((
+        no_store(),
+        Json(AdminListResponse {
+            user_email,
+            user_email_verified: verified.unwrap_or_default(),
+            crates,
+        }),
+    ))
 }
 
 #[derive(Debug, Serialize)]

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -8,12 +8,15 @@ use crate::models::{Crate, CrateOwnerInvitation, User};
 use crate::schema::{crate_owner_invitations, crates, users};
 use crate::util::RequestUtils;
 use crate::util::errors::{AppResult, BoxedAppError, bad_request, custom, forbidden, internal};
+use crate::util::no_store;
 use crate::views::{
     EncodableCrateOwnerInvitation, EncodableCrateOwnerInvitationV1, EncodablePublicUser,
     InvitationResponse,
 };
 use axum::Json;
 use axum::extract::{FromRequestParts, Path, Query};
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
 use chrono::Utc;
 use diesel::pg::Pg;
 use diesel::prelude::*;
@@ -46,7 +49,7 @@ pub struct LegacyListResponse {
 pub async fn list_crate_owner_invitations_for_user(
     app: AppState,
     req: Parts,
-) -> AppResult<Json<LegacyListResponse>> {
+) -> AppResult<(TypedHeader<CacheControl>, Json<LegacyListResponse>)> {
     let mut conn = app.db_read().await?;
     let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
 
@@ -77,10 +80,13 @@ pub async fn list_crate_owner_invitations_for_user(
         })
         .collect::<AppResult<Vec<EncodableCrateOwnerInvitationV1>>>()?;
 
-    Ok(Json(LegacyListResponse {
-        crate_owner_invitations,
-        users,
-    }))
+    Ok((
+        no_store(),
+        Json(LegacyListResponse {
+            crate_owner_invitations,
+            users,
+        }),
+    ))
 }
 
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
@@ -112,13 +118,13 @@ pub async fn list_crate_owner_invitations(
     app: AppState,
     params: ListQueryParams,
     req: Parts,
-) -> AppResult<Json<PrivateListResponse>> {
+) -> AppResult<(TypedHeader<CacheControl>, Json<PrivateListResponse>)> {
     let mut conn = app.db_read().await?;
     let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
 
     let filter = params.try_into()?;
     let list = prepare_list(&app, &req, auth, filter, &conn).await?;
-    Ok(Json(list))
+    Ok((no_store(), Json(list)))
 }
 
 enum ListFilter {

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -7,7 +7,10 @@ use crate::controllers::krate::CratePath;
 use crate::models::{Crate, Follow};
 use crate::schema::*;
 use crate::util::errors::{AppResult, crate_not_found};
+use crate::util::no_store;
 use axum::Json;
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use http::request::Parts;
@@ -94,7 +97,7 @@ pub async fn get_following_crate(
     app: AppState,
     path: CratePath,
     req: Parts,
-) -> AppResult<Json<FollowingResponse>> {
+) -> AppResult<(TypedHeader<CacheControl>, Json<FollowingResponse>)> {
     use diesel::dsl::exists;
 
     let mut conn = app.db_read_prefer_primary().await?;
@@ -108,5 +111,5 @@ pub async fn get_following_crate(
         .get_result(&mut conn)
         .await?;
 
-    Ok(Json(FollowingResponse { following }))
+    Ok((no_store(), Json(FollowingResponse { following })))
 }

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -3,7 +3,9 @@
 use crate::auth::AuthCheck;
 use axum::Json;
 use axum::extract::FromRequestParts;
+use axum_extra::TypedHeader;
 use axum_extra::extract::Query;
+use axum_extra::headers::CacheControl;
 use derive_more::Deref;
 use diesel::alias;
 use diesel::dsl::{InnerJoinQuerySource, LeftJoinQuerySource, exists};
@@ -26,6 +28,7 @@ use crate::views::EncodableCrate;
 use crate::controllers::helpers::pagination::{Page, PaginationOptions, PaginationQueryParams};
 use crate::models::krate::ALL_COLUMNS;
 use crate::util::RequestUtils;
+use crate::util::no_store;
 use crate::util::string_excl_null::StringExclNull;
 use crates_io_diesel_helpers::{array_agg, canon_crate_name, lower};
 
@@ -74,7 +77,7 @@ pub async fn list_crates(
     app: AppState,
     params: ListQueryParams,
     req: Parts,
-) -> AppResult<Json<ListResponse>> {
+) -> AppResult<(Option<TypedHeader<CacheControl>>, Json<ListResponse>)> {
     // Notes:
     // The different use cases this function covers is handled through passing
     // in parameters in the GET request.
@@ -96,6 +99,11 @@ pub async fn list_crates(
     use seek::*;
 
     let filter_params = FilterParams::from(params, &req, &mut conn).await?;
+
+    // When the results are filtered by the followed crates of the authenticated
+    // user, the response depends on the user's identity and must not be cached.
+    let cache_control = filter_params.auth_user_id.map(|_| no_store());
+
     let sort = filter_params.sort.as_deref();
 
     let selection = (
@@ -262,14 +270,17 @@ pub async fn list_crates(
         })
         .collect::<Vec<_>>();
 
-    Ok(Json(ListResponse {
-        crates,
-        meta: ListMeta {
-            total,
-            next_page,
-            prev_page,
-        },
-    }))
+    Ok((
+        cache_control,
+        Json(ListResponse {
+            crates,
+            meta: ListMeta {
+                total,
+                next_page,
+                prev_page,
+            },
+        }),
+    ))
 }
 
 #[derive(Debug, Deserialize, FromRequestParts, IntoParams)]

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -1,13 +1,20 @@
 use crate::app::AppState;
 use crate::tasks::spawn_blocking;
 use crate::util::errors::{AppResult, custom, forbidden, not_found};
+use crate::util::no_store;
 use axum::extract::Path;
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
 use http::request::Parts;
 use http::{StatusCode, header};
 use prometheus::TextEncoder;
 
 /// Handles the `GET /api/private/metrics/{kind}` endpoint.
-pub async fn prometheus(app: AppState, Path(kind): Path<String>, req: Parts) -> AppResult<String> {
+pub async fn prometheus(
+    app: AppState,
+    Path(kind): Path<String>,
+    req: Parts,
+) -> AppResult<(TypedHeader<CacheControl>, String)> {
     if let Some(expected_token) = &app.config.metrics_authorization_token {
         let provided_token = req
             .headers
@@ -34,5 +41,5 @@ pub async fn prometheus(app: AppState, Path(kind): Path<String>, req: Parts) -> 
         _ => return Err(not_found()),
     };
 
-    Ok(TextEncoder::new().encode_to_string(&metrics)?)
+    Ok((no_store(), TextEncoder::new().encode_to_string(&metrics)?))
 }

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -6,10 +6,13 @@ use crate::models::{NewEmail, NewOauthGithub, NewUser};
 use crate::schema::users;
 use crate::util::diesel::is_read_only_error;
 use crate::util::errors::{AppResult, bad_request, server_error};
+use crate::util::no_store;
 use crate::util::oauth::ReqwestClient;
 use crate::views::EncodableMe;
 use axum::Json;
 use axum::extract::{FromRequestParts, Query};
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
 use crates_io_github::GitHubUser;
 use crates_io_session::SessionExtension;
 use diesel::prelude::*;
@@ -61,8 +64,11 @@ pub async fn begin_session(app: AppState, session: SessionExtension) -> Json<Beg
     responses((status = 200, description = "Successful Response", body = inline(BeginResponse))),
 )]
 #[deprecated = "Use the `POST` endpoint instead"]
-pub async fn begin_session_get(app: AppState, session: SessionExtension) -> Json<BeginResponse> {
-    begin(&app, &session)
+pub async fn begin_session_get(
+    app: AppState,
+    session: SessionExtension,
+) -> (TypedHeader<CacheControl>, Json<BeginResponse>) {
+    (no_store(), begin(&app, &session))
 }
 
 fn begin(app: &AppState, session: &SessionExtension) -> Json<BeginResponse> {
@@ -144,8 +150,11 @@ pub async fn authorize_session_get(
     app: AppState,
     session: SessionExtension,
     req: Parts,
-) -> AppResult<Json<EncodableMe>> {
-    authorize(query.code, query.state, app, session, req).await
+) -> AppResult<(TypedHeader<CacheControl>, Json<EncodableMe>)> {
+    Ok((
+        no_store(),
+        authorize(query.code, query.state, app, session, req).await?,
+    ))
 }
 
 async fn authorize(

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -197,7 +197,7 @@ async fn authorize(
     // Log in by setting a cookie and the middleware authentication
     session.insert("user_id".to_string(), user_id.to_string());
 
-    super::user::me::get_authenticated_user(app, req).await
+    super::user::me::authenticated_user(&mut conn, user_id).await
 }
 
 pub async fn save_user_to_database(

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -9,10 +9,13 @@ use crate::auth::AuthCheck;
 use crate::middleware::real_ip::RealIp;
 use crate::models::token::{CrateScope, EndpointScope};
 use crate::util::errors::{AppResult, bad_request, custom};
+use crate::util::no_store;
 use crate::util::token::PlainToken;
 use axum::Json;
 use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Response};
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
 use axum_extra::json;
 use axum_extra::response::ErasedJson;
 use chrono::{DateTime, Utc};
@@ -66,7 +69,7 @@ pub async fn list_api_tokens(
     app: AppState,
     Query(params): Query<GetParams>,
     req: Parts,
-) -> AppResult<ErasedJson> {
+) -> AppResult<(TypedHeader<CacheControl>, ErasedJson)> {
     let mut conn = app.db_read_prefer_primary().await?;
     let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
     let user = auth.user();
@@ -83,7 +86,7 @@ pub async fn list_api_tokens(
         .load(&mut conn)
         .await?;
 
-    Ok(json!({ "api_tokens": tokens }))
+    Ok((no_store(), json!({ "api_tokens": tokens })))
 }
 
 /// Properties for a new API token.
@@ -251,7 +254,7 @@ pub async fn find_api_token(
     app: AppState,
     Path(id): Path<i32>,
     req: Parts,
-) -> AppResult<Json<GetResponse>> {
+) -> AppResult<(TypedHeader<CacheControl>, Json<GetResponse>)> {
     let mut conn = app.db_write().await?;
     let auth = AuthCheck::default().check(&req, &mut conn).await?;
     let user = auth.user();
@@ -261,7 +264,7 @@ pub async fn find_api_token(
         .first(&mut conn)
         .await?;
 
-    Ok(Json(GetResponse { api_token }))
+    Ok((no_store(), Json(GetResponse { api_token })))
 }
 
 /// Revoke API token.

--- a/src/controllers/trustpub/github_configs/list.rs
+++ b/src/controllers/trustpub/github_configs/list.rs
@@ -7,8 +7,11 @@ use crate::controllers::krate::load_crate;
 use crate::controllers::trustpub::github_configs::json::{self, ListResponse, ListResponseMeta};
 use crate::util::RequestUtils;
 use crate::util::errors::{AppResult, bad_request, forbidden};
+use crate::util::no_store;
 use axum::Json;
 use axum::extract::{FromRequestParts, Query};
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
 use crates_io_database::models::OwnerKind;
 use crates_io_database::models::token::EndpointScope;
 use crates_io_database::models::trustpub::GitHubConfig;
@@ -45,8 +48,8 @@ pub async fn list_trustpub_github_configs(
     state: AppState,
     params: ListQueryParams,
     parts: Parts,
-) -> AppResult<Json<ListResponse>> {
-    match (&params.krate, params.user_id) {
+) -> AppResult<(TypedHeader<CacheControl>, Json<ListResponse>)> {
+    let configs = match (&params.krate, params.user_id) {
         (Some(krate), None) => list_by_crate(state, krate, parts).await,
         (None, Some(user_id)) => list_by_user(state, user_id, parts).await,
         (Some(_), Some(_)) => Err(bad_request(
@@ -55,7 +58,9 @@ pub async fn list_trustpub_github_configs(
         (None, None) => Err(bad_request(
             "Must specify either `crate` or `user_id` query parameter",
         )),
-    }
+    }?;
+
+    Ok((no_store(), configs))
 }
 
 async fn list_by_crate(

--- a/src/controllers/trustpub/gitlab_configs/list.rs
+++ b/src/controllers/trustpub/gitlab_configs/list.rs
@@ -7,8 +7,11 @@ use crate::controllers::krate::load_crate;
 use crate::controllers::trustpub::gitlab_configs::json::{self, ListResponse, ListResponseMeta};
 use crate::util::RequestUtils;
 use crate::util::errors::{AppResult, bad_request, forbidden};
+use crate::util::no_store;
 use axum::Json;
 use axum::extract::{FromRequestParts, Query};
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
 use crates_io_database::models::OwnerKind;
 use crates_io_database::models::token::EndpointScope;
 use crates_io_database::models::trustpub::GitLabConfig;
@@ -45,8 +48,8 @@ pub async fn list_trustpub_gitlab_configs(
     state: AppState,
     params: ListQueryParams,
     parts: Parts,
-) -> AppResult<Json<ListResponse>> {
-    match (&params.krate, params.user_id) {
+) -> AppResult<(TypedHeader<CacheControl>, Json<ListResponse>)> {
+    let configs = match (&params.krate, params.user_id) {
         (Some(krate), None) => list_by_crate(state, krate, parts).await,
         (None, Some(user_id)) => list_by_user(state, user_id, parts).await,
         (Some(_), Some(_)) => Err(bad_request(
@@ -55,7 +58,9 @@ pub async fn list_trustpub_gitlab_configs(
         (None, None) => Err(bad_request(
             "Must specify either `crate` or `user_id` query parameter",
         )),
-    }
+    }?;
+
+    Ok((no_store(), configs))
 }
 
 async fn list_by_crate(

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -6,8 +6,11 @@ use crate::models::krate::CrateName;
 use crate::models::{CrateOwner, Follow, OwnerKind, User, Version, VersionOwnerAction};
 use crate::schema::{crate_owners, crates, emails, follows, users, versions};
 use crate::util::errors::AppResult;
+use crate::util::no_store;
 use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCrate};
 use axum::Json;
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use futures_util::FutureExt;
@@ -23,14 +26,17 @@ use serde::Serialize;
     extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(EncodableMe))),
 )]
-pub async fn get_authenticated_user(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
+pub async fn get_authenticated_user(
+    app: AppState,
+    req: Parts,
+) -> AppResult<(TypedHeader<CacheControl>, Json<EncodableMe>)> {
     let mut conn = app.db_read_prefer_primary().await?;
     let user_id = AuthCheck::only_cookie()
         .check(&req, &mut conn)
         .await?
         .user_id();
 
-    authenticated_user(&mut conn, user_id).await
+    Ok((no_store(), authenticated_user(&mut conn, user_id).await?))
 }
 
 /// Load the profile of the user with the given id.
@@ -103,7 +109,7 @@ pub struct UpdatesResponseMeta {
 pub async fn get_authenticated_user_updates(
     app: AppState,
     req: Parts,
-) -> AppResult<Json<UpdatesResponse>> {
+) -> AppResult<(TypedHeader<CacheControl>, Json<UpdatesResponse>)> {
     let mut conn = app.db_read_prefer_primary().await?;
     let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
 
@@ -135,8 +141,11 @@ pub async fn get_authenticated_user_updates(
         })
         .collect::<Vec<_>>();
 
-    Ok(Json(UpdatesResponse {
-        versions,
-        meta: UpdatesResponseMeta { more },
-    }))
+    Ok((
+        no_store(),
+        Json(UpdatesResponse {
+            versions,
+            meta: UpdatesResponseMeta { more },
+        }),
+    ))
 }

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -9,7 +9,7 @@ use crate::util::errors::AppResult;
 use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCrate};
 use axum::Json;
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use futures_util::FutureExt;
 use http::request::Parts;
 use serde::Serialize;
@@ -30,6 +30,14 @@ pub async fn get_authenticated_user(app: AppState, req: Parts) -> AppResult<Json
         .await?
         .user_id();
 
+    authenticated_user(&mut conn, user_id).await
+}
+
+/// Load the profile of the user with the given id.
+pub async fn authenticated_user(
+    conn: &mut AsyncPgConnection,
+    user_id: i32,
+) -> AppResult<Json<EncodableMe>> {
     let ((user, verified, email, verification_sent), owned_crates) = tokio::try_join!(
         users::table
             .find(user_id)

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -17,6 +17,7 @@ use chrono::{Duration, NaiveDate, Utc};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::request::Parts;
+use http::{HeaderValue, header};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -46,11 +47,18 @@ pub async fn download_version(
 ) -> AppResult<Response> {
     let wants_json = req.wants_json();
     let redirect_url = app.storage.crate_location(&path.name, &path.version);
-    if wants_json {
-        Ok(json!({ "url": redirect_url }).into_response())
+    let response = if wants_json {
+        json!({ "url": redirect_url }).into_response()
     } else {
-        Ok(redirect(redirect_url))
-    }
+        redirect(redirect_url)
+    };
+
+    // The response body depends on the `Accept` request header.
+    Ok((
+        [(header::VARY, HeaderValue::from_static("accept"))],
+        response,
+    )
+        .into_response())
 }
 
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]

--- a/src/controllers/version/readme.rs
+++ b/src/controllers/version/readme.rs
@@ -4,6 +4,7 @@ use crate::util::{RequestUtils, redirect};
 use axum::Json;
 use axum::response::{IntoResponse, Response};
 use http::request::Parts;
+use http::{HeaderValue, header};
 use serde::Serialize;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -26,9 +27,16 @@ pub struct UrlResponse {
 )]
 pub async fn get_version_readme(app: AppState, path: CrateVersionPath, req: Parts) -> Response {
     let url = app.storage.readme_location(&path.name, &path.version);
-    if req.wants_json() {
+    let response = if req.wants_json() {
         Json(UrlResponse { url }).into_response()
     } else {
         redirect(url)
-    }
+    };
+
+    // The response body depends on the `Accept` request header.
+    (
+        [(header::VARY, HeaderValue::from_static("accept"))],
+        response,
+    )
+        .into_response()
 }

--- a/src/middleware/common_headers.rs
+++ b/src/middleware/common_headers.rs
@@ -43,7 +43,6 @@ pub async fn add_common_headers(request: Request, next: Next) -> impl IntoRespon
         headers.insert(header::X_CONTENT_TYPE_OPTIONS, v("nosniff"));
         headers.insert(header::X_FRAME_OPTIONS, v("SAMEORIGIN"));
         headers.insert(header::X_XSS_PROTECTION, v("0"));
-        headers.insert(header::VARY, v("Accept, Accept-Encoding, Cookie"));
     }
 
     (headers, response)

--- a/src/middleware/static_or_continue.rs
+++ b/src/middleware/static_or_continue.rs
@@ -1,10 +1,11 @@
 //! This module implements middleware to serve static files from the
 //! specified directory.
 
+use axum::body::Body;
 use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::Response;
-use http::{Method, StatusCode};
+use http::{HeaderValue, Method, StatusCode, header};
 use std::path::Path;
 use tower::ServiceExt;
 use tower_http::services::ServeDir;
@@ -18,21 +19,77 @@ pub async fn serve_svelte(request: Request, next: Next) -> Response {
 }
 
 async fn serve<P: AsRef<Path>>(path: P, request: Request, next: Next) -> Response {
-    // index.html is a Jinja template, which is to be rendered by `frontend_html::serve`.
-    if matches!(*request.method(), Method::GET | Method::HEAD)
-        && !matches!(request.uri().path().as_bytes(), b"/" | b"/index.html")
-    {
-        let mut static_req = Request::new(());
-        *static_req.method_mut() = request.method().clone();
-        *static_req.uri_mut() = request.uri().clone();
-        *static_req.headers_mut() = request.headers().clone();
+    match serve_static(path, request).await {
+        Ok(response) => response,
+        Err(request) => next.run(request).await,
+    }
+}
 
-        let serve_dir = ServeDir::new(path).precompressed_br().precompressed_gzip();
-        let Ok(response) = serve_dir.oneshot(static_req).await;
-        if response.status() != StatusCode::NOT_FOUND {
-            return response.map(axum::body::Body::new);
-        }
+/// Serve a static file from `path`, using the precompressed `.br`/`.gz`
+/// variants when available and accepted.
+///
+/// Returns the original request back as [`Err`] when it should fall through to
+/// the next handler: for non-GET/HEAD methods, for the `/` and `/index.html`
+/// Jinja template (rendered by `frontend_html::serve`), and when no matching
+/// file exists.
+async fn serve_static<P: AsRef<Path>>(path: P, request: Request) -> Result<Response, Request> {
+    if !matches!(*request.method(), Method::GET | Method::HEAD)
+        || matches!(request.uri().path().as_bytes(), b"/" | b"/index.html")
+    {
+        return Err(request);
     }
 
-    next.run(request).await
+    let mut static_req = Request::new(());
+    *static_req.method_mut() = request.method().clone();
+    *static_req.uri_mut() = request.uri().clone();
+    *static_req.headers_mut() = request.headers().clone();
+
+    let serve_dir = ServeDir::new(path).precompressed_br().precompressed_gzip();
+    let Ok(response) = serve_dir.oneshot(static_req).await;
+    if response.status() == StatusCode::NOT_FOUND {
+        return Err(request);
+    }
+
+    let mut response = response.map(Body::new);
+
+    // FIXME: `ServeDir` does not set `Vary: Accept-Encoding` on precompressed
+    // responses yet. Remove this once a tower-http release including
+    // https://github.com/tower-rs/tower-http/pull/692 is available.
+    response
+        .headers_mut()
+        .insert(header::VARY, HeaderValue::from_static("accept-encoding"));
+
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::serve_static;
+    use axum::body::Body;
+    use axum::extract::Request;
+    use claims::{assert_err, assert_ok};
+    use http::{StatusCode, header};
+
+    #[tokio::test]
+    async fn serves_file_with_vary_accept_encoding() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("app.js"), b"console.log(1)").unwrap();
+
+        let request = Request::get("/app.js").body(Body::empty()).unwrap();
+        let response = assert_ok!(serve_static(dir.path(), request).await);
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::VARY).unwrap(),
+            "accept-encoding"
+        );
+    }
+
+    #[tokio::test]
+    async fn falls_through_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let request = Request::get("/missing.js").body(Body::empty()).unwrap();
+        assert_err!(serve_static(dir.path(), request).await);
+    }
 }

--- a/src/tests/caching.rs
+++ b/src/tests/caching.rs
@@ -1,0 +1,148 @@
+//! Tests for the HTTP caching headers that control CDN and browser caching.
+//!
+//! Responses that depend on the authenticated identity must carry
+//! `Cache-Control: no-store` so that no shared cache (CDN) or browser cache
+//! stores them. Identity can come from a session cookie or an API token, so
+//! `no-store` is used instead of relying on `Vary: Cookie`.
+
+use crate::builders::CrateBuilder;
+use crate::util::{MockRequestExt, RequestHelper, TestApp};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn me_is_not_cached() {
+    let (_, _, user) = TestApp::init().with_user().await;
+    let response = user.get::<()>("/api/v1/me").await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn me_updates_is_not_cached() {
+    let (_, _, user) = TestApp::init().with_user().await;
+    let response = user.get::<()>("/api/v1/me/updates").await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn me_tokens_is_not_cached() {
+    let (_, _, user) = TestApp::init().with_user().await;
+    let response = user.get::<()>("/api/v1/me/tokens").await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn me_token_is_not_cached() {
+    let (_, _, user, token) = TestApp::init().with_token().await;
+    let url = format!("/api/v1/me/tokens/{}", token.as_model().id);
+    let response = user.get::<()>(&url).await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn me_crate_owner_invitations_is_not_cached() {
+    let (_, _, user) = TestApp::init().with_user().await;
+    let response = user.get::<()>("/api/v1/me/crate_owner_invitations").await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn private_crate_owner_invitations_is_not_cached() {
+    let (_, _, user) = TestApp::init().with_user().await;
+    let id = user.as_model().id;
+    let url = format!("/api/private/crate_owner_invitations?invitee_id={id}");
+    let response = user.get::<()>(&url).await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trustpub_github_configs_is_not_cached() {
+    let (_, _, user) = TestApp::init().with_user().await;
+    let id = user.as_model().id;
+    let url = format!("/api/v1/trusted_publishing/github_configs?user_id={id}");
+    let response = user.get::<()>(&url).await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trustpub_gitlab_configs_is_not_cached() {
+    let (_, _, user) = TestApp::init().with_user().await;
+    let id = user.as_model().id;
+    let url = format!("/api/v1/trusted_publishing/gitlab_configs?user_id={id}");
+    let response = user.get::<()>(&url).await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn crate_following_status_is_not_cached() {
+    let (app, _, user) = TestApp::init().with_user().await;
+    let mut conn = app.db_conn().await;
+    CrateBuilder::new("foo", user.as_model().id)
+        .expect_build(&mut conn)
+        .await;
+    let response = user.get::<()>("/api/v1/crates/foo/following").await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_with_following_is_not_cached() {
+    let (_, _, user) = TestApp::init().with_user().await;
+    let response = user.get::<()>("/api/v1/crates?following=yes").await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_begin_is_not_cached() {
+    let (_, anon) = TestApp::init().empty().await;
+    let response = anon.get::<()>("/api/private/session/begin").await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_list_is_not_cached() {
+    use crates_io::schema::users;
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
+
+    let (app, _, user) = TestApp::init().with_user().await;
+    let mut conn = app.db_conn().await;
+    diesel::update(user.as_model())
+        .set(users::is_admin.eq(true))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let response = user.admin_list::<()>(&user.as_model().gh_login).await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_is_not_cached() {
+    let (_, anon) = TestApp::init()
+        .with_config(|config| config.metrics_authorization_token = Some("secret".into()))
+        .empty()
+        .await;
+    let mut request = anon.get_request("/api/private/metrics/service");
+    request.header("Authorization", "Bearer secret");
+    let response = anon.run::<()>(request).await;
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_without_following_is_cacheable() {
+    let (_, anon) = TestApp::init().empty().await;
+    let response = anon.get::<()>("/api/v1/crates").await;
+    response.assert_no_cache_control();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn public_endpoint_is_cacheable() {
+    let (_, anon) = TestApp::init().empty().await;
+    let response = anon.get::<()>("/api/v1/categories").await;
+    response.assert_no_cache_control();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn public_endpoint_is_cacheable_for_authenticated_users() {
+    let (_, _, user) = TestApp::init().with_user().await;
+    let response = user.get::<()>("/api/v1/categories").await;
+    response.assert_no_cache_control();
+}

--- a/src/tests/caching.rs
+++ b/src/tests/caching.rs
@@ -144,14 +144,13 @@ async fn download_varies_on_accept() {
     response.assert_redirect_ends_with("/crates/foo/foo-1.0.0.crate");
     response.assert_vary(&["accept"]);
 
-    // `Accept: application/json` returns a 200 with the URL as JSON, which the
-    // common-headers middleware still overrides with the global `Vary` value.
+    // `Accept: application/json` returns a 200 with the URL as JSON.
     let mut request = anon.get_request("/api/v1/crates/foo/1.0.0/download");
     request.header(header::ACCEPT, "application/json");
     let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert!(response.json().get("url").is_some());
-    response.assert_vary(&["accept", "accept-encoding", "cookie"]);
+    response.assert_vary(&["accept", "accept-encoding"]);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -169,7 +168,7 @@ async fn readme_varies_on_accept() {
     let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert!(response.json().get("url").is_some());
-    response.assert_vary(&["accept", "accept-encoding", "cookie"]);
+    response.assert_vary(&["accept", "accept-encoding"]);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -177,6 +176,9 @@ async fn public_endpoint_is_cacheable() {
     let (_, anon) = TestApp::init().empty().await;
     let response = anon.get::<()>("/api/v1/categories").await;
     response.assert_no_cache_control();
+    // The only `Vary` value is `Accept-Encoding`, added by the compression
+    // middleware.
+    response.assert_vary(&["accept-encoding"]);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/caching.rs
+++ b/src/tests/caching.rs
@@ -7,6 +7,7 @@
 
 use crate::builders::CrateBuilder;
 use crate::util::{MockRequestExt, RequestHelper, TestApp};
+use http::{StatusCode, header};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn me_is_not_cached() {
@@ -131,6 +132,44 @@ async fn search_without_following_is_cacheable() {
     let (_, anon) = TestApp::init().empty().await;
     let response = anon.get::<()>("/api/v1/crates").await;
     response.assert_no_cache_control();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn download_varies_on_accept() {
+    let (_, anon) = TestApp::init().empty().await;
+
+    // The default `Accept` header redirects (302) to the crate file.
+    let response = anon.get::<()>("/api/v1/crates/foo/1.0.0/download").await;
+    assert_eq!(response.status(), StatusCode::FOUND);
+    response.assert_redirect_ends_with("/crates/foo/foo-1.0.0.crate");
+    response.assert_vary(&["accept"]);
+
+    // `Accept: application/json` returns a 200 with the URL as JSON, which the
+    // common-headers middleware still overrides with the global `Vary` value.
+    let mut request = anon.get_request("/api/v1/crates/foo/1.0.0/download");
+    request.header(header::ACCEPT, "application/json");
+    let response = anon.run::<()>(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response.json().get("url").is_some());
+    response.assert_vary(&["accept", "accept-encoding", "cookie"]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn readme_varies_on_accept() {
+    let (_, anon) = TestApp::init().empty().await;
+
+    // The default `Accept` header redirects (302) to the rendered readme.
+    let response = anon.get::<()>("/api/v1/crates/foo/1.0.0/readme").await;
+    assert_eq!(response.status(), StatusCode::FOUND);
+    response.assert_redirect_ends_with("/readmes/foo/foo-1.0.0.html");
+    response.assert_vary(&["accept"]);
+
+    let mut request = anon.get_request("/api/v1/crates/foo/1.0.0/readme");
+    request.header(header::ACCEPT, "application/json");
+    let response = anon.run::<()>(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response.json().get("url").is_some());
+    response.assert_vary(&["accept", "accept-encoding", "cookie"]);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod account_lock;
 mod authentication;
 mod blocked_routes;
 pub use crates_io_test_utils::builders;
+mod caching;
 mod categories;
 mod cors;
 mod dump_db;

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -3,6 +3,7 @@ use bytes::Bytes;
 use claims::{assert_none, assert_ok, assert_some, assert_some_eq};
 use googletest::prelude::*;
 use serde_json::Value;
+use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::str::from_utf8;
 
@@ -74,6 +75,28 @@ impl<T> Response<T> {
     #[track_caller]
     pub fn assert_no_cache_control(&self) -> &Self {
         assert_none!(self.response.headers().get(header::CACHE_CONTROL));
+        self
+    }
+
+    /// Assert that the `Vary` header lists exactly the given values, ignoring
+    /// order, case, and how the values are spread across multiple header lines.
+    #[track_caller]
+    pub fn assert_vary(&self, expected: &[&str]) -> &Self {
+        let actual = self
+            .response
+            .headers()
+            .get_all(header::VARY)
+            .iter()
+            .flat_map(|value| assert_ok!(value.to_str()).split(','))
+            .map(|token| token.trim().to_ascii_lowercase())
+            .collect::<HashSet<_>>();
+
+        let expected = expected
+            .iter()
+            .map(|token| token.to_ascii_lowercase())
+            .collect::<HashSet<_>>();
+
+        assert_eq!(actual, expected);
         self
     }
 

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -1,6 +1,6 @@
 use crate::util::matchers::is_success;
 use bytes::Bytes;
-use claims::{assert_ok, assert_some, assert_some_eq};
+use claims::{assert_none, assert_ok, assert_some, assert_some_eq};
 use googletest::prelude::*;
 use serde_json::Value;
 use std::marker::PhantomData;
@@ -58,6 +58,22 @@ impl<T> Response<T> {
         let location = assert_some!(headers.get(header::LOCATION));
         let location = assert_ok!(location.to_str());
         assert_that!(location, ends_with(target));
+        self
+    }
+
+    /// Assert that the response carries the given `Cache-Control` header value.
+    #[track_caller]
+    pub fn assert_cache_control(&self, expected: &str) -> &Self {
+        let value = assert_some!(self.response.headers().get(header::CACHE_CONTROL));
+        assert_eq!(assert_ok!(value.to_str()), expected);
+        self
+    }
+
+    /// Assert that no `Cache-Control` header is present, i.e. the response may be
+    /// freely cached by shared caches.
+    #[track_caller]
+    pub fn assert_no_cache_control(&self) -> &Self {
+        assert_none!(self.response.headers().get(header::CACHE_CONTROL));
         self
     }
 

--- a/src/util/request_helpers.rs
+++ b/src/util/request_helpers.rs
@@ -1,5 +1,7 @@
 use crate::controllers::util::RequestPartsExt;
 use axum::response::{IntoResponse, Response};
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
 use http::header::AsHeaderName;
 use http::{HeaderMap, StatusCode, header};
 use indexmap::IndexMap;
@@ -24,6 +26,15 @@ impl HeaderMapExt for HeaderMap {
 
 pub fn redirect(url: String) -> Response {
     (StatusCode::FOUND, [(header::LOCATION, url)]).into_response()
+}
+
+/// Build a `Cache-Control: no-store` header that prevents any cache (shared CDN
+/// cache or browser cache) from storing a per-user response.
+///
+/// Used on responses that depend on the authenticated identity, which can come
+/// from a session cookie or an API token.
+pub fn no_store() -> TypedHeader<CacheControl> {
+    TypedHeader(CacheControl::new().with_no_store())
 }
 
 pub trait RequestUtils {


### PR DESCRIPTION
The common-headers middleware applied `Vary: Accept, Accept-Encoding, Cookie` to almost every response. `Cookie` is high cardinality, so a shared CDN cache keys a separate entry per session and effectively stops caching, which defeated the ten-year `Cache-Control` on the content-hashed frontend assets and prevented public API responses from being cached. `Accept` has the same problem to a smaller degree, and neither value was needed on the bulk of responses.

This replaces the blanket header with values scoped to where they matter. Responses that depend on who is authenticated now set `Cache-Control: no-store`, so neither a shared cache nor a browser stores them. That covers the `/me` family, API token listing, crate owner invitations, trusted publishing configuration, the crate following status, the session routes, and crate search when it is filtered by `?following=`. `no-store` rather than `Vary: Cookie` is deliberate, because authentication can come from an API token as well as a session cookie, and because it also keeps one user's response out of the next person's browser cache on a shared computer.

The two endpoints that genuinely vary on the request `Accept` header, the crate download and readme redirects, now set `Vary: Accept` themselves. The static asset responses set `Vary: Accept-Encoding`, which `ServeDir` does not emit for precompressed variants yet ([tower-rs/tower-http#692](https://github.com/tower-rs/tower-http/pull/692)), so dropping the global header would otherwise let a shared cache hand a Brotli file to a client that only accepts gzip. With those cases handled, the global header is gone, and compressed responses still pick up `Vary: Accept-Encoding` from the compression layer.

The per-user set was found by auditing every GET handler for responses that change with the authenticated identity. A new `caching` integration module asserts these cases, along with a couple of public endpoints as smoke tests.

### Related

- https://github.com/rust-lang/crates.io/pull/910
- https://github.com/tower-rs/tower-http/pull/692
