### PR TITLE
session: Accept `POST` on the OAuth endpoints

### DIFF
--- a/e2e/acceptance/login.spec.ts
+++ b/e2e/acceptance/login.spec.ts
@@ -35,11 +35,11 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
     let user = await msw.db.user.create({ name: 'John Doe' });
 
     msw.worker.use(
-      http.get('/api/private/session/authorize', async ({ request }) => {
-        let url = new URL(request.url);
-        expect([...url.searchParams.keys()]).toEqual(['code', 'state']);
-        expect(url.searchParams.get('code')).toBe(MOCK_CODE);
-        expect(url.searchParams.get('state')).toBe(MOCK_STATE);
+      http.post('/api/private/session/authorize', async ({ request }) => {
+        let body = await request.json();
+        expect(Object.keys(body)).toEqual(['code', 'state']);
+        expect(body.code).toBe(MOCK_CODE);
+        expect(body.state).toBe(MOCK_STATE);
 
         await msw.db.mswSession.create({ user });
         return HttpResponse.json({ ok: true });
@@ -55,7 +55,7 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
     await setupGitHubOAuthRoutes(page);
 
     msw.worker.use(
-      http.get('/api/private/session/authorize', () =>
+      http.post('/api/private/session/authorize', () =>
         HttpResponse.json({ errors: [{ detail: 'Forbidden' }] }, { status: 403 }),
       ),
     );
@@ -71,11 +71,11 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
     let user = await msw.db.user.create({ name: 'John Doe' });
 
     msw.worker.use(
-      http.get('/api/private/session/authorize', async ({ request }) => {
-        let url = new URL(request.url);
-        expect([...url.searchParams.keys()]).toEqual(['code', 'state']);
-        expect(url.searchParams.get('code')).toBe(MOCK_CODE);
-        expect(url.searchParams.get('state')).toBe(MOCK_STATE);
+      http.post('/api/private/session/authorize', async ({ request }) => {
+        let body = await request.json();
+        expect(Object.keys(body)).toEqual(['code', 'state']);
+        expect(body.code).toBe(MOCK_CODE);
+        expect(body.state).toBe(MOCK_STATE);
 
         await msw.db.mswSession.create({ user });
         return HttpResponse.json({ ok: true });

--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -78,14 +78,20 @@ export interface paths {
         };
         /**
          * Begin authentication flow.
+         * @deprecated
+         * @description `GET` variant retained for clients that have not migrated to the `POST`
+         *     endpoint yet. New clients should use the `POST` endpoint instead.
+         */
+        get: operations["begin_session_get"];
+        put?: never;
+        /**
+         * Begin authentication flow.
          * @description This route will return an authorization URL for the GitHub OAuth flow including the crates.io
          *     `client_id` and a randomly generated `state` secret.
          *
          *     see <https://developer.github.com/v3/oauth/#redirect-users-to-request-github-access>
          */
-        get: operations["begin_session"];
-        put?: never;
-        post?: never;
+        post: operations["begin_session"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1944,6 +1950,31 @@ export interface operations {
                         }[];
                         /** @description The authenticated user. */
                         user: components["schemas"]["AuthenticatedUser"];
+                    };
+                };
+            };
+        };
+    };
+    begin_session_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example b84a63c4ea3fcb4ac84 */
+                        state: string;
+                        /** @example https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg */
+                        url: string;
                     };
                 };
             };

--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -48,21 +48,22 @@ export interface paths {
         };
         /**
          * Complete authentication flow.
+         * @deprecated
+         * @description `GET` variant retained for clients that have not migrated to the `POST`
+         *     endpoint yet. New clients should use the `POST` endpoint instead.
+         */
+        get: operations["authorize_session_get"];
+        put?: never;
+        /**
+         * Complete authentication flow.
          * @description This route is called from the GitHub API OAuth flow after the user accepted or rejected
          *     the data access permissions. It will check the `state` parameter and then call the GitHub API
          *     to exchange the temporary `code` for an API token. The API token is returned together with
          *     the corresponding user information.
          *
          *     see <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>
-         *
-         *     ## Query Parameters
-         *
-         *     - `code` – temporary code received from the GitHub API  **(Required)**
-         *     - `state` – state parameter received from the GitHub API  **(Required)**
          */
-        get: operations["authorize_session"];
-        put?: never;
-        post?: never;
+        post: operations["authorize_session"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1905,7 +1906,7 @@ export interface operations {
             };
         };
     };
-    authorize_session: {
+    authorize_session_get: {
         parameters: {
             query: {
                 /**
@@ -1924,6 +1925,60 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The crates that the authenticated user owns. */
+                        owned_crates: {
+                            /** @deprecated */
+                            email_notifications: boolean;
+                            /**
+                             * Format: int32
+                             * @description The opaque identifier of the crate.
+                             * @example 123
+                             */
+                            id: number;
+                            /**
+                             * @description The name of the crate.
+                             * @example serde
+                             */
+                            name: string;
+                        }[];
+                        /** @description The authenticated user. */
+                        user: components["schemas"]["AuthenticatedUser"];
+                    };
+                };
+            };
+        };
+    };
+    authorize_session: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description Temporary code received from the GitHub API.
+                     * @example 901dd10e07c7e9fa1cd5
+                     */
+                    code: string;
+                    /**
+                     * @description State parameter received from the GitHub API.
+                     * @example fYcUY3FMdUUz00FC7vLT7A
+                     */
+                    state: string;
+                };
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -39,13 +39,33 @@ pub struct BeginResponse {
 ///
 /// see <https://developer.github.com/v3/oauth/#redirect-users-to-request-github-access>
 #[utoipa::path(
-    get,
+    post,
     path = "/api/private/session/begin",
     tag = "session",
     extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(BeginResponse))),
 )]
 pub async fn begin_session(app: AppState, session: SessionExtension) -> Json<BeginResponse> {
+    begin(&app, &session)
+}
+
+/// Begin authentication flow.
+///
+/// `GET` variant retained for clients that have not migrated to the `POST`
+/// endpoint yet. New clients should use the `POST` endpoint instead.
+#[utoipa::path(
+    get,
+    path = "/api/private/session/begin",
+    tag = "session",
+    extensions(("x-internal" = json!(true))),
+    responses((status = 200, description = "Successful Response", body = inline(BeginResponse))),
+)]
+#[deprecated = "Use the `POST` endpoint instead"]
+pub async fn begin_session_get(app: AppState, session: SessionExtension) -> Json<BeginResponse> {
+    begin(&app, &session)
+}
+
+fn begin(app: &AppState, session: &SessionExtension) -> Json<BeginResponse> {
     let (url, state) = app
         .github_oauth
         .authorize_url(oauth2::CsrfToken::new_random)

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -91,6 +91,16 @@ pub struct AuthorizeQuery {
     state: CsrfToken,
 }
 
+#[derive(Clone, Debug, Deserialize, utoipa::ToSchema)]
+pub struct AuthorizeBody {
+    /// Temporary code received from the GitHub API.
+    #[schema(value_type = String, example = "901dd10e07c7e9fa1cd5")]
+    code: AuthorizationCode,
+    /// State parameter received from the GitHub API.
+    #[schema(value_type = String, example = "fYcUY3FMdUUz00FC7vLT7A")]
+    state: CsrfToken,
+}
+
 /// Complete authentication flow.
 ///
 /// This route is called from the GitHub API OAuth flow after the user accepted or rejected
@@ -99,11 +109,27 @@ pub struct AuthorizeQuery {
 /// the corresponding user information.
 ///
 /// see <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>
+#[utoipa::path(
+    post,
+    path = "/api/private/session/authorize",
+    tag = "session",
+    request_body = inline(AuthorizeBody),
+    extensions(("x-internal" = json!(true))),
+    responses((status = 200, description = "Successful Response", body = inline(EncodableMe))),
+)]
+pub async fn authorize_session(
+    app: AppState,
+    session: SessionExtension,
+    req: Parts,
+    Json(body): Json<AuthorizeBody>,
+) -> AppResult<Json<EncodableMe>> {
+    authorize(body.code, body.state, app, session, req).await
+}
+
+/// Complete authentication flow.
 ///
-/// ## Query Parameters
-///
-/// - `code` – temporary code received from the GitHub API  **(Required)**
-/// - `state` – state parameter received from the GitHub API  **(Required)**
+/// `GET` variant retained for clients that have not migrated to the `POST`
+/// endpoint yet. New clients should use the `POST` endpoint instead.
 #[utoipa::path(
     get,
     path = "/api/private/session/authorize",
@@ -112,8 +138,19 @@ pub struct AuthorizeQuery {
     extensions(("x-internal" = json!(true))),
     responses((status = 200, description = "Successful Response", body = inline(EncodableMe))),
 )]
-pub async fn authorize_session(
+#[deprecated = "Use the `POST` endpoint instead"]
+pub async fn authorize_session_get(
     query: AuthorizeQuery,
+    app: AppState,
+    session: SessionExtension,
+    req: Parts,
+) -> AppResult<Json<EncodableMe>> {
+    authorize(query.code, query.state, app, session, req).await
+}
+
+async fn authorize(
+    code: AuthorizationCode,
+    state: CsrfToken,
     app: AppState,
     session: SessionExtension,
     req: Parts,
@@ -121,7 +158,7 @@ pub async fn authorize_session(
     // Make sure that the state we just got matches the session state that we
     // should have issued earlier.
     let session_state = session.remove("github_oauth_state").map(CsrfToken::new);
-    if session_state.is_none_or(|state| query.state.secret() != state.secret()) {
+    if session_state.is_none_or(|session_state| state.secret() != session_state.secret()) {
         return Err(bad_request("invalid state parameter"));
     }
 
@@ -134,7 +171,7 @@ pub async fn authorize_session(
 
     let token = app
         .github_oauth
-        .exchange_code(query.code)
+        .exchange_code(code)
         .request_async(&client)
         .await
         .map_err(|err| {

--- a/src/router.rs
+++ b/src/router.rs
@@ -87,7 +87,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         .routes(routes!(user::email_verification::resend_email_verification))
         .routes(routes!(site_metadata::get_site_metadata))
         // Session management
-        .routes(routes!(session::begin_session))
+        .routes(routes!(session::begin_session, session::begin_session_get))
         .routes(routes!(session::authorize_session))
         .routes(routes!(session::end_session))
         // OIDC / Trusted Publishing

--- a/src/router.rs
+++ b/src/router.rs
@@ -88,7 +88,10 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         .routes(routes!(site_metadata::get_site_metadata))
         // Session management
         .routes(routes!(session::begin_session, session::begin_session_get))
-        .routes(routes!(session::authorize_session))
+        .routes(routes!(
+            session::authorize_session,
+            session::authorize_session_get
+        ))
         .routes(routes!(session::end_session))
         // OIDC / Trusted Publishing
         .routes(routes!(

--- a/src/tests/routes/session/authorize.rs
+++ b/src/tests/routes/session/authorize.rs
@@ -8,3 +8,24 @@ async fn access_token_needs_data() {
     assert_snapshot!(response.status(), @"400 Bad Request");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to deserialize query string: missing field `code`"}]}"#);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_rejects_invalid_state() {
+    let (_, anon) = TestApp::init().empty().await;
+    let body = r#"{"code":"901dd10e07c7e9fa1cd5","state":"fYcUY3FMdUUz00FC7vLT7A"}"#;
+    let response = anon
+        .post::<()>("/api/private/session/authorize", body)
+        .await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"invalid state parameter"}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_needs_data() {
+    let (_, anon) = TestApp::init().empty().await;
+    let response = anon
+        .post::<()>("/api/private/session/authorize", "{}")
+        .await;
+    assert_snapshot!(response.status(), @"422 Unprocessable Entity");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `code` at line 1 column 2"}]}"#);
+}

--- a/src/tests/routes/session/begin.rs
+++ b/src/tests/routes/session/begin.rs
@@ -13,3 +13,10 @@ async fn auth_gives_a_token() {
     let json: AuthResponse = anon.get("/api/private/session/begin").await.good();
     assert!(json.url.contains(&json.state));
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_gives_a_token() {
+    let (_, anon) = TestApp::init().empty().await;
+    let json: AuthResponse = anon.post("/api/private/session/begin", "").await.good();
+    assert!(json.url.contains(&json.state));
+}

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1464,8 +1464,9 @@ expression: response.json()
     },
     "/api/private/session/authorize": {
       "get": {
-        "description": "This route is called from the GitHub API OAuth flow after the user accepted or rejected\nthe data access permissions. It will check the `state` parameter and then call the GitHub API\nto exchange the temporary `code` for an API token. The API token is returned together with\nthe corresponding user information.\n\nsee <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>\n\n## Query Parameters\n\n- `code` – temporary code received from the GitHub API  **(Required)**\n- `state` – state parameter received from the GitHub API  **(Required)**",
-        "operationId": "authorize_session",
+        "deprecated": true,
+        "description": "`GET` variant retained for clients that have not migrated to the `POST`\nendpoint yet. New clients should use the `POST` endpoint instead.",
+        "operationId": "authorize_session_get",
         "parameters": [
           {
             "description": "Temporary code received from the GitHub API.",
@@ -1488,6 +1489,91 @@ expression: response.json()
             }
           }
         ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "owned_crates": {
+                      "description": "The crates that the authenticated user owns.",
+                      "items": {
+                        "properties": {
+                          "email_notifications": {
+                            "deprecated": true,
+                            "type": "boolean"
+                          },
+                          "id": {
+                            "description": "The opaque identifier of the crate.",
+                            "example": 123,
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "The name of the crate.",
+                            "example": "serde",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email_notifications"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/AuthenticatedUser",
+                      "description": "The authenticated user."
+                    }
+                  },
+                  "required": [
+                    "user",
+                    "owned_crates"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Complete authentication flow.",
+        "tags": [
+          "session"
+        ]
+      },
+      "post": {
+        "description": "This route is called from the GitHub API OAuth flow after the user accepted or rejected\nthe data access permissions. It will check the `state` parameter and then call the GitHub API\nto exchange the temporary `code` for an API token. The API token is returned together with\nthe corresponding user information.\n\nsee <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>",
+        "operationId": "authorize_session",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "code": {
+                    "description": "Temporary code received from the GitHub API.",
+                    "example": "901dd10e07c7e9fa1cd5",
+                    "type": "string"
+                  },
+                  "state": {
+                    "description": "State parameter received from the GitHub API.",
+                    "example": "fYcUY3FMdUUz00FC7vLT7A",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "state"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1547,6 +1547,41 @@ expression: response.json()
     },
     "/api/private/session/begin": {
       "get": {
+        "deprecated": true,
+        "description": "`GET` variant retained for clients that have not migrated to the `POST`\nendpoint yet. New clients should use the `POST` endpoint instead.",
+        "operationId": "begin_session_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "state": {
+                      "example": "b84a63c4ea3fcb4ac84",
+                      "type": "string"
+                    },
+                    "url": {
+                      "example": "https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "state"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Begin authentication flow.",
+        "tags": [
+          "session"
+        ]
+      },
+      "post": {
         "description": "This route will return an authorization URL for the GitHub OAuth flow including the crates.io\n`client_id` and a randomly generated `state` secret.\n\nsee <https://developer.github.com/v3/oauth/#redirect-users-to-request-github-access>",
         "operationId": "begin_session",
         "responses": {

--- a/svelte/src/lib/utils/session.svelte.ts
+++ b/svelte/src/lib/utils/session.svelte.ts
@@ -194,8 +194,8 @@ export class SessionState {
     popup.close();
 
     let { code, state } = result;
-    let { data, error } = await this.#client.GET('/api/private/session/authorize', {
-      params: { query: { code, state } },
+    let { data, error } = await this.#client.POST('/api/private/session/authorize', {
+      body: { code, state },
     });
 
     if (!data) {

--- a/svelte/static/github-auth-loading.html
+++ b/svelte/static/github-auth-loading.html
@@ -2,13 +2,13 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'sha256-qfh2Go0si80c5fCQM7vtMfMYVJPGGpVLgWpgpPssfvw='; connect-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'sha256-i5nR3QajmwedqnK4C56WqUvUw7IeiNoSffTuUmPhLWQ='; connect-src 'self'">
   <title>crates.io - Redirecting to GitHub</title>
 </head>
 <body>
   <p>Please wait while we redirect you to GitHub...</p>
   <script>
-    fetch('/api/private/session/begin')
+    fetch('/api/private/session/begin', { method: 'POST' })
       .then(r => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();


### PR DESCRIPTION
The `/api/private/session/begin` and `/api/private/session/authorize` endpoints are served over `GET`, but both have side effects. `begin` stores a freshly generated CSRF token in the session, and `authorize` exchanges a single-use OAuth code, writes the user record, and logs the user in. Neither is safe or idempotent in the HTTP sense, and `authorize` additionally carries the single-use `code` in the query string, where it ends up in server logs, browser history, and `Referer` headers.

This adds `POST` variants as the canonical endpoints. `authorize` reads `code` and `state` from a JSON body so the code no longer leaks into URLs. The frontend (loading page and session store) and the login e2e tests move to `POST` in the same PR.

The `GET` variants are retained and marked deprecated in the OpenAPI document so that frontends already cached in browsers keep working across the deploy. A follow-up PR removes them once no live client relies on `GET`.