### PR TITLE
Remove redundant icon sizing from `Icon` component

### DIFF
--- a/svelte/src/lib/components/Icon.svelte
+++ b/svelte/src/lib/components/Icon.svelte
@@ -34,8 +34,6 @@
 <style>
   .icon {
     display: inline-block;
-    width: 1em;
-    height: 1em;
     flex-shrink: 0;
   }
 </style>


### PR DESCRIPTION
UnoCSS generates `width: 1em` and `height: 1em` on the icon classes themselves, so declaring them again on the `.icon` wrapper is redundant. This drops the duplicate declarations.