### PR TITLE
Fix dropdown trigger icon size in version list rows

### DIFF
--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -378,6 +378,11 @@
         color: var(--grey900);
         background-color: white;
       }
+
+      :global(.icon) {
+        width: 2em;
+        height: 2em;
+      }
     }
 
     :global(.menu) {


### PR DESCRIPTION
The UnoCSS icon migration left the actions dropdown trigger icon smaller than it was before. This sets it back to 2em to match the previous size.