### PR TITLE
Size icons via `--icon-size` instead of `:global(.icon)`

### DIFF
--- a/svelte/src/lib/components/ColorSchemeMenu.svelte
+++ b/svelte/src/lib/components/ColorSchemeMenu.svelte
@@ -57,11 +57,7 @@
   .color-scheme-menu {
     display: flex;
     align-items: center;
-
-    & :global(.icon) {
-      width: 1.4em;
-      height: 1.4em;
-    }
+    --icon-size: 1.4em;
 
     & :global(.trigger) {
       background: none;

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -160,11 +160,7 @@
     gap: var(--space-3xs);
     white-space: nowrap;
     cursor: default;
-
-    :global(.icon) {
-      width: 1.25em;
-      height: 1.25em;
-    }
+    --icon-size: 1.25em;
   }
 
   .description {

--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -246,12 +246,8 @@
         margin-right: var(--space-3xs);
         background-color: white;
         border-radius: 50%;
-
-        :global(.icon) {
-          width: 0.7em;
-          height: 0.7em;
-          color: #b13b89;
-        }
+        color: #b13b89;
+        --icon-size: 0.7em;
       }
     }
   }

--- a/svelte/src/lib/components/Header.svelte
+++ b/svelte/src/lib/components/Header.svelte
@@ -321,6 +321,7 @@
     margin: calc(var(--space-2xs) * -1);
     padding: var(--space-2xs);
     cursor: pointer;
+    --icon-size: 1.25em;
 
     &:disabled {
       cursor: wait;
@@ -335,8 +336,6 @@
   }
 
   .login-button :global(.icon) {
-    width: 1.25em;
-    height: 1.25em;
     margin-right: var(--space-2xs);
     opacity: 0.5;
   }

--- a/svelte/src/lib/components/Icon.svelte
+++ b/svelte/src/lib/components/Icon.svelte
@@ -1,3 +1,13 @@
+<!--
+  @component
+  Renders a UnoCSS icon as an inline `<span>`.
+
+  The icon is a `1em` box, so it scales with the surrounding `font-size`
+  by default. Prefer sizing it that way. When the icon needs a size that
+  differs from its text context, set the `--icon-size` custom property
+  (e.g. `--icon-size: 1.25em`) on a parent instead of overriding `.icon`
+  via `:global`.
+-->
 <script lang="ts">
   import type { HTMLAttributes } from 'svelte/elements';
 
@@ -34,6 +44,7 @@
 <style>
   .icon {
     display: inline-block;
+    font-size: var(--icon-size, 1em);
     flex-shrink: 0;
   }
 </style>

--- a/svelte/src/lib/components/Pagination.svelte
+++ b/svelte/src/lib/components/Pagination.svelte
@@ -119,11 +119,7 @@
     width: 2em;
     height: 2em;
     border-radius: 50%;
-
-    :global(.icon) {
-      width: 1.25em;
-      height: 1.25em;
-    }
+    --icon-size: 1.25em;
   }
 
   .next.disabled,

--- a/svelte/src/lib/components/SearchForm.svelte
+++ b/svelte/src/lib/components/SearchForm.svelte
@@ -175,13 +175,10 @@
     border-bottom-right-radius: var(--border-radius);
     cursor: pointer;
 
+    --icon-size: var(--submit-icon-size);
+
     &:hover {
       background-color: var(--yellow700);
     }
-  }
-
-  .submit-button :global(.icon) {
-    width: var(--submit-icon-size);
-    height: var(--submit-icon-size);
   }
 </style>

--- a/svelte/src/lib/components/dependency-list/Row.svelte
+++ b/svelte/src/lib/components/dependency-list/Row.svelte
@@ -214,10 +214,9 @@
     padding: 0;
     margin: var(--space-2xs) var(--space-3xs);
     list-style: none;
+    --icon-size: 1.25em;
 
     :global(.icon) {
-      width: 1.25em;
-      height: 1.25em;
       margin-right: 0.1em;
       margin-bottom: 0.2em;
       vertical-align: middle;

--- a/svelte/src/lib/components/frontpage/HeroButtons.svelte
+++ b/svelte/src/lib/components/frontpage/HeroButtons.svelte
@@ -29,10 +29,12 @@
     padding-bottom: var(--space-l);
   }
 
+  .hero-button {
+    --icon-size: 1.5em;
+  }
+
   .hero-button :global(.icon) {
     color: #c4890e;
-    width: 1.5em;
-    height: 1.5em;
     margin: -0.25em;
     margin-right: var(--space-3xs);
   }

--- a/svelte/src/lib/components/frontpage/StatsValue.svelte
+++ b/svelte/src/lib/components/frontpage/StatsValue.svelte
@@ -24,6 +24,7 @@
     grid-template-columns: 1fr auto;
     grid-template-rows: auto auto;
     justify-items: end;
+    --icon-size: var(--space-xl-2xl);
   }
 
   .value {
@@ -44,8 +45,6 @@
   .stats-value > :global(.icon) {
     grid-column: 2;
     grid-row: 1 / 3;
-    width: var(--space-xl-2xl);
-    height: var(--space-xl-2xl);
     margin-left: var(--space-s);
     margin-top: calc(-1 * var(--space-4xs-3xs));
     color: light-dark(#545454, #adc0cd);

--- a/svelte/src/lib/components/sort-dropdown/Dropdown.svelte
+++ b/svelte/src/lib/components/sort-dropdown/Dropdown.svelte
@@ -29,6 +29,7 @@
 <style>
   .sort-dropdown {
     display: inline-block;
+    --icon-size: 1.25em;
 
     & :global(.trigger) {
       background-color: var(--main-bg-dark);
@@ -39,8 +40,6 @@
     }
 
     & :global(.icon) {
-      width: 1.25em;
-      height: 1.25em;
       color: #1a9c5d;
       margin-right: var(--space-2xs);
     }

--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -443,11 +443,7 @@
     border: 1px solid light-dark(white, #808080);
     border-radius: 50%;
     transition: all var(--transition-fast);
-
-    & > :global(.icon) {
-      height: 1.5em;
-      width: 1.5em;
-    }
+    --icon-size: 1.5em;
 
     .row:hover &,
     .row.focused & {
@@ -506,6 +502,7 @@
     text-transform: uppercase;
     letter-spacing: 0.7px;
     font-size: 13px;
+    --icon-size: 1.25em;
 
     :global(a) {
       position: relative;
@@ -522,8 +519,6 @@
     }
 
     :global(.icon) {
-      width: 1.25em;
-      height: 1.25em;
       margin-right: var(--space-4xs);
       margin-top: -0.125em;
       vertical-align: middle;
@@ -573,10 +568,12 @@
     text-transform: initial;
   }
 
+  .trustpub {
+    --icon-size: 1em;
+  }
+
   .trustpub :global(.icon) {
     margin-left: 0.2em;
-    width: 1em;
-    height: 1em;
   }
 
   .bytes {
@@ -588,10 +585,9 @@
     padding: 0;
     margin: var(--space-2xs) var(--space-3xs);
     list-style: none;
+    --icon-size: 1.25em;
 
     :global(.icon) {
-      width: 1.25em;
-      height: 1.25em;
       margin-right: 0.1em;
       margin-bottom: 0.2em;
       vertical-align: middle;

--- a/svelte/src/routes/dashboard/+page.svelte
+++ b/svelte/src/routes/dashboard/+page.svelte
@@ -163,14 +163,13 @@
       gap: var(--space-3xs);
       font-size: 1.05em;
       margin: 0;
+      --icon-size: 1.25em;
 
       > :global(*) {
         flex-shrink: 0;
       }
 
       :global(.icon) {
-        width: 1.25em;
-        height: 1.25em;
         margin-top: -0.125em;
         margin-bottom: -0.125em;
         color: #b13b89;

--- a/svelte/src/routes/settings/tokens/new/+page.svelte
+++ b/svelte/src/routes/settings/tokens/new/+page.svelte
@@ -374,14 +374,13 @@
     color: light-dark(var(--grey600), var(--grey700));
     padding: var(--space-3xs);
     margin: calc(-1 * var(--space-3xs));
+    --icon-size: 1.25em;
 
     &:hover {
       color: light-dark(var(--grey700), var(--grey600));
     }
 
     :global(.icon) {
-      width: 1.25em;
-      height: 1.25em;
       margin: -0.125em;
     }
   }
@@ -517,15 +516,11 @@
       flex-shrink: 0;
       display: flex;
       align-items: center;
+      --icon-size: 1.5em;
 
       &:hover {
         background: light-dark(var(--grey200), #333333);
         color: light-dark(var(--grey900), white);
-      }
-
-      :global(.icon) {
-        height: 1.5em;
-        width: 1.5em;
       }
     }
 

--- a/svelte/src/routes/teams/[team_id]/+page.svelte
+++ b/svelte/src/routes/teams/[team_id]/+page.svelte
@@ -87,15 +87,11 @@
 
   .github-link {
     margin-left: var(--space-s);
+    --icon-size: 32px;
 
     &,
     &:hover {
       color: var(--main-color);
-    }
-
-    :global(.icon) {
-      width: 32px;
-      height: 32px;
     }
   }
 

--- a/svelte/src/routes/users/[user_id]/+page.svelte
+++ b/svelte/src/routes/users/[user_id]/+page.svelte
@@ -61,14 +61,11 @@
   }
 
   .github-link {
+    --icon-size: 32px;
+
     &,
     &:hover {
       color: var(--main-color);
-    }
-
-    :global(.icon) {
-      width: 32px;
-      height: 32px;
     }
   }
 


### PR DESCRIPTION
We had ~30 `:global(.icon)` blocks across the frontend whose only job was to override an icon's size. Reaching into the `Icon` component's `.icon` class with `:global` is awkward and easy to get wrong.

This adds an `--icon-size` custom property to `Icon`. The icon renders as a `1em` box (UnoCSS preset-icons default), so `.icon` now drives `font-size` from `var(--icon-size, 1em)`. Parents size an icon by setting the property on a containing element, which inherits through the component boundary without `:global` and works inside media queries.

Each call site is converted in its own commit. Where a `:global(.icon)` block only set the size, it is removed entirely. Where it also set non-inheritable properties (margin, opacity, vertical-align) or a `color` that would otherwise tint sibling text, those stay in `:global` and only the size moves to the property.

After the sweep no `:global(.icon)` block sets `width`/`height` anymore.
