### PR TITLE
Show tooltip for truncated front-page versions

### DIFF
--- a/svelte/src/lib/components/frontpage/ListItem.svelte
+++ b/svelte/src/lib/components/frontpage/ListItem.svelte
@@ -57,6 +57,7 @@
   {#if version}
     <div class="version" id={trailingId}>
       <span class="sr-only">version </span><span data-test-version>{version}</span>
+      <Tooltip text={version} onlyWhenTruncated delay={350} side="bottom" />
     </div>
   {:else if downloads != null}
     <div class="downloads" id={trailingId} data-test-downloads>


### PR DESCRIPTION
The version on front-page list items is clipped with `text-overflow: ellipsis` once it exceeds `max-width: 5em`, but unlike the subtitle it had no tooltip to reveal the full value.

This adds a `Tooltip` to the `.version` element so the complete version string shows on hover when truncated, matching the subtitle behavior.