### PR TITLE
Split `FollowButton` into presentational and connected parts

### DIFF
--- a/svelte/src/lib/components/CrateFollowButton.svelte
+++ b/svelte/src/lib/components/CrateFollowButton.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import { createClient } from '@crates-io/api-client';
+
+  import FollowButton from '$lib/components/FollowButton.svelte';
+  import { getNotifications } from '$lib/notifications.svelte';
+
+  interface Props {
+    /** The name of the crate to follow/unfollow. */
+    crateName: string;
+  }
+
+  let { crateName }: Props = $props();
+
+  let notifications = getNotifications();
+  let client = createClient({ fetch });
+
+  let following = $state(false);
+  let isLoadingState = $state(true);
+  let isToggling = $state(false);
+  let loadError = $state(false);
+
+  let isLoading = $derived(isLoadingState || isToggling);
+  let status = $derived<'loading' | 'following' | 'not-following'>(
+    isLoading ? 'loading' : following ? 'following' : 'not-following',
+  );
+
+  $effect(() => {
+    loadFollowState(crateName);
+  });
+
+  async function loadFollowState(name: string) {
+    isLoadingState = true;
+    loadError = false;
+
+    try {
+      let result = await client.GET('/api/v1/crates/{name}/following', {
+        params: { path: { name } },
+      });
+
+      if (!result.response.ok) {
+        throw new Error(`Failed to load follow state: ${result.response.status}`);
+      }
+
+      following = result.data!.following;
+    } catch {
+      loadError = true;
+      notifications.error(
+        `Something went wrong while trying to figure out if you are already following the ${name} crate. Please try again later!`,
+      );
+    } finally {
+      isLoadingState = false;
+    }
+  }
+
+  async function toggleFollow() {
+    isToggling = true;
+
+    try {
+      let options = { params: { path: { name: crateName } } };
+
+      let result = following
+        ? await client.DELETE('/api/v1/crates/{name}/follow', options)
+        : await client.PUT('/api/v1/crates/{name}/follow', options);
+
+      if (!result.response.ok) {
+        throw new Error(`Failed to ${following ? 'unfollow' : 'follow'} crate: ${result.response.status}`);
+      }
+
+      following = !following;
+    } catch {
+      notifications.error(
+        `Something went wrong when ${following ? 'unfollowing' : 'following'} the ${crateName} crate. Please try again later!`,
+      );
+    } finally {
+      isToggling = false;
+    }
+  }
+</script>
+
+<FollowButton {status} disabled={loadError} onclick={toggleFollow} />

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -3,7 +3,7 @@
 
   import { resolve } from '$app/paths';
 
-  import FollowButton from '$lib/components/FollowButton.svelte';
+  import CrateFollowButton from '$lib/components/CrateFollowButton.svelte';
   import Icon from '$lib/components/Icon.svelte';
   import * as NavTabs from '$lib/components/nav-tabs';
   import Tooltip from '$lib/components/Tooltip.svelte';
@@ -105,7 +105,7 @@
 
   {#if session.currentUser}
     <div class="follow-button">
-      <FollowButton crateName={crate.name} />
+      <CrateFollowButton crateName={crate.name} />
     </div>
   {/if}
 </div>

--- a/svelte/src/lib/components/FollowButton.stories.svelte
+++ b/svelte/src/lib/components/FollowButton.stories.svelte
@@ -1,0 +1,40 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import FollowButton from './FollowButton.svelte';
+
+  const { Story } = defineMeta({
+    title: 'FollowButton',
+    component: FollowButton,
+    tags: ['autodocs'],
+    args: {
+      onclick: () => {},
+    },
+  });
+</script>
+
+<Story name="Default" args={{ status: 'not-following' }} parameters={{ chromatic: { disableSnapshot: true } }} />
+
+<!-- This is using a single Story with multiple examples to reduce the amount of snapshots generated for visual regression testing -->
+<Story name="Combined" asChild>
+  <h1>Follow</h1>
+  <FollowButton status="not-following" onclick={() => {}} />
+
+  <h1>Following</h1>
+  <FollowButton status="following" onclick={() => {}} />
+
+  <h1>Loading</h1>
+  <FollowButton status="loading" onclick={() => {}} />
+
+  <h1>Disabled</h1>
+  <FollowButton status="not-following" disabled onclick={() => {}} />
+</Story>
+
+<style>
+  h1 {
+    font-size: 0.875rem;
+    font-weight: normal;
+    opacity: 0.2;
+    margin: 1rem 0 0.25rem;
+  }
+</style>

--- a/svelte/src/lib/components/FollowButton.svelte
+++ b/svelte/src/lib/components/FollowButton.svelte
@@ -1,90 +1,28 @@
 <script lang="ts">
-  import { createClient } from '@crates-io/api-client';
-
   import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
-  import { getNotifications } from '$lib/notifications.svelte';
 
   interface Props {
-    /** The name of the crate to follow/unfollow. */
-    crateName: string;
+    /** Which follow state the button represents. */
+    status: 'loading' | 'following' | 'not-following';
+    /** Disables the button independently of the loading state. */
+    disabled?: boolean;
+    /** Called when the user clicks the button. */
+    onclick: () => void;
   }
 
-  let { crateName }: Props = $props();
-
-  let notifications = getNotifications();
-  let client = createClient({ fetch });
-
-  let following = $state(false);
-  let isLoadingState = $state(true);
-  let isToggling = $state(false);
-  let loadError = $state(false);
-
-  let isLoading = $derived(isLoadingState || isToggling);
-  let isDisabled = $derived(isLoading || loadError);
-
-  $effect(() => {
-    loadFollowState(crateName);
-  });
-
-  async function loadFollowState(name: string) {
-    isLoadingState = true;
-    loadError = false;
-
-    try {
-      let result = await client.GET('/api/v1/crates/{name}/following', {
-        params: { path: { name } },
-      });
-
-      if (!result.response.ok) {
-        throw new Error(`Failed to load follow state: ${result.response.status}`);
-      }
-
-      following = result.data!.following;
-    } catch {
-      loadError = true;
-      notifications.error(
-        `Something went wrong while trying to figure out if you are already following the ${name} crate. Please try again later!`,
-      );
-    } finally {
-      isLoadingState = false;
-    }
-  }
-
-  async function toggleFollow() {
-    isToggling = true;
-
-    try {
-      let options = { params: { path: { name: crateName } } };
-
-      let result = following
-        ? await client.DELETE('/api/v1/crates/{name}/follow', options)
-        : await client.PUT('/api/v1/crates/{name}/follow', options);
-
-      if (!result.response.ok) {
-        throw new Error(`Failed to ${following ? 'unfollow' : 'follow'} crate: ${result.response.status}`);
-      }
-
-      following = !following;
-    } catch {
-      notifications.error(
-        `Something went wrong when ${following ? 'unfollowing' : 'following'} the ${crateName} crate. Please try again later!`,
-      );
-    } finally {
-      isToggling = false;
-    }
-  }
+  let { status, disabled = false, onclick }: Props = $props();
 </script>
 
 <button
   type="button"
-  disabled={isDisabled}
+  disabled={disabled || status === 'loading'}
   data-test-follow-button
   class="follow-button button button--tan"
-  onclick={toggleFollow}
+  {onclick}
 >
-  {#if isLoading}
+  {#if status === 'loading'}
     <LoadingSpinner theme="light" />
-  {:else if following}
+  {:else if status === 'following'}
     Unfollow
   {:else}
     Follow


### PR DESCRIPTION
`FollowButton` previously combined the follow-state API calls, the loading and error handling, and the markup in a single component, which made it impossible to render in isolation. This extracts the data side into a new connected `CrateFollowButton` that owns the API client and state and reduces `FollowButton` to a presentational component driven entirely by props. `CrateHeader` now renders `CrateFollowButton`.

The presentational component takes a single `status` of `loading`, `following`, or `not-following` instead of separate booleans, expressing the three mutually exclusive display states directly in the prop type.

With the markup decoupled from the data fetching, `FollowButton` gains Storybook stories. A `Combined` story renders every visual state for visual regression testing, and a `Default` story keeps dynamic props for local development.