### PR TITLE
Improve `CrateHeader` design

### DIFF
--- a/e2e/acceptance/crate-following.spec.ts
+++ b/e2e/acceptance/crate-following.spec.ts
@@ -31,7 +31,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
 
     let followButton = page.locator('[data-test-follow-button]');
     let spinner = followButton.locator('[data-test-spinner]');
-    await expect(followButton).toHaveText('Loading…');
+    await expect(followButton).toHaveText('Loading');
     await expect(followButton).toBeDisabled();
     await expect(spinner).toBeVisible();
 
@@ -43,7 +43,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     let followDeferred = Promise.withResolvers<Response>();
     msw.worker.use(http.put('/api/v1/crates/:crate_id/follow', () => followDeferred.promise));
     await followButton.click();
-    await expect(followButton).toHaveText('Loading…');
+    await expect(followButton).toHaveText('Loading');
     await expect(followButton).toBeDisabled();
     await expect(spinner).toBeVisible();
 
@@ -55,7 +55,7 @@ test.describe('Acceptance | Crate following', { tag: '@acceptance' }, () => {
     let unfollowDeferred = Promise.withResolvers<Response>();
     msw.worker.use(http.delete('/api/v1/crates/:crate_id/follow', () => unfollowDeferred.promise));
     await followButton.click();
-    await expect(followButton).toHaveText('Loading…');
+    await expect(followButton).toHaveText('Loading');
     await expect(followButton).toBeDisabled();
     await expect(spinner).toBeVisible();
 

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -222,7 +222,7 @@
     }
 
     .follow-button {
-      margin: -10px -10px 0 var(--space-s);
+      margin: 0 calc(var(--space-s) - var(--space-m)) 0 var(--space-s);
       grid-column: 2;
       grid-row: 1;
     }

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -128,10 +128,13 @@
 
 <style>
   .header {
+    --shadow: 0 2px 3px light-dark(hsla(51, 50%, 44%, 0.35), #232321);
+
     padding: var(--space-s) var(--space-m);
-    background-color: var(--main-bg-dark);
+    background-color: light-dark(white, #141413);
     margin-bottom: var(--space-s);
     border-radius: 5px;
+    box-shadow: var(--shadow);
   }
 
   .heading {

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -94,10 +94,7 @@
       {#each keywords as keyword (keyword.id)}
         <li>
           <a href={resolve('/keywords/[keyword_id]', { keyword_id: keyword.id })} data-test-keyword={keyword.id}>
-            <!-- TODO: Replace with `flex-wrap` after the Svelte migration. The leading whitespace
-                 inside the <a> mirrors the Ember rendering and is what allows the list to wrap. -->
-            <!-- eslint-disable-next-line svelte/no-useless-mustaches -->
-            {' '}<span class="hash" aria-hidden="true">#</span>{keyword.id}
+            <span class="hash" aria-hidden="true">#</span>{keyword.id}
           </a>
         </li>
       {/each}
@@ -183,23 +180,35 @@
 
   .keywords {
     list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2xs);
     margin: var(--space-xs) 0 0;
     padding: 0;
-    font-size: calc(0.9 * var(--space-s));
+    font-size: calc(0.85 * var(--space-s));
+    overflow: hidden;
 
-    > * {
-      display: inline;
+    a {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-4xs);
+      padding: var(--space-4xs) var(--space-xs);
+      color: var(--main-color-light);
+      background: var(--main-bg);
+      border-radius: 99999px;
+      white-space: nowrap;
+      transition: color var(--transition-fast);
 
-      + * {
-        margin-left: var(--space-s);
+      &:hover {
+        color: var(--main-color);
       }
     }
   }
 
   .hash {
-    margin-right: 1px;
     font-family: var(--font-monospace);
-    font-size: 90%;
+    color: var(--main-color-light);
+    opacity: 0.65;
   }
 
   .follow-button {

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -64,23 +64,25 @@
 </script>
 
 <div class="header" data-test-heading>
-  <h1 class="heading">
-    <span data-test-crate-name>{crate.name}</span>
-    {#if version}
-      <small data-test-crate-version>v{version.num}</small>
-
-      {#if version.yanked}
-        <span class="yanked-badge" data-test-yanked>
-          <Icon class="i-mdi:trash-can-outline" /> Yanked
-
-          <Tooltip>
-            This crate has been yanked, but it is still available for download for other crates that may be depending on
-            it.
-          </Tooltip>
-        </span>
+  <div class="title-row">
+    <h1 class="heading">
+      <span data-test-crate-name>{crate.name}</span>
+      {#if version}
+        <small data-test-crate-version>v{version.num}</small>
       {/if}
+    </h1>
+
+    {#if version?.yanked}
+      <span class="yanked-badge" data-test-yanked>
+        <Icon class="i-mdi:trash-can-outline" /> Yanked
+
+        <Tooltip>
+          This crate has been yanked, but it is still available for download for other crates that may be depending on
+          it.
+        </Tooltip>
+      </span>
     {/if}
-  </h1>
+  </div>
 
   {#if crate.description}
     <div class="description">
@@ -135,6 +137,13 @@
     margin-bottom: var(--space-s);
     border-radius: 5px;
     box-shadow: var(--shadow);
+  }
+
+  .title-row {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
   }
 
   .heading {

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -146,8 +146,11 @@
     margin: 0;
     padding: 0;
     word-break: break-word;
+    font-size: var(--space-l);
 
     small {
+      font-size: var(--space-m);
+      font-weight: 500;
       color: var(--main-color-light);
     }
   }
@@ -174,6 +177,7 @@
 
   .description {
     margin-top: var(--space-xs);
+    font-size: calc(0.9 * var(--space-s));
     line-height: 1.35;
   }
 
@@ -181,6 +185,7 @@
     list-style: none;
     margin: var(--space-xs) 0 0;
     padding: 0;
+    font-size: calc(0.9 * var(--space-s));
 
     > * {
       display: inline;

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -4,7 +4,6 @@
   import { resolve } from '$app/paths';
 
   import CrateFollowButton from '$lib/components/CrateFollowButton.svelte';
-  import Icon from '$lib/components/Icon.svelte';
   import * as NavTabs from '$lib/components/nav-tabs';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import { getSession } from '$lib/utils/session.svelte';
@@ -74,7 +73,7 @@
 
     {#if version?.yanked}
       <span class="yanked-badge" data-test-yanked>
-        <Icon class="i-mdi:trash-can-outline" /> Yanked
+        Yanked
 
         <Tooltip>
           This crate has been yanked, but it is still available for download for other crates that may be depending on
@@ -139,15 +138,8 @@
     box-shadow: var(--shadow);
   }
 
-  .title-row {
-    display: flex;
-    align-items: baseline;
-    flex-wrap: wrap;
-    gap: var(--space-xs);
-  }
-
   .heading {
-    display: flex;
+    display: inline-flex;
     align-items: baseline;
     flex-wrap: wrap;
     gap: var(--space-xs);
@@ -161,18 +153,23 @@
   }
 
   .yanked-badge {
-    background: #d30000;
+    display: inline-block;
+    margin-left: var(--space-2xs);
+    margin-top: var(--space-2xs);
+    /* Suppress the text-derived baseline so the synthesized baseline is the
+       pill's bottom edge, letting it sit on the title's baseline. */
+    overflow: hidden;
+
+    background: light-dark(oklch(0.9 0.02 24), oklch(0.25 0.03 24));
     border-radius: 99999px;
-    padding: var(--space-3xs) var(--space-s);
-    font-size: var(--space-s);
-    color: white;
-    align-self: center;
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-3xs);
+    padding: var(--space-4xs) var(--space-2xs);
+    font-size: calc(0.9 * var(--space-xs));
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: light-dark(oklch(0.5 0.15 24), oklch(0.8 0.07 24));
     white-space: nowrap;
     cursor: default;
-    --icon-size: 1.25em;
   }
 
   .description {

--- a/svelte/src/lib/components/FollowButton.svelte
+++ b/svelte/src/lib/components/FollowButton.svelte
@@ -18,11 +18,11 @@
   type="button"
   disabled={disabled || status === 'loading'}
   data-test-follow-button
-  class="follow-button button button--tan"
+  class="follow-button button-reset"
   {onclick}
 >
   {#if status === 'loading'}
-    <LoadingSpinner theme="light" />
+    <LoadingSpinner theme="light" style="--spinner-size: 0.8em" label={null} /> Loading
   {:else if status === 'following'}
     <Icon class="i-mdi:bell" /> Unfollow
   {:else}
@@ -32,9 +32,30 @@
 
 <style>
   .follow-button {
-    height: 48px;
-    width: 150px;
+    display: inline-flex;
+    align-items: center;
     justify-content: center;
-    gap: var(--space-2xs);
+    gap: var(--space-3xs);
+    border: 1px solid var(--gray-border);
+    border-radius: 99999px;
+    font-size: var(--space-xs);
+    font-weight: 500;
+    padding: var(--space-3xs) var(--space-xs);
+    cursor: pointer;
+
+    transition:
+      border-color var(--transition-fast),
+      background var(--transition-fast);
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    &:hover:not(:disabled),
+    &:focus:not(:disabled) {
+      border-color: var(--yellow500);
+      background: light-dark(#fffdf5, #1b1b18);
+    }
   }
 </style>

--- a/svelte/src/lib/components/FollowButton.svelte
+++ b/svelte/src/lib/components/FollowButton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from '$lib/components/Icon.svelte';
   import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 
   interface Props {
@@ -23,9 +24,9 @@
   {#if status === 'loading'}
     <LoadingSpinner theme="light" />
   {:else if status === 'following'}
-    Unfollow
+    <Icon class="i-mdi:bell" /> Unfollow
   {:else}
-    Follow
+    <Icon class="i-mdi:bell-outline" /> Follow
   {/if}
 </button>
 
@@ -34,5 +35,6 @@
     height: 48px;
     width: 150px;
     justify-content: center;
+    gap: var(--space-2xs);
   }
 </style>

--- a/svelte/src/lib/components/LoadingSpinner.svelte
+++ b/svelte/src/lib/components/LoadingSpinner.svelte
@@ -3,13 +3,21 @@
 
   interface Props extends HTMLAttributes<HTMLDivElement> {
     theme?: 'light';
+    /**
+     * Screen reader label for the spinner. Set to `null` when an adjacent
+     * visible label already describes the loading state, to avoid announcing
+     * it twice.
+     */
+    label?: string | null;
   }
 
-  let { theme, class: className, ...restProps }: Props = $props();
+  let { theme, label = 'Loading…', class: className, ...restProps }: Props = $props();
 </script>
 
 <div class={['spinner', theme, className]} data-test-spinner {...restProps}>
-  <span class="sr-only">Loading…</span>
+  {#if label}
+    <span class="sr-only">{label}</span>
+  {/if}
 </div>
 
 <style>


### PR DESCRIPTION
A visual refresh of the crate header, along with a matching restyle of the follow button. See the individual commit messages for the details of each change.

### Before

<img width="868" height="486" alt="Screen Shot 2026-06-04 at 12 45 15" src="https://github.com/user-attachments/assets/3a0db620-d8f0-4868-b04a-e16d1e4b4c15" />

### After 

<img width="868" height="486" alt="Screen Shot 2026-06-04 at 12 45 05" src="https://github.com/user-attachments/assets/481efdc3-3688-48ac-84fc-3afa923aad4b" />
