### PR TITLE
Improve keyword list accessibility

### DIFF
--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -11,7 +11,7 @@
 - main:
   - heading "nanomsg v0.6.1" [level=1]
   - text: A high-level, Rust idiomatic wrapper around nanomsg.
-  - list:
+  - list "Keywords":
     - listitem:
       - link "network":
         - /url: /keywords/network

--- a/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-dependencies.spec.ts-snapshots/aria.yml
@@ -13,7 +13,7 @@
   - text: A high-level, Rust idiomatic wrapper around nanomsg.
   - list:
     - listitem:
-      - link "#network":
+      - link "network":
         - /url: /keywords/network
   - navigation "nanomsg crate subpages":
     - list:

--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -306,7 +306,7 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await page.goto('/crates/nanomsg');
     await expect(page.locator('[data-test-keyword]')).toBeVisible();
 
-    await page.getByRole('link', { name: '#network', exact: true }).click();
+    await page.getByRole('link', { name: 'network', exact: true }).click();
     await expect(page).toHaveURL('/keywords/network');
     await page.getByRole('link', { name: 'nanomsg', exact: true }).click();
 

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -89,7 +89,7 @@
   {/if}
 
   {#if keywords.length !== 0}
-    <ul class="keywords">
+    <ul class="keywords" aria-label="Keywords">
       {#each keywords as keyword (keyword.id)}
         <li>
           <a href={resolve('/keywords/[keyword_id]', { keyword_id: keyword.id })} data-test-keyword={keyword.id}>

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -96,7 +96,7 @@
             <!-- TODO: Replace with `flex-wrap` after the Svelte migration. The leading whitespace
                  inside the <a> mirrors the Ember rendering and is what allows the list to wrap. -->
             <!-- eslint-disable-next-line svelte/no-useless-mustaches -->
-            {' '}<span class="hash">#</span>{keyword.id}
+            {' '}<span class="hash" aria-hidden="true">#</span>{keyword.id}
           </a>
         </li>
       {/each}


### PR DESCRIPTION
Two small accessibility improvements to the keyword list in the crate header.

The `#` prefix on each keyword is purely decorative, so it is now marked `aria-hidden`, reducing each link's accessible name to the keyword itself (e.g. `network` rather than `#network`). With that prefix hidden, the list no longer has any cue that its links are keywords, so the `<ul>` gets an `aria-label` to announce it as the keyword list.