### PR TITLE
Suggest standard-library replacements on crate pages

### DIFF
--- a/e2e/acceptance/crate-native-replacement.spec.ts
+++ b/e2e/acceptance/crate-native-replacement.spec.ts
@@ -26,4 +26,34 @@ test.describe('Acceptance | crate page | native replacement', { tag: '@acceptanc
     await expect(page.locator('[data-test-heading] [data-test-crate-name]')).toHaveText('nanomsg');
     await expect(page.locator('[data-test-native-replacement-banner]')).toHaveCount(0);
   });
+
+  test('marks superseded crates in the dependency list', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'nanomsg' });
+    let version = await msw.db.version.create({ crate, num: '0.6.1' });
+
+    let lazyStatic = await msw.db.crate.create({ name: 'lazy_static' });
+    await msw.db.version.create({ crate: lazyStatic, num: '1.4.0' });
+    await msw.db.dependency.create({ crate: lazyStatic, version, req: '^1.0.0', kind: 'normal' });
+
+    let serde = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate: serde, num: '1.0.0' });
+    await msw.db.dependency.create({ crate: serde, version, req: '^1.0.0', kind: 'normal' });
+
+    await page.goto('/crates/nanomsg/dependencies');
+
+    let marker = page.locator('[data-test-native-replacement="lazy_static"]');
+    await expect(marker).toHaveCount(1);
+    await expect(marker.getByRole('link', { name: 'This dependency might not be needed anymore.' })).toHaveAttribute(
+      'href',
+      'https://doc.rust-lang.org/std/sync/struct.LazyLock.html',
+    );
+
+    await marker.hover();
+    let tooltip = page.locator('[data-test-native-replacement-tooltip]');
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toContainText('This dependency might not be needed anymore.');
+    await expect(tooltip).toContainText('std::sync::LazyLock');
+
+    await expect(page.locator('[data-test-native-replacement="serde"]')).toHaveCount(0);
+  });
 });

--- a/e2e/acceptance/crate-native-replacement.spec.ts
+++ b/e2e/acceptance/crate-native-replacement.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@/e2e/helper';
+
+test.describe('Acceptance | crate page | native replacement', { tag: '@acceptance' }, () => {
+  test('shows the banner for a crate superseded by std', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'lazy_static' });
+    await msw.db.version.create({ crate, num: '1.4.0' });
+
+    await page.goto('/crates/lazy_static');
+
+    let banner = page.locator('[data-test-native-replacement-banner]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText('You might not need this dependency.');
+    await expect(banner).toContainText('std::sync::LazyLock');
+    await expect(banner.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+      'href',
+      'https://doc.rust-lang.org/std/sync/struct.LazyLock.html',
+    );
+  });
+
+  test('does not show the banner for a crate without a replacement', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'nanomsg' });
+    await msw.db.version.create({ crate, num: '0.6.1' });
+
+    await page.goto('/crates/nanomsg');
+
+    await expect(page.locator('[data-test-heading] [data-test-crate-name]')).toHaveText('nanomsg');
+    await expect(page.locator('[data-test-native-replacement-banner]')).toHaveCount(0);
+  });
+});

--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -12,8 +12,10 @@
   import DownloadChart from '$lib/components/download-chart/DownloadChart.svelte';
   import * as Dropdown from '$lib/components/dropdown';
   import Icon from '$lib/components/Icon.svelte';
+  import NativeReplacementBanner from '$lib/components/NativeReplacementBanner.svelte';
   import ReadmePlaceholder from '$lib/components/ReadmePlaceholder.svelte';
   import RenderedHtml from '$lib/components/RenderedHtml.svelte';
+  import { nativeReplacements } from '$lib/data/native-replacements';
   import { loadReadme } from '$lib/utils/readme';
 
   type Crate = components['schemas']['Crate'];
@@ -58,6 +60,8 @@
 
   let downloadsContext = $derived(requestedVersion ? version : crate);
 
+  let nativeReplacement = $derived(nativeReplacements[crate.name]);
+
   let retryReadmePromise = $state<typeof readmePromise | null>(null);
   let activeReadmePromise = $derived(retryReadmePromise ?? readmePromise);
 
@@ -78,6 +82,12 @@
 </script>
 
 <CrateHeader {crate} {version} versionNum={requestedVersion} {keywords} {ownersPromise} />
+
+{#if nativeReplacement}
+  <div class="native-replacement">
+    <NativeReplacementBanner replacement={nativeReplacement} />
+  </div>
+{/if}
 
 <div class="crate-info">
   <div class="docs" data-test-docs>
@@ -173,6 +183,10 @@
 </div>
 
 <style>
+  .native-replacement {
+    margin-bottom: var(--space-m);
+  }
+
   .crate-info {
     @media only screen and (min-width: 890px) {
       display: grid;

--- a/svelte/src/lib/components/NativeReplacementBanner.stories.svelte
+++ b/svelte/src/lib/components/NativeReplacementBanner.stories.svelte
@@ -1,0 +1,42 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import { nativeReplacements } from '$lib/data/native-replacements';
+  import NativeReplacementBanner from './NativeReplacementBanner.svelte';
+
+  const { Story } = defineMeta({
+    title: 'NativeReplacementBanner',
+    component: NativeReplacementBanner,
+    tags: ['autodocs'],
+  });
+</script>
+
+<Story
+  name="Default"
+  args={{ replacement: nativeReplacements.lazy_static }}
+  parameters={{ chromatic: { disableSnapshot: true } }}
+/>
+
+<!-- This is using a single Story with multiple examples to reduce the amount of snapshots generated for visual regression testing -->
+<Story name="Combined" asChild>
+  <h1>Full</h1>
+  <NativeReplacementBanner replacement={nativeReplacements.lazy_static} />
+
+  <h1>Full (macro)</h1>
+  <NativeReplacementBanner replacement={nativeReplacements.matches} />
+
+  <h1>Partial</h1>
+  <NativeReplacementBanner replacement={nativeReplacements.num_cpus} />
+
+  <h1>Partial (release-notes link)</h1>
+  <NativeReplacementBanner replacement={nativeReplacements.once_cell} />
+</Story>
+
+<style>
+  h1 {
+    font-size: 0.875rem;
+    font-weight: normal;
+    opacity: 0.2;
+    margin: 1rem 0 0.25rem;
+  }
+</style>

--- a/svelte/src/lib/components/NativeReplacementBanner.svelte
+++ b/svelte/src/lib/components/NativeReplacementBanner.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import type { NativeReplacement } from '$lib/data/native-replacements';
+
+  import Alert from '$lib/components/Alert.svelte';
+
+  interface Props {
+    replacement: NativeReplacement;
+  }
+
+  let { replacement }: Props = $props();
+</script>
+
+<Alert variant="tip" data-test-native-replacement-banner>
+  <strong>You might not need this dependency.</strong>
+  <p>
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -- curated, in-repo HTML, never user input -->
+    {@html replacement.description}
+    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- always an external std/release-notes URL -->
+    <a href={replacement.url} target="_blank" rel="noopener noreferrer">Learn more</a>
+  </p>
+</Alert>
+
+<style>
+  strong {
+    font-size: 0.9em;
+    font-weight: 500;
+  }
+
+  p {
+    margin: var(--space-2xs) 0 0;
+    font-size: 0.9em;
+    line-height: 1.4;
+  }
+
+  p :global(code) {
+    font-family: var(--font-monospace);
+    font-size: 0.9em;
+    letter-spacing: -2%;
+    background: rgba(64, 186, 80, 0.25);
+    padding: 0.1em 0.25em;
+    border-radius: 0.3em;
+  }
+</style>

--- a/svelte/src/lib/components/NativeReplacementBanner.svelte.test.ts
+++ b/svelte/src/lib/components/NativeReplacementBanner.svelte.test.ts
@@ -1,0 +1,33 @@
+import type { NativeReplacement } from '$lib/data/native-replacements';
+
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+import NativeReplacementBanner from './NativeReplacementBanner.svelte';
+
+const STD_URL = 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html';
+
+const replacement: NativeReplacement = {
+  description: 'Use <code>std::sync::LazyLock</code> (Rust 1.80) instead.',
+  url: STD_URL,
+};
+
+describe('NativeReplacementBanner', () => {
+  it('renders the description HTML and a "Learn more" link', async () => {
+    render(NativeReplacementBanner, { replacement });
+
+    let banner = page.getByCSS('[data-test-native-replacement-banner]');
+    await expect.element(banner).toBeVisible();
+    await expect.element(banner).toHaveTextContent('You might not need this dependency.');
+
+    let code = page.getByCSS('[data-test-native-replacement-banner] code');
+    expect(code.elements()).toHaveLength(1);
+    await expect.element(code).toHaveTextContent('std::sync::LazyLock');
+
+    let link = page.getByRole('link', { name: 'Learn more' });
+    await expect.element(link).toHaveAttribute('href', STD_URL);
+    await expect.element(link).toHaveAttribute('target', '_blank');
+    await expect.element(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/svelte/src/lib/components/dependency-list/Row.stories.svelte
+++ b/svelte/src/lib/components/dependency-list/Row.stories.svelte
@@ -46,6 +46,12 @@
   <h1>No Description</h1>
   <Row dependency={createDependency()} descriptionPromise={resolved(null)} />
 
+  <h1>Superseded by std (native replacement)</h1>
+  <Row
+    dependency={createDependency({ crate_id: 'lazy_static' })}
+    descriptionPromise={resolved('A macro for declaring lazily evaluated statics')}
+  />
+
   <h1>Loading Description</h1>
   <Row dependency={createDependency()} descriptionPromise={pending()} />
 

--- a/svelte/src/lib/components/dependency-list/Row.svelte
+++ b/svelte/src/lib/components/dependency-list/Row.svelte
@@ -6,6 +6,7 @@
   import Icon from '$lib/components/Icon.svelte';
   import Placeholder from '$lib/components/Placeholder.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
+  import { nativeReplacements } from '$lib/data/native-replacements';
 
   type Dependency = components['schemas']['Dependency'];
 
@@ -19,6 +20,10 @@
   let focused = $state(false);
 
   let formattedReq = $derived(dependency.req === '*' ? '' : dependency.req);
+
+  let nativeReplacement = $derived(nativeReplacements[dependency.crate_id]);
+
+  const replacementHint = 'This dependency might not be needed anymore.';
 
   let featuresDescription = $derived.by(() => {
     let { default_features: defaultFeatures, features } = dependency;
@@ -54,6 +59,24 @@
       >
         {dependency.crate_id}
       </a>
+
+      {#if nativeReplacement}
+        <span class="native-replacement" data-test-native-replacement={dependency.crate_id}>
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- always an external std/release-notes URL -->
+          <a href={nativeReplacement.url} target="_blank" rel="noopener noreferrer" aria-label={replacementHint}>
+            <Icon class="i-octicon:light-bulb-16" />
+          </a>
+          <Tooltip>
+            <div class="replacement-tooltip" data-test-native-replacement-tooltip>
+              <strong>{replacementHint}</strong>
+              <p>
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -- curated, in-repo HTML, never user input -->
+                {@html nativeReplacement.description}
+              </p>
+            </div>
+          </Tooltip>
+        </span>
+      {/if}
 
       {#if dependency.optional}
         <span class="optional-label" data-test-optional>optional</span>
@@ -147,8 +170,48 @@
       cursor: help;
     }
 
+    .native-replacement {
+      position: absolute;
+      top: 0;
+      right: 0;
+
+      a {
+        display: inline-flex;
+        padding: var(--space-2xs);
+        padding-top: calc(0.2em + var(--space-2xs));
+        color: var(--grey600);
+
+        &:hover {
+          color: var(--yellow500);
+        }
+      }
+    }
+
     @media only screen and (max-width: 550px) {
       display: block;
+    }
+  }
+
+  .replacement-tooltip {
+    text-align: left;
+
+    strong {
+      font-weight: 500;
+    }
+
+    p {
+      margin: var(--space-3xs) 0 0;
+      font-size: 0.9em;
+      line-height: 1.4;
+    }
+
+    :global(code) {
+      font-family: var(--font-monospace);
+      font-size: 0.9em;
+      letter-spacing: -2%;
+      background: rgba(255, 255, 255, 0.15);
+      padding: 0.1em 0.25em;
+      border-radius: 0.3em;
     }
   }
 

--- a/svelte/src/lib/components/dependency-list/Row.svelte.test.ts
+++ b/svelte/src/lib/components/dependency-list/Row.svelte.test.ts
@@ -1,0 +1,50 @@
+import type { components } from '@crates-io/api-client';
+
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+import Row from './Row.svelte';
+
+type Dependency = components['schemas']['Dependency'];
+
+const HINT = 'This dependency might not be needed anymore.';
+
+function createDependency(overrides: Partial<Dependency> = {}): Dependency {
+  return {
+    id: 1,
+    crate_id: 'serde',
+    version_id: 42,
+    req: '^1.0',
+    kind: 'normal',
+    optional: false,
+    default_features: true,
+    features: [],
+    downloads: 100_000,
+    ...overrides,
+  };
+}
+
+describe('dependency-list/Row', () => {
+  it('shows the native-replacement marker for a superseded dependency', async () => {
+    let dependency = createDependency({ crate_id: 'lazy_static' });
+
+    render(Row, { dependency, descriptionPromise: Promise.resolve(null) });
+
+    let link = page.getByRole('link', { name: HINT });
+    await expect.element(link).toHaveAttribute('href', 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html');
+    await expect.element(link).toHaveAttribute('target', '_blank');
+    await expect.element(link).toHaveAttribute('rel', 'noopener noreferrer');
+
+    expect(page.getByCSS('[data-test-native-replacement="lazy_static"]').elements()).toHaveLength(1);
+  });
+
+  it('shows no marker for a dependency without a replacement', async () => {
+    let dependency = createDependency({ crate_id: 'serde' });
+
+    render(Row, { dependency, descriptionPromise: Promise.resolve(null) });
+
+    await expect.element(page.getByCSS('[data-test-crate-name]')).toHaveTextContent('serde');
+    expect(page.getByCSS('[data-test-native-replacement]').elements()).toHaveLength(0);
+  });
+});

--- a/svelte/src/lib/data/native-replacements.ts
+++ b/svelte/src/lib/data/native-replacements.ts
@@ -58,8 +58,8 @@ export const nativeReplacements: Record<string, NativeReplacement> = {
   once_cell: {
     description:
       'Most of <code>once_cell</code> is now in <code>std</code>: <code>OnceCell</code>/<code>OnceLock</code> ' +
-      '(Rust 1.70) and <code>LazyCell</code>/<code>LazyLock</code> (Rust 1.80). A few APIs (e.g. fallible ' +
-      '<code>get_or_try_init</code>) are not yet stable in <code>std</code>.',
+      '(Rust 1.70) and <code>LazyCell</code>/<code>LazyLock</code> (Rust 1.80). The <code>race</code> module and ' +
+      'fallible <code>get_or_try_init</code> have no stable <code>std</code> equivalent yet.',
     url: 'https://blog.rust-lang.org/2024/07/25/Rust-1.80.0/',
   },
 

--- a/svelte/src/lib/data/native-replacements.ts
+++ b/svelte/src/lib/data/native-replacements.ts
@@ -1,3 +1,43 @@
+/**
+ * Native replacement policy
+ * =========================
+ *
+ * This dataset flags crates whose functionality has been absorbed into the
+ * Rust standard library, so a reader can see that `std` now provides what the
+ * crate offers. Every entry is a checkable factual statement about `std`, never
+ * an editorial judgement about a competing third-party crate.
+ *
+ * Scope
+ * -----
+ * Standard-library replacements only. The set deliberately does not include
+ * "prefer this nicer crate instead" style recommendations.
+ *
+ * Inclusion criteria
+ * ------------------
+ * Two kinds of entries qualify:
+ *
+ *   - Full: the crate's functionality is entirely available via a stable `std`
+ *     API.
+ *   - Partial: the bulk of the crate's common use case has moved to `std`, but
+ *     not all of it. The `description` must spell out what is still missing.
+ *
+ * Coverage is judged roughly, and only the dominant use case counts. If just a
+ * small slice of a crate's purpose lives in `std`, it does not qualify, since
+ * flagging it would be misleading and noisy. `itertools` is the canonical
+ * exclusion: a few adaptors have `std` equivalents, but the crate is
+ * overwhelmingly not replaced by `std`.
+ *
+ * Every entry's `description` must cite the stable `std` API(s) and the Rust
+ * version(s) that stabilized them.
+ *
+ * Maintainer notice-and-comment
+ * -----------------------------
+ * Entries should arrive as PRs judged against the criteria above. Before an entry
+ * lands, the maintainer(s) of the crate being flagged get a window to weigh in,
+ * either to object or to show that the replacement is less complete than claimed,
+ * in which case the entry becomes partial or is rejected.
+ */
+
 /** A crate whose functionality is (largely) available in std. */
 export interface NativeReplacement {
   /** HTML fragment describing the std replacement. */

--- a/svelte/src/lib/data/native-replacements.ts
+++ b/svelte/src/lib/data/native-replacements.ts
@@ -1,0 +1,38 @@
+/** A crate whose functionality is (largely) available in std. */
+export interface NativeReplacement {
+  /** HTML fragment describing the std replacement. */
+  description: string;
+  /** Representative docs URL (std docs or release notes) shown as a "Learn more" link. */
+  url: string;
+}
+
+export const nativeReplacements: Record<string, NativeReplacement> = {
+  lazy_static: {
+    description:
+      'The standard library provides <code>std::sync::LazyLock</code> (stable since Rust 1.80), which lets ' +
+      'you replace the <code>lazy_static!</code> macro with a plain <code>static</code> and remove the ' +
+      'dependency.',
+    url: 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html',
+  },
+
+  once_cell: {
+    description:
+      'Most of <code>once_cell</code> is now in <code>std</code>: <code>OnceCell</code>/<code>OnceLock</code> ' +
+      '(Rust 1.70) and <code>LazyCell</code>/<code>LazyLock</code> (Rust 1.80). A few APIs (e.g. fallible ' +
+      '<code>get_or_try_init</code>) are not yet stable in <code>std</code>.',
+    url: 'https://blog.rust-lang.org/2024/07/25/Rust-1.80.0/',
+  },
+
+  matches: {
+    description: 'The <code>matches!</code> macro has been part of the standard library since Rust 1.42.',
+    url: 'https://doc.rust-lang.org/std/macro.matches.html',
+  },
+
+  num_cpus: {
+    description:
+      'For most uses, <code>std::thread::available_parallelism</code> (Rust 1.59) returns the parallelism ' +
+      'available to the process. (It does not distinguish physical vs logical cores the way ' +
+      '<code>num_cpus</code> does.)',
+    url: 'https://doc.rust-lang.org/std/thread/fn.available_parallelism.html',
+  },
+};

--- a/svelte/src/lib/data/native-replacements.ts
+++ b/svelte/src/lib/data/native-replacements.ts
@@ -64,7 +64,9 @@ export const nativeReplacements: Record<string, NativeReplacement> = {
   },
 
   matches: {
-    description: 'The <code>matches!</code> macro has been part of the standard library since Rust 1.42.',
+    description:
+      'The <code>matches!</code> macro has been in <code>std</code> since Rust 1.42, and ' +
+      '<code>assert_matches!</code> / <code>debug_assert_matches!</code> followed in Rust 1.96.',
     url: 'https://doc.rust-lang.org/std/macro.matches.html',
   },
 


### PR DESCRIPTION
When a crate's functionality is now available in the standard library, this shows a banner on the crate page and a small marker in dependency lists, each pointing the reader at the relevant `std` API. The suggestion is deliberately limited to the standard library and never compares third-party crates against each other, so every entry stays a checkable factual statement about `std` rather than an opinion.

The data lives in a curated module at `svelte/src/lib/data/native-replacements.ts`, which maps a crate name to one or more `std` targets. Each target records the Rust version that stabilized it and a documentation URL, and each entry carries a flag for whether `std` covers the crate fully or only its common case, alongside a short curated description. It ships seeded with `lazy_static`, `once_cell`, `matches`, and `num_cpus`. The rules for what qualifies sit right next to the data as a module-level doc comment, covering the limited scope, the bar for full and partial entries, and a step where the maintainer of a flagged crate can weigh in before the entry lands.

The banner appears on the crate page for every version of a flagged crate, and the dependency list shows a marker whose tooltip carries the same description and links straight to the `std` item. Both surfaces are visible in the `NativeReplacementBanner` and `dependency-list/Row` Storybook stories, and they are covered by component tests and end-to-end tests for the present and absent cases.

### Crate page screenshot
<img width="960" height="522" alt="grafik" src="https://github.com/user-attachments/assets/c88ef0d6-89b0-403f-b795-589b2108c999" />

### Dependency list screenshot
<img width="1698" height="644" alt="grafik" src="https://github.com/user-attachments/assets/1828284b-51fe-4312-9734-94412a2f3dc2" />


### Related

- Original inspiration: https://npmx.dev/package/left-pad
- https://github.com/e18e/module-replacements
- https://github.com/npmx-dev/npmx.dev/blob/01c510088489b3988586342af3c6df0ad48d7cdb/app/components/Package/Replacement.vue
- https://nesbitt.io/2026/04/16/features-everyone-should-steal-from-npmx.html
- https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/std.20lib.20replacements/with/600131994