### PR TITLE
Add `docs/LOGGING.md` with backend logging conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Test database setup: Set `TEST_DATABASE_URL` in `.env` to a separate database (e
 - Never ignore deprecation warnings; fix them immediately or use `#[expect(deprecated)]`.
 - Rate limiting configuration lives in `/src/rate_limiter.rs`; new endpoints should use appropriate limiters.
 - CDN and caching behavior is configured in the [rust-lang/simpleinfra](https://github.com/rust-lang/simpleinfra) repository, not here. The backend only sets `Cache-Control`/`Vary` headers and whether the CDNs honor them depends on the Fastly/CloudFront config in that repo. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the CDN overview.
-- Structured logging uses `tracing`; add spans for request context.
+- Structured logging uses `tracing`; add spans for request context. See [`docs/LOGGING.md`](docs/LOGGING.md) for conventions on log messages, fields, and levels.
 - Authentication happens via session cookies (web users) or API tokens (cargo CLI, third-party clients).
 - OpenAPI spec: Auto-generated from backend code; update by running `cargo test --package crates_io --lib openapi` and accepting the snapshot changes.
 - New API endpoints should follow the conventions in [`docs/API-DESIGN.md`](docs/API-DESIGN.md) (URL shape, request/response envelopes, errors, pagination, auth, OpenAPI annotations).
@@ -220,6 +220,7 @@ Before submitting:
 - `/docs/CONTRIBUTING.md` - Setup instructions, detailed workflows, Docker setup, GitHub OAuth configuration
 - `/docs/ARCHITECTURE.md` - System architecture and design decisions
 - `/docs/API-DESIGN.md` - JSON API conventions for new endpoints
+- `/docs/LOGGING.md` - Conventions for backend log messages, fields, and levels
 - `/docs/PR-REVIEW.md` - Guidelines for reviewing pull requests
 - `/docs/AI-TOOLS.md` - Guidelines for using AI tools when contributing
 - `/script/import-database-dump.sh` - Import production database dump for testing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,7 +75,7 @@ Authorization for crates is based on ownership. A crate is owned by one or more 
 
 ## Observability
 
-The backend emits structured logs through the `tracing` framework. In production these logs are shipped to DataDog, which indexes and archives them and is where we search and investigate what the running system is doing.
+The backend emits structured logs through the `tracing` framework. In production these logs are shipped to DataDog, which indexes and archives them and is where we search and investigate what the running system is doing. See [`LOGGING.md`](LOGGING.md) for the conventions on how to write these logs.
 
 Errors and panics are additionally reported to Sentry, which groups them and captures the context needed to debug them, with sensitive headers stripped before anything is sent. The backend also exposes operational metrics in Prometheus format, such as queue depths and database pool usage, for monitoring and dashboards.
 

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,77 @@
+# Logging guidelines
+
+This document captures the conventions for writing backend logs so they are
+useful both to a human reading them and to queries in Datadog.
+
+The backend logs through the [`tracing`](https://docs.rs/tracing) framework. In
+production these logs are emitted as structured JSON and shipped to Datadog (see
+[`ARCHITECTURE.md`](ARCHITECTURE.md#observability) for details). Write each
+log line so it reads clearly on its own and exposes the values you will want to
+search by.
+
+## Message vs. fields
+
+A log line has a free-text message and a set of structured key/value fields.
+They serve different purposes and complement each other:
+
+- The **message** describes what happened and must read clearly on its own.
+  Interpolate the relevant identifiers into the text so two lines for different
+  inputs do not look identical.
+- **Fields** carry the values you will want to filter, group, or correlate on
+  in Datadog. Fields make those values queryable. The message keeps them
+  readable.
+
+Because both views are useful, a key identifier usually appears in both: keep it
+in the readable message and add it as a field.
+
+```rust
+// Bad: readable, but you cannot filter by crate in Datadog
+info!("Generated OG image for crate `{name}`");
+
+// Bad: filterable, but every line reads the same in the log view
+info!(krate.name = %name, "Generated OG image");
+
+// Good: readable in the log view and filterable by `krate.name`
+info!(krate.name = %name, "Generated OG image for crate `{name}`");
+```
+
+Avoid vague messages with no context. `"operation failed"` tells the reader
+nothing. Say which operation failed for what input.
+
+## Field naming
+
+- Use dotted names that group related fields by their domain entity:
+  `krate.name`, `user.id`, `version.num`. We spell it `krate` because `crate` is
+  a reserved word in Rust.
+- Use the same name for the same thing everywhere, so a single query finds every
+  occurrence.
+- Put the unit in the name for measurements: `duration_ms`, `size_bytes`.
+- Use `tracing`'s sigils to control how a value is recorded: `%value` for its
+  `Display` representation, `?value` for its `Debug` representation.
+
+## Log levels
+
+The production default level is `INFO`, so `debug!` and `trace!` are only visible
+when the level is raised locally or temporarily.
+
+- `error!`: an operation failed and someone should look into it. Keep these
+  rare and actionable. A flood of errors that nobody acts on trains everyone to
+  ignore them. Log a failure once, at the boundary where it is handled, not at
+  every layer it passes through.
+- `warn!`: something unexpected happened but the system recovered or carried on
+  in a degraded state (a fallback kicked in, a retry was needed, a config value
+  is off). Worth watching for trends.
+- `info!`: normal, high-level events describing what the system is doing, and
+  the bulk of what we see in production. Keep it high-level rather than per-item
+  detail.
+- `debug!`: diagnostic detail for investigating a problem.
+- `trace!`: very fine-grained detail, rarely needed.
+
+## What never to log
+
+Never put secrets or personal data into a message or a field. This includes:
+
+- passwords and other credentials
+- tokens, secrets, and session cookies
+- personal data such as email addresses, IP addresses, or real names
+- raw request or response bodies, which may contain any of the above


### PR DESCRIPTION
This adds a contributor-facing guide covering the message-vs-fields rule, field naming, log levels, and what never to log. It links the new doc from `AGENTS.md` and the Observability section of `docs/ARCHITECTURE.md`.