### PR TITLE
Interpolate error values into log messages

### DIFF
--- a/crates/crates_io_cdn_logs/src/cloudfront.rs
+++ b/crates/crates_io_cdn_logs/src/cloudfront.rs
@@ -104,7 +104,7 @@ pub async fn count_downloads(reader: impl AsyncBufRead + Unpin) -> anyhow::Resul
         let date = match date.parse::<NaiveDate>() {
             Ok(date) => date,
             Err(error) => {
-                warn!(%date, %error, "Failed to parse date");
+                warn!(%date, "Failed to parse date `{date}`: {error}");
                 continue;
             }
         };

--- a/crates/crates_io_docs_rs/src/lib.rs
+++ b/crates/crates_io_docs_rs/src/lib.rs
@@ -61,7 +61,7 @@ impl RealDocsRsClient {
             Ok(Some(url)) => url,
             Ok(None) => Url::parse(DEFAULT_BASE_URL).unwrap(),
             Err(err) => {
-                warn!(?err, "Failed to parse DOCS_RS_BASE_URL");
+                warn!("Failed to parse DOCS_RS_BASE_URL: {err}");
                 return None;
             }
         };

--- a/crates/crates_io_tarball/examples/check_all_crates.rs
+++ b/crates/crates_io_tarball/examples/check_all_crates.rs
@@ -68,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
 async fn process_path(path: &Path, pb: &ProgressBar) {
     let file = File::open(path)
         .await
-        .map_err(|error| pb.suspend(|| warn!(%error, "Failed to read crate file")));
+        .map_err(|error| pb.suspend(|| warn!("Failed to read crate file: {error}")));
 
     let Ok(mut file) = file else {
         return;
@@ -81,7 +81,9 @@ async fn process_path(path: &Path, pb: &ProgressBar) {
     let result = process_tarball(&pkg_name, &mut file, u64::MAX).await;
     pb.suspend(|| match result {
         Ok(result) => debug!(%pkg_name, path = %path.display(), ?result),
-        Err(error) => warn!(%pkg_name, path = %path.display(), %error, "Failed to process tarball"),
+        Err(error) => {
+            warn!(%pkg_name, path = %path.display(), "Failed to process tarball: {error}")
+        }
     })
 }
 

--- a/crates/crates_io_worker/src/runner.rs
+++ b/crates/crates_io_worker/src/runner.rs
@@ -116,7 +116,7 @@ impl RunHandle {
     pub async fn wait_for_shutdown(self) {
         join_all(self.handles).await.into_iter().for_each(|result| {
             if let Err(error) = result {
-                warn!(%error, "Background worker task panicked");
+                warn!("Background worker task panicked: {error}");
             }
         });
     }

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -123,7 +123,7 @@ fn main() -> anyhow::Result<()> {
         let environment = environment.clone();
         move || {
             if let Err(err) = environment.lock_index() {
-                warn!(%err, "Failed to clone index");
+                warn!("Failed to clone index: {err}");
             };
         }
     });

--- a/src/bin/crates-admin/default_versions.rs
+++ b/src/bin/crates-admin/default_versions.rs
@@ -38,7 +38,7 @@ pub async fn run(command: Command) -> anyhow::Result<()> {
         };
 
         if let Err(error) = result {
-            pb.suspend(|| warn!(%crate_id, %error, "Failed to update the default version"));
+            pb.suspend(|| warn!(%crate_id, "Failed to update the default version: {error}"));
         }
     }
 

--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -79,13 +79,13 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
                 );
             }
             Err(error) => {
-                warn!(%crate_name, ?error, "Failed to delete versions from the database")
+                warn!(%crate_name, "Failed to delete versions from the database: {error}")
             }
         }
 
         info!(%crate_name, %crate_id, "Updating default version in the database");
         if let Err(error) = update_default_version(crate_id, conn).await {
-            warn!(%crate_name, %crate_id, ?error, "Failed to update default version");
+            warn!(%crate_name, %crate_id, "Failed to update default version: {error}");
         }
 
         Ok::<_, anyhow::Error>(opts)
@@ -108,7 +108,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
     for version in &opts.versions {
         debug!(%crate_name, %version, "Deleting crate file from S3");
         if let Err(error) = store.delete_crate_file(crate_name, version).await {
-            warn!(%crate_name, %version, ?error, "Failed to delete crate file from S3");
+            warn!(%crate_name, %version, "Failed to delete crate file from S3: {error}");
         } else {
             paths.push(store.crate_location(crate_name, version));
         }
@@ -117,7 +117,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         match store.delete_readme(crate_name, version).await {
             Err(object_store::Error::NotFound { .. }) => {}
             Err(error) => {
-                warn!(%crate_name, %version, ?error, "Failed to delete readme file from S3")
+                warn!(%crate_name, %version, "Failed to delete readme file from S3: {error}")
             }
             Ok(_) => {
                 paths.push(store.readme_location(crate_name, version));

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -123,7 +123,7 @@ fn log_instance_metrics_thread(app: Arc<App>) {
     std::thread::spawn(move || {
         loop {
             if let Err(err) = log_instance_metrics_inner(&app) {
-                error!(?err, "log_instance_metrics error");
+                error!("log_instance_metrics error: {err}");
             }
             std::thread::sleep(interval);
         }

--- a/src/cloudfront.rs
+++ b/src/cloudfront.rs
@@ -143,6 +143,6 @@ impl CloudFront {
             .await
             .map(|_| ()) // We don't care about the result, just that it worked
             .inspect(|_| debug!("Invalidation request successful"))
-            .inspect_err(|error| warn!(?error, "Invalidation request failed"))?)
+            .inspect_err(|error| warn!("Invalidation request failed: {error}"))?)
     }
 }

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -206,8 +206,8 @@ async fn alert_revoke_token(
 
     if let Err(error) = send_notification_email(&token, alert, state, conn).await {
         warn!(
-            token_id = %token.id, user_id = %token.user_id, ?error,
-            "Failed to send email notification",
+            token_id = %token.id, user_id = %token.user_id,
+            "Failed to send email notification: {error}",
         )
     }
 
@@ -303,8 +303,8 @@ async fn send_trustpub_notification_emails(
 
         let Ok(email_template) = message.inspect_err(|error| {
             warn!(
-                %email, ?crate_names, ?error,
-                "Failed to create trusted publishing token exposure email template"
+                %email, ?crate_names,
+                "Failed to create trusted publishing token exposure email template: {error}"
             );
         }) else {
             continue;
@@ -312,8 +312,8 @@ async fn send_trustpub_notification_emails(
 
         if let Err(error) = state.emails.send(&email, email_template).await {
             warn!(
-                %email, ?crate_names, ?error,
-                "Failed to send trusted publishing token exposure notification"
+                %email, ?crate_names,
+                "Failed to send trusted publishing token exposure notification: {error}"
             );
         }
     }

--- a/src/middleware/cargo_compat.rs
+++ b/src/middleware/cargo_compat.rs
@@ -108,7 +108,7 @@ async fn ensure_json_errors(res: Response) -> Response {
     }
 
     convert_to_json_response(res).await.unwrap_or_else(|error| {
-        error!(%error, "Failed to convert response to JSON");
+        error!("Failed to convert response to JSON: {error}");
         StatusCode::INTERNAL_SERVER_ERROR.into_response()
     })
 }

--- a/src/sentry/mod.rs
+++ b/src/sentry/mod.rs
@@ -18,7 +18,7 @@ pub fn init() -> Option<ClientInitGuard> {
     let config = match SentryConfig::from_environment() {
         Ok(config) => config,
         Err(error) => {
-            warn!(%error, "Failed to read Sentry configuration from environment");
+            warn!("Failed to read Sentry configuration from environment: {error}");
             return None;
         }
     };

--- a/src/tests/util/chaosproxy.rs
+++ b/src/tests/util/chaosproxy.rs
@@ -39,7 +39,7 @@ impl ChaosProxy {
         let instance_clone = instance.clone();
         tokio::spawn(async move {
             if let Err(error) = instance_clone.server_loop(listener).await {
-                error!(%error, "ChaosProxy server error");
+                error!("ChaosProxy server error: {error}");
             }
         });
 
@@ -126,7 +126,7 @@ impl ChaosProxy {
         tokio::spawn(async move {
             if let Err(error) = proxy_data(break_networking_send, client_read, backend_write).await
             {
-                error!(%error, "ChaosProxy connection error");
+                error!("ChaosProxy connection error: {error}");
             }
         });
 
@@ -134,7 +134,7 @@ impl ChaosProxy {
         tokio::spawn(async move {
             if let Err(error) = proxy_data(break_networking_send, backend_read, client_write).await
             {
-                error!(%error, "ChaosProxy connection error");
+                error!("ChaosProxy connection error: {error}");
             }
         });
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -164,7 +164,7 @@ impl From<EmailError> for BoxedAppError {
             EmailError::AddressError(error) => Box::new(error),
             EmailError::MessageBuilderError(error) => Box::new(error),
             EmailError::TransportError(error) => {
-                error!(?error, "Failed to send email");
+                error!("Failed to send email: {error}");
                 server_error("Failed to send the email")
             }
         }

--- a/src/worker/jobs/docs_rs_queue_rebuild.rs
+++ b/src/worker/jobs/docs_rs_queue_rebuild.rs
@@ -49,8 +49,7 @@ impl BackgroundJob for DocsRsQueueRebuild {
                 error!(
                     name = self.name,
                     version = self.version,
-                    ?err,
-                    "couldn't queue docs rebuild. won't retry"
+                    "couldn't queue docs rebuild. won't retry: {err}"
                 );
                 Ok(())
             }

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -91,9 +91,8 @@ async fn check(
                 if let Err(error) = send_notification_email(emails, recipient, &email_context).await
                 {
                     error!(
-                        ?error,
                         ?recipient,
-                        "Failed to send possible typosquat notification"
+                        "Failed to send possible typosquat notification: {error}"
                     );
                 }
             }


### PR DESCRIPTION
This moves the error value out of the structured fields and into the free-text log message so each line reads clearly on its own. The error text is not a useful value to filter or group by in Datadog, so it does not need to be a queryable field.