### PR TITLE
Ignore self-referencing dependencies when checking crate deletion requirements

### DIFF
--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -4,7 +4,7 @@ use crate::controllers::helpers::authorization::Rights;
 use crate::controllers::krate::CratePath;
 use crate::email::EmailMessage;
 use crate::models::NewDeletedCrate;
-use crate::schema::{crate_downloads, crates, dependencies};
+use crate::schema::{crate_downloads, crates, dependencies, versions};
 use crate::util::errors::{AppResult, BoxedAppError, custom};
 use crate::worker::jobs;
 use axum::extract::rejection::QueryRejection;
@@ -187,7 +187,13 @@ pub fn max_downloads(age: &TimeDelta) -> u64 {
 
 async fn has_rev_dep(mut conn: &AsyncPgConnection, crate_id: i32) -> QueryResult<bool> {
     let rev_dep = dependencies::table
+        .inner_join(versions::table)
         .filter(dependencies::crate_id.eq(crate_id))
+        // Ignore self-referencing dependencies, i.e. dependencies where the
+        // depending version belongs to the same crate that is being depended
+        // upon. Some crates depend on themselves (e.g. for backwards
+        // compatibility), and these should not block deletion.
+        .filter(versions::crate_id.ne(crate_id))
         .select(dependencies::id)
         .first::<i32>(&mut conn)
         .await

--- a/src/tests/routes/crates/delete.rs
+++ b/src/tests/routes/crates/delete.rs
@@ -295,6 +295,30 @@ async fn test_rev_deps() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_self_referencing_dep() -> anyhow::Result<()> {
+    let (_app, anon, user) = TestApp::full().with_user().await;
+
+    publish_crate(&user, "foo").await;
+
+    // Publish a new version of the same crate that depends on itself. Some
+    // crates do this for backwards compatibility reasons, and it should not
+    // prevent the crate from being deleted.
+    let pb = PublishBuilder::new("foo", "2.0.0")
+        .dependency(DependencyBuilder::new("foo").version_req("^1.0.0"));
+    let response = user.publish_crate(pb).await;
+    assert_snapshot!(response.status(), @"200 OK");
+
+    let response = delete_crate(&user, "foo").await;
+    assert_snapshot!(response.status(), @"204 No Content");
+    assert!(response.body().is_empty());
+
+    // Assert that the crate no longer exists
+    assert_crate_exists(&anon, "foo", false).await;
+
+    Ok(())
+}
+
 // Publishes a crate with the given name and a single `v1.0.0` version.
 async fn publish_crate(user: &impl RequestHelper, name: &str) {
     let pb = PublishBuilder::new(name, "1.0.0");


### PR DESCRIPTION
Crates that depend on themselves (e.g. for backwards compatibility) were incorrectly blocked from deletion by the reverse-dependency check. Exclude dependencies whose depending version belongs to the crate itself, so a self-reference no longer counts as a reverse dependency.