### PR TITLE
CI: Enable pipefail for cargo-insta install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,10 @@ jobs:
 
       - name: Install cargo-insta
         run: curl -LsSf https://github.com/mitsuhiko/insta/releases/download/${CARGO_INSTA_VERSION}/cargo-insta-installer.sh | sh
+        # `shell: bash` enables `pipefail` so a failing `curl` fails the step
+        # instead of being masked by `sh` exiting successfully.
+        # See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+        shell: bash
 
       - run: sudo systemctl start postgresql.service
       - run: sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'postgres'"


### PR DESCRIPTION
The default GitHub Actions bash shell runs with `-e` but without `pipefail`, so in `curl ... | sh` the pipeline reports the exit status of `sh` only. A failing `curl` (e.g. a transient 504 from the release download) writes nothing to stdout, `sh` then runs nothing and exits 0, and the install step is marked successful even though cargo-insta was never installed. The failure only surfaces later in `cargo insta test` as `no such command: insta`.

Setting `shell: bash` opts the step into `-eo pipefail`, so the `curl` failure propagates and fails the step at the right place.

Failed run: https://github.com/rust-lang/crates.io/actions/runs/27123490740/job/80046085091