### PR TITLE
Wake background workers via Postgres NOTIFY/LISTEN

### DIFF
--- a/crates/crates_io_worker/Cargo.toml
+++ b/crates/crates_io_worker/Cargo.toml
@@ -16,11 +16,11 @@ sentry-core = { version = "=0.48.2", features = ["client"] }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.150"
 thiserror = "=2.0.18"
-tokio = { version = "=1.52.3", features = ["rt", "time"]}
+tokio = { version = "=1.52.3", features = ["macros", "rt", "sync", "time"]}
 tracing = "=0.1.44"
 
 [dev-dependencies]
 claims = "=0.8.0"
 crates_io_test_db = { path = "../crates_io_test_db" }
 insta = { version = "=1.47.2", features = ["json"] }
-tokio = { version = "=1.52.3", features = ["macros", "sync"]}
+tokio = { version = "=1.52.3", features = ["macros", "rt-multi-thread", "sync"]}

--- a/crates/crates_io_worker/README.md
+++ b/crates/crates_io_worker/README.md
@@ -35,7 +35,7 @@ The system consists of three main components:
   - Executes job logic with error handling and retry logic
   - Reports job completion or failure back to the database
 
-Jobs are stored in the `background_jobs` PostgreSQL table and processed asynchronously by worker instances that poll for available work in their assigned queues.
+Jobs are stored in the `background_jobs` PostgreSQL table and processed asynchronously by worker instances that poll for available work in their assigned queues. To avoid unnecessary polling latency, a database trigger emits a `NOTIFY` on the `background_jobs` channel whenever a job is enqueued, and the `Runner` keeps a dedicated connection open to `LISTEN` for these notifications and wake the workers immediately. Polling also runs as a fallback so that retriable jobs are eventually picked up even without a notification.
 
 ### Job Processing and Locking
 

--- a/crates/crates_io_worker/src/lib.rs
+++ b/crates/crates_io_worker/src/lib.rs
@@ -3,6 +3,7 @@
 mod background_job;
 mod errors;
 mod job_registry;
+mod listener;
 mod runner;
 pub mod schema;
 mod storage;

--- a/crates/crates_io_worker/src/listener.rs
+++ b/crates/crates_io_worker/src/listener.rs
@@ -1,0 +1,70 @@
+use diesel_async::pooled_connection::deadpool::{Object, Pool};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use futures_util::StreamExt;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Notify;
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
+
+/// The Postgres `LISTEN`/`NOTIFY` channel that a database trigger signals
+/// whenever a new background job is inserted.
+pub const CHANNEL: &str = "background_jobs";
+
+/// How long to wait before the first reconnect attempt after the listener
+/// connection was lost. Subsequent failures back off exponentially up to
+/// [`MAX_RECONNECT_DELAY`].
+const INITIAL_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+
+/// The upper bound for the exponential reconnect backoff, so that a sustained
+/// outage does not stop the listener from retrying entirely.
+const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(60);
+
+/// Listen for `NOTIFY` messages on the [`CHANNEL`] and wake up the workers
+/// whenever a new job is enqueued.
+///
+/// This keeps a dedicated connection open for the lifetime of the runner. If
+/// the connection is lost, it is re-established automatically, backing off
+/// exponentially while reconnect attempts keep failing.
+pub async fn listen_for_new_jobs(pool: Pool<AsyncPgConnection>, notify: Arc<Notify>) {
+    let mut delay = INITIAL_RECONNECT_DELAY;
+    loop {
+        if let Err(error) = listen(&pool, &notify, &mut delay).await {
+            warn!("Background job listener failed, reconnecting in {delay:?}: {error}");
+        }
+        sleep(delay).await;
+        delay = (delay * 2).min(MAX_RECONNECT_DELAY);
+    }
+}
+
+async fn listen(
+    pool: &Pool<AsyncPgConnection>,
+    notify: &Notify,
+    delay: &mut Duration,
+) -> anyhow::Result<()> {
+    // Take the connection out of the pool so that it stays dedicated to
+    // listening and is never recycled for regular queries.
+    let mut conn = Object::take(pool.get().await?);
+
+    diesel::sql_query(format!("LISTEN {CHANNEL}"))
+        .execute(&mut conn)
+        .await?;
+
+    // The connection is up and listening, so reset the backoff for the next
+    // reconnect regardless of how this session eventually ends.
+    *delay = INITIAL_RECONNECT_DELAY;
+
+    info!("Listening for new background jobs…");
+
+    let mut stream = std::pin::pin!(conn.notifications_stream());
+    while let Some(notification) = stream.next().await {
+        // Surface per-notification errors so the caller reconnects. A cleanly
+        // closed connection instead ends the stream and reconnects the same way.
+        notification?;
+
+        debug!("Received notification about a new background job.");
+        notify.notify_waiters();
+    }
+
+    Ok(())
+}

--- a/crates/crates_io_worker/src/runner.rs
+++ b/crates/crates_io_worker/src/runner.rs
@@ -1,16 +1,19 @@
 use crate::background_job::DEFAULT_QUEUE;
 use crate::job_registry::JobRegistry;
 use crate::worker::Worker;
-use crate::{BackgroundJob, storage};
+use crate::{BackgroundJob, listener, storage};
 use anyhow::anyhow;
 use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::deadpool::Pool;
+use futures_util::FutureExt;
 use futures_util::future::join_all;
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Notify;
 use tokio::task::JoinHandle;
-use tracing::{Instrument, info, info_span, warn};
+use tracing::{Instrument, error, info, info_span, warn};
 
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -67,6 +70,31 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context> {
     ///
     /// This returns a `RunningRunner` which can be used to wait for the workers to shutdown.
     pub fn start(&self) -> RunHandle {
+        // Workers wait on this to be woken up when a new job is enqueued.
+        let notify = Arc::new(Notify::new());
+
+        // Listen for `NOTIFY` messages and wake up the workers. This is skipped
+        // when shutting down on an empty queue (e.g. in tests), where workers
+        // simply poll until the queue drains.
+        if !self.shutdown_when_queue_empty {
+            let pool = self.connection_pool.clone();
+            let notify = notify.clone();
+            tokio::spawn(async move {
+                // `listen_for_new_jobs()` loops forever, so it should never
+                // return. Catch a panic (or an unexpected return) and log it,
+                // since the workers otherwise silently fall back to polling.
+                if AssertUnwindSafe(listener::listen_for_new_jobs(pool, notify))
+                    .catch_unwind()
+                    .await
+                    .is_err()
+                {
+                    error!("Background job listener panicked");
+                } else {
+                    warn!("Background job listener stopped unexpectedly");
+                }
+            });
+        }
+
         let mut handles = Vec::new();
         for (queue_name, queue) in &self.queues {
             for i in 1..=queue.num_workers {
@@ -79,6 +107,7 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context> {
                     job_registry: Arc::new(queue.job_registry.clone()),
                     shutdown_when_queue_empty: self.shutdown_when_queue_empty,
                     poll_interval: queue.poll_interval,
+                    notify: notify.clone(),
                 };
 
                 let span = info_span!("worker", worker.name = %name);

--- a/crates/crates_io_worker/src/worker.rs
+++ b/crates/crates_io_worker/src/worker.rs
@@ -9,6 +9,7 @@ use futures_util::FutureExt;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Notify;
 use tokio::time::sleep;
 use tracing::{Instrument, debug, error, info_span, warn};
 
@@ -18,24 +19,39 @@ pub struct Worker<Context> {
     pub(crate) job_registry: Arc<JobRegistry<Context>>,
     pub(crate) shutdown_when_queue_empty: bool,
     pub(crate) poll_interval: Duration,
+    /// Signaled by the [`listener`](crate::listener) when a new job is enqueued.
+    pub(crate) notify: Arc<Notify>,
 }
 
 impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
     /// Run background jobs forever, or until the queue is empty if `shutdown_when_queue_empty` is set.
     pub async fn run(&self) {
         loop {
+            // Register interest in notifications *before* querying the database,
+            // so that a notification arriving while we run or look up a job is
+            // not missed.
+            let mut notified = std::pin::pin!(self.notify.notified());
+            notified.as_mut().enable();
+
             match self.run_next_job().await {
-                Ok(Some(_)) => {}
+                // A job was run, so immediately look for the next one.
+                Ok(Some(_)) => continue,
                 Ok(None) if self.shutdown_when_queue_empty => {
                     debug!("No pending background worker jobs found. Shutting down the worker…");
                     break;
                 }
                 Ok(None) => {
                     debug!(
-                        "No pending background worker jobs found. Polling again in {:?}…",
+                        "No pending background worker jobs found. Waiting for a notification, or polling again in {:?}…",
                         self.poll_interval
                     );
-                    sleep(self.poll_interval).await;
+                    // Wake up as soon as a new job is enqueued, but keep polling
+                    // as a fallback so that retriable jobs are eventually picked
+                    // up even without a notification.
+                    tokio::select! {
+                        _ = notified => {}
+                        _ = sleep(self.poll_interval) => {}
+                    }
                 }
                 Err(error) => {
                     error!("Failed to run job: {error}");

--- a/crates/crates_io_worker/tests/runner.rs
+++ b/crates/crates_io_worker/tests/runner.rs
@@ -5,13 +5,16 @@ use crates_io_worker::{BackgroundJob, Runner};
 use diesel::prelude::*;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::deadpool::Pool;
-use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use futures_util::StreamExt;
 use insta::assert_compact_json_snapshot;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
-use tokio::sync::Barrier;
+use std::time::Duration;
+use tokio::sync::{Barrier, Notify};
+use tokio::time::{sleep, timeout};
 
 async fn all_jobs(conn: &mut AsyncPgConnection) -> QueryResult<Vec<(String, Value)>> {
     background_jobs::table
@@ -310,6 +313,107 @@ async fn jobs_can_be_deduplicated() -> anyhow::Result<()> {
     // Resolve the final barrier to finish the test
     test_context.assertions_finished_barrier.wait().await;
     runner.wait_for_shutdown().await;
+
+    Ok(())
+}
+
+/// A database trigger should emit a `NOTIFY` on the `background_jobs` channel
+/// whenever a job is enqueued, so that listening workers can wake up
+/// immediately instead of waiting for the next poll.
+#[tokio::test]
+async fn enqueueing_a_job_emits_a_notification() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize)]
+    struct TestJob;
+
+    impl BackgroundJob for TestJob {
+        const JOB_NAME: &'static str = "test";
+        type Context = ();
+
+        async fn run(&self, _ctx: Self::Context) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    let test_database = TestDatabase::new();
+
+    // One connection listens on the channel…
+    let mut listen_conn = AsyncPgConnection::establish(test_database.url()).await?;
+    diesel::sql_query("LISTEN background_jobs")
+        .execute(&mut listen_conn)
+        .await?;
+
+    // …while another one enqueues a job.
+    let conn = AsyncPgConnection::establish(test_database.url()).await?;
+    TestJob.enqueue(&conn).await?;
+
+    // The listener should receive a notification on the expected channel.
+    let mut notifications = std::pin::pin!(listen_conn.notifications_stream());
+    let notification = timeout(Duration::from_secs(5), notifications.next())
+        .await?
+        .expect("notification stream ended unexpectedly")?;
+
+    assert_eq!(notification.channel, "background_jobs");
+
+    Ok(())
+}
+
+/// A worker should be woken by the database notification as soon as a job is
+/// enqueued, instead of waiting for the next poll. The poll interval is set far
+/// higher than the assertion timeout, so a timely pickup can only be the result
+/// of the notification rather than of polling.
+///
+/// This runs on a multi-threaded runtime because, unlike the other tests, it
+/// keeps a non-shutdown runner (with its listener) alive in the background, and
+/// relies on the timeout firing independently of those busy tasks.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn workers_wake_up_on_notification() -> anyhow::Result<()> {
+    #[derive(Clone)]
+    struct TestContext {
+        job_ran: Arc<Notify>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct TestJob;
+
+    impl BackgroundJob for TestJob {
+        const JOB_NAME: &'static str = "test";
+        type Context = TestContext;
+
+        async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+            ctx.job_ran.notify_one();
+            Ok(())
+        }
+    }
+
+    let test_database = TestDatabase::new();
+
+    let test_context = TestContext {
+        job_ran: Arc::new(Notify::new()),
+    };
+
+    let pool = pool(test_database.url())?;
+    let conn = pool.get().await?;
+
+    // Note the deliberately long poll interval and the lack of
+    // `shutdown_when_queue_empty()`, so that the listener is started and the
+    // worker relies on the notification rather than polling.
+    let runner = Runner::new(pool, test_context.clone())
+        .register_job_type::<TestJob>()
+        .configure_default_queue(|queue| queue.poll_interval(Duration::from_secs(3600)));
+
+    let _handle = runner.start();
+
+    // Give the listener a moment to establish its `LISTEN` before enqueueing, so
+    // that the notification is not emitted before anyone is listening.
+    sleep(Duration::from_secs(1)).await;
+
+    // Enqueue the job only once the worker is idle and waiting for a notification.
+    TestJob.enqueue(&conn).await?;
+
+    // The worker should wake up and run the job well within the poll interval.
+    timeout(Duration::from_secs(5), test_context.job_ran.notified())
+        .await
+        .map_err(|_| anyhow::anyhow!("worker was not woken by the notification"))?;
 
     Ok(())
 }

--- a/migrations/2026-06-07-120000-0000_notify_on_background_job_insert/down.sql
+++ b/migrations/2026-06-07-120000-0000_notify_on_background_job_insert/down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS background_jobs_notify_on_insert ON background_jobs;
+DROP FUNCTION IF EXISTS notify_background_job_inserted CASCADE;

--- a/migrations/2026-06-07-120000-0000_notify_on_background_job_insert/up.sql
+++ b/migrations/2026-06-07-120000-0000_notify_on_background_job_insert/up.sql
@@ -1,0 +1,18 @@
+-- Send a `NOTIFY` on the `background_jobs` channel whenever new jobs are
+-- inserted, so that idle background workers can wake up immediately instead of
+-- waiting for their next poll. This is a statement-level trigger, so batch
+-- inserts only emit a single notification. The notification is delivered when
+-- the surrounding transaction commits, i.e. once the new jobs are visible.
+
+CREATE OR REPLACE FUNCTION notify_background_job_inserted() RETURNS TRIGGER AS $$
+BEGIN
+    NOTIFY background_jobs;
+    RETURN NULL;
+END
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS background_jobs_notify_on_insert ON background_jobs;
+CREATE TRIGGER background_jobs_notify_on_insert
+    AFTER INSERT ON background_jobs
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE notify_background_job_inserted();

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -1,7 +1,8 @@
 //! Runs enqueued background jobs
 //!
 //! This binary will loop until interrupted. It will run all jobs in the
-//! background queue, sleeping for 1 second whenever the queue is empty. If we
+//! background queue, waiting for a Postgres `NOTIFY` (or polling once per
+//! second as a fallback) whenever the queue is empty. If we
 //! are unable to spawn workers to run jobs (either because we couldn't connect
 //! to the DB, an error occurred while loading, or we just never heard back from
 //! the worker thread), we will rebuild the runner and try again up to 5 times.


### PR DESCRIPTION
Background workers previously discovered newly enqueued jobs only by polling the database once per second. This adds a database trigger that emits a `NOTIFY` on the`background_jobs` channel whenever jobs are inserted, and a dedicated listener connection in the runner that wakes the workers as soon as a notification arrives.

Polling is kept as a fallback so that retriable jobs are eventually picked up even without a notification. The listener is skipped when the runner is configured to shut down on an empty queue (e.g. in tests).