### PR TITLE
tests: Give reverse dependency crates distinct download counts

### DIFF
--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -189,6 +189,7 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
         .expect_build(&mut conn)
         .await;
     CrateBuilder::new("c2", user.id)
+        .downloads(100)
         .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
         .expect_build(&mut conn)
         .await;
@@ -204,6 +205,7 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
 
     // c3's version will have the published by info recorded
     CrateBuilder::new("c3", user.id)
+        .downloads(10)
         .version(VersionBuilder::new("3.0.0").dependency(&c1, None))
         .expect_build(&mut conn)
         .await;

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present-2.snap
@@ -7,7 +7,7 @@ expression: response.json()
     {
       "crate_id": "c1",
       "default_features": false,
-      "downloads": 0,
+      "downloads": 100,
       "features": [],
       "id": 1,
       "kind": "normal",
@@ -19,7 +19,7 @@ expression: response.json()
     {
       "crate_id": "c1",
       "default_features": false,
-      "downloads": 0,
+      "downloads": 10,
       "features": [],
       "id": 2,
       "kind": "normal",


### PR DESCRIPTION
Order the reverse-dependency snapshot by a real signal instead of an incidental id tiebreak: c2 and c3 now have different download counts, so they sort deterministically by downloads.