### PR TITLE
Move reverse dependency query to `ReverseDependency::for_crate()`

### DIFF
--- a/crates/crates_io_database/src/models/dependency.rs
+++ b/crates/crates_io_database/src/models/dependency.rs
@@ -1,9 +1,12 @@
+use crate::models::helpers::with_count::*;
 use crate::models::{Crate, Version};
 use crate::pg_enum;
 use crate::schema::*;
 use crates_io_index::DependencyKind as IndexDependencyKind;
 use diesel::prelude::*;
-use diesel::sql_types::{BigInt, Text};
+use diesel::sql_types::{BigInt, Integer, Text};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use tracing::instrument;
 
 #[derive(Identifiable, Associations, Debug, HasQuery, QueryableByName)]
 #[diesel(
@@ -32,6 +35,26 @@ pub struct ReverseDependency {
     pub crate_downloads: i64,
     #[diesel(sql_type = Text, column_name = crate_name)]
     pub name: String,
+}
+
+impl ReverseDependency {
+    #[instrument(skip_all, fields(krate.name = %krate.name))]
+    pub async fn for_crate(
+        krate: &Crate,
+        mut conn: &AsyncPgConnection,
+        offset: i64,
+        limit: i64,
+    ) -> QueryResult<(Vec<Self>, i64)> {
+        let rows: Vec<WithCount<Self>> =
+            diesel::sql_query(include_str!("krate_reverse_dependencies.sql"))
+                .bind::<Integer, _>(krate.id)
+                .bind::<BigInt, _>(offset)
+                .bind::<BigInt, _>(limit)
+                .load(&mut conn)
+                .await?;
+
+        Ok(rows.records_and_total())
+    }
 }
 
 pg_enum! {

--- a/crates/crates_io_database/src/models/dependency.rs
+++ b/crates/crates_io_database/src/models/dependency.rs
@@ -38,16 +38,16 @@ pub struct ReverseDependency {
 }
 
 impl ReverseDependency {
-    #[instrument(skip_all, fields(krate.name = %krate.name))]
+    #[instrument(skip_all, fields(crate_id))]
     pub async fn for_crate(
-        krate: &Crate,
+        crate_id: i32,
         mut conn: &AsyncPgConnection,
         offset: i64,
         limit: i64,
     ) -> QueryResult<(Vec<Self>, i64)> {
         let rows: Vec<WithCount<Self>> =
             diesel::sql_query(include_str!("krate_reverse_dependencies.sql"))
-                .bind::<Integer, _>(krate.id)
+                .bind::<Integer, _>(crate_id)
                 .bind::<BigInt, _>(offset)
                 .bind::<BigInt, _>(limit)
                 .load(&mut conn)

--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -1,7 +1,6 @@
 use crate::fns::canon_crate_name;
-use crate::models::helpers::with_count::*;
 use crate::models::version::TopVersions;
-use crate::models::{CrateOwner, Owner, OwnerKind, ReverseDependency, User, Version};
+use crate::models::{CrateOwner, Owner, OwnerKind, User, Version};
 use crate::schema::*;
 use chrono::{DateTime, Utc};
 use diesel::associations::Identifiable;
@@ -13,7 +12,6 @@ use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use secrecy::SecretString;
 use serde::Serialize;
 use thiserror::Error;
-use tracing::instrument;
 
 use super::Team;
 
@@ -274,28 +272,6 @@ impl Crate {
         }
 
         Ok(())
-    }
-
-    /// Returns (dependency, dependent crate name, dependent crate downloads)
-    #[instrument(skip_all, fields(krate.name = %self.name))]
-    pub async fn reverse_dependencies(
-        &self,
-        mut conn: &AsyncPgConnection,
-        offset: i64,
-        limit: i64,
-    ) -> QueryResult<(Vec<ReverseDependency>, i64)> {
-        use diesel::sql_query;
-        use diesel::sql_types::{BigInt, Integer};
-
-        let rows: Vec<WithCount<ReverseDependency>> =
-            sql_query(include_str!("krate_reverse_dependencies.sql"))
-                .bind::<Integer, _>(self.id)
-                .bind::<BigInt, _>(offset)
-                .bind::<BigInt, _>(limit)
-                .load(&mut conn)
-                .await?;
-
-        Ok(rows.records_and_total())
     }
 }
 

--- a/src/controllers/krate/rev_deps.rs
+++ b/src/controllers/krate/rev_deps.rs
@@ -1,7 +1,7 @@
 use crate::app::AppState;
 use crate::controllers::helpers::pagination::{PaginationOptions, PaginationQueryParams};
 use crate::controllers::krate::CratePath;
-use crate::models::{CrateName, User, Version, VersionOwnerAction};
+use crate::models::{CrateName, ReverseDependency, User, Version, VersionOwnerAction};
 use crate::util::errors::AppResult;
 use crate::views::{EncodableDependency, EncodableVersion};
 use axum::Json;
@@ -50,7 +50,7 @@ pub async fn list_reverse_dependencies(
 
     let offset = pagination_options.offset().unwrap_or_default();
     let limit = pagination_options.per_page;
-    let (rev_deps, total) = krate.reverse_dependencies(&conn, offset, limit).await?;
+    let (rev_deps, total) = ReverseDependency::for_crate(&krate, &conn, offset, limit).await?;
 
     let rev_deps: Vec<_> = rev_deps
         .into_iter()

--- a/src/controllers/krate/rev_deps.rs
+++ b/src/controllers/krate/rev_deps.rs
@@ -50,7 +50,7 @@ pub async fn list_reverse_dependencies(
 
     let offset = pagination_options.offset().unwrap_or_default();
     let limit = pagination_options.per_page;
-    let (rev_deps, total) = ReverseDependency::for_crate(&krate, &conn, offset, limit).await?;
+    let (rev_deps, total) = ReverseDependency::for_crate(krate.id, &conn, offset, limit).await?;
 
     let rev_deps: Vec<_> = rev_deps
         .into_iter()


### PR DESCRIPTION
This moves the reverse-dependency query off `Crate` and onto the `ReverseDependency` type it returns, and changes it to take a crate id instead of a `Crate` reference since that is all it needs.

Pure refactor, no behavior change.