### PR TITLE
CI: Use line-tables-only debuginfo in backend test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
     if: needs.filter-jobs.outputs.backend-test == 'true'
 
     env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
       RUST_BACKTRACE: 1
       TEST_DATABASE_URL: postgres://postgres:postgres@localhost/cargo_registry_test
       RUSTFLAGS: '-D warnings'


### PR DESCRIPTION
The backend test job compiled with full debug info (the default for the `dev`/`test` profiles). Line tables alone are enough to keep `file:line` locations in panic backtraces, while emitting far less DWARF, which cuts codegen and link time and shrinks the cached `target/` directory.

The `test` profile inherits this from `dev`, so the single `CARGO_PROFILE_DEV_DEBUG` override covers both the `cargo build --tests` and `cargo insta test` steps.