### PR TITLE
Add banner for crates marked as unmaintained by a RustSec advisory

### DIFF
--- a/e2e/acceptance/crate-unmaintained.spec.ts
+++ b/e2e/acceptance/crate-unmaintained.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@/e2e/helper';
+import { http, HttpResponse } from 'msw';
+
+const ADVISORY = 'RUSTSEC-2021-0139';
+
+function unmaintainedAdvisory() {
+  return [
+    {
+      id: ADVISORY,
+      summary: 'nanomsg is unmaintained',
+      details: 'The author has stated that this crate is no longer maintained.',
+      affected: [{ ranges: [], database_specific: { informational: 'unmaintained' } }],
+    },
+  ];
+}
+
+test.describe('Acceptance | crate page | unmaintained', { tag: '@acceptance' }, () => {
+  test('shows the banner for a crate marked unmaintained by RustSec', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'nanomsg' });
+    await msw.db.version.create({ crate, num: '0.6.1' });
+
+    msw.worker.use(
+      http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(unmaintainedAdvisory())),
+    );
+
+    await page.goto('/crates/nanomsg');
+
+    let banner = page.locator('[data-test-unmaintained-banner]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText('This crate has been marked as unmaintained');
+
+    let link = banner.getByRole('link', { name: ADVISORY });
+    await expect(link).toHaveAttribute('href', `https://rustsec.org/advisories/${ADVISORY}.html`);
+  });
+
+  test('does not show the banner when there are no advisories', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate, num: '1.0.0' });
+
+    msw.worker.use(
+      http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.text('not found', { status: 404 })),
+    );
+
+    await page.goto('/crates/serde');
+
+    await expect(page.locator('[data-test-heading] [data-test-crate-name]')).toHaveText('serde');
+    await expect(page.locator('[data-test-unmaintained-banner]')).toHaveCount(0);
+  });
+
+  test('does not show the banner for an advisory with a patched version', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'patched' });
+    await msw.db.version.create({ crate, num: '1.0.0' });
+
+    let advisories = [
+      {
+        id: ADVISORY,
+        summary: 'patched is unmaintained but has a fix',
+        details: '',
+        affected: [
+          {
+            ranges: [{ type: 'SEMVER', events: [{ introduced: '0.0.0-0' }, { fixed: '1.0.0' }] }],
+            database_specific: { informational: 'unmaintained' },
+          },
+        ],
+      },
+    ];
+
+    msw.worker.use(http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.json(advisories)));
+
+    await page.goto('/crates/patched');
+
+    await expect(page.locator('[data-test-heading] [data-test-crate-name]')).toHaveText('patched');
+    await expect(page.locator('[data-test-unmaintained-banner]')).toHaveCount(0);
+  });
+});

--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -84,7 +84,7 @@
 <CrateHeader {crate} {version} versionNum={requestedVersion} {keywords} {ownersPromise} />
 
 {#if nativeReplacement}
-  <div class="native-replacement">
+  <div class="banner">
     <NativeReplacementBanner replacement={nativeReplacement} />
   </div>
 {/if}
@@ -183,7 +183,7 @@
 </div>
 
 <style>
-  .native-replacement {
+  .banner {
     margin-bottom: var(--space-m);
   }
 

--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -4,6 +4,7 @@
   import type { NativeReplacement } from '$lib/data/native-replacements';
   import type { DocsRsStatus } from '$lib/utils/docs-rs';
   import type { PlaygroundCrate } from '$lib/utils/playground';
+  import type { Unmaintained } from '$lib/utils/rustsec';
 
   import { resolve } from '$app/paths';
 
@@ -16,6 +17,7 @@
   import NativeReplacementBanner from '$lib/components/NativeReplacementBanner.svelte';
   import ReadmePlaceholder from '$lib/components/ReadmePlaceholder.svelte';
   import RenderedHtml from '$lib/components/RenderedHtml.svelte';
+  import UnmaintainedBanner from '$lib/components/UnmaintainedBanner.svelte';
   import { loadReadme } from '$lib/utils/readme';
 
   type Crate = components['schemas']['Crate'];
@@ -36,6 +38,7 @@
     docsRsStatusPromise: Promise<DocsRsStatus | null>;
     downloadsPromise: Promise<DownloadChartData>;
     nativeReplacement?: NativeReplacement;
+    unmaintained: Unmaintained | null;
   }
 
   let {
@@ -50,6 +53,7 @@
     docsRsStatusPromise,
     downloadsPromise,
     nativeReplacement,
+    unmaintained,
   }: Props = $props();
   let owners: Owner[] = $state([]);
 
@@ -82,6 +86,12 @@
 </script>
 
 <CrateHeader {crate} {version} versionNum={requestedVersion} {keywords} {ownersPromise} />
+
+{#if unmaintained}
+  <div class="banner">
+    <UnmaintainedBanner {unmaintained} />
+  </div>
+{/if}
 
 {#if nativeReplacement}
   <div class="banner">

--- a/svelte/src/lib/components/UnmaintainedBanner.stories.svelte
+++ b/svelte/src/lib/components/UnmaintainedBanner.stories.svelte
@@ -1,0 +1,19 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import UnmaintainedBanner from './UnmaintainedBanner.svelte';
+
+  const { Story } = defineMeta({
+    title: 'UnmaintainedBanner',
+    component: UnmaintainedBanner,
+    tags: ['autodocs'],
+    args: {
+      unmaintained: {
+        id: 'RUSTSEC-2021-0139',
+        url: 'https://rustsec.org/advisories/RUSTSEC-2021-0139.html',
+      },
+    },
+  });
+</script>
+
+<Story name="Default" />

--- a/svelte/src/lib/components/UnmaintainedBanner.svelte
+++ b/svelte/src/lib/components/UnmaintainedBanner.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import type { Unmaintained } from '$lib/utils/rustsec';
+
+  import Alert from '$lib/components/Alert.svelte';
+
+  interface Props {
+    unmaintained: Unmaintained;
+  }
+
+  let { unmaintained }: Props = $props();
+</script>
+
+<Alert variant="warning" data-test-unmaintained-banner>
+  <strong>This crate has been marked as unmaintained.</strong>
+  <p>
+    It is unlikely to receive further updates or fixes. See
+    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- always an external rustsec.org URL -->
+    <a href={unmaintained.url} target="_blank" rel="noopener noreferrer">{unmaintained.id}</a>
+    for details and possible alternatives.
+  </p>
+</Alert>
+
+<style>
+  strong {
+    font-size: 0.9em;
+    font-weight: 500;
+  }
+
+  p {
+    margin: var(--space-2xs) 0 0;
+    font-size: 0.9em;
+    line-height: 1.4;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
+</style>

--- a/svelte/src/lib/components/UnmaintainedBanner.svelte.test.ts
+++ b/svelte/src/lib/components/UnmaintainedBanner.svelte.test.ts
@@ -1,0 +1,29 @@
+import type { Unmaintained } from '$lib/utils/rustsec';
+
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+import UnmaintainedBanner from './UnmaintainedBanner.svelte';
+
+const ADVISORY_URL = 'https://rustsec.org/advisories/RUSTSEC-2021-0139.html';
+
+const unmaintained: Unmaintained = {
+  id: 'RUSTSEC-2021-0139',
+  url: ADVISORY_URL,
+};
+
+describe('UnmaintainedBanner', () => {
+  it('renders the explanation and a link to the advisory', async () => {
+    render(UnmaintainedBanner, { unmaintained });
+
+    let banner = page.getByCSS('[data-test-unmaintained-banner]');
+    await expect.element(banner).toBeVisible();
+    await expect.element(banner).toHaveTextContent('This crate has been marked as unmaintained');
+
+    let link = page.getByRole('link', { name: 'RUSTSEC-2021-0139' });
+    await expect.element(link).toHaveAttribute('href', ADVISORY_URL);
+    await expect.element(link).toHaveAttribute('target', '_blank');
+    await expect.element(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/svelte/src/lib/utils/rustsec.test.ts
+++ b/svelte/src/lib/utils/rustsec.test.ts
@@ -1,8 +1,70 @@
 import type { Advisory } from './rustsec';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { versionRanges } from './rustsec';
+import { enrichAdvisories, fetchAdvisories, versionRanges } from './rustsec';
+
+const UNMAINTAINED = 'RUSTSEC-2021-0139';
+
+function unmaintainedAdvisory(overrides: Partial<Advisory> = {}): Advisory {
+  return {
+    id: UNMAINTAINED,
+    summary: 'foo is unmaintained',
+    details: '',
+    affected: [{ ranges: [], database_specific: { informational: 'unmaintained' } }],
+    ...overrides,
+  };
+}
+
+describe('fetchAdvisories', () => {
+  it('returns the parsed advisory list', async () => {
+    let advisories = [unmaintainedAdvisory()];
+    let fetch = vi.fn().mockResolvedValue(Response.json(advisories));
+
+    expect(await fetchAdvisories(fetch, 'foo')).toEqual(advisories);
+    expect(fetch).toHaveBeenCalledWith('https://rustsec.org/packages/foo.json');
+  });
+
+  it('returns an empty array on a 404 response', async () => {
+    let fetch = vi.fn().mockResolvedValue(Response.json('not found', { status: 404 }));
+    expect(await fetchAdvisories(fetch, 'foo')).toEqual([]);
+  });
+
+  it('throws on other non-OK responses', async () => {
+    let fetch = vi.fn().mockResolvedValue(Response.json('boom', { status: 500 }));
+    await expect(fetchAdvisories(fetch, 'foo')).rejects.toThrow('HTTP error! status: 500');
+  });
+});
+
+describe('enrichAdvisories', () => {
+  it('enriches advisories with version ranges and CVSS', () => {
+    let advisory: Advisory = {
+      id: 'RUSTSEC-2020-0001',
+      summary: 'vulnerable',
+      details: '',
+      affected: [{ ranges: [{ type: 'SEMVER', events: [{ introduced: '0.0.0-0' }, { fixed: '1.2.0' }] }] }],
+      severity: [
+        { type: 'CVSS_V3', score: 'CVSS:3.1/AV:N' },
+        { type: 'CVSS_V4', score: 'CVSS:4.0/AV:N' },
+      ],
+    };
+
+    let [enriched] = enrichAdvisories([advisory]);
+    expect(enriched.versionRanges).toBe('<1.2.0');
+    expect(enriched.cvss).toBe('CVSS:4.0/AV:N');
+  });
+
+  it('filters out withdrawn and informational unmaintained advisories', () => {
+    let advisories: Advisory[] = [
+      unmaintainedAdvisory(),
+      { id: 'RUSTSEC-2020-0002', summary: 'withdrawn', details: '', withdrawn: '2022-01-01T00:00:00Z' },
+      { id: 'RUSTSEC-2020-0003', summary: 'real', details: '' },
+    ];
+
+    let result = enrichAdvisories(advisories);
+    expect(result.map(a => a.id)).toEqual(['RUSTSEC-2020-0003']);
+  });
+});
 
 describe('versionRanges', () => {
   it('returns null when advisory has no affected field', () => {

--- a/svelte/src/lib/utils/rustsec.test.ts
+++ b/svelte/src/lib/utils/rustsec.test.ts
@@ -1,10 +1,16 @@
 import type { Advisory } from './rustsec';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { enrichAdvisories, fetchAdvisories, findUnmaintained, versionRanges } from './rustsec';
+import { enrichAdvisories, fetchAdvisories, findUnmaintained, loadUnmaintained, versionRanges } from './rustsec';
 
 const UNMAINTAINED = 'RUSTSEC-2021-0139';
+const UNMAINTAINED_TIMEOUT_MS = 5000;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 function unmaintainedAdvisory(overrides: Partial<Advisory> = {}): Advisory {
   return {
@@ -99,6 +105,41 @@ describe('findUnmaintained', () => {
       ],
     });
     expect(findUnmaintained([advisory])).toBe(null);
+  });
+});
+
+describe('loadUnmaintained', () => {
+  it('returns the advisory data for an unmaintained crate', async () => {
+    let fetch = vi.fn().mockResolvedValue(Response.json([unmaintainedAdvisory()]));
+
+    expect(await loadUnmaintained(fetch, 'foo')).toEqual({
+      id: UNMAINTAINED,
+      url: `https://rustsec.org/advisories/${UNMAINTAINED}.html`,
+    });
+  });
+
+  it('returns null when the crate has no advisories', async () => {
+    let fetch = vi.fn().mockResolvedValue(Response.json('not found', { status: 404 }));
+    expect(await loadUnmaintained(fetch, 'foo')).toBe(null);
+  });
+
+  it('returns null and warns on a failed request', async () => {
+    let warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let fetch = vi.fn().mockRejectedValue(new Error('offline'));
+
+    expect(await loadUnmaintained(fetch, 'foo')).toBe(null);
+    expect(warn).toHaveBeenCalledWith('Failed to load RustSec advisories: Error: offline');
+  });
+
+  it('returns null when RustSec does not answer within the timeout', async () => {
+    vi.useFakeTimers();
+    let { promise } = Promise.withResolvers<Response>();
+    let fetch = vi.fn().mockReturnValue(promise);
+
+    let result = loadUnmaintained(fetch, 'foo');
+    await vi.advanceTimersByTimeAsync(UNMAINTAINED_TIMEOUT_MS);
+
+    expect(await result).toBe(null);
   });
 });
 

--- a/svelte/src/lib/utils/rustsec.test.ts
+++ b/svelte/src/lib/utils/rustsec.test.ts
@@ -2,7 +2,7 @@ import type { Advisory } from './rustsec';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { enrichAdvisories, fetchAdvisories, versionRanges } from './rustsec';
+import { enrichAdvisories, fetchAdvisories, findUnmaintained, versionRanges } from './rustsec';
 
 const UNMAINTAINED = 'RUSTSEC-2021-0139';
 
@@ -63,6 +63,42 @@ describe('enrichAdvisories', () => {
 
     let result = enrichAdvisories(advisories);
     expect(result.map(a => a.id)).toEqual(['RUSTSEC-2020-0003']);
+  });
+});
+
+describe('findUnmaintained', () => {
+  it('returns the advisory id and url for an unmaintained crate', () => {
+    let result = findUnmaintained([unmaintainedAdvisory()]);
+
+    expect(result).toEqual({ id: UNMAINTAINED, url: `https://rustsec.org/advisories/${UNMAINTAINED}.html` });
+  });
+
+  it('returns null when there are no advisories', () => {
+    expect(findUnmaintained([])).toBe(null);
+  });
+
+  it('ignores advisories that are not informational unmaintained', () => {
+    let advisory = unmaintainedAdvisory({
+      affected: [{ ranges: [], database_specific: { informational: 'unsound' } }],
+    });
+    expect(findUnmaintained([advisory])).toBe(null);
+  });
+
+  it('ignores withdrawn advisories', () => {
+    let advisory = unmaintainedAdvisory({ withdrawn: '2022-01-01T00:00:00Z' });
+    expect(findUnmaintained([advisory])).toBe(null);
+  });
+
+  it('ignores advisories that point at a patched version', () => {
+    let advisory = unmaintainedAdvisory({
+      affected: [
+        {
+          ranges: [{ type: 'SEMVER', events: [{ introduced: '0.0.0-0' }, { fixed: '1.2.0' }] }],
+          database_specific: { informational: 'unmaintained' },
+        },
+      ],
+    });
+    expect(findUnmaintained([advisory])).toBe(null);
   });
 });
 

--- a/svelte/src/lib/utils/rustsec.ts
+++ b/svelte/src/lib/utils/rustsec.ts
@@ -31,6 +31,14 @@ export interface EnrichedAdvisory extends Advisory {
   cvss: string | null;
 }
 
+/** The data the unmaintained banner needs about a single advisory. */
+export interface Unmaintained {
+  /** The RustSec advisory id, e.g. `RUSTSEC-2021-0139`. */
+  id: string;
+  /** Link to the advisory page on rustsec.org. */
+  url: string;
+}
+
 /**
  * Extracts version ranges from a RustSec advisory.
  *
@@ -122,4 +130,30 @@ export function enrichAdvisories(advisories: Advisory[]): EnrichedAdvisory[] {
       versionRanges: versionRanges(advisory),
       cvss: extractCvss(advisory),
     }));
+}
+
+/**
+ * Returns the first advisory that marks the crate as unmaintained, or `null` if
+ * there is none.
+ *
+ * An advisory only counts when it marks the crate as unmaintained without
+ * offering a way out: it must carry the `unmaintained` informational marker, must
+ * not have been withdrawn, and must not point at any patched version.
+ */
+export function findUnmaintained(advisories: Advisory[]): Unmaintained | null {
+  let advisory = advisories.find(advisory => {
+    if (advisory.withdrawn) {
+      return false;
+    }
+
+    let affected = advisory.affected ?? [];
+    let unmaintained = affected.some(entry => entry.database_specific?.informational === 'unmaintained');
+    let patched = affected.some(entry => entry.ranges?.some(range => range.events?.some(event => event.fixed != null)));
+    return unmaintained && !patched;
+  });
+  if (!advisory) {
+    return null;
+  }
+
+  return { id: advisory.id, url: `https://rustsec.org/advisories/${advisory.id}.html` };
 }

--- a/svelte/src/lib/utils/rustsec.ts
+++ b/svelte/src/lib/utils/rustsec.ts
@@ -86,7 +86,7 @@ function extractCvss(advisory: Advisory): string | null {
   return cvssEntry?.score ?? null;
 }
 
-export async function fetchAdvisories(crateId: string, fetch: typeof globalThis.fetch): Promise<EnrichedAdvisory[]> {
+export async function fetchAdvisories(fetch: typeof globalThis.fetch, crateId: string): Promise<EnrichedAdvisory[]> {
   let url = `https://rustsec.org/packages/${crateId}.json`;
   let response = await fetch(url);
   if (response.status === 404) {

--- a/svelte/src/lib/utils/rustsec.ts
+++ b/svelte/src/lib/utils/rustsec.ts
@@ -1,3 +1,6 @@
+/** Maximum time {@link loadUnmaintained()} waits for RustSec before giving up. */
+const UNMAINTAINED_TIMEOUT_MS = 5000;
+
 interface RangeEvent {
   introduced?: string;
   fixed?: string;
@@ -130,6 +133,30 @@ export function enrichAdvisories(advisories: Advisory[]): EnrichedAdvisory[] {
       versionRanges: versionRanges(advisory),
       cvss: extractCvss(advisory),
     }));
+}
+
+/**
+ * Loads the crate's RustSec advisories and returns the first one marking it as
+ * unmaintained, or `null` if there is none.
+ *
+ * The banner is decorative, so this never rejects: on a network error, a non-OK
+ * response, or when RustSec does not answer within {@link UNMAINTAINED_TIMEOUT_MS}, it
+ * resolves to `null` so a slow or flaky RustSec never blocks or breaks the page.
+ */
+export function loadUnmaintained(fetch: typeof globalThis.fetch, crateId: string): Promise<Unmaintained | null> {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  let timeout = new Promise<null>(resolve => {
+    timeoutId = setTimeout(() => resolve(null), UNMAINTAINED_TIMEOUT_MS);
+  });
+
+  let load = fetchAdvisories(fetch, crateId)
+    .then(findUnmaintained)
+    .catch(error => {
+      console.warn(`Failed to load RustSec advisories: ${error}`);
+      return null;
+    });
+
+  return Promise.race([load, timeout]).finally(() => clearTimeout(timeoutId));
 }
 
 /**

--- a/svelte/src/lib/utils/rustsec.ts
+++ b/svelte/src/lib/utils/rustsec.ts
@@ -25,6 +25,7 @@ export interface Advisory {
   severity?: { type: string; score: string }[];
 }
 
+/** A security advisory enriched with the data the crate security page renders. */
 export interface EnrichedAdvisory extends Advisory {
   versionRanges: string | null;
   cvss: string | null;
@@ -86,25 +87,39 @@ function extractCvss(advisory: Advisory): string | null {
   return cvssEntry?.score ?? null;
 }
 
-export async function fetchAdvisories(fetch: typeof globalThis.fetch, crateId: string): Promise<EnrichedAdvisory[]> {
-  let url = `https://rustsec.org/packages/${crateId}.json`;
-  let response = await fetch(url);
+/**
+ * Fetches the raw RustSec advisory list for a crate.
+ *
+ * Returns an empty array when the crate has no advisories (RustSec answers with
+ * `404` in that case) and throws for any other non-OK response.
+ */
+export async function fetchAdvisories(fetch: typeof globalThis.fetch, crateId: string): Promise<Advisory[]> {
+  let response = await fetch(`https://rustsec.org/packages/${crateId}.json`);
   if (response.status === 404) {
     return [];
   } else if (response.ok) {
-    let advisories: Advisory[] = await response.json();
-    return advisories
-      .filter(
-        advisory =>
-          !advisory.withdrawn &&
-          !advisory.affected?.some(affected => affected.database_specific?.informational === 'unmaintained'),
-      )
-      .map(advisory => ({
-        ...advisory,
-        versionRanges: versionRanges(advisory),
-        cvss: extractCvss(advisory),
-      }));
+    return response.json();
   } else {
     throw new Error(`HTTP error! status: ${response.status}`);
   }
+}
+
+/**
+ * Filters a raw advisory list down to the advisories shown on the crate security
+ * page: withdrawn and purely informational `unmaintained` advisories are dropped,
+ * and each remaining advisory is enriched with its affected version ranges and
+ * CVSS score.
+ */
+export function enrichAdvisories(advisories: Advisory[]): EnrichedAdvisory[] {
+  return advisories
+    .filter(
+      advisory =>
+        !advisory.withdrawn &&
+        !advisory.affected?.some(affected => affected.database_specific?.informational === 'unmaintained'),
+    )
+    .map(advisory => ({
+      ...advisory,
+      versionRanges: versionRanges(advisory),
+      cvss: extractCvss(advisory),
+    }));
 }

--- a/svelte/src/routes/crates/[crate_id]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/+page.svelte
@@ -17,6 +17,7 @@
   readmePromise={data.readmePromise}
   playgroundCratesPromise={data.playgroundCratesPromise}
   docsRsStatusPromise={data.docsRsStatusPromise}
+  unmaintained={data.unmaintained}
   {downloadsPromise}
   nativeReplacement={data.nativeReplacements[data.crate.name]}
 />

--- a/svelte/src/routes/crates/[crate_id]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/+page.ts
@@ -3,6 +3,7 @@ import { createClient } from '@crates-io/api-client';
 import { loadNativeReplacements } from '$lib/data/native-replacements';
 import { loadDocsRsStatus } from '$lib/utils/docs-rs';
 import { loadReadme } from '$lib/utils/readme';
+import { loadUnmaintained } from '$lib/utils/rustsec';
 
 export async function load({ fetch, params, parent }) {
   let client = createClient({ fetch });
@@ -10,11 +11,15 @@ export async function load({ fetch, params, parent }) {
   let crateName = params.crate_id;
   let downloadsPromise = loadDownloads(client, crateName);
 
-  let [{ crate, defaultVersion }, nativeReplacements] = await Promise.all([parent(), loadNativeReplacements(fetch)]);
+  let [{ crate, defaultVersion }, nativeReplacements, unmaintained] = await Promise.all([
+    parent(),
+    loadNativeReplacements(fetch),
+    loadUnmaintained(fetch, crateName),
+  ]);
   let readmePromise = loadReadme(fetch, crate.name, defaultVersion.num);
   let docsRsStatusPromise = loadDocsRsStatus(fetch, crate.name, defaultVersion.num);
 
-  return { readmePromise, downloadsPromise, docsRsStatusPromise, nativeReplacements };
+  return { readmePromise, downloadsPromise, docsRsStatusPromise, nativeReplacements, unmaintained };
 }
 
 /**

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
@@ -18,6 +18,7 @@
   readmePromise={data.readmePromise}
   playgroundCratesPromise={data.playgroundCratesPromise}
   docsRsStatusPromise={data.docsRsStatusPromise}
+  unmaintained={data.unmaintained}
   {downloadsPromise}
   nativeReplacement={data.nativeReplacements[data.crate.name]}
 />

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.ts
@@ -3,6 +3,7 @@ import { createClient } from '@crates-io/api-client';
 import { loadNativeReplacements } from '$lib/data/native-replacements';
 import { loadDocsRsStatus } from '$lib/utils/docs-rs';
 import { loadReadme } from '$lib/utils/readme';
+import { loadUnmaintained } from '$lib/utils/rustsec';
 
 export async function load({ fetch, params }) {
   let crateName = params.crate_id;
@@ -11,9 +12,12 @@ export async function load({ fetch, params }) {
   let readmePromise = loadReadme(fetch, crateName, versionNum);
   let downloadsPromise = loadDownloads(fetch, crateName, versionNum);
   let docsRsStatusPromise = loadDocsRsStatus(fetch, crateName, versionNum);
-  let nativeReplacements = await loadNativeReplacements(fetch);
+  let [nativeReplacements, unmaintained] = await Promise.all([
+    loadNativeReplacements(fetch),
+    loadUnmaintained(fetch, crateName),
+  ]);
 
-  return { readmePromise, downloadsPromise, docsRsStatusPromise, nativeReplacements };
+  return { readmePromise, downloadsPromise, docsRsStatusPromise, nativeReplacements, unmaintained };
 }
 
 /**

--- a/svelte/src/routes/crates/[crate_id]/security/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/security/+page.ts
@@ -6,7 +6,7 @@ export async function load({ fetch, params }) {
   let crateName = params.crate_id;
 
   try {
-    let advisories = await fetchAdvisories(crateName, fetch);
+    let advisories = await fetchAdvisories(fetch, crateName);
     return { advisories };
   } catch {
     error(500, { message: `${crateName}: Failed to load advisories`, tryAgain: true });

--- a/svelte/src/routes/crates/[crate_id]/security/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/security/+page.ts
@@ -1,13 +1,13 @@
 import { error } from '@sveltejs/kit';
 
-import { fetchAdvisories } from '$lib/utils/rustsec';
+import { enrichAdvisories, fetchAdvisories } from '$lib/utils/rustsec';
 
 export async function load({ fetch, params }) {
   let crateName = params.crate_id;
 
   try {
     let advisories = await fetchAdvisories(fetch, crateName);
-    return { advisories };
+    return { advisories: enrichAdvisories(advisories) };
   } catch {
     error(500, { message: `${crateName}: Failed to load advisories`, tryAgain: true });
   }


### PR DESCRIPTION
Also refactor a bit to keep all the RustSec logic together.

<img width="992" height="191" alt="Screenshot 2026-06-10 at 14 02 27" src="https://github.com/user-attachments/assets/dc2ceb12-f8bf-469f-ba17-abe847ad0f1e" />

(With help from Claude.)
