### PR TITLE
jobs/generate_og_image: Read owner avatars from `oauth_github`

### DIFF
--- a/src/worker/jobs/generate_og_image.rs
+++ b/src/worker/jobs/generate_og_image.rs
@@ -192,10 +192,11 @@ async fn fetch_user_owners(
 ) -> QueryResult<Vec<(String, Option<String>)>> {
     crate_owners::table
         .inner_join(users::table.on(crate_owners::owner_id.eq(users::id)))
+        .left_join(oauth_github::table.on(users::id.eq(oauth_github::user_id)))
         .filter(crate_owners::crate_id.eq(crate_id))
         .filter(crate_owners::owner_kind.eq(OwnerKind::User))
         .filter(crate_owners::deleted.eq(false))
-        .select((users::gh_login, users::gh_avatar))
+        .select((users::gh_login, oauth_github::avatar.nullable()))
         .load(&mut conn)
         .await
 }


### PR DESCRIPTION
`fetch_user_owners()` now sources avatars from `oauth_github.avatar` via a left-join instead of the `users.gh_avatar` column, matching how the `User` struct already reads the field (see #13800). This removes the one remaining read path of `users.gh_avatar`.

/cc @carols10cents 

### Related 

- #13800