### PR TITLE
controllers/krate: Name a reverse dependency in delete error

### DIFF
--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -104,8 +104,11 @@ pub async fn delete_crate(
 
     // All crates with reverse dependencies are blocked from being deleted to avoid unexpected
     // historical index changes.
-    if has_rev_dep(&conn, krate.id).await? {
-        let msg = "only crates without reverse dependencies can be deleted";
+    if let Some(rev_dep) = RevDep::for_crate(krate.id, &conn).await? {
+        let msg = format!(
+            "only crates without reverse dependencies can be deleted (e.g. {}@{} depends on this crate)",
+            rev_dep.name, rev_dep.version
+        );
         return Err(custom(StatusCode::UNPROCESSABLE_ENTITY, msg));
     }
 
@@ -185,19 +188,32 @@ pub fn max_downloads(age: &TimeDelta) -> u64 {
     DOWNLOADS_PER_MONTH_LIMIT * age_months
 }
 
-async fn has_rev_dep(mut conn: &AsyncPgConnection, crate_id: i32) -> QueryResult<bool> {
-    let rev_dep = dependencies::table
-        .inner_join(versions::table)
-        .filter(dependencies::crate_id.eq(crate_id))
-        // Ignore self-referencing dependencies, i.e. dependencies where the
-        // depending version belongs to the same crate that is being depended
-        // upon. Some crates depend on themselves (e.g. for backwards
-        // compatibility), and these should not block deletion.
-        .filter(versions::crate_id.ne(crate_id))
-        .select(dependencies::id)
-        .first::<i32>(&mut conn)
-        .await
-        .optional()?;
+/// Information about a single crate version that depends on another crate.
+#[derive(Debug, HasQuery)]
+#[diesel(base_query = dependencies::table.inner_join(versions::table.inner_join(crates::table)))]
+struct RevDep {
+    /// The name of the crate that depends on the crate being deleted.
+    #[diesel(select_expression = crates::name)]
+    name: String,
+    /// The version of that crate which declares the dependency.
+    #[diesel(select_expression = versions::num)]
+    version: String,
+}
 
-    Ok(rev_dep.is_some())
+impl RevDep {
+    /// Queries the database for the first matching reverse dependency of a crate, if any.
+    async fn for_crate(crate_id: i32, mut conn: &AsyncPgConnection) -> QueryResult<Option<Self>> {
+        Self::query()
+            .filter(dependencies::crate_id.eq(crate_id))
+            // Ignore self-referencing dependencies, i.e. dependencies where the
+            // depending version belongs to the same crate that is being depended
+            // upon. Some crates depend on themselves (e.g. for backwards
+            // compatibility), and these should not block deletion.
+            .filter(versions::crate_id.ne(crate_id))
+            // Order by indexed columns so the result is deterministic.
+            .order_by((dependencies::version_id.desc(), dependencies::id.desc()))
+            .first(&mut conn)
+            .await
+            .optional()
+    }
 }

--- a/src/tests/routes/crates/delete.rs
+++ b/src/tests/routes/crates/delete.rs
@@ -1,4 +1,5 @@
 use crate::builders::{DependencyBuilder, PublishBuilder};
+use crate::routes::crates::versions::yank_unyank::YankRequestHelper;
 use crate::util::{RequestHelper, Response, TestApp};
 use axum::RequestPartsExt;
 use bigdecimal::ToPrimitive;
@@ -281,14 +282,23 @@ async fn test_rev_deps() -> anyhow::Result<()> {
 
     publish_crate(&user, "foo").await;
 
-    // Publish another crate
+    // Publish another crate with two versions that both depend on `foo`, so we
+    // can confirm the error message names a deterministic version.
     let pb = PublishBuilder::new("bar", "1.0.0").dependency(DependencyBuilder::new("foo"));
     let response = user.publish_crate(pb).await;
     assert_snapshot!(response.status(), @"200 OK");
 
+    let pb = PublishBuilder::new("bar", "2.0.0").dependency(DependencyBuilder::new("foo"));
+    let response = user.publish_crate(pb).await;
+    assert_snapshot!(response.status(), @"200 OK");
+
+    // Yank the version that would be named in the error to confirm that yanked
+    // versions still count as reverse dependencies.
+    user.yank("bar", "2.0.0").await.good();
+
     let response = delete_crate(&user, "foo").await;
     assert_snapshot!(response.status(), @"422 Unprocessable Entity");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"only crates without reverse dependencies can be deleted"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"only crates without reverse dependencies can be deleted (e.g. bar@2.0.0 depends on this crate)"}]}"#);
 
     assert_crate_exists(&anon, "foo", true).await;
 


### PR DESCRIPTION
When a crate deletion is blocked by reverse dependencies, the error now names an example dependent version (e.g. `bar@1.0.0`) so the caller can see what is blocking the deletion.

This replaces the `has_rev_dep()` boolean check with a `RevDep` struct queried via `for_crate()`, which fetches the dependent crate's name and version.

### Related

- Closes https://github.com/rust-lang/crates.io/issues/12881