### PR TITLE
msw: Add default handler for RustSec advisory requests

### DIFF
--- a/e2e/acceptance/security.spec.ts
+++ b/e2e/acceptance/security.spec.ts
@@ -93,10 +93,6 @@ test.describe('Acceptance | crate security page', { tag: '@acceptance' }, () => 
     let crate = await msw.db.crate.create({ name: 'safe-crate' });
     await msw.db.version.create({ crate, num: '1.0.0' });
 
-    msw.worker.use(
-      http.get('https://rustsec.org/packages/:crateId.json', () => HttpResponse.text('not found', { status: 404 })),
-    );
-
     await page.goto('/crates/safe-crate/security');
 
     await expect(page.locator('[data-no-advisories]')).toBeVisible();

--- a/packages/crates-io-msw/handlers/rustsec.js
+++ b/packages/crates-io-msw/handlers/rustsec.js
@@ -1,0 +1,9 @@
+import { http, HttpResponse } from 'msw';
+
+export default [
+  // By default, crates have no RustSec advisories. Individual tests can override
+  // this handler to return advisories for a specific crate.
+  http.get('https://rustsec.org/packages/:crateId.json', () => {
+    return HttpResponse.text('not found', { status: 404 });
+  }),
+];

--- a/packages/crates-io-msw/index.js
+++ b/packages/crates-io-msw/index.js
@@ -8,6 +8,7 @@ import inviteHandlers from './handlers/invites.js';
 import keywordHandlers from './handlers/keywords.js';
 import metadataHandlers from './handlers/metadata.js';
 import playgroundHandlers from './handlers/playground.js';
+import rustsecHandlers from './handlers/rustsec.js';
 import sessionHandlers from './handlers/sessions.js';
 import summaryHandlers from './handlers/summary.js';
 import teamHandlers from './handlers/teams.js';
@@ -26,6 +27,7 @@ export const handlers = [
   ...keywordHandlers,
   ...metadataHandlers,
   ...playgroundHandlers,
+  ...rustsecHandlers,
   ...sessionHandlers,
   ...summaryHandlers,
   ...teamHandlers,


### PR DESCRIPTION
Adds a default MSW handler for `rustsec.org/packages/:crateId.json` that returns 404, so tests don't have to register their own "no advisories" handler. Individual tests can still override it to return advisory data or error responses.

The first commit is by @djc, extracted from https://github.com/rust-lang/crates.io/pull/13900. The second commit drops the now-redundant 404 override in the security page e2e test.