### PR TITLE
CI: Reuse Playwright Chromium for Percy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,10 @@ jobs:
 
       - run: pnpm playwright install chromium
 
+      # Reuse the Chromium that Playwright just installed instead of letting
+      # @percy/core download its own.
+      - run: echo "PERCY_BROWSER_EXECUTABLE=$(node -e "console.log(require('@playwright/test').chromium.executablePath())")" >> "$GITHUB_ENV"
+
       - if: github.repository == 'rust-lang/crates.io'
         run: pnpm percy exec -- pnpm e2e:svelte
 


### PR DESCRIPTION
Percy's CLI downloads its own Chromium build for visual snapshots. With the Node.js 24 upgrade in #13732 that download started failing, breaking the e2e job by not sending any snapshots to Percy.

This points `PERCY_BROWSER_EXECUTABLE` at the Chromium that `pnpm playwright install` already provides, so `@percy/core` reuses it instead of fetching its own. That sidesteps the failing download and, incidentally, skips a redundant browser download to speed up the job.

### Related
- #13732