### PR TITLE
CI: Inline `PNPM_VERSION` env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ env:
   CARGO_MACHETE_VERSION: 0.9.2
   # renovate: datasource=crate depName=diesel-guard versioning=semver
   DIESEL_GUARD_VERSION: 0.11.0
-  # renovate: datasource=npm depName=pnpm
-  PNPM_VERSION: 11.5.3
   # renovate: datasource=pypi depName=zizmor
   ZIZMOR_VERSION: 1.25.2
 
@@ -185,7 +183,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: 11.5.3
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -210,7 +208,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: 11.5.3
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -234,7 +232,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: 11.5.3
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -267,7 +265,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: 11.5.3
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -331,7 +329,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: 11.5.3
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -359,7 +357,7 @@ jobs:
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: 11.5.3
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
Renovate's `github-actions` manager detects the `version` input of `pnpm/action-setup` natively these days, so the env var workaround is no longer needed.