### PR TITLE
Replace `GitHubClient` auth args with `GitHubAuth` enum

### DIFF
--- a/crates/crates_io_github/Cargo.toml
+++ b/crates/crates_io_github/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = "=0.1.89"
 mockall = { version = "=0.14.0", optional = true }
 oauth2 = { version = "=5.0.0", default-features = false }
 reqwest = { version = "=0.13.4", features = ["json"] }
+secrecy = "=0.10.3"
 serde = { version = "=1.0.228", features = ["derive"] }
 thiserror = "=2.0.18"
 tracing = "=0.1.44"
@@ -24,7 +25,6 @@ url = "=2.5.8"
 [dev-dependencies]
 clap = { version = "=4.6.1", features = ["derive", "env", "unicode", "wrap_help"] }
 mockito = "=1.7.2"
-secrecy = "=0.10.3"
 serde_json = "=1.0.150"
 tokio = { version = "=1.52.3", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "=0.3.23", features = ["env-filter"] }

--- a/crates/crates_io_github/examples/fetch_ref.rs
+++ b/crates/crates_io_github/examples/fetch_ref.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use crates_io_github::{GitHubClient, RealGitHubClient, parse_github_slug};
+use crates_io_github::{GitHubAuth, GitHubClient, RealGitHubClient, parse_github_slug};
 use reqwest::Client;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
@@ -28,9 +28,10 @@ async fn main() -> Result<()> {
     let ref_name = format!("refs/heads/{}", opts.branch);
 
     let client = RealGitHubClient::new(Client::new());
-    let git_ref = client.get_ref(&owner, &repo, &ref_name).await?;
+    let auth = GitHubAuth::None;
+    let git_ref = client.get_ref(&owner, &repo, &ref_name, &auth).await?;
     let commit = client
-        .get_commit(&owner, &repo, &git_ref.object.sha)
+        .get_commit(&owner, &repo, &git_ref.object.sha, &auth)
         .await?;
 
     println!("ref:      {}", git_ref.ref_name);

--- a/crates/crates_io_github/examples/test_github_client.rs
+++ b/crates/crates_io_github/examples/test_github_client.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use crates_io_github::{GitHubClient, RealGitHubClient};
+use crates_io_github::{GitHubAuth, GitHubClient, RealGitHubClient};
 use oauth2::AccessToken;
 use reqwest::Client;
 use secrecy::{ExposeSecret, SecretString};
@@ -7,50 +7,90 @@ use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
 #[derive(clap::Parser, Debug)]
+struct Options {
+    #[clap(flatten)]
+    auth: AuthArgs,
+
+    #[clap(subcommand)]
+    request: Request,
+}
+
+/// Authentication options shared by all requests.
+///
+/// When no credentials are provided the request is sent unauthenticated.
+/// An access token results in bearer authentication, while the client
+/// id/secret or username/password pairs result in HTTP basic authentication.
+#[derive(clap::Args, Debug)]
+struct AuthArgs {
+    /// OAuth or personal access token used for bearer authentication.
+    #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
+    access_token: Option<SecretString>,
+
+    /// OAuth client id used for basic authentication.
+    #[clap(long, env = "GITHUB_CLIENT_ID", requires = "client_secret")]
+    client_id: Option<String>,
+    /// OAuth client secret used for basic authentication.
+    #[clap(
+        long,
+        env = "GITHUB_CLIENT_SECRET",
+        hide_env_values = true,
+        requires = "client_id"
+    )]
+    client_secret: Option<SecretString>,
+
+    /// Username used for basic authentication.
+    #[clap(long, env = "GITHUB_USERNAME", requires = "password")]
+    username: Option<String>,
+    /// Password used for basic authentication.
+    #[clap(
+        long,
+        env = "GITHUB_PASSWORD",
+        hide_env_values = true,
+        requires = "username"
+    )]
+    password: Option<SecretString>,
+}
+
+#[derive(clap::Subcommand, Debug)]
 enum Request {
-    CurrentUser {
-        #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
-        access_token: SecretString,
-    },
+    CurrentUser,
     GetUser {
         name: String,
-        #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
-        access_token: SecretString,
     },
     GetUserById {
         account_id: i64,
-        #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
-        access_token: SecretString,
     },
     OrgByName {
         org_name: String,
-        #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
-        access_token: SecretString,
     },
     TeamByName {
         org_name: String,
         team_name: String,
-        #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
-        access_token: SecretString,
     },
     OrgMembership {
         org_id: i32,
         username: String,
-        #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
-        access_token: SecretString,
     },
     TeamMembership {
         org_id: i32,
         team_id: i32,
         username: String,
-        #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
-        access_token: SecretString,
     },
-    PublicKeys {
-        client_id: String,
-        #[clap(long, env = "GITHUB_CLIENT_SECRET", hide_env_values = true)]
-        client_secret: SecretString,
-    },
+    PublicKeys,
+}
+
+impl AuthArgs {
+    fn into_auth(self) -> GitHubAuth {
+        if let Some(access_token) = self.access_token {
+            GitHubAuth::bearer(AccessToken::new(access_token.expose_secret().into()))
+        } else if let (Some(username), Some(password)) = (self.client_id, self.client_secret) {
+            GitHubAuth::basic(username, password)
+        } else if let (Some(username), Some(password)) = (self.username, self.password) {
+            GitHubAuth::basic(username, password)
+        } else {
+            GitHubAuth::None
+        }
+    }
 }
 
 #[tokio::main]
@@ -62,54 +102,38 @@ async fn main() -> Result<()> {
     let client = Client::new();
     let github_client = RealGitHubClient::new(client);
 
-    match Request::parse() {
-        Request::CurrentUser { access_token } => {
-            let access_token = AccessToken::new(access_token.expose_secret().into());
-            let response = github_client.current_user(&access_token).await?;
+    let options = Options::parse();
+    let auth = options.auth.into_auth();
+
+    match options.request {
+        Request::CurrentUser => {
+            let response = github_client.current_user(&auth).await?;
             println!("{response:#?}");
         }
-        Request::GetUser { name, access_token } => {
-            let access_token = AccessToken::new(access_token.expose_secret().into());
-            let response = github_client.get_user(&name, &access_token).await?;
+        Request::GetUser { name } => {
+            let response = github_client.get_user(&name, &auth).await?;
             println!("{response:#?}");
         }
-        Request::GetUserById {
-            account_id,
-            access_token,
-        } => {
-            let access_token = AccessToken::new(access_token.expose_secret().into());
-            let response = github_client
-                .get_user_by_id(account_id, &access_token)
-                .await?;
+        Request::GetUserById { account_id } => {
+            let response = github_client.get_user_by_id(account_id, &auth).await?;
             println!("{response:#?}");
         }
-        Request::OrgByName {
-            org_name,
-            access_token,
-        } => {
-            let access_token = AccessToken::new(access_token.expose_secret().into());
-            let response = github_client.org_by_name(&org_name, &access_token).await?;
+        Request::OrgByName { org_name } => {
+            let response = github_client.org_by_name(&org_name, &auth).await?;
             println!("{response:#?}");
         }
         Request::TeamByName {
             org_name,
             team_name,
-            access_token,
         } => {
-            let access_token = AccessToken::new(access_token.expose_secret().into());
             let response = github_client
-                .team_by_name(&org_name, &team_name, &access_token)
+                .team_by_name(&org_name, &team_name, &auth)
                 .await?;
             println!("{response:#?}");
         }
-        Request::OrgMembership {
-            org_id,
-            username,
-            access_token,
-        } => {
-            let access_token = AccessToken::new(access_token.expose_secret().into());
+        Request::OrgMembership { org_id, username } => {
             let response = github_client
-                .org_membership(org_id, &username, &access_token)
+                .org_membership(org_id, &username, &auth)
                 .await?;
             println!("{response:#?}");
         }
@@ -117,21 +141,14 @@ async fn main() -> Result<()> {
             org_id,
             team_id,
             username,
-            access_token,
         } => {
-            let access_token = AccessToken::new(access_token.expose_secret().into());
             let response = github_client
-                .team_membership(org_id, team_id, &username, &access_token)
+                .team_membership(org_id, team_id, &username, &auth)
                 .await?;
             println!("{response:#?}");
         }
-        Request::PublicKeys {
-            client_id,
-            client_secret,
-        } => {
-            let response = github_client
-                .public_keys(&client_id, client_secret.expose_secret())
-                .await?;
+        Request::PublicKeys => {
+            let response = github_client.public_keys(&auth).await?;
             println!("{response:#?}");
         }
     }

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -10,6 +10,7 @@ pub use crate::slug::{ParseSlugError, parse_github_slug};
 use oauth2::AccessToken;
 use reqwest::{self, RequestBuilder, header};
 
+use secrecy::{ExposeSecret, SecretString};
 use serde::de::DeserializeOwned;
 
 use std::str;
@@ -21,47 +22,106 @@ use url::Url;
 
 type Result<T> = std::result::Result<T, GitHubError>;
 
+/// Authentication mode for a request to the GitHub API.
+///
+/// Each [`GitHubClient`] method takes a `&GitHubAuth` so the
+/// authentication mode is decided at the call site rather than baked into
+/// the method signature.
+#[derive(Debug, Clone)]
+pub enum GitHubAuth {
+    /// Unauthenticated request. Used for reads against public
+    /// repositories where the unauthenticated rate limit is sufficient.
+    None,
+    /// OAuth/installation bearer token authentication.
+    Bearer { token: AccessToken },
+    /// HTTP basic authentication, used for the secret-scanning public key
+    /// endpoint where the OAuth client id/secret act as the credentials.
+    Basic {
+        username: String,
+        password: SecretString,
+    },
+}
+
+impl GitHubAuth {
+    /// Creates a [`GitHubAuth::Bearer`] authentication mode from a bearer
+    /// token.
+    pub fn bearer(token: AccessToken) -> Self {
+        GitHubAuth::Bearer { token }
+    }
+
+    /// Creates an [`GitHubAuth::Basic`] authentication mode from a username
+    /// and password.
+    pub fn basic(username: impl Into<String>, password: impl Into<SecretString>) -> Self {
+        GitHubAuth::Basic {
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+
+    /// Applies this authentication mode to the given request builder.
+    fn apply(&self, request: RequestBuilder) -> RequestBuilder {
+        match self {
+            GitHubAuth::None => request,
+            GitHubAuth::Bearer { token } => request.bearer_auth(token.secret()),
+            GitHubAuth::Basic { username, password } => {
+                request.basic_auth(username, Some(password.expose_secret()))
+            }
+        }
+    }
+}
+
 #[cfg_attr(feature = "mock", mockall::automock)]
 #[async_trait]
 pub trait GitHubClient: Send + Sync {
-    async fn current_user(&self, auth: &AccessToken) -> Result<GitHubUser>;
-    async fn get_user(&self, name: &str, auth: &AccessToken) -> Result<GitHubUser>;
-    async fn get_user_by_id(&self, account_id: i64, auth: &AccessToken) -> Result<GitHubUser>;
-    async fn org_by_name(&self, org_name: &str, auth: &AccessToken) -> Result<GitHubOrganization>;
+    async fn current_user(&self, auth: &GitHubAuth) -> Result<GitHubUser>;
+    async fn get_user(&self, name: &str, auth: &GitHubAuth) -> Result<GitHubUser>;
+    async fn get_user_by_id(&self, account_id: i64, auth: &GitHubAuth) -> Result<GitHubUser>;
+    async fn org_by_name(&self, org_name: &str, auth: &GitHubAuth) -> Result<GitHubOrganization>;
     async fn team_by_name(
         &self,
         org_name: &str,
         team_name: &str,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<GitHubTeam>;
     async fn team_membership(
         &self,
         org_id: i32,
         team_id: i32,
         username: &str,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<Option<GitHubTeamMembership>>;
     async fn org_membership(
         &self,
         org_id: i32,
         username: &str,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<Option<GitHubOrgMembership>>;
-    async fn public_keys(&self, username: &str, password: &str) -> Result<Vec<GitHubPublicKey>>;
+
+    /// Returns the list of public keys that can be used to verify GitHub
+    /// secret alert signatures.
+    async fn public_keys(&self, auth: &GitHubAuth) -> Result<Vec<GitHubPublicKey>>;
 
     /// Fetches a single git ref.
     ///
     /// `ref_name` may be given either fully qualified (e.g.
     /// `"refs/heads/master"`) or without the `refs/` prefix (e.g.
-    /// `"heads/master"`). The call is unauthenticated; the crates.io
-    /// index repositories are public and the 60/hour unauthenticated
-    /// rate limit is plenty for this use case.
-    async fn get_ref(&self, owner: &str, repo: &str, ref_name: &str) -> Result<GitRef>;
+    /// `"heads/master"`).
+    async fn get_ref(
+        &self,
+        owner: &str,
+        repo: &str,
+        ref_name: &str,
+        auth: &GitHubAuth,
+    ) -> Result<GitRef>;
 
     /// Fetches a single commit object by its SHA.
-    ///
-    /// Unauthenticated, same rationale as [`GitHubClient::get_ref`].
-    async fn get_commit(&self, owner: &str, repo: &str, sha: &str) -> Result<GitCommit>;
+    async fn get_commit(
+        &self,
+        owner: &str,
+        repo: &str,
+        sha: &str,
+        auth: &GitHubAuth,
+    ) -> Result<GitCommit>;
 
     /// Creates a new commit object in the given repository.
     ///
@@ -73,7 +133,7 @@ pub trait GitHubClient: Send + Sync {
         owner: &str,
         repo: &str,
         input: &CreateCommit<'a>,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<GitCommit>;
 
     /// Creates a new git ref.
@@ -86,7 +146,7 @@ pub trait GitHubClient: Send + Sync {
         repo: &str,
         ref_name: &str,
         sha: &str,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<GitRef>;
 
     /// Updates an existing git ref to point at `sha`.
@@ -101,7 +161,7 @@ pub trait GitHubClient: Send + Sync {
         ref_name: &str,
         sha: &str,
         force: bool,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<GitRef>;
 }
 
@@ -122,10 +182,9 @@ impl RealGitHubClient {
     }
 
     /// Does all the nonsense for sending a GET to GitHub.
-    async fn _request<T, A>(&self, url: &str, apply_auth: A) -> Result<T>
+    async fn request<T>(&self, url: &str, auth: &GitHubAuth) -> Result<T>
     where
         T: DeserializeOwned,
-        A: Fn(RequestBuilder) -> RequestBuilder,
     {
         let url = self
             .base_url
@@ -139,7 +198,7 @@ impl RealGitHubClient {
             .header(header::ACCEPT, "application/vnd.github.v3+json")
             .header(header::USER_AGENT, "crates.io (https://crates.io)");
 
-        let response = apply_auth(request).send().await?.error_for_status()?;
+        let response = auth.apply(request).send().await?.error_for_status()?;
 
         let headers = response.headers();
         let remaining = headers.get("x-ratelimit-remaining");
@@ -150,17 +209,16 @@ impl RealGitHubClient {
     }
 
     /// Sends a request with a JSON body to GitHub.
-    async fn _mutate<B, T, A>(
+    async fn _mutate<B, T>(
         &self,
         method: reqwest::Method,
         url: &str,
         body: &B,
-        apply_auth: A,
+        auth: &GitHubAuth,
     ) -> Result<T>
     where
         B: Serialize + ?Sized,
         T: DeserializeOwned,
-        A: Fn(RequestBuilder) -> RequestBuilder,
     {
         let url = self
             .base_url
@@ -175,7 +233,7 @@ impl RealGitHubClient {
             .header(header::USER_AGENT, "crates.io (https://crates.io)")
             .json(body);
 
-        let response = apply_auth(request).send().await?.error_for_status()?;
+        let response = auth.apply(request).send().await?.error_for_status()?;
 
         let headers = response.headers();
         let remaining = headers.get("x-ratelimit-remaining");
@@ -184,42 +242,25 @@ impl RealGitHubClient {
 
         response.json().await.map_err(Into::into)
     }
-
-    /// Sends a GET to GitHub using OAuth access token authentication
-    pub async fn request<T>(&self, url: &str, auth: &AccessToken) -> Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        self._request(url, |r| r.bearer_auth(auth.secret())).await
-    }
-
-    /// Sends a GET to GitHub using basic authentication
-    pub async fn request_basic<T>(&self, url: &str, username: &str, password: &str) -> Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        self._request(url, |r| r.basic_auth(username, Some(password)))
-            .await
-    }
 }
 
 #[async_trait]
 impl GitHubClient for RealGitHubClient {
-    async fn current_user(&self, auth: &AccessToken) -> Result<GitHubUser> {
+    async fn current_user(&self, auth: &GitHubAuth) -> Result<GitHubUser> {
         self.request("/user", auth).await
     }
 
-    async fn get_user(&self, name: &str, auth: &AccessToken) -> Result<GitHubUser> {
+    async fn get_user(&self, name: &str, auth: &GitHubAuth) -> Result<GitHubUser> {
         let url = format!("/users/{name}");
         self.request(&url, auth).await
     }
 
-    async fn get_user_by_id(&self, account_id: i64, auth: &AccessToken) -> Result<GitHubUser> {
+    async fn get_user_by_id(&self, account_id: i64, auth: &GitHubAuth) -> Result<GitHubUser> {
         let url = format!("/user/{account_id}");
         self.request(&url, auth).await
     }
 
-    async fn org_by_name(&self, org_name: &str, auth: &AccessToken) -> Result<GitHubOrganization> {
+    async fn org_by_name(&self, org_name: &str, auth: &GitHubAuth) -> Result<GitHubOrganization> {
         let url = format!("/orgs/{org_name}");
         self.request(&url, auth).await
     }
@@ -228,7 +269,7 @@ impl GitHubClient for RealGitHubClient {
         &self,
         org_name: &str,
         team_name: &str,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<GitHubTeam> {
         let url = format!("/orgs/{org_name}/teams/{team_name}");
         self.request(&url, auth).await
@@ -239,7 +280,7 @@ impl GitHubClient for RealGitHubClient {
         org_id: i32,
         team_id: i32,
         username: &str,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<Option<GitHubTeamMembership>> {
         let url = format!("/organizations/{org_id}/team/{team_id}/memberships/{username}");
         match self.request(&url, auth).await {
@@ -254,7 +295,7 @@ impl GitHubClient for RealGitHubClient {
         &self,
         org_id: i32,
         username: &str,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<Option<GitHubOrgMembership>> {
         let url = format!("/organizations/{org_id}/memberships/{username}");
         match self.request(&url, auth).await {
@@ -264,27 +305,35 @@ impl GitHubClient for RealGitHubClient {
         }
     }
 
-    /// Returns the list of public keys that can be used to verify GitHub secret alert signatures
-    async fn public_keys(&self, username: &str, password: &str) -> Result<Vec<GitHubPublicKey>> {
+    async fn public_keys(&self, auth: &GitHubAuth) -> Result<Vec<GitHubPublicKey>> {
         let url = "/meta/public_keys/secret_scanning";
-        match self
-            .request_basic::<GitHubPublicKeyList>(url, username, password)
-            .await
-        {
+        match self.request::<GitHubPublicKeyList>(url, auth).await {
             Ok(v) => Ok(v.public_keys),
             Err(e) => Err(e),
         }
     }
 
-    async fn get_ref(&self, owner: &str, repo: &str, ref_name: &str) -> Result<GitRef> {
+    async fn get_ref(
+        &self,
+        owner: &str,
+        repo: &str,
+        ref_name: &str,
+        auth: &GitHubAuth,
+    ) -> Result<GitRef> {
         let ref_path = ref_name.strip_prefix("refs/").unwrap_or(ref_name);
         let path = format!("/repos/{owner}/{repo}/git/ref/{ref_path}");
-        self._request(&path, std::convert::identity).await
+        self.request(&path, auth).await
     }
 
-    async fn get_commit(&self, owner: &str, repo: &str, sha: &str) -> Result<GitCommit> {
+    async fn get_commit(
+        &self,
+        owner: &str,
+        repo: &str,
+        sha: &str,
+        auth: &GitHubAuth,
+    ) -> Result<GitCommit> {
         let path = format!("/repos/{owner}/{repo}/git/commits/{sha}");
-        self._request(&path, std::convert::identity).await
+        self.request(&path, auth).await
     }
 
     async fn create_commit<'a>(
@@ -292,13 +341,11 @@ impl GitHubClient for RealGitHubClient {
         owner: &str,
         repo: &str,
         input: &CreateCommit<'a>,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<GitCommit> {
         let path = format!("/repos/{owner}/{repo}/git/commits");
-        self._mutate(reqwest::Method::POST, &path, input, |r| {
-            r.bearer_auth(auth.secret())
-        })
-        .await
+        self._mutate(reqwest::Method::POST, &path, input, auth)
+            .await
     }
 
     async fn create_ref(
@@ -307,7 +354,7 @@ impl GitHubClient for RealGitHubClient {
         repo: &str,
         ref_name: &str,
         sha: &str,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<GitRef> {
         #[derive(Serialize)]
         struct Body<'a> {
@@ -318,10 +365,8 @@ impl GitHubClient for RealGitHubClient {
 
         let path = format!("/repos/{owner}/{repo}/git/refs");
         let body = Body { ref_name, sha };
-        self._mutate(reqwest::Method::POST, &path, &body, |r| {
-            r.bearer_auth(auth.secret())
-        })
-        .await
+        self._mutate(reqwest::Method::POST, &path, &body, auth)
+            .await
     }
 
     async fn update_ref(
@@ -331,7 +376,7 @@ impl GitHubClient for RealGitHubClient {
         ref_name: &str,
         sha: &str,
         force: bool,
-        auth: &AccessToken,
+        auth: &GitHubAuth,
     ) -> Result<GitRef> {
         #[derive(Serialize)]
         struct Body<'a> {
@@ -342,10 +387,8 @@ impl GitHubClient for RealGitHubClient {
         let ref_path = ref_name.strip_prefix("refs/").unwrap_or(ref_name);
         let path = format!("/repos/{owner}/{repo}/git/refs/{ref_path}");
         let body = Body { sha, force };
-        self._mutate(reqwest::Method::PATCH, &path, &body, |r| {
-            r.bearer_auth(auth.secret())
-        })
-        .await
+        self._mutate(reqwest::Method::PATCH, &path, &body, auth)
+            .await
     }
 }
 
@@ -529,7 +572,7 @@ mod tests {
             .await;
 
         let client = client_with_server(&server);
-        let auth = AccessToken::new("test-token".into());
+        let auth = GitHubAuth::bearer(AccessToken::new("test-token".into()));
         let user = client.get_user("johnnydee", &auth).await.unwrap();
 
         assert_eq!(user.login, "johnnydee");
@@ -553,8 +596,9 @@ mod tests {
             .await;
 
         let client = client_with_server(&server);
+        let auth = GitHubAuth::None;
         let got = client
-            .get_ref("rust-lang", "crates.io-index", "refs/heads/master")
+            .get_ref("rust-lang", "crates.io-index", "refs/heads/master", &auth)
             .await
             .unwrap();
 
@@ -577,8 +621,9 @@ mod tests {
             .await;
 
         let client = client_with_server(&server);
+        let auth = GitHubAuth::None;
         let got = client
-            .get_ref("rust-lang", "crates.io-index", "heads/master")
+            .get_ref("rust-lang", "crates.io-index", "heads/master", &auth)
             .await
             .unwrap();
 
@@ -602,8 +647,9 @@ mod tests {
             .await;
 
         let client = client_with_server(&server);
+        let auth = GitHubAuth::None;
         let got = client
-            .get_commit("rust-lang", "crates.io-index", sha)
+            .get_commit("rust-lang", "crates.io-index", sha, &auth)
             .await
             .unwrap();
 
@@ -644,7 +690,7 @@ mod tests {
             .await;
 
         let client = client_with_server(&server);
-        let auth = AccessToken::new("test-token".into());
+        let auth = GitHubAuth::bearer(AccessToken::new("test-token".into()));
         let parents = [parent];
         let input = CreateCommit {
             message: "collapse",
@@ -691,7 +737,7 @@ mod tests {
             .await;
 
         let client = client_with_server(&server);
-        let auth = AccessToken::new("test-token".into());
+        let auth = GitHubAuth::bearer(AccessToken::new("test-token".into()));
 
         let got = client
             .create_ref("rust-lang", "crates.io-index", ref_name, sha, &auth)
@@ -734,7 +780,7 @@ mod tests {
             .await;
 
         let client = client_with_server(&server);
-        let auth = AccessToken::new("test-token".into());
+        let auth = GitHubAuth::bearer(AccessToken::new("test-token".into()));
 
         let got = client
             .update_ref(
@@ -750,5 +796,66 @@ mod tests {
 
         assert_eq!(got.ref_name, "refs/heads/master");
         assert_eq!(got.object.sha, new_sha);
+    }
+
+    #[tokio::test]
+    async fn none_auth_sends_no_authorization_header() {
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock("GET", "/users/johnnydee")
+            .match_header("authorization", Matcher::Missing)
+            .with_status(200)
+            .with_body(USER_BODY)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let user = client
+            .get_user("johnnydee", &GitHubAuth::None)
+            .await
+            .unwrap();
+
+        assert_eq!(user.login, "johnnydee");
+    }
+
+    #[tokio::test]
+    async fn token_auth_sends_bearer_header() {
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock("GET", "/users/johnnydee")
+            .match_header("authorization", "Bearer test-token")
+            .with_status(200)
+            .with_body(USER_BODY)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let auth = GitHubAuth::bearer(AccessToken::new("test-token".into()));
+        let user = client.get_user("johnnydee", &auth).await.unwrap();
+
+        assert_eq!(user.login, "johnnydee");
+    }
+
+    #[tokio::test]
+    async fn basic_auth_sends_basic_header() {
+        // base64("client-id:client-secret")
+        let expected = "Basic Y2xpZW50LWlkOmNsaWVudC1zZWNyZXQ=";
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock("GET", "/users/johnnydee")
+            .match_header("authorization", expected)
+            .with_status(200)
+            .with_body(USER_BODY)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let auth = GitHubAuth::basic("client-id", "client-secret");
+        let user = client.get_user("johnnydee", &auth).await.unwrap();
+
+        assert_eq!(user.login, "johnnydee");
     }
 }

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -10,7 +10,7 @@ use axum::body::Bytes;
 use base64::{Engine, engine::general_purpose};
 use crates_io_database::models::OwnerKind;
 use crates_io_database::schema::trustpub_tokens;
-use crates_io_github::GitHubPublicKey;
+use crates_io_github::{GitHubAuth, GitHubPublicKey};
 use crates_io_trustpub::access_token::AccessToken;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -62,9 +62,11 @@ async fn get_public_keys(state: &AppState) -> Result<Vec<GitHubPublicKey>, Boxed
     }
 
     // Fetch from GitHub API
-    let client_id = &state.config.gh_client_id;
-    let client_secret = state.config.gh_client_secret.secret();
-    let keys = state.github.public_keys(client_id, client_secret).await?;
+    let auth = GitHubAuth::basic(
+        state.config.gh_client_id.as_str(),
+        state.config.gh_client_secret.secret().clone(),
+    );
+    let keys = state.github.public_keys(&auth).await?;
 
     // Populate cache
     cache.keys.clone_from(&keys);

--- a/src/controllers/helpers/authorization.rs
+++ b/src/controllers/helpers/authorization.rs
@@ -1,7 +1,7 @@
 use crate::models::{Owner, User};
 use crate::util::errors::{BoxedAppError, custom};
 use crate::util::gh_token_encryption::GitHubTokenEncryption;
-use crates_io_github::{GitHubClient, GitHubError};
+use crates_io_github::{GitHubAuth, GitHubClient, GitHubError};
 use http::StatusCode;
 
 /// Access rights to the crate (publishing and ownership management)
@@ -32,6 +32,8 @@ impl Rights {
             .decrypt(&user.gh_encrypted_token)
             .map_err(GitHubError::Other)?;
 
+        let auth = GitHubAuth::bearer(token);
+
         let mut best = Self::None;
         for owner in owners {
             match *owner {
@@ -46,7 +48,7 @@ impl Rights {
                     // the answer. If this is not the case, then we could accidentally leak
                     // private membership information here.
                     let is_team_member = match gh_client
-                        .team_membership(team.org_id, team.github_id, &user.gh_login, &token)
+                        .team_membership(team.org_id, team.github_id, &user.gh_login, &auth)
                         .await
                     {
                         Ok(membership) => membership.is_some_and(|m| m.is_active()),

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -15,13 +15,12 @@ use crate::{App, app::AppState};
 use crate::{auth::AuthCheck, email::EmailMessage};
 use axum::Json;
 use chrono::Utc;
-use crates_io_github::{GitHubClient, GitHubError};
+use crates_io_github::{GitHubAuth, GitHubClient, GitHubError};
 use diesel::prelude::*;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use http::StatusCode;
 use http::request::Parts;
 use minijinja::context;
-use oauth2::AccessToken;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -447,7 +446,9 @@ pub async fn create_or_update_github_team(
                 format!("Failed to decrypt GitHub token: {err}"),
             )
         })?;
-    let team = gh_client.team_by_name(org_name, team_name, &token).await
+
+    let auth = GitHubAuth::bearer(token);
+    let team = gh_client.team_by_name(org_name, team_name, &auth).await
         .map_err(|_| {
             bad_request(format_args!(
                 "could not find the github team {org_name}/{team_name}. \
@@ -460,12 +461,12 @@ pub async fn create_or_update_github_team(
     let gh_login = &req_user.gh_login;
 
     let is_team_member = gh_client
-        .team_membership(org_id, team.id, gh_login, &token)
+        .team_membership(org_id, team.id, gh_login, &auth)
         .await?
         .is_some_and(|m| m.is_active());
 
     let can_add_team =
-        is_team_member || is_gh_org_owner(gh_client, org_id, gh_login, &token).await?;
+        is_team_member || is_gh_org_owner(gh_client, org_id, gh_login, &auth).await?;
 
     if !can_add_team {
         return Err(custom(
@@ -474,7 +475,7 @@ pub async fn create_or_update_github_team(
         ));
     }
 
-    let org = gh_client.org_by_name(org_name, &token).await?;
+    let org = gh_client.org_by_name(org_name, &auth).await?;
 
     NewTeam::builder()
         .login(&login.to_lowercase())
@@ -492,9 +493,9 @@ async fn is_gh_org_owner(
     gh_client: &dyn GitHubClient,
     org_id: i32,
     gh_login: &str,
-    token: &AccessToken,
+    auth: &GitHubAuth,
 ) -> Result<bool, GitHubError> {
-    let membership = gh_client.org_membership(org_id, gh_login, token).await?;
+    let membership = gh_client.org_membership(org_id, gh_login, auth).await?;
     Ok(membership.is_some_and(|m| m.is_active_admin()))
 }
 

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -9,7 +9,7 @@ use crate::util::errors::{AppResult, bad_request, server_error};
 use crate::util::oauth::ReqwestClient;
 use crate::views::EncodableMe;
 use axum::Json;
-use crates_io_github::GitHubUser;
+use crates_io_github::{GitHubAuth, GitHubUser};
 use crates_io_session::SessionExtension;
 use diesel::prelude::*;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
@@ -124,7 +124,8 @@ pub async fn authorize_session(
     })?;
 
     // Fetch the user info from GitHub using the access token we just got and create a user record
-    let ghuser = app.github.current_user(token).await?;
+    let auth = GitHubAuth::bearer(token.clone());
+    let ghuser = app.github.current_user(&auth).await?;
 
     let mut conn = app.db_write().await?;
     let user_id = save_user_to_database(&ghuser, &encrypted_token, &app.emails, &mut conn).await?;

--- a/src/controllers/trustpub/github_configs/create.rs
+++ b/src/controllers/trustpub/github_configs/create.rs
@@ -10,7 +10,7 @@ use crates_io_database::models::OwnerKind;
 use crates_io_database::models::token::EndpointScope;
 use crates_io_database::models::trustpub::{GitHubConfig, NewGitHubConfig};
 use crates_io_database::schema::{crate_owners, emails, users};
-use crates_io_github::GitHubError;
+use crates_io_github::{GitHubAuth, GitHubError};
 use crates_io_trustpub::github::validation::{
     validate_environment, validate_owner, validate_repo, validate_workflow_filename,
 };
@@ -96,6 +96,7 @@ pub async fn create_trustpub_github_config(
         warn!("Failed to decrypt GitHub token for user {login}: {err}");
         server_error("Internal server error")
     })?;
+    let gh_auth = GitHubAuth::bearer(gh_auth);
 
     let github_user = match state.github.get_user(owner, &gh_auth).await {
         Ok(user) => user,

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -95,7 +95,7 @@ async fn insert_trustpub_token(
 fn github_mock() -> MockGitHubClient {
     let mut mock = MockGitHubClient::new();
 
-    mock.expect_public_keys().returning(|_, _| {
+    mock.expect_public_keys().returning(|_| {
         let key = GitHubPublicKey {
             key_identifier: KEY_IDENTIFIER.to_string(),
             key: PUBLIC_KEY.to_string(),

--- a/src/tests/worker/squash_index.rs
+++ b/src/tests/worker/squash_index.rs
@@ -30,9 +30,9 @@ fn master_ref(sha: &str) -> GitRef {
 /// Queue a one-shot `get_ref(refs/heads/master)` that returns `sha`.
 fn expect_get_master(mock: &mut MockGitHubClient, sha: &'static str) {
     mock.expect_get_ref()
-        .withf(|owner, repo, ref_name| owner == OWNER && repo == REPO && ref_name == MASTER_REF)
+        .withf(|owner, repo, ref_name, _| owner == OWNER && repo == REPO && ref_name == MASTER_REF)
         .times(1)
-        .returning(move |_, _, _| Ok(master_ref(sha)));
+        .returning(move |_, _, _, _| Ok(master_ref(sha)));
 }
 
 /// Queue a `get_commit(commit_sha)` that returns a commit pointing at `tree_sha`.
@@ -42,9 +42,9 @@ fn expect_get_commit(
     tree_sha: &'static str,
 ) {
     mock.expect_get_commit()
-        .withf(move |owner, repo, sha| owner == OWNER && repo == REPO && sha == commit_sha)
+        .withf(move |owner, repo, sha, _| owner == OWNER && repo == REPO && sha == commit_sha)
         .times(1)
-        .returning(move |_, _, _| {
+        .returning(move |_, _, _, _| {
             Ok(GitCommit {
                 sha: commit_sha.into(),
                 tree: GitObject {

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -2,7 +2,7 @@ use crate::worker::Environment;
 use crate::worker::jobs::ArchiveIndexBranch;
 use anyhow::{Context, anyhow};
 use chrono::Utc;
-use crates_io_github::{CreateCommit, parse_github_slug};
+use crates_io_github::{CreateCommit, GitHubAuth, parse_github_slug};
 use crates_io_worker::BackgroundJob;
 use oauth2::AccessToken;
 use secrecy::ExposeSecret;
@@ -66,18 +66,22 @@ impl BackgroundJob for SquashIndex {
 
         let github = env.github.as_ref();
 
-        let original_head = github.get_ref(&owner, &repo, MASTER_REF).await?;
+        let original_head = github
+            .get_ref(&owner, &repo, MASTER_REF, &GitHubAuth::None)
+            .await?;
         let original_sha = original_head.object.sha;
         info!("Read original HEAD: {original_sha}");
 
-        let original_commit = github.get_commit(&owner, &repo, &original_sha).await?;
+        let original_commit = github
+            .get_commit(&owner, &repo, &original_sha, &GitHubAuth::None)
+            .await?;
         let tree_sha = original_commit.tree.sha;
 
         let snapshot_branch = snapshot_branch_name();
         let message = squash_commit_message(&original_sha, &snapshot_branch);
 
         let token = index_sync_github_app.installation_token().await?;
-        let auth = AccessToken::new(token.expose_secret().into());
+        let auth = GitHubAuth::bearer(AccessToken::new(token.expose_secret().into()));
 
         let squash_start = Instant::now();
         let input = CreateCommit {
@@ -101,7 +105,9 @@ impl BackgroundJob for SquashIndex {
         // Best-effort drift check. GitHub has no CAS for refs, so the
         // `repository` queue is the real primary defense; this only
         // shrinks the race window.
-        let current_head = github.get_ref(&owner, &repo, MASTER_REF).await?;
+        let current_head = github
+            .get_ref(&owner, &repo, MASTER_REF, &GitHubAuth::None)
+            .await?;
         if current_head.object.sha != original_sha {
             return Err(anyhow!(
                 "`{}` drifted during squash (was {original_sha}, now {})",

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use chrono::Utc;
-use crates_io_github::{GitHubError, GitHubUser};
+use crates_io_github::{GitHubAuth, GitHubError, GitHubUser};
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
@@ -97,7 +97,9 @@ impl UpdateUserFromGithub {
             .gh_token_encryption
             .decrypt(&oauth_github.encrypted_token)?;
 
-        match github.current_user(&token).await {
+        let auth = GitHubAuth::bearer(token);
+
+        match github.current_user(&auth).await {
             Ok(github_user) => Ok(github_user),
             // If the user is not found, the account has been deleted. Update to the ghost
             // username.
@@ -131,15 +133,11 @@ impl UpdateUserFromGithub {
                         return Err(error);
                     };
 
-                    let token = AccessToken::new(
-                        sync_github_app
-                            .installation_token()
-                            .await?
-                            .expose_secret()
-                            .into(),
-                    );
+                    let token = sync_github_app.installation_token().await?;
+                    let token = AccessToken::new(token.expose_secret().into());
+                    let auth = GitHubAuth::bearer(token);
 
-                    match github.get_user_by_id(self.account_id, &token).await {
+                    match github.get_user_by_id(self.account_id, &auth).await {
                         Ok(github_user) => Ok(github_user),
                         Err(GitHubError::NotFound(_)) => Ok(self.ghost_user(oauth_github.user_id)),
                         // For any other error, stop and try this user again later.


### PR DESCRIPTION
Each `GitHubClient` method previously took a bearer `&AccessToken`, while `public_keys()` took `username`/`password` strings and the index reads went unauthenticated. This collapses those into one `GitHubAuth` enum with `None`, `Bearer`, and `Basic` variants, passed as `&GitHubAuth` to every method so the caller picks the mode.

`GitHubAuth::apply()` sets the matching header on the `RequestBuilder`. This lets `_request()` and `_mutate()` drop their auth-closure parameter and removes the separate `request()`/`request_basic()` helpers. The basic password becomes a `SecretString`, so `secrecy` moves to a regular dependency.