### PR TITLE
Bound relevance-sorted crate search to the most-downloaded candidates

### DIFF
--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -168,6 +168,9 @@ export interface paths {
          *     - Alphabetical listing of crates
          *     - List of crates under a specific owner
          *     - Listing a user's followed crates
+         *
+         *     When sorting by relevance, only the first 1000 results can be accessed, even
+         *     though `meta.total` may report a higher number of matching crates.
          */
         get: operations["list_crates"];
         put?: never;

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -32,6 +32,10 @@ use crate::util::no_store;
 use crate::util::string_excl_null::StringExclNull;
 use crates_io_database::fns::{array_agg, canon_crate_name, lower};
 
+/// The maximum number of crates that are ranked by relevance for a search
+/// query (see [`FilterParams::relevance_candidate_ids`]).
+const RELEVANCE_CANDIDATE_LIMIT: i64 = 1000;
+
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ListResponse {
     crates: Vec<EncodableCrate>,
@@ -61,6 +65,9 @@ pub struct ListMeta {
 /// - Alphabetical listing of crates
 /// - List of crates under a specific owner
 /// - Listing a user's followed crates
+///
+/// When sorting by relevance, only the first 1000 results can be accessed, even
+/// though `meta.total` may report a higher number of matching crates.
 #[utoipa::path(
     get,
     path = "/api/v1/crates",
@@ -136,6 +143,16 @@ pub async fn list_crates(
         query = query.order(Crate::with_name(q_string).desc());
 
         if sort == "relevance" {
+            // Ranking every crate that matches the query is prohibitively
+            // expensive for short or common terms (see
+            // `relevance_candidate_ids`), so we restrict the ranking to a
+            // bounded set of the most promising candidates. Results beyond this
+            // set are intentionally not reachable when sorting by relevance.
+            let candidate_ids = filter_params
+                .relevance_candidate_ids(&mut conn, RELEVANCE_CANDIDATE_LIMIT)
+                .await?;
+            query = query.filter(crates::id.eq_any(candidate_ids));
+
             let q = plainto_tsquery_with_search_config(TsConfigurationByName("english"), q_string);
             let rank = ts_rank_cd(crates::textsearchable_index_col, q);
             query = query.select((
@@ -203,6 +220,19 @@ pub async fn list_crates(
         .gather(&req)?;
 
     let explicit_page = matches!(pagination.page, Page::Numeric(_));
+
+    // When sorting by relevance only the first `RELEVANCE_CANDIDATE_LIMIT`
+    // results are reachable, so reject explicit pages that start beyond it
+    // instead of returning an empty page. Seek pagination needs no equivalent:
+    // it stops handing out keys once it reaches the boundary.
+    if matches!(seek, Some(Seek::Relevance))
+        && let Some(offset) = pagination.offset()
+        && offset >= RELEVANCE_CANDIDATE_LIMIT
+    {
+        return Err(bad_request(format!(
+            "Cannot page beyond the first {RELEVANCE_CANDIDATE_LIMIT} results when sorting by relevance. Please take a look at https://crates.io/data-access for alternatives."
+        )));
+    }
 
     // To avoid breaking existing users, seek-based pagination is only used if an explicit page has
     // not been provided. This way clients relying on meta.next_page will use the faster seek-based
@@ -489,6 +519,35 @@ impl FilterParams {
         }
 
         query
+    }
+
+    /// Returns the ids of the crates to rank by relevance for the search query.
+    ///
+    /// Ranking every match with `ts_rank_cd` is too expensive for short or
+    /// common terms, which match a large fraction of crates each with a large,
+    /// TOAST-ed `tsvector`. Instead we rank only the `limit` matches with the
+    /// most recent downloads, plus any exact name match regardless of its
+    /// download count.
+    async fn relevance_candidate_ids(
+        &self,
+        conn: &mut AsyncPgConnection,
+        limit: i64,
+    ) -> AppResult<Vec<i32>> {
+        let q_string = self.q_string.as_ref().expect("q_string should not be None");
+        let ids = self
+            .make_query()
+            .left_join(recent_crate_downloads::table)
+            .select(crates::id)
+            .order((
+                Crate::with_name(q_string.as_str()).desc(),
+                recent_crate_downloads::downloads.desc().nulls_last(),
+                crates::id,
+            ))
+            .limit(limit)
+            .load::<i32>(conn)
+            .await?;
+
+        Ok(ids)
     }
 
     fn seek_after(&self, seek_payload: &seek::SeekPayload) -> BoxedCondition<'_> {

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -149,7 +149,12 @@ pub async fn list_crates(
                 default_versions::num_versions.nullable(),
             ));
             seek = Some(Seek::Relevance);
-            query = query.then_order_by(rank.desc())
+            // Within equal relevance, prefer the more popular crate. Common
+            // terms produce many ties on `ts_rank_cd`, so without this the top
+            // results would be ordered alphabetically by name.
+            query = query
+                .then_order_by(rank.desc())
+                .then_order_by(recent_crate_downloads::downloads.desc().nulls_last())
         } else {
             query = query.select((
                 ALL_COLUMNS,
@@ -617,14 +622,24 @@ impl FilterParams {
             SeekPayload::Relevance(Relevance {
                 exact_match: exact,
                 rank: rank_in,
+                recent_downloads,
                 id,
             }) => {
                 // Equivalent of:
+                // for recent_downloads is not None:
                 // ```
-                // WHERE (exact_match = exact_match' AND rank = rank' AND name > name')
+                // WHERE (exact_match = exact_match' AND rank = rank' AND recent_downloads = recent_downloads' AND name > name')
+                //      OR (exact_match = exact_match' AND rank = rank' AND (recent_downloads < recent_downloads' OR recent_downloads IS NULL))
                 //      OR (exact_match = exact_match' AND rank < rank')
                 //      OR exact_match < exact_match'
-                // ORDER BY exact_match DESC, rank DESC, name ASC
+                // ORDER BY exact_match DESC, rank DESC, recent_downloads DESC NULLS LAST, name ASC
+                // ```
+                // for recent_downloads is None:
+                // ```
+                // WHERE (exact_match = exact_match' AND rank = rank' AND recent_downloads IS NULL AND name > name')
+                //      OR (exact_match = exact_match' AND rank < rank')
+                //      OR exact_match < exact_match'
+                // ORDER BY exact_match DESC, rank DESC, recent_downloads DESC NULLS LAST, name ASC
                 // ```
                 let q_string = self.q_string.as_ref().expect("q_string should not be None");
                 let q = plainto_tsquery_with_search_config(
@@ -633,17 +648,44 @@ impl FilterParams {
                 );
                 let rank = ts_rank_cd(crates::textsearchable_index_col, q);
                 let name_exact_match = Crate::with_name(q_string.as_str());
-                vec![
-                    Box::new(
-                        name_exact_match
-                            .eq(exact)
-                            .and(rank.eq(rank_in))
-                            .and(crates::name.nullable().gt(crate_name_by_id(id)))
-                            .nullable(),
-                    ),
-                    Box::new(name_exact_match.eq(exact).and(rank.lt(rank_in)).nullable()),
+                let downloads = recent_crate_downloads::downloads;
+
+                let mut conditions: Vec<BoxedCondition<'_>> = vec![
                     Box::new(name_exact_match.lt(exact).nullable()),
-                ]
+                    Box::new(name_exact_match.eq(exact).and(rank.lt(rank_in)).nullable()),
+                ];
+                // Break the exact-match/rank tie by recent downloads
+                // (DESC NULLS LAST), then by name.
+                match recent_downloads {
+                    Some(dl) => {
+                        conditions.push(Box::new(
+                            name_exact_match
+                                .eq(exact)
+                                .and(rank.eq(rank_in))
+                                .and(downloads.lt(dl).or(downloads.is_null()))
+                                .nullable(),
+                        ));
+                        conditions.push(Box::new(
+                            name_exact_match
+                                .eq(exact)
+                                .and(rank.eq(rank_in))
+                                .and(downloads.eq(dl))
+                                .and(crates::name.nullable().gt(crate_name_by_id(id)))
+                                .nullable(),
+                        ));
+                    }
+                    None => {
+                        conditions.push(Box::new(
+                            name_exact_match
+                                .eq(exact)
+                                .and(rank.eq(rank_in))
+                                .and(downloads.is_null())
+                                .and(crates::name.nullable().gt(crate_name_by_id(id)))
+                                .nullable(),
+                        ));
+                    }
+                }
+                conditions
             }
         };
 
@@ -698,6 +740,7 @@ mod seek {
             Relevance {
                 exact_match: bool,
                 rank: f32,
+                recent_downloads: Option<i64>,
                 id: i32,
             },
         }
@@ -726,6 +769,7 @@ mod seek {
                 Seek::Relevance => SeekPayload::Relevance(Relevance {
                     exact_match,
                     rank,
+                    recent_downloads,
                     id,
                 }),
             }

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -370,15 +370,15 @@ async fn relevance_search_ranks_most_relevant_crate_first() -> anyhow::Result<()
     assert_debug_snapshot!(crate_names, @r#"
     [
         "relevant_widget",
-        "filler_widget_0001",
-        "filler_widget_0002",
-        "filler_widget_0003",
-        "filler_widget_0004",
-        "filler_widget_0005",
-        "filler_widget_0006",
-        "filler_widget_0007",
-        "filler_widget_0008",
-        "filler_widget_0009",
+        "filler_widget_1111",
+        "filler_widget_1110",
+        "filler_widget_1109",
+        "filler_widget_1108",
+        "filler_widget_1107",
+        "filler_widget_1106",
+        "filler_widget_1105",
+        "filler_widget_1104",
+        "filler_widget_1103",
     ]
     "#);
 
@@ -409,15 +409,15 @@ async fn relevance_search_always_includes_exact_name_match() -> anyhow::Result<(
     assert_debug_snapshot!(crate_names, @r#"
     [
         "widget",
-        "filler_widget_0001",
-        "filler_widget_0002",
-        "filler_widget_0003",
-        "filler_widget_0004",
-        "filler_widget_0005",
-        "filler_widget_0006",
-        "filler_widget_0007",
-        "filler_widget_0008",
-        "filler_widget_0009",
+        "filler_widget_1111",
+        "filler_widget_1110",
+        "filler_widget_1109",
+        "filler_widget_1108",
+        "filler_widget_1107",
+        "filler_widget_1106",
+        "filler_widget_1105",
+        "filler_widget_1104",
+        "filler_widget_1103",
     ]
     "#);
 
@@ -577,15 +577,15 @@ async fn index_sorting() -> anyhow::Result<()> {
     assert_eq!(calls, 5);
 
     // Sort by relevance
-    // ordering (exact match desc, rank desc, name asc)
+    // ordering (exact match desc, rank desc, recent downloads desc nulls last, name asc)
     let query = "q=foo_sort";
     let (resp, calls) = page_with_seek(&anon, query).await;
     for json in search_both(&anon, query).await {
         assert_eq!(json.meta.total, 3);
         assert_eq!(resp[0].crates[0].name, "foo_sort");
-        // same rank, by name asc
-        assert_eq!(resp[1].crates[0].name, "bar_sort");
-        assert_eq!(resp[2].crates[0].name, "baz_sort");
+        // same rank, by recent downloads desc (baz_sort 50, bar_sort 0)
+        assert_eq!(resp[1].crates[0].name, "baz_sort");
+        assert_eq!(resp[2].crates[0].name, "bar_sort");
     }
     assert_eq!(calls, 4);
     let ranks = querystring_rank(&mut conn, "foo_sort").await;
@@ -598,9 +598,9 @@ async fn index_sorting() -> anyhow::Result<()> {
     for json in search_both(&anon, query).await {
         assert_eq!(json.meta.total, 3);
         assert_eq!(resp[0].crates[0].name, "foo_sort");
-        // same rank, by name asc
-        assert_eq!(resp[1].crates[0].name, "bar_sort");
-        assert_eq!(resp[2].crates[0].name, "baz_sort");
+        // same rank, by recent downloads desc (baz_sort 50, bar_sort 0)
+        assert_eq!(resp[1].crates[0].name, "baz_sort");
+        assert_eq!(resp[2].crates[0].name, "bar_sort");
     }
     assert_eq!(calls, 4);
     let ranks = querystring_rank(&mut conn, "foo%20sort").await;

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -343,12 +343,13 @@ async fn insert_popular_widget_matches(conn: &mut diesel_async::AsyncPgConnectio
         .unwrap();
 }
 
-/// Relevance ranking surfaces the most textually relevant crate first, even
-/// when it has far fewer recent downloads than the other matches.
+/// A more textually relevant crate that is not among the most-downloaded
+/// matches is excluded from relevance results, since ranking is bounded to the
+/// most-downloaded candidates.
 #[tokio::test(flavor = "multi_thread")]
-async fn relevance_search_ranks_most_relevant_crate_first() -> anyhow::Result<()> {
-    // A large field of equally-relevant matches for the more relevant crate
-    // below to be ranked ahead of.
+async fn relevance_search_is_bounded_to_most_downloaded_candidates() -> anyhow::Result<()> {
+    // More matches than RELEVANCE_CANDIDATE_LIMIT (1000), so the least
+    // downloaded matches fall outside the candidate set.
     const POPULAR_MATCH_COUNT: i64 = 1111;
 
     let (app, anon, user) = TestApp::init().with_user().await;
@@ -357,7 +358,8 @@ async fn relevance_search_ranks_most_relevant_crate_first() -> anyhow::Result<()
 
     insert_popular_widget_matches(&mut conn, POPULAR_MATCH_COUNT).await;
 
-    // Higher text relevance, but no recent downloads.
+    // Higher text relevance, but no recent downloads, so it falls outside the
+    // candidate set.
     CrateBuilder::new("relevant_widget", user.id)
         .description("widget widget widget")
         .recent_downloads(0)
@@ -369,7 +371,6 @@ async fn relevance_search_ranks_most_relevant_crate_first() -> anyhow::Result<()
     let crate_names = json.crates.into_iter().map(|c| c.name).collect::<Vec<_>>();
     assert_debug_snapshot!(crate_names, @r#"
     [
-        "relevant_widget",
         "filler_widget_1111",
         "filler_widget_1110",
         "filler_widget_1109",
@@ -379,6 +380,7 @@ async fn relevance_search_ranks_most_relevant_crate_first() -> anyhow::Result<()
         "filler_widget_1105",
         "filler_widget_1104",
         "filler_widget_1103",
+        "filler_widget_1102",
     ]
     "#);
 
@@ -420,6 +422,32 @@ async fn relevance_search_always_includes_exact_name_match() -> anyhow::Result<(
         "filler_widget_1103",
     ]
     "#);
+
+    Ok(())
+}
+
+/// Requesting an explicit page beyond the bounded candidate set returns an
+/// error instead of a silently empty page. Seek pagination has no equivalent
+/// guard because it stops handing out keys once it reaches the boundary.
+#[tokio::test(flavor = "multi_thread")]
+async fn relevance_search_rejects_paging_beyond_candidate_limit() -> anyhow::Result<()> {
+    const POPULAR_MATCH_COUNT: i64 = 1111;
+
+    let (app, anon, _user) = TestApp::init().with_user().await;
+    let mut conn = app.db_conn().await;
+
+    insert_popular_widget_matches(&mut conn, POPULAR_MATCH_COUNT).await;
+
+    // The last page within the candidate limit still succeeds.
+    let json = anon.search("q=widget&per_page=100&page=10").await;
+    assert_eq!(json.crates.len(), 100);
+
+    // The next page would start beyond the candidate limit and is rejected.
+    let response = anon
+        .get_with_query::<()>("/api/v1/crates", "q=widget&per_page=100&page=11")
+        .await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Cannot page beyond the first 1000 results when sorting by relevance. Please take a look at https://crates.io/data-access for alternatives."}]}"#);
 
     Ok(())
 }

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -2,14 +2,14 @@ use crate::builders::{CrateBuilder, VersionBuilder};
 use crate::util::{RequestHelper, TestApp};
 use crate::{new_category, new_user};
 use crates_io::models::Category;
-use crates_io::schema::crates;
+use crates_io::schema::{crates, version_downloads, versions};
 use crates_io_database::schema::categories;
 use diesel::sql_types::Timestamptz;
 use diesel::{dsl::*, prelude::*, update};
 use diesel_async::RunQueryDsl;
 use googletest::prelude::*;
 use http::StatusCode;
-use insta::{assert_json_snapshot, assert_snapshot};
+use insta::{assert_debug_snapshot, assert_json_snapshot, assert_snapshot};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -275,6 +275,151 @@ async fn exact_match_first_on_queries() -> anyhow::Result<()> {
         assert_eq!(json.crates[1].name, "bar-exact");
         assert_eq!(json.crates[2].name, "foo_exact");
     }
+
+    Ok(())
+}
+
+/// Inserts `count` crates that all match a search for `widget` (via their
+/// description). Each crate gets a distinct recent-download count equal to its
+/// index, so the most-downloaded candidates are unambiguous. Names are
+/// zero-padded so that lexical and numeric order match.
+async fn insert_popular_widget_matches(conn: &mut diesel_async::AsyncPgConnection, count: i64) {
+    let new_crates = (1..=count)
+        .map(|i| {
+            (
+                crates::name.eq(format!("filler_widget_{i:04}")),
+                crates::description.eq("widget"),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let crate_ids: Vec<i32> = insert_into(crates::table)
+        .values(new_crates)
+        .returning(crates::id)
+        .get_results(conn)
+        .await
+        .unwrap();
+
+    let new_versions = crate_ids
+        .iter()
+        .map(|&crate_id| {
+            (
+                versions::crate_id.eq(crate_id),
+                versions::num.eq("1.0.0"),
+                versions::num_no_build.eq("1.0.0"),
+                versions::crate_size.eq(0),
+                versions::checksum.eq("0".repeat(64)),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let version_ids: Vec<i32> = insert_into(versions::table)
+        .values(new_versions)
+        .returning(versions::id)
+        .get_results(conn)
+        .await
+        .unwrap();
+
+    let new_downloads = version_ids
+        .iter()
+        .zip(1..=count)
+        .map(|(&version_id, i)| {
+            (
+                version_downloads::version_id.eq(version_id),
+                version_downloads::downloads.eq(i as i32),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    insert_into(version_downloads::table)
+        .values(new_downloads)
+        .execute(conn)
+        .await
+        .unwrap();
+
+    diesel::sql_query("REFRESH MATERIALIZED VIEW recent_crate_downloads")
+        .execute(conn)
+        .await
+        .unwrap();
+}
+
+/// Relevance ranking surfaces the most textually relevant crate first, even
+/// when it has far fewer recent downloads than the other matches.
+#[tokio::test(flavor = "multi_thread")]
+async fn relevance_search_ranks_most_relevant_crate_first() -> anyhow::Result<()> {
+    // A large field of equally-relevant matches for the more relevant crate
+    // below to be ranked ahead of.
+    const POPULAR_MATCH_COUNT: i64 = 1111;
+
+    let (app, anon, user) = TestApp::init().with_user().await;
+    let mut conn = app.db_conn().await;
+    let user = user.as_model();
+
+    insert_popular_widget_matches(&mut conn, POPULAR_MATCH_COUNT).await;
+
+    // Higher text relevance, but no recent downloads.
+    CrateBuilder::new("relevant_widget", user.id)
+        .description("widget widget widget")
+        .recent_downloads(0)
+        .expect_build(&mut conn)
+        .await;
+
+    let json = anon.search("q=widget").await;
+    assert_eq!(json.meta.total as i64, POPULAR_MATCH_COUNT + 1);
+    let crate_names = json.crates.into_iter().map(|c| c.name).collect::<Vec<_>>();
+    assert_debug_snapshot!(crate_names, @r#"
+    [
+        "relevant_widget",
+        "filler_widget_0001",
+        "filler_widget_0002",
+        "filler_widget_0003",
+        "filler_widget_0004",
+        "filler_widget_0005",
+        "filler_widget_0006",
+        "filler_widget_0007",
+        "filler_widget_0008",
+        "filler_widget_0009",
+    ]
+    "#);
+
+    Ok(())
+}
+
+/// An exact name match is always ranked, and ranked first, even with no
+/// downloads and many more popular matches.
+#[tokio::test(flavor = "multi_thread")]
+async fn relevance_search_always_includes_exact_name_match() -> anyhow::Result<()> {
+    const POPULAR_MATCH_COUNT: i64 = 1111;
+
+    let (app, anon, user) = TestApp::init().with_user().await;
+    let mut conn = app.db_conn().await;
+    let user = user.as_model();
+
+    insert_popular_widget_matches(&mut conn, POPULAR_MATCH_COUNT).await;
+
+    // Exact name match, but without any recent downloads.
+    CrateBuilder::new("widget", user.id)
+        .recent_downloads(0)
+        .expect_build(&mut conn)
+        .await;
+
+    let json = anon.search("q=widget").await;
+    assert_eq!(json.meta.total as i64, POPULAR_MATCH_COUNT + 1);
+    let crate_names = json.crates.into_iter().map(|c| c.name).collect::<Vec<_>>();
+    assert_debug_snapshot!(crate_names, @r#"
+    [
+        "widget",
+        "filler_widget_0001",
+        "filler_widget_0002",
+        "filler_widget_0003",
+        "filler_widget_0004",
+        "filler_widget_0005",
+        "filler_widget_0006",
+        "filler_widget_0007",
+        "filler_widget_0008",
+        "filler_widget_0009",
+    ]
+    "#);
 
     Ok(())
 }

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1791,7 +1791,7 @@ expression: response.json()
     },
     "/api/v1/crates": {
       "get": {
-        "description": "Called in a variety of scenarios in the front end, including:\n- Alphabetical listing of crates\n- List of crates under a specific owner\n- Listing a user's followed crates",
+        "description": "Called in a variety of scenarios in the front end, including:\n- Alphabetical listing of crates\n- List of crates under a specific owner\n- Listing a user's followed crates\n\nWhen sorting by relevance, only the first 1000 results can be accessed, even\nthough `meta.total` may report a higher number of matching crates.",
         "operationId": "list_crates",
         "parameters": [
           {

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -1537,7 +1537,7 @@ expression: response.json()
     },
     "/api/v1/crates": {
       "get": {
-        "description": "Called in a variety of scenarios in the front end, including:\n- Alphabetical listing of crates\n- List of crates under a specific owner\n- Listing a user's followed crates",
+        "description": "Called in a variety of scenarios in the front end, including:\n- Alphabetical listing of crates\n- List of crates under a specific owner\n- Listing a user's followed crates\n\nWhen sorting by relevance, only the first 1000 results can be accessed, even\nthough `meta.total` may report a higher number of matching crates.",
         "operationId": "list_crates",
         "parameters": [
           {


### PR DESCRIPTION
Sorting crate search by relevance ranked every crate matching the query with `ts_rank_cd()`. For short or common terms (`time`, `test`, `data`, ...) that is a large fraction of all crates, each requiring its large, TOAST-ed `tsvector` to be read just to be ranked and then discarded below the result limit, taking up to ~1-2s.

This restricts relevance ranking to the 1000 matching crates with the most recent downloads and ranks only those. The candidate selection in `relevance_candidate_ids()` sorts by an integer column rather than the `tsvector`, so the expensive `ts_rank_cd()` now runs over at most 1000 rows instead of 50k+. An exact name match is always kept among the candidates regardless of its download count, and a crate's score still reflects all of its searchable text within the candidate set.

It also breaks `ts_rank_cd()` ties by recent downloads before name. Common terms produce many equally-ranked matches, so previously the top results were effectively ordered alphabetically. With the tiebreaker the more popular crates surface first, and crates without recent downloads sort last. The `Seek::Relevance` pagination key gains a recent-downloads level so seek-based paging stays consistent with the ordering.

The reachable range covers what the frontend displays and the deepest non-bot API paging. An explicit page that starts beyond the cap now returns a `400` instead of a silently empty page, and seek pagination stops at the boundary on its own. The endpoint doc comment records the cap so it surfaces in the OpenAPI description and the generated TypeScript client.

The one visible behavior change worth flagging: a highly relevant but rarely downloaded crate no longer appears in relevance results, since ranking is bounded to the most-downloaded candidates. This is intentional. It demotes obscure README-keyword-dense crates in favor of widely-used ones for common terms. Other sorts (`new`, `alphabetical`, ...) stay unbounded.

### Related

- https://github.com/rust-lang/crates.io/issues/5312
- https://github.com/rust-lang/crates.io/issues/2541
- https://github.com/rust-lang/crates.io/issues/1370
