### PR TITLE
Render Markdown definition lists

### DIFF
--- a/crates/crates_io_markdown/src/lib.rs
+++ b/crates/crates_io_markdown/src/lib.rs
@@ -88,6 +88,7 @@ impl<'a> MarkdownRenderer<'a> {
         let extension_options = options::Extension::builder()
             .alerts(true)
             .autolink(true)
+            .description_lists(true)
             .multiline_block_quotes(true)
             .strikethrough(true)
             .table(true)
@@ -644,6 +645,19 @@ There can also be some text in between!
     fn tables_with_rowspan_and_colspan() {
         let text = "<table><tr><th rowspan=\"1\" colspan=\"2\">Target</th></tr></table>\n";
         assert_snapshot!(markdown_to_html(text, None, ""), @r#"<table><tbody><tr><th rowspan="1" colspan="2">Target</th></tr></tbody></table>"#);
+    }
+
+    #[test]
+    fn definition_lists() {
+        let text = "First term\n: First definition\n\nSecond term\n: Second definition\n";
+        assert_snapshot!(markdown_to_html(text, None, ""), @r#"
+        <dl>
+        <dt>First term</dt>
+        <dd>First definition</dd>
+        <dt>Second term</dt>
+        <dd>Second definition</dd>
+        </dl>
+        "#);
     }
 
     #[test]


### PR DESCRIPTION
Closes #13890.

Most forges (GitHub, GitLab, Forgejo) render Markdown [definition lists](https://www.markdownguide.org/extended-syntax/#definition-lists):

```markdown
First term
: First definition
```

crates.io previously ignored this syntax. This enables comrak's `description_lists`
extension so definition lists in crate READMEs and descriptions render as
`<dl>`/`<dt>`/`<dd>`:

```html
<dl>
<dt>First term</dt>
<dd>First definition</dd>
</dl>
```

The `<dl>`/`<dt>`/`<dd>` tags are already on the `ammonia` sanitizer allowlist, so
no sanitizer change is needed. Added a snapshot test covering the rendering.

`cargo test -p crates_io_markdown`, `cargo clippy -p crates_io_markdown --all-targets`
and `cargo fmt` all pass.