### PR TITLE
crates/security: Move `convertMarkdown()` out of `load()`

### DIFF
--- a/svelte/src/routes/crates/[crate_id]/security/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/security/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { micromark } from 'micromark';
+  import { gfm, gfmHtml } from 'micromark-extension-gfm';
+
   import CrateHeader from '$lib/components/CrateHeader.svelte';
 
   let { data } = $props();
@@ -18,6 +21,13 @@
       return `https://www.first.org/cvss/calculator/${match[1]}#${cvss}`;
     }
     return null;
+  }
+
+  function convertMarkdown(markdown: string): string {
+    return micromark(markdown, {
+      extensions: [gfm()],
+      htmlExtensions: [gfmHtml()],
+    });
   }
 </script>
 
@@ -58,7 +68,7 @@
           </div>
         {/if}
         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-        {@html data.convertMarkdown(advisory.details)}
+        {@html convertMarkdown(advisory.details)}
       </li>
     {/each}
   </ul>

--- a/svelte/src/routes/crates/[crate_id]/security/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/security/+page.ts
@@ -6,20 +6,8 @@ export async function load({ fetch, params }) {
   let crateName = params.crate_id;
 
   try {
-    let [advisories, micromarkModule, gfmModule] = await Promise.all([
-      fetchAdvisories(crateName, fetch),
-      import('micromark'),
-      import('micromark-extension-gfm'),
-    ]);
-
-    let convertMarkdown = (markdown: string): string => {
-      return micromarkModule.micromark(markdown, {
-        extensions: [gfmModule.gfm()],
-        htmlExtensions: [gfmModule.gfmHtml()],
-      });
-    };
-
-    return { advisories, convertMarkdown };
+    let advisories = await fetchAdvisories(crateName, fetch);
+    return { advisories };
   } catch {
     error(500, { message: `${crateName}: Failed to load advisories`, tryAgain: true });
   }


### PR DESCRIPTION
This moves the `micromark` imports and the `convertMarkdown()` function definition out of the universal `load()` function and into the page component with static imports. The conversion call itself was always in the component via `{@html}`.

The dynamic `import()` + `Promise.all()` pattern was carried over from the Ember.js app, which does not code-split by route and needed the dynamic import to keep `micromark` out of the main bundle. SvelteKit code-splits per route, so the component module (including `micromark`) already loads concurrently with `load()`, making the manual import unnecessary.

Returning a function from `load()` also mixed a rendering concern into the data layer. The function definition now lives in the component alongside its call site.