### PR TITLE
tests/session: Assert on `state` token and snapshot authorize URL

### DIFF
--- a/src/tests/routes/session/begin.rs
+++ b/src/tests/routes/session/begin.rs
@@ -1,15 +1,40 @@
 use crate::util::{RequestHelper, TestApp};
+use insta::assert_snapshot;
+use oauth2::ClientId;
 use serde::Deserialize;
+use url::Url;
 
 #[derive(Deserialize)]
 struct AuthResponse {
     url: String,
-    state: String,
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn post_gives_a_token() {
-    let (_, anon) = TestApp::init().empty().await;
+    let (_, anon) = TestApp::init()
+        .with_config(|config| config.gh_client_id = ClientId::new("test-client-id".into()))
+        .empty()
+        .await;
+
     let json: AuthResponse = anon.post("/api/private/session/begin", "").await.good();
-    assert!(json.url.contains(&json.state));
+
+    let url = Url::parse(&json.url).unwrap();
+    let state = url
+        .query_pairs()
+        .find(|(key, _)| key == "state")
+        .map(|(_, value)| value.into_owned())
+        .expect("missing `state` query parameter");
+
+    // The `state` is an oauth2 CSRF token: 16 random bytes encoded as URL-safe
+    // base64 without padding, which results in 22 characters.
+    assert_eq!(state.len(), 22);
+    assert!(state.bytes().all(is_base64));
+
+    let url = json.url.replace(&state, "[STATE]");
+    assert_snapshot!(url, @"https://github.com/login/oauth/authorize?response_type=code&client_id=test-client-id&state=[STATE]&scope=read%3Aorg");
+}
+
+/// Checks whether `b` is a URL-safe base64 character.
+fn is_base64(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'-' || b == b'_'
 }


### PR DESCRIPTION
This adjusts the test to verify that the `state` query parameter is a 22-character URL-safe base64 oauth2 CSRF token and it uses a snapshot assertion for the full authorization URL with the random `state` redacted. This should detect any unintentional changes to the URL from refactorings or dependency updates.