### PR TITLE
Load native-replacement data from the upstream dataset

### DIFF
--- a/packages/crates-io-msw/handlers/native-replacements.js
+++ b/packages/crates-io-msw/handlers/native-replacements.js
@@ -1,0 +1,13 @@
+import { http, HttpResponse } from 'msw';
+
+const replacements = {
+  lazy_static: {
+    description:
+      'The standard library provides `std::sync::LazyLock` (stable since Rust 1.80), which lets you replace the `lazy_static!` macro with a plain `static` and remove the dependency.',
+    url: 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html',
+  },
+};
+
+export default [
+  http.get('https://rust-lang.github.io/std-replacement-data/all.json', () => HttpResponse.json(replacements)),
+];

--- a/packages/crates-io-msw/index.js
+++ b/packages/crates-io-msw/index.js
@@ -7,6 +7,7 @@ import gitlabHandlers from './handlers/gitlab.js';
 import inviteHandlers from './handlers/invites.js';
 import keywordHandlers from './handlers/keywords.js';
 import metadataHandlers from './handlers/metadata.js';
+import nativeReplacementHandlers from './handlers/native-replacements.js';
 import playgroundHandlers from './handlers/playground.js';
 import rustsecHandlers from './handlers/rustsec.js';
 import sessionHandlers from './handlers/sessions.js';
@@ -26,6 +27,7 @@ export const handlers = [
   ...inviteHandlers,
   ...keywordHandlers,
   ...metadataHandlers,
+  ...nativeReplacementHandlers,
   ...playgroundHandlers,
   ...rustsecHandlers,
   ...sessionHandlers,

--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { components } from '@crates-io/api-client';
   import type { DownloadChartData } from '$lib/components/download-chart/data';
+  import type { NativeReplacement } from '$lib/data/native-replacements';
   import type { DocsRsStatus } from '$lib/utils/docs-rs';
   import type { PlaygroundCrate } from '$lib/utils/playground';
 
@@ -15,7 +16,6 @@
   import NativeReplacementBanner from '$lib/components/NativeReplacementBanner.svelte';
   import ReadmePlaceholder from '$lib/components/ReadmePlaceholder.svelte';
   import RenderedHtml from '$lib/components/RenderedHtml.svelte';
-  import { nativeReplacements } from '$lib/data/native-replacements';
   import { loadReadme } from '$lib/utils/readme';
 
   type Crate = components['schemas']['Crate'];
@@ -35,6 +35,7 @@
     playgroundCratesPromise: Promise<PlaygroundCrate[]>;
     docsRsStatusPromise: Promise<DocsRsStatus | null>;
     downloadsPromise: Promise<DownloadChartData>;
+    nativeReplacement?: NativeReplacement;
   }
 
   let {
@@ -48,6 +49,7 @@
     playgroundCratesPromise,
     docsRsStatusPromise,
     downloadsPromise,
+    nativeReplacement,
   }: Props = $props();
   let owners: Owner[] = $state([]);
 
@@ -59,8 +61,6 @@
   let stackedGraph = $state(true);
 
   let downloadsContext = $derived(requestedVersion ? version : crate);
-
-  let nativeReplacement = $derived(nativeReplacements[crate.name]);
 
   let retryReadmePromise = $state<typeof readmePromise | null>(null);
   let activeReadmePromise = $derived(retryReadmePromise ?? readmePromise);

--- a/svelte/src/lib/components/NativeReplacementBanner.stories.svelte
+++ b/svelte/src/lib/components/NativeReplacementBanner.stories.svelte
@@ -1,7 +1,6 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
-  import { nativeReplacements } from '$lib/data/native-replacements';
   import NativeReplacementBanner from './NativeReplacementBanner.svelte';
 
   const { Story } = defineMeta({
@@ -9,27 +8,47 @@
     component: NativeReplacementBanner,
     tags: ['autodocs'],
   });
+
+  const full = {
+    description:
+      'The standard library provides `std::sync::LazyLock` (stable since Rust 1.80), which lets you replace the `lazy_static!` macro with a plain `static` and remove the dependency.',
+    url: 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html',
+  };
+
+  const fullMacro = {
+    description:
+      'The `matches!` macro has been in `std` since Rust 1.42, and `assert_matches!` / `debug_assert_matches!` followed in Rust 1.96.',
+    url: 'https://doc.rust-lang.org/std/macro.matches.html',
+  };
+
+  const partial = {
+    description:
+      'For most uses, `std::thread::available_parallelism` (Rust 1.59) returns the parallelism available to the process. (It does not distinguish physical vs logical cores the way `num_cpus` does.)',
+    url: 'https://doc.rust-lang.org/std/thread/fn.available_parallelism.html',
+  };
+
+  const partialReleaseNotes = {
+    description:
+      'Most of `once_cell` is now in `std`: `OnceCell`/`OnceLock` (Rust 1.70) and `LazyCell`/`LazyLock` (Rust 1.80). The `race` module and fallible `get_or_try_init` have no stable `std` equivalent yet.',
+    url: 'https://blog.rust-lang.org/2024/07/25/Rust-1.80.0/',
+  };
 </script>
 
-<Story
-  name="Default"
-  args={{ replacement: nativeReplacements.lazy_static }}
-  parameters={{ chromatic: { disableSnapshot: true } }}
-/>
+<Story name="Default" args={{ replacement: full }} parameters={{ chromatic: { disableSnapshot: true } }} />
 
 <!-- This is using a single Story with multiple examples to reduce the amount of snapshots generated for visual regression testing -->
 <Story name="Combined" asChild>
   <h1>Full</h1>
-  <NativeReplacementBanner replacement={nativeReplacements.lazy_static} />
+  <NativeReplacementBanner replacement={full} />
 
   <h1>Full (macro)</h1>
-  <NativeReplacementBanner replacement={nativeReplacements.matches} />
+  <NativeReplacementBanner replacement={fullMacro} />
 
   <h1>Partial</h1>
-  <NativeReplacementBanner replacement={nativeReplacements.num_cpus} />
+  <NativeReplacementBanner replacement={partial} />
 
   <h1>Partial (release-notes link)</h1>
-  <NativeReplacementBanner replacement={nativeReplacements.once_cell} />
+  <NativeReplacementBanner replacement={partialReleaseNotes} />
 </Story>
 
 <style>

--- a/svelte/src/lib/components/NativeReplacementBanner.svelte
+++ b/svelte/src/lib/components/NativeReplacementBanner.svelte
@@ -2,6 +2,7 @@
   import type { NativeReplacement } from '$lib/data/native-replacements';
 
   import Alert from '$lib/components/Alert.svelte';
+  import { renderSimpleMarkdown } from '$lib/utils/markdown';
 
   interface Props {
     replacement: NativeReplacement;
@@ -12,9 +13,11 @@
 
 <Alert variant="tip" data-test-native-replacement-banner>
   <strong>You might not need this dependency.</strong>
+  <div class="description">
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -- escaped micromark output -->
+    {@html renderSimpleMarkdown(replacement.description)}
+  </div>
   <p>
-    <!-- eslint-disable-next-line svelte/no-at-html-tags -- curated, in-repo HTML, never user input -->
-    {@html replacement.description}
     <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- always an external std/release-notes URL -->
     <a href={replacement.url} target="_blank" rel="noopener noreferrer">Learn more</a>
   </p>
@@ -26,13 +29,14 @@
     font-weight: 500;
   }
 
+  .description :global(p),
   p {
     margin: var(--space-2xs) 0 0;
     font-size: 0.9em;
     line-height: 1.4;
   }
 
-  p :global(code) {
+  .description :global(code) {
     font-family: var(--font-monospace);
     font-size: 0.9em;
     letter-spacing: -2%;

--- a/svelte/src/lib/components/NativeReplacementBanner.svelte.test.ts
+++ b/svelte/src/lib/components/NativeReplacementBanner.svelte.test.ts
@@ -9,12 +9,12 @@ import NativeReplacementBanner from './NativeReplacementBanner.svelte';
 const STD_URL = 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html';
 
 const replacement: NativeReplacement = {
-  description: 'Use <code>std::sync::LazyLock</code> (Rust 1.80) instead.',
+  description: 'Use `std::sync::LazyLock` (Rust 1.80) instead.',
   url: STD_URL,
 };
 
 describe('NativeReplacementBanner', () => {
-  it('renders the description HTML and a "Learn more" link', async () => {
+  it('renders the description Markdown and a "Learn more" link', async () => {
     render(NativeReplacementBanner, { replacement });
 
     let banner = page.getByCSS('[data-test-native-replacement-banner]');

--- a/svelte/src/lib/components/dependency-list/Row.stories.svelte
+++ b/svelte/src/lib/components/dependency-list/Row.stories.svelte
@@ -50,6 +50,10 @@
   <Row
     dependency={createDependency({ crate_id: 'lazy_static' })}
     descriptionPromise={resolved('A macro for declaring lazily evaluated statics')}
+    nativeReplacement={{
+      description: 'Use `std::sync::LazyLock` instead.',
+      url: 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html',
+    }}
   />
 
   <h1>Loading Description</h1>

--- a/svelte/src/lib/components/dependency-list/Row.svelte
+++ b/svelte/src/lib/components/dependency-list/Row.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import type { components } from '@crates-io/api-client';
+  import type { NativeReplacement } from '$lib/data/native-replacements';
 
   import { resolve } from '$app/paths';
 
   import Icon from '$lib/components/Icon.svelte';
   import Placeholder from '$lib/components/Placeholder.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
-  import { nativeReplacements } from '$lib/data/native-replacements';
   import { renderSimpleMarkdown } from '$lib/utils/markdown';
 
   type Dependency = components['schemas']['Dependency'];
@@ -14,15 +14,14 @@
   interface Props {
     dependency: Dependency;
     descriptionPromise: Promise<string | null> | undefined;
+    nativeReplacement?: NativeReplacement;
   }
 
-  let { dependency, descriptionPromise }: Props = $props();
+  let { dependency, descriptionPromise, nativeReplacement }: Props = $props();
 
   let focused = $state(false);
 
   let formattedReq = $derived(dependency.req === '*' ? '' : dependency.req);
-
-  let nativeReplacement = $derived(nativeReplacements[dependency.crate_id]);
 
   const replacementHint = 'This dependency might not be needed anymore.';
 

--- a/svelte/src/lib/components/dependency-list/Row.svelte
+++ b/svelte/src/lib/components/dependency-list/Row.svelte
@@ -7,6 +7,7 @@
   import Placeholder from '$lib/components/Placeholder.svelte';
   import Tooltip from '$lib/components/Tooltip.svelte';
   import { nativeReplacements } from '$lib/data/native-replacements';
+  import { renderSimpleMarkdown } from '$lib/utils/markdown';
 
   type Dependency = components['schemas']['Dependency'];
 
@@ -69,10 +70,8 @@
           <Tooltip>
             <div class="replacement-tooltip" data-test-native-replacement-tooltip>
               <strong>{replacementHint}</strong>
-              <p>
-                <!-- eslint-disable-next-line svelte/no-at-html-tags -- curated, in-repo HTML, never user input -->
-                {@html nativeReplacement.description}
-              </p>
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -- escaped micromark output -->
+              {@html renderSimpleMarkdown(nativeReplacement.description)}
             </div>
           </Tooltip>
         </span>
@@ -199,7 +198,7 @@
       font-weight: 500;
     }
 
-    p {
+    :global(p) {
       margin: var(--space-3xs) 0 0;
       font-size: 0.9em;
       line-height: 1.4;

--- a/svelte/src/lib/components/dependency-list/Row.svelte.test.ts
+++ b/svelte/src/lib/components/dependency-list/Row.svelte.test.ts
@@ -10,6 +10,11 @@ type Dependency = components['schemas']['Dependency'];
 
 const HINT = 'This dependency might not be needed anymore.';
 
+const LAZY_STATIC_REPLACEMENT = {
+  description: 'Use `std::sync::LazyLock` instead.',
+  url: 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html',
+};
+
 function createDependency(overrides: Partial<Dependency> = {}): Dependency {
   return {
     id: 1,
@@ -29,7 +34,11 @@ describe('dependency-list/Row', () => {
   it('shows the native-replacement marker for a superseded dependency', async () => {
     let dependency = createDependency({ crate_id: 'lazy_static' });
 
-    render(Row, { dependency, descriptionPromise: Promise.resolve(null) });
+    render(Row, {
+      dependency,
+      descriptionPromise: Promise.resolve(null),
+      nativeReplacement: LAZY_STATIC_REPLACEMENT,
+    });
 
     let link = page.getByRole('link', { name: HINT });
     await expect.element(link).toHaveAttribute('href', 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html');

--- a/svelte/src/lib/data/native-replacements.test.ts
+++ b/svelte/src/lib/data/native-replacements.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TIMEOUT_MS = 5000;
+
+const SAMPLE = {
+  lazy_static: {
+    description: 'Use `std::sync::LazyLock` instead.',
+    url: 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html',
+  },
+};
+
+// The loader caches its result in module state, so each test imports a fresh
+// copy of the module.
+async function importLoader() {
+  let module = await import('./native-replacements');
+  return module.loadNativeReplacements;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('loadNativeReplacements', () => {
+  it('returns the parsed dataset on success', async () => {
+    let loadNativeReplacements = await importLoader();
+    let fetch = vi.fn().mockResolvedValue(Response.json(SAMPLE));
+
+    await expect(loadNativeReplacements(fetch)).resolves.toEqual(SAMPLE);
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('caches the result across calls', async () => {
+    let loadNativeReplacements = await importLoader();
+    let fetch = vi.fn().mockResolvedValue(Response.json(SAMPLE));
+
+    await loadNativeReplacements(fetch);
+    await loadNativeReplacements(fetch);
+
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('dedupes concurrent in-flight requests', async () => {
+    let loadNativeReplacements = await importLoader();
+    let fetch = vi.fn().mockResolvedValue(Response.json(SAMPLE));
+
+    await Promise.all([loadNativeReplacements(fetch), loadNativeReplacements(fetch)]);
+
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it('resolves to an empty map and warns on a network error', async () => {
+    let loadNativeReplacements = await importLoader();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let fetch = vi.fn().mockRejectedValue(new Error('offline'));
+
+    await expect(loadNativeReplacements(fetch)).resolves.toEqual({});
+  });
+
+  it('resolves to an empty map on a non-2xx response', async () => {
+    let loadNativeReplacements = await importLoader();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let fetch = vi.fn().mockResolvedValue(Response.json({}, { status: 500 }));
+
+    await expect(loadNativeReplacements(fetch)).resolves.toEqual({});
+  });
+
+  it('retries after a failed fetch', async () => {
+    let loadNativeReplacements = await importLoader();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let fetch = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce(Response.json(SAMPLE));
+
+    await expect(loadNativeReplacements(fetch)).resolves.toEqual({});
+    await expect(loadNativeReplacements(fetch)).resolves.toEqual(SAMPLE);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after the timeout but warms the cache for the next call', async () => {
+    vi.useFakeTimers();
+    let loadNativeReplacements = await importLoader();
+
+    let { promise, resolve } = Promise.withResolvers<Response>();
+    let fetch = vi.fn().mockReturnValue(promise);
+
+    let first = loadNativeReplacements(fetch);
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS);
+    await expect(first).resolves.toEqual({});
+
+    resolve(Response.json(SAMPLE));
+
+    await expect(loadNativeReplacements(fetch)).resolves.toEqual(SAMPLE);
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+});

--- a/svelte/src/lib/data/native-replacements.ts
+++ b/svelte/src/lib/data/native-replacements.ts
@@ -1,42 +1,5 @@
-/**
- * Native replacement policy
- * =========================
- *
- * This dataset flags crates whose functionality has been absorbed into the
- * Rust standard library, so a reader can see that `std` now provides what the
- * crate offers. Every entry is a checkable factual statement about `std`, never
- * an editorial judgement about a competing third-party crate.
- *
- * Scope
- * -----
- * Standard-library replacements only. The set deliberately does not include
- * "prefer this nicer crate instead" style recommendations.
- *
- * Inclusion criteria
- * ------------------
- * Two kinds of entries qualify:
- *
- *   - Full: the crate's functionality is entirely available via a stable `std`
- *     API.
- *   - Partial: the bulk of the crate's common use case has moved to `std`, but
- *     not all of it. The `description` must spell out what is still missing.
- *
- * Coverage is judged roughly, and only the dominant use case counts. If just a
- * small slice of a crate's purpose lives in `std`, it does not qualify, since
- * flagging it would be misleading and noisy. `itertools` is the canonical
- * exclusion: a few adaptors have `std` equivalents, but the crate is
- * overwhelmingly not replaced by `std`.
- *
- * Every entry's `description` must cite the stable `std` API(s) and the Rust
- * version(s) that stabilized them.
- *
- * Maintainer notice-and-comment
- * -----------------------------
- * Entries should arrive as PRs judged against the criteria above. Before an entry
- * lands, the maintainer(s) of the crate being flagged get a window to weigh in,
- * either to object or to show that the replacement is less complete than claimed,
- * in which case the entry becomes partial or is rejected.
- */
+// The dataset and its inclusion policy live at
+// https://github.com/rust-lang/std-replacement-data.
 
 /** A crate whose functionality is (largely) available in std. */
 export interface NativeReplacement {
@@ -91,36 +54,3 @@ async function fetchNativeReplacements(fetch: typeof globalThis.fetch): Promise<
     return {};
   }
 }
-
-export const nativeReplacements: NativeReplacements = {
-  lazy_static: {
-    description:
-      'The standard library provides `std::sync::LazyLock` (stable since Rust 1.80), which lets ' +
-      'you replace the `lazy_static!` macro with a plain `static` and remove the ' +
-      'dependency.',
-    url: 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html',
-  },
-
-  once_cell: {
-    description:
-      'Most of `once_cell` is now in `std`: `OnceCell`/`OnceLock` ' +
-      '(Rust 1.70) and `LazyCell`/`LazyLock` (Rust 1.80). The `race` module and ' +
-      'fallible `get_or_try_init` have no stable `std` equivalent yet.',
-    url: 'https://blog.rust-lang.org/2024/07/25/Rust-1.80.0/',
-  },
-
-  matches: {
-    description:
-      'The `matches!` macro has been in `std` since Rust 1.42, and ' +
-      '`assert_matches!` / `debug_assert_matches!` followed in Rust 1.96.',
-    url: 'https://doc.rust-lang.org/std/macro.matches.html',
-  },
-
-  num_cpus: {
-    description:
-      'For most uses, `std::thread::available_parallelism` (Rust 1.59) returns the parallelism ' +
-      'available to the process. (It does not distinguish physical vs logical cores the way ' +
-      '`num_cpus` does.)',
-    url: 'https://doc.rust-lang.org/std/thread/fn.available_parallelism.html',
-  },
-};

--- a/svelte/src/lib/data/native-replacements.ts
+++ b/svelte/src/lib/data/native-replacements.ts
@@ -40,7 +40,7 @@
 
 /** A crate whose functionality is (largely) available in std. */
 export interface NativeReplacement {
-  /** HTML fragment describing the std replacement. */
+  /** Markdown describing the std replacement. */
   description: string;
   /** Representative docs URL (std docs or release notes) shown as a "Learn more" link. */
   url: string;
@@ -49,32 +49,32 @@ export interface NativeReplacement {
 export const nativeReplacements: Record<string, NativeReplacement> = {
   lazy_static: {
     description:
-      'The standard library provides <code>std::sync::LazyLock</code> (stable since Rust 1.80), which lets ' +
-      'you replace the <code>lazy_static!</code> macro with a plain <code>static</code> and remove the ' +
+      'The standard library provides `std::sync::LazyLock` (stable since Rust 1.80), which lets ' +
+      'you replace the `lazy_static!` macro with a plain `static` and remove the ' +
       'dependency.',
     url: 'https://doc.rust-lang.org/std/sync/struct.LazyLock.html',
   },
 
   once_cell: {
     description:
-      'Most of <code>once_cell</code> is now in <code>std</code>: <code>OnceCell</code>/<code>OnceLock</code> ' +
-      '(Rust 1.70) and <code>LazyCell</code>/<code>LazyLock</code> (Rust 1.80). The <code>race</code> module and ' +
-      'fallible <code>get_or_try_init</code> have no stable <code>std</code> equivalent yet.',
+      'Most of `once_cell` is now in `std`: `OnceCell`/`OnceLock` ' +
+      '(Rust 1.70) and `LazyCell`/`LazyLock` (Rust 1.80). The `race` module and ' +
+      'fallible `get_or_try_init` have no stable `std` equivalent yet.',
     url: 'https://blog.rust-lang.org/2024/07/25/Rust-1.80.0/',
   },
 
   matches: {
     description:
-      'The <code>matches!</code> macro has been in <code>std</code> since Rust 1.42, and ' +
-      '<code>assert_matches!</code> / <code>debug_assert_matches!</code> followed in Rust 1.96.',
+      'The `matches!` macro has been in `std` since Rust 1.42, and ' +
+      '`assert_matches!` / `debug_assert_matches!` followed in Rust 1.96.',
     url: 'https://doc.rust-lang.org/std/macro.matches.html',
   },
 
   num_cpus: {
     description:
-      'For most uses, <code>std::thread::available_parallelism</code> (Rust 1.59) returns the parallelism ' +
+      'For most uses, `std::thread::available_parallelism` (Rust 1.59) returns the parallelism ' +
       'available to the process. (It does not distinguish physical vs logical cores the way ' +
-      '<code>num_cpus</code> does.)',
+      '`num_cpus` does.)',
     url: 'https://doc.rust-lang.org/std/thread/fn.available_parallelism.html',
   },
 };

--- a/svelte/src/lib/data/native-replacements.ts
+++ b/svelte/src/lib/data/native-replacements.ts
@@ -46,7 +46,53 @@ export interface NativeReplacement {
   url: string;
 }
 
-export const nativeReplacements: Record<string, NativeReplacement> = {
+/** The native-replacement dataset, keyed by crate name. */
+export type NativeReplacements = Record<string, NativeReplacement>;
+
+const DATA_URL = 'https://rust-lang.github.io/std-replacement-data/all.json';
+
+/** Maximum time a single {@link loadNativeReplacements} call waits for the data. */
+const TIMEOUT_MS = 5000;
+
+let cache: Promise<NativeReplacements> | undefined;
+
+/**
+ * Loads the native-replacement dataset from the upstream repository.
+ *
+ * The data is optional, so this never rejects: on a network error, a non-2xx
+ * response, or invalid JSON it logs a warning and resolves to an empty map.
+ *
+ * The fetch runs at most once per session and its result is cached. A failed
+ * fetch clears the cache so a later call retries. Each call gives up after
+ * {@link TIMEOUT_MS} to avoid blocking rendering, but the underlying request is
+ * not aborted: if it completes later, it warms the cache for the next call.
+ */
+export function loadNativeReplacements(fetch: typeof globalThis.fetch): Promise<NativeReplacements> {
+  cache ??= fetchNativeReplacements(fetch);
+
+  let timeoutId: ReturnType<typeof setTimeout>;
+  let timeout = new Promise<NativeReplacements>(resolve => {
+    timeoutId = setTimeout(() => resolve({}), TIMEOUT_MS);
+  });
+
+  return Promise.race([cache, timeout]).finally(() => clearTimeout(timeoutId));
+}
+
+async function fetchNativeReplacements(fetch: typeof globalThis.fetch): Promise<NativeReplacements> {
+  try {
+    let response = await fetch(DATA_URL, { priority: 'low' });
+    if (!response.ok) {
+      throw new Error(`Unexpected response status: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.warn(`Failed to load native-replacement data: ${error}`);
+    cache = undefined;
+    return {};
+  }
+}
+
+export const nativeReplacements: NativeReplacements = {
   lazy_static: {
     description:
       'The standard library provides `std::sync::LazyLock` (stable since Rust 1.80), which lets ' +

--- a/svelte/src/lib/utils/markdown.ts
+++ b/svelte/src/lib/utils/markdown.ts
@@ -1,0 +1,13 @@
+import { micromark } from 'micromark';
+
+/**
+ * Renders a Markdown string to an HTML string.
+ *
+ * Raw HTML in the input is escaped (micromark's `allowDangerousHtml` defaults
+ * to `false`), so the result is safe to inject even when the Markdown comes
+ * from an external source. No extensions are enabled, so only plain
+ * CommonMark constructs are supported.
+ */
+export function renderSimpleMarkdown(markdown: string): string {
+  return micromark(markdown);
+}

--- a/svelte/src/routes/crates/[crate_id]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import CrateVersionPage from '$lib/components/CrateVersionPage.svelte';
-  import { nativeReplacements } from '$lib/data/native-replacements';
 
   let { data } = $props();
 
@@ -19,5 +18,5 @@
   playgroundCratesPromise={data.playgroundCratesPromise}
   docsRsStatusPromise={data.docsRsStatusPromise}
   {downloadsPromise}
-  nativeReplacement={nativeReplacements[data.crate.name]}
+  nativeReplacement={data.nativeReplacements[data.crate.name]}
 />

--- a/svelte/src/routes/crates/[crate_id]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CrateVersionPage from '$lib/components/CrateVersionPage.svelte';
+  import { nativeReplacements } from '$lib/data/native-replacements';
 
   let { data } = $props();
 
@@ -18,4 +19,5 @@
   playgroundCratesPromise={data.playgroundCratesPromise}
   docsRsStatusPromise={data.docsRsStatusPromise}
   {downloadsPromise}
+  nativeReplacement={nativeReplacements[data.crate.name]}
 />

--- a/svelte/src/routes/crates/[crate_id]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/+page.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@crates-io/api-client';
 
+import { loadNativeReplacements } from '$lib/data/native-replacements';
 import { loadDocsRsStatus } from '$lib/utils/docs-rs';
 import { loadReadme } from '$lib/utils/readme';
 
@@ -9,11 +10,11 @@ export async function load({ fetch, params, parent }) {
   let crateName = params.crate_id;
   let downloadsPromise = loadDownloads(client, crateName);
 
-  let { crate, defaultVersion } = await parent();
+  let [{ crate, defaultVersion }, nativeReplacements] = await Promise.all([parent(), loadNativeReplacements(fetch)]);
   let readmePromise = loadReadme(fetch, crate.name, defaultVersion.num);
   let docsRsStatusPromise = loadDocsRsStatus(fetch, crate.name, defaultVersion.num);
 
-  return { readmePromise, downloadsPromise, docsRsStatusPromise };
+  return { readmePromise, downloadsPromise, docsRsStatusPromise, nativeReplacements };
 }
 
 /**

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CrateVersionPage from '$lib/components/CrateVersionPage.svelte';
+  import { nativeReplacements } from '$lib/data/native-replacements';
 
   let { data } = $props();
 
@@ -19,4 +20,5 @@
   playgroundCratesPromise={data.playgroundCratesPromise}
   docsRsStatusPromise={data.docsRsStatusPromise}
   {downloadsPromise}
+  nativeReplacement={nativeReplacements[data.crate.name]}
 />

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import CrateVersionPage from '$lib/components/CrateVersionPage.svelte';
-  import { nativeReplacements } from '$lib/data/native-replacements';
 
   let { data } = $props();
 
@@ -20,5 +19,5 @@
   playgroundCratesPromise={data.playgroundCratesPromise}
   docsRsStatusPromise={data.docsRsStatusPromise}
   {downloadsPromise}
-  nativeReplacement={nativeReplacements[data.crate.name]}
+  nativeReplacement={data.nativeReplacements[data.crate.name]}
 />

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/+page.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@crates-io/api-client';
 
+import { loadNativeReplacements } from '$lib/data/native-replacements';
 import { loadDocsRsStatus } from '$lib/utils/docs-rs';
 import { loadReadme } from '$lib/utils/readme';
 
@@ -10,8 +11,9 @@ export async function load({ fetch, params }) {
   let readmePromise = loadReadme(fetch, crateName, versionNum);
   let downloadsPromise = loadDownloads(fetch, crateName, versionNum);
   let docsRsStatusPromise = loadDocsRsStatus(fetch, crateName, versionNum);
+  let nativeReplacements = await loadNativeReplacements(fetch);
 
-  return { readmePromise, downloadsPromise, docsRsStatusPromise };
+  return { readmePromise, downloadsPromise, docsRsStatusPromise, nativeReplacements };
 }
 
 /**

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import CrateHeader from '$lib/components/CrateHeader.svelte';
   import Row from '$lib/components/dependency-list/Row.svelte';
+  import { nativeReplacements } from '$lib/data/native-replacements';
 
   let { data } = $props();
 
@@ -22,7 +23,13 @@
 {#if normal.length !== 0}
   <ul class="list" data-test-dependencies>
     {#each normal as dependency (dependency.id)}
-      <li><Row {dependency} descriptionPromise={descriptions.get(dependency.crate_id)} /></li>
+      <li>
+        <Row
+          {dependency}
+          descriptionPromise={descriptions.get(dependency.crate_id)}
+          nativeReplacement={nativeReplacements[dependency.crate_id]}
+        />
+      </li>
     {/each}
   </ul>
 {:else}
@@ -35,7 +42,13 @@
   <h2 class="heading">Build-Dependencies</h2>
   <ul class="list" data-test-build-dependencies>
     {#each build as dependency (dependency.id)}
-      <li><Row {dependency} descriptionPromise={descriptions.get(dependency.crate_id)} /></li>
+      <li>
+        <Row
+          {dependency}
+          descriptionPromise={descriptions.get(dependency.crate_id)}
+          nativeReplacement={nativeReplacements[dependency.crate_id]}
+        />
+      </li>
     {/each}
   </ul>
 {/if}
@@ -44,7 +57,13 @@
   <h2 class="heading">Dev-Dependencies</h2>
   <ul class="list" data-test-dev-dependencies>
     {#each dev as dependency (dependency.id)}
-      <li><Row {dependency} descriptionPromise={descriptions.get(dependency.crate_id)} /></li>
+      <li>
+        <Row
+          {dependency}
+          descriptionPromise={descriptions.get(dependency.crate_id)}
+          nativeReplacement={nativeReplacements[dependency.crate_id]}
+        />
+      </li>
     {/each}
   </ul>
 {/if}

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import CrateHeader from '$lib/components/CrateHeader.svelte';
   import Row from '$lib/components/dependency-list/Row.svelte';
-  import { nativeReplacements } from '$lib/data/native-replacements';
 
   let { data } = $props();
 
@@ -9,6 +8,7 @@
   let build = $derived(data.dependencies.filter(d => d.kind === 'build'));
   let dev = $derived(data.dependencies.filter(d => d.kind === 'dev'));
   let descriptions = $derived(data.descriptionMap);
+  let nativeReplacements = $derived(data.nativeReplacements);
 </script>
 
 <CrateHeader

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/dependencies/+page.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@crates-io/api-client';
 import { error } from '@sveltejs/kit';
 
+import { loadNativeReplacements } from '$lib/data/native-replacements';
 import { loadCrateDescriptions } from '$lib/utils/crate-descriptions';
 
 export async function load({ fetch, params }) {
@@ -9,14 +10,17 @@ export async function load({ fetch, params }) {
   let crateName = params.crate_id;
   let versionNum = params.version_num;
 
-  let dependencies = await loadDependencies(client, crateName, versionNum);
+  let [dependencies, nativeReplacements] = await Promise.all([
+    loadDependencies(client, crateName, versionNum),
+    loadNativeReplacements(fetch),
+  ]);
 
   let descriptionMap = loadCrateDescriptions(
     client,
     dependencies.map(d => d.crate_id),
   );
 
-  return { dependencies, descriptionMap };
+  return { dependencies, descriptionMap, nativeReplacements };
 }
 
 async function loadDependencies(client: ReturnType<typeof createClient>, name: string, version: string) {

--- a/svelte/svelte.config.js
+++ b/svelte/svelte.config.js
@@ -44,6 +44,8 @@ const config = {
           'https://docs.rs',
           // Rust Playground top-100 crates list
           'https://play.rust-lang.org',
+          // std-replacement dataset
+          'https://rust-lang.github.io',
           // Trusted Publisher setup verifies the workflow file exists in the repo
           'https://raw.githubusercontent.com',
           // RustSec advisory lookup on the crate security tab


### PR DESCRIPTION
The native-replacement banner and dependency-list markers were driven by a hardcoded TypeScript dataset. This switches them to fetch the dataset from https://rust-lang.github.io/std-replacement-data/all.json so it can be curated in the upstream repository instead of here.

The data is fetched in the page `load()` functions, in parallel with the page's other requests, so it resolves before render and does not cause layout shift. The result is cached for the session and the fetch never blocks rendering for long: each call gives up after 5 seconds without aborting the request, so a slow response still warms the cache for the next navigation. Any failure (network error, non-2xx response, invalid JSON) logs a warning and falls back to showing no banner.

The upstream descriptions are in Markdown now instead of HTML, so we convert them to HTML with the `micromark` library before rendering. That also escapes any raw HTML from the now-external source.

The CSP `connect-src` directive gains `https://rust-lang.github.io`, and the MSW test layer stubs the endpoint so the existing tests keep exercising the feature.

### Related

- https://github.com/rust-lang/std-replacement-data
- https://github.com/rust-lang/crates.io/pull/13855#issuecomment-4638182013
