### PR TITLE
middleware/static_or_continue: Drop manual `Vary` header insert

### DIFF
--- a/src/middleware/static_or_continue.rs
+++ b/src/middleware/static_or_continue.rs
@@ -5,7 +5,7 @@ use axum::body::Body;
 use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::Response;
-use http::{HeaderValue, Method, StatusCode, header};
+use http::{Method, StatusCode};
 use std::path::Path;
 use tower::ServiceExt;
 use tower_http::services::ServeDir;
@@ -50,16 +50,7 @@ async fn serve_static<P: AsRef<Path>>(path: P, request: Request) -> Result<Respo
         return Err(request);
     }
 
-    let mut response = response.map(Body::new);
-
-    // FIXME: `ServeDir` does not set `Vary: Accept-Encoding` on precompressed
-    // responses yet. Remove this once a tower-http release including
-    // https://github.com/tower-rs/tower-http/pull/692 is available.
-    response
-        .headers_mut()
-        .insert(header::VARY, HeaderValue::from_static("accept-encoding"));
-
-    Ok(response)
+    Ok(response.map(Body::new))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`ServeDir` now sets `Vary: accept-encoding` itself when precompression is configured, as of tower-rs/tower-http#692 which shipped in tower-http 0.7.0 (#13960). This removes the redundant manual insert in `serve_static()` along with its now-unused `HeaderValue`/`header` imports.

The existing `serves_file_with_vary_accept_encoding` test still passes with the manual insert gone, so it now verifies `ServeDir`'s own behavior rather than our patch.