### PR TITLE
Add funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: rustfoundation
+custom: ['rust-lang.org/funding']


### PR DESCRIPTION
This adds a "Sponsor" button to the crates.io repo, pointing both to the Rust Foundation [Sponsors page](https://github.com/sponsors/rustfoundation) and to the Rust [Funding page](https://rust-lang.org/funding/).

Same as [rust-lang/cargo#17103](https://github.com/rust-lang/cargo/pull/17103) and the [compiler repo](https://github.com/rust-lang/rust).