### PR TITLE
trustpub: Set descriptive `User-Agent` in GitLab token exchange script

### DIFF
--- a/svelte/src/routes/docs/trusted-publishing/+page.svelte
+++ b/svelte/src/routes/docs/trusted-publishing/+page.svelte
@@ -12,6 +12,7 @@ set -e
 echo "Exchanging OIDC token..." >&2
 RESPONSE=$(curl -s -X POST https://crates.io/api/v1/trusted_publishing/tokens \\
   -H "Content-Type: application/json" \\
+  -H "User-Agent: gitlab-trusted-publishing (your@email.com)" \\
   -d "{\\"jwt\\": \\"$CRATES_IO_ID_TOKEN\\"}")
 
 # Extract publish token


### PR DESCRIPTION
The GitLab Trusted Publishing docs include a token exchange helper script that calls the crates.io API with `curl`. The `curl` call sent no `User-Agent` header, so curl defaulted to `curl/x.y.z`, which crates.io blocks.

This adds a descriptive `User-Agent` following the format the server recommends in its rejection message (tool name plus contact info):

```
User-Agent: gitlab-trusted-publishing (your@email.com)
```

The `your@email.com` placeholder signals that users should substitute their own contact address.