### PR TITLE
Cap reverse dependencies pagination

### DIFF
--- a/src/controllers/krate/rev_deps.rs
+++ b/src/controllers/krate/rev_deps.rs
@@ -44,7 +44,9 @@ pub async fn list_reverse_dependencies(
 ) -> AppResult<Json<RevDepsResponse>> {
     let mut conn = app.db_read().await?;
 
-    let pagination_options = PaginationOptions::builder().gather(&req)?;
+    let pagination_options = PaginationOptions::builder()
+        .limit_page_numbers()
+        .gather(&req)?;
 
     let krate = path.load_crate(&conn).await?;
 

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -250,6 +250,32 @@ async fn reverse_dependencies_query_supports_u64_version_number_parts() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn reverse_dependencies_blocks_high_page_numbers() {
+    let (app, anon, user) = TestApp::init()
+        .with_config(|config| {
+            config.max_allowed_page_offset = 1;
+        })
+        .with_user()
+        .await;
+
+    let mut conn = app.db_conn().await;
+    let user = user.as_model();
+
+    CrateBuilder::new("c1", user.id)
+        .expect_build(&mut conn)
+        .await;
+
+    let response = anon
+        .get_with_query::<()>(
+            "/api/v1/crates/c1/reverse_dependencies",
+            "page=2&per_page=1",
+        )
+        .await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Page 2 is unavailable for performance reasons. Please take a look at https://crates.io/data-access for alternatives."}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_crate() {
     let (_, anon) = TestApp::init().empty().await;
 

--- a/svelte/src/routes/crates/[crate_id]/reverse_dependencies/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/reverse_dependencies/+page.svelte
@@ -5,9 +5,11 @@
   import Row from '$lib/components/rev-dep-list/Row.svelte';
   import { calculatePagination } from '$lib/utils/pagination';
 
+  const MAX_PAGES = 20;
+
   let { data } = $props();
 
-  let pagination = $derived(calculatePagination(data.page, data.perPage, data.total));
+  let pagination = $derived(calculatePagination(data.page, data.perPage, data.total, MAX_PAGES));
 </script>
 
 <CrateHeader crate={data.crate} keywords={data.keywords} ownersPromise={data.ownersPromise} />


### PR DESCRIPTION
The reverse dependencies endpoint and its frontend page lacked the pagination caps that the crate search and listing pages already enforce.

- Backend: gather pagination options with `limit_page_numbers()`, so the endpoint honors `max_allowed_page_offset` (default 200) and rejects larger page offsets with a 400, matching `/api/v1/crates`.
- Frontend: pass `MAX_PAGES = 20` to `calculatePagination()`, so the pagination UI stops offering pages past 20, matching the search and listing pages.