### PR TITLE
controllers/session: Fail login if `oauth_github` write fails

### DIFF
--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -176,8 +176,9 @@ async fn create_or_update_user(
         let user_id = new_user.insert_or_update(conn).await?;
 
         // To assist in eventually someday allowing OAuth with more than GitHub, also
-        // write the GitHub info to the `oauth_github` table. Nothing currently reads
-        // from this table. Only log errors but don't fail login if this writing fails.
+        // write the GitHub info to the `oauth_github` table. This table is read when
+        // loading user details (e.g. the avatar), so a failure to write must fail the
+        // request just like a failure to write to the `users` table.
         let new_oauth_github = NewOauthGithub::builder()
             .user_id(user_id)
             .account_id(new_user.gh_id as i64)
@@ -185,9 +186,8 @@ async fn create_or_update_user(
             .login(new_user.gh_login)
             .maybe_avatar(new_user.gh_avatar)
             .build();
-        if let Err(e) = new_oauth_github.insert_or_update(conn).await {
-            error!("Error inserting or updating oauth_github record: {e}");
-        }
+
+        new_oauth_github.insert_or_update(conn).await?;
 
         // To send the user an account verification email
         if let Some(user_email) = email {


### PR DESCRIPTION
The comment above the `oauth_github` write claimed "Nothing currently reads from this table", but that is no longer true. The table is read in several production paths, most notably the `User` base query, which left-joins `oauth_github` to load the avatar on every user load.

Since the data is now read back, only logging an error on a failed write leaves the `oauth_github` row out of sync with the `users` table. This propagates the error inside the transaction so the write is rolled back and the request fails, just like a failed write to the `users` table.

The read-only-mode fallback in `save_user_to_database()` still catches the error and looks up the existing user, so read-only deploys are unaffected.