### PR TITLE
Disable default features of `tar` and `astral-tokio-tar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,6 @@ dependencies = [
  "rustc-hash",
  "tokio",
  "tokio-stream",
- "xattr",
 ]
 
 [[package]]
@@ -7348,7 +7347,6 @@ checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
- "xattr",
 ]
 
 [[package]]
@@ -9487,16 +9485,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ path = "src/tests/mod.rs"
 [dependencies]
 aes-gcm = { version = "=0.10.3", features = ["std"] }
 anyhow = "=1.0.102"
-astral-tokio-tar = "=0.6.2"
+astral-tokio-tar = { version = "=0.6.2", default-features = false }
 async-compression = { version = "=0.4.42", default-features = false, features = ["gzip", "tokio"] }
 async-trait = "=0.1.89"
 aws-credential-types = { version = "=1.2.14", features = ["hardcoded-credentials"] }
@@ -136,7 +136,7 @@ serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.150"
 sha2 = "=0.11.0"
 spdx = "=0.13.4"
-tar = "=0.4.46"
+tar = { version = "=0.4.46", default-features = false }
 tempfile = "=3.27.0"
 thiserror = "=2.0.18"
 tikv-jemallocator = { version = "=0.7.0", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }

--- a/crates/crates_io_database_dump/Cargo.toml
+++ b/crates/crates_io_database_dump/Cargo.toml
@@ -15,7 +15,7 @@ flate2 = "=1.1.9"
 minijinja = "=2.20.0"
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.150"
-tar = "=0.4.46"
+tar = { version = "=0.4.46", default-features = false }
 tempfile = "=3.27.0"
 toml = "=1.1.2"
 tracing = "=0.1.44"

--- a/crates/crates_io_tarball/Cargo.toml
+++ b/crates/crates_io_tarball/Cargo.toml
@@ -11,12 +11,12 @@ workspace = true
 builder = ["dep:flate2", "dep:tar"]
 
 [dependencies]
-astral-tokio-tar = "=0.6.2"
+astral-tokio-tar = { version = "=0.6.2", default-features = false }
 crates_io_cargo_toml = { path = "../crates_io_cargo_toml" }
 flate2 = { version = "=1.1.9", optional = true }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.150"
-tar = { version = "=0.4.46", optional = true }
+tar = { version = "=0.4.46", optional = true, default-features = false }
 thiserror = "=2.0.18"
 tracing = "=0.1.44"
 tokio = { version = "=1.52.3", features = ["io-util", "macros", "rt-multi-thread"] }
@@ -31,6 +31,6 @@ flate2 = { version = "=1.1.9" }
 indicatif = { version = "=0.18.4", features = ["rayon"] }
 insta = "=1.48.0"
 rayon = "=1.12.0"
-tar = { version = "=0.4.46" }
+tar = { version = "=0.4.46", default-features = false }
 tracing-subscriber = { version = "=0.3.23", features = ["env-filter"] }
 walkdir = "=2.5.0"


### PR DESCRIPTION
Both crates default to the `xattr` feature, which preserves Unix extended attributes when packing and unpacking archives. We only build and read crate tarballs and database dumps, none of which carry extended attributes, so the feature pulls in the `xattr` crate for no benefit.