### PR TITLE
cdn_logs: Speed up download log parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "bytestring",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "http 0.2.12",
  "httparse",
@@ -129,7 +129,7 @@ dependencies = [
  "cfg-if",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -1758,6 +1758,7 @@ dependencies = [
  "clap",
  "criterion",
  "derive_more",
+ "foldhash 0.2.0",
  "insta",
  "percent-encoding",
  "semver",
@@ -3104,6 +3105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "font-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,7 +3488,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]

--- a/crates/crates_io_cdn_logs/Cargo.toml
+++ b/crates/crates_io_cdn_logs/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "=1.0.102"
 async-compression = { version = "=0.4.42", features = ["gzip", "tokio", "zstd"] }
 chrono = { version = "=0.4.45", features = ["serde"] }
 derive_more = { version = "=2.1.1", features = ["deref"] }
+foldhash = "=0.2.0"
 percent-encoding = "=2.3.2"
 semver = "=1.0.28"
 serde = { version = "=1.0.228", features = ["derive"] }

--- a/crates/crates_io_cdn_logs/src/cloudfront.rs
+++ b/crates/crates_io_cdn_logs/src/cloudfront.rs
@@ -60,33 +60,60 @@ pub async fn count_downloads(reader: impl AsyncBufRead + Unpin) -> anyhow::Resul
             continue;
         }
 
-        let values = line.split('\t').collect::<Vec<_>>();
+        let mut num_values = 0;
+        let mut date = None;
+        let mut method = None;
+        let mut path = None;
+        let mut status = None;
+        let mut user_agent = None;
+        for (i, value) in line.split('\t').enumerate() {
+            let index = Some(i);
+            if index == date_index {
+                date = Some(value);
+            } else if index == method_index {
+                method = Some(value);
+            } else if index == path_index {
+                path = Some(value);
+            } else if index == status_index {
+                status = Some(value);
+            } else if index == user_agent_index {
+                user_agent = Some(value);
+            }
+            num_values = i + 1;
+        }
 
-        let num_values = values.len();
         if num_values != num_fields {
             warn!("Expected {num_fields} fields, but found {num_values}");
             continue;
         }
 
-        let method = get_value(&values, method_index, FIELD_METHOD);
+        let Some(method) = method else {
+            warn!("Failed to find {FIELD_METHOD} field.");
+            continue;
+        };
         if method != "GET" {
             // Ignore non-GET requests.
             continue;
         }
 
-        let status = get_value(&values, status_index, FIELD_STATUS);
+        let Some(status) = status else {
+            warn!("Failed to find {FIELD_STATUS} field.");
+            continue;
+        };
         if status != "200" {
             // Ignore non-200 responses.
             continue;
         }
 
-        let user_agent = get_optional_value(&values, user_agent_index);
         if user_agent.is_some_and(|ua| !should_count_user_agent(ua)) {
             // Ignore requests from user agents that should not be counted.
             continue;
         }
 
-        let path = get_value(&values, path_index, FIELD_PATH);
+        let Some(path) = path else {
+            warn!("Failed to find {FIELD_PATH} field.");
+            continue;
+        };
 
         // Deal with paths like `/crates/tikv-jemalloc-sys/tikv-jemalloc-sys-0.5.4%252B5.3.0-patched.crate`.
         //
@@ -100,7 +127,10 @@ pub async fn count_downloads(reader: impl AsyncBufRead + Unpin) -> anyhow::Resul
             continue;
         };
 
-        let date = get_value(&values, date_index, FIELD_DATE);
+        let Some(date) = date else {
+            warn!("Failed to find {FIELD_DATE} field.");
+            continue;
+        };
         let date = match date.parse::<NaiveDate>() {
             Ok(date) => date,
             Err(error) => {
@@ -118,20 +148,6 @@ pub async fn count_downloads(reader: impl AsyncBufRead + Unpin) -> anyhow::Resul
 #[instrument(level = "debug", skip(path))]
 fn decode_path(path: &str) -> Cow<'_, str> {
     percent_encoding::percent_decode_str(path).decode_utf8_lossy()
-}
-
-fn get_value<'a>(values: &'a [&'a str], index: Option<usize>, field_name: &'static str) -> &'a str {
-    index
-        .and_then(|i| values.get(i))
-        .copied()
-        .unwrap_or_else(|| {
-            warn!(?index, "Failed to find {field_name} field.");
-            ""
-        })
-}
-
-fn get_optional_value<'a>(values: &'a [&'a str], index: Option<usize>) -> Option<&'a str> {
-    index.and_then(|i| values.get(i)).copied()
 }
 
 #[cfg(test)]

--- a/crates/crates_io_cdn_logs/src/cloudfront.rs
+++ b/crates/crates_io_cdn_logs/src/cloudfront.rs
@@ -4,9 +4,9 @@
 //! and <https://www.w3.org/TR/WD-logfile.html>.
 
 use crate::DownloadsMap;
+use crate::date::parse_date;
 use crate::paths::parse_path;
 use crate::user_agent::should_count_user_agent;
-use chrono::NaiveDate;
 use std::borrow::Cow;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt};
 use tracing::{instrument, warn};
@@ -131,12 +131,9 @@ pub async fn count_downloads(reader: impl AsyncBufRead + Unpin) -> anyhow::Resul
             warn!("Failed to find {FIELD_DATE} field.");
             continue;
         };
-        let date = match date.parse::<NaiveDate>() {
-            Ok(date) => date,
-            Err(error) => {
-                warn!(%date, "Failed to parse date `{date}`: {error}");
-                continue;
-            }
+        let Some(date) = parse_date(date) else {
+            warn!("Failed to parse date `{date}`");
+            continue;
         };
 
         downloads.add(name, version, date);

--- a/crates/crates_io_cdn_logs/src/date.rs
+++ b/crates/crates_io_cdn_logs/src/date.rs
@@ -1,0 +1,48 @@
+use chrono::NaiveDate;
+
+/// Parses a `YYYY-MM-DD` date, the format used by both the CloudFront `date`
+/// field and the date portion of the Fastly `date_time` timestamp.
+///
+/// This avoids chrono's general-purpose format machinery, which is noticeably
+/// slower when the format is known and fixed.
+pub fn parse_date(date: &str) -> Option<NaiveDate> {
+    let bytes = date.as_bytes();
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
+    }
+
+    // The `-` checks above guarantee these slices fall on UTF-8 char
+    // boundaries (a `-` byte can never be part of a multi-byte character), so
+    // the indexing cannot panic. The non-ASCII test cases below cover this.
+    let year = date[0..4].parse().ok()?;
+    let month = date[5..7].parse().ok()?;
+    let day = date[8..10].parse().ok()?;
+    NaiveDate::from_ymd_opt(year, month, day)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_date() {
+        assert_eq!(
+            parse_date("2024-01-16"),
+            NaiveDate::from_ymd_opt(2024, 1, 16)
+        );
+
+        // Wrong length, separators, or non-digits are rejected.
+        assert_eq!(parse_date(""), None);
+        assert_eq!(parse_date("2024-1-6"), None);
+        assert_eq!(parse_date("2024/01/16"), None);
+        assert_eq!(parse_date("2024-01-16T00"), None);
+        assert_eq!(parse_date("abcd-01-16"), None);
+        assert_eq!(parse_date("2024-13-16"), None);
+
+        // Non-ASCII input must return `None` rather than panic on a slice that
+        // could fall inside a multi-byte UTF-8 character (`é` is two bytes, so
+        // `"2024-01-é"` is exactly ten bytes and reaches the digit slices).
+        assert_eq!(parse_date("2024-01-é"), None);
+        assert_eq!(parse_date("é2024-01-16"), None);
+    }
+}

--- a/crates/crates_io_cdn_logs/src/download_map.rs
+++ b/crates/crates_io_cdn_logs/src/download_map.rs
@@ -1,15 +1,16 @@
 use chrono::NaiveDate;
 use derive_more::Deref;
+use foldhash::quality::FixedState;
 use semver::Version;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 
 #[derive(Clone, Default, Deref)]
-pub struct DownloadsMap(HashMap<(String, Version, NaiveDate), u64>);
+pub struct DownloadsMap(HashMap<(String, Version, NaiveDate), u64, FixedState>);
 
 impl DownloadsMap {
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self(HashMap::default())
     }
 
     /// Increments the download count for the given crate version on the given date.

--- a/crates/crates_io_cdn_logs/src/fastly/json.rs
+++ b/crates/crates_io_cdn_logs/src/fastly/json.rs
@@ -1,6 +1,6 @@
 //! Imported from <https://github.com/rust-lang/simpleinfra/blob/4fb365809295de075d28d8b2d51f6f419537be7d/terragrunt/modules/crates-io/compute-static/src/log_line.rs>
 
-use chrono::{DateTime, Utc};
+use chrono::NaiveDate;
 use serde::Deserialize;
 use std::borrow::Cow;
 
@@ -14,10 +14,11 @@ use std::borrow::Cow;
 /// - The `ip` field is not included, because we don't need it.
 /// - The `method` and `status` fields are not optional, because we handle
 ///   parsing errors gracefully.
-/// - The `date_time` field is using `chrono` like the rest of the
-///   crates.io codebase.
-/// - The `method`, `url`, and `version` fields are using `Cow` to avoid
-///   unnecessary allocations.
+/// - The `date_time` field is kept as a borrowed string and only its date
+///   portion is parsed on demand (see [`LogLine::date`]), to avoid parsing the
+///   full timestamp for every line when we only need the date.
+/// - The `date_time`, `method`, `url`, and `version` fields are using `Cow` to
+///   avoid unnecessary allocations.
 ///
 /// The `version` field is deserialized as a plain struct field rather than a
 /// serde tag, because an internally tagged enum forces serde to buffer the
@@ -26,7 +27,8 @@ use std::borrow::Cow;
 pub struct LogLine<'a> {
     #[serde(borrow)]
     pub version: Cow<'a, str>,
-    pub date_time: DateTime<Utc>,
+    #[serde(borrow)]
+    pub date_time: Cow<'a, str>,
     #[serde(borrow)]
     pub method: Cow<'a, str>,
     #[serde(borrow)]
@@ -41,8 +43,10 @@ impl LogLine<'_> {
         &self.version
     }
 
-    pub fn date_time(&self) -> DateTime<Utc> {
-        self.date_time
+    /// Parses the date portion (`YYYY-MM-DD`) from the start of the `date_time`
+    /// timestamp. Fastly emits UTC timestamps, so this is the UTC date.
+    pub fn date(&self) -> Option<NaiveDate> {
+        self.date_time.get(..10).and_then(|date| date.parse().ok())
     }
 
     pub fn method(&self) -> &str {
@@ -83,7 +87,7 @@ mod tests {
         assert_debug_snapshot!(output, @r#"
         LogLine {
             version: "1",
-            date_time: 2024-01-16T16:03:04.440073230Z,
+            date_time: "2024-01-16T16:03:04.44007323Z",
             method: "GET",
             url: "https://static.staging.crates.io/?1705420437",
             status: 403,
@@ -91,10 +95,7 @@ mod tests {
         }
         "#);
 
-        assert_eq!(
-            output.date_time().to_string(),
-            "2024-01-16 16:03:04.440073230 UTC"
-        );
+        assert_eq!(output.date().unwrap().to_string(), "2024-01-16");
         assert_eq!(output.method(), "GET");
         assert_eq!(output.url(), "https://static.staging.crates.io/?1705420437");
         assert_eq!(output.status(), 403);
@@ -111,7 +112,7 @@ mod tests {
         assert_debug_snapshot!(output, @r#"
         LogLine {
             version: "1",
-            date_time: 2025-10-26T23:57:34.867635728Z,
+            date_time: "2025-10-26T23:57:34.867635728Z",
             method: "GET",
             url: "https://static.crates.io/crates/scale-info/2.11.3/download",
             status: 200,
@@ -125,10 +126,7 @@ mod tests {
         }
         "#);
 
-        assert_eq!(
-            output.date_time().to_string(),
-            "2025-10-26 23:57:34.867635728 UTC"
-        );
+        assert_eq!(output.date().unwrap().to_string(), "2025-10-26");
         assert_eq!(output.method(), "GET");
         assert_eq!(
             output.url(),

--- a/crates/crates_io_cdn_logs/src/fastly/json.rs
+++ b/crates/crates_io_cdn_logs/src/fastly/json.rs
@@ -1,5 +1,6 @@
 //! Imported from <https://github.com/rust-lang/simpleinfra/blob/4fb365809295de075d28d8b2d51f6f419537be7d/terragrunt/modules/crates-io/compute-static/src/log_line.rs>
 
+use crate::date::parse_date;
 use chrono::NaiveDate;
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -46,7 +47,7 @@ impl LogLine<'_> {
     /// Parses the date portion (`YYYY-MM-DD`) from the start of the `date_time`
     /// timestamp. Fastly emits UTC timestamps, so this is the UTC date.
     pub fn date(&self) -> Option<NaiveDate> {
-        self.date_time.get(..10).and_then(|date| date.parse().ok())
+        self.date_time.get(..10).and_then(parse_date)
     }
 
     pub fn method(&self) -> &str {

--- a/crates/crates_io_cdn_logs/src/fastly/json.rs
+++ b/crates/crates_io_cdn_logs/src/fastly/json.rs
@@ -6,49 +6,6 @@ use std::borrow::Cow;
 
 /// This struct corresponds to the JSON payload of a log line from
 /// Fastly's CDN logs.
-#[derive(Debug, Deserialize)]
-#[serde(tag = "version")]
-pub enum LogLine<'a> {
-    #[serde(borrow, rename = "1")]
-    V1(LogLineV1<'a>),
-}
-
-impl LogLine<'_> {
-    pub fn date_time(&self) -> DateTime<Utc> {
-        match self {
-            LogLine::V1(line) => line.date_time,
-        }
-    }
-
-    pub fn method(&self) -> &str {
-        match self {
-            LogLine::V1(line) => &line.method,
-        }
-    }
-
-    pub fn url(&self) -> &str {
-        match self {
-            LogLine::V1(line) => &line.url,
-        }
-    }
-
-    pub fn status(&self) -> u16 {
-        match self {
-            LogLine::V1(line) => line.status,
-        }
-    }
-
-    pub fn user_agent(&self) -> Option<&str> {
-        match self {
-            LogLine::V1(line) => line
-                .http
-                .as_ref()
-                .and_then(|http| http.useragent.as_deref()),
-        }
-    }
-}
-
-/// This struct corresponds to the `"version": "1"` variant of the [LogLine] enum.
 ///
 /// Compared to the implementation in the [rust-lang/simpleinfra](https://github.com/rust-lang/simpleinfra/)
 /// repository, there are a couple of differences:
@@ -59,10 +16,16 @@ impl LogLine<'_> {
 ///   parsing errors gracefully.
 /// - The `date_time` field is using `chrono` like the rest of the
 ///   crates.io codebase.
-/// - The `method` and `url` fields are using `Cow` to avoid
+/// - The `method`, `url`, and `version` fields are using `Cow` to avoid
 ///   unnecessary allocations.
+///
+/// The `version` field is deserialized as a plain struct field rather than a
+/// serde tag, because an internally tagged enum forces serde to buffer the
+/// whole payload into an intermediate representation before dispatching.
 #[derive(Debug, Deserialize)]
-pub struct LogLineV1<'a> {
+pub struct LogLine<'a> {
+    #[serde(borrow)]
+    pub version: Cow<'a, str>,
     pub date_time: DateTime<Utc>,
     #[serde(borrow)]
     pub method: Cow<'a, str>,
@@ -71,6 +34,34 @@ pub struct LogLineV1<'a> {
     pub status: u16,
     #[serde(borrow)]
     pub http: Option<Http<'a>>,
+}
+
+impl LogLine<'_> {
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    pub fn date_time(&self) -> DateTime<Utc> {
+        self.date_time
+    }
+
+    pub fn method(&self) -> &str {
+        &self.method
+    }
+
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    pub fn status(&self) -> u16 {
+        self.status
+    }
+
+    pub fn user_agent(&self) -> Option<&str> {
+        self.http
+            .as_ref()
+            .and_then(|http| http.useragent.as_deref())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -90,15 +81,14 @@ mod tests {
         let input = r#"{"bytes":null,"date_time":"2024-01-16T16:03:04.44007323Z","ip":"45.79.107.220","method":"GET","status":403,"url":"https://static.staging.crates.io/?1705420437","version":"1"}"#;
         let output = assert_ok!(serde_json::from_str::<LogLine<'_>>(input));
         assert_debug_snapshot!(output, @r#"
-        V1(
-            LogLineV1 {
-                date_time: 2024-01-16T16:03:04.440073230Z,
-                method: "GET",
-                url: "https://static.staging.crates.io/?1705420437",
-                status: 403,
-                http: None,
-            },
-        )
+        LogLine {
+            version: "1",
+            date_time: 2024-01-16T16:03:04.440073230Z,
+            method: "GET",
+            url: "https://static.staging.crates.io/?1705420437",
+            status: 403,
+            http: None,
+        }
         "#);
 
         assert_eq!(
@@ -110,12 +100,8 @@ mod tests {
         assert_eq!(output.status(), 403);
         assert_eq!(output.user_agent(), None);
 
-        match output {
-            LogLine::V1(l) => {
-                assert!(is_borrowed(&l.method));
-                assert!(is_borrowed(&l.url));
-            }
-        }
+        assert!(is_borrowed(&output.method));
+        assert!(is_borrowed(&output.url));
     }
 
     #[test]
@@ -123,21 +109,20 @@ mod tests {
         let input = r#"{"bytes":36308,"content_type":"application/gzip","date_time":"2025-10-26T23:57:34.867635728Z","http":{"protocol":"HTTP/2","referer":null,"useragent":"cargo/1.92.0-nightly (344c4567c 2025-10-21)"},"ip":"192.0.2.1","method":"GET","status":200,"url":"https://static.crates.io/crates/scale-info/2.11.3/download","version":"1"}"#;
         let output = assert_ok!(serde_json::from_str::<LogLine<'_>>(input));
         assert_debug_snapshot!(output, @r#"
-        V1(
-            LogLineV1 {
-                date_time: 2025-10-26T23:57:34.867635728Z,
-                method: "GET",
-                url: "https://static.crates.io/crates/scale-info/2.11.3/download",
-                status: 200,
-                http: Some(
-                    Http {
-                        useragent: Some(
-                            "cargo/1.92.0-nightly (344c4567c 2025-10-21)",
-                        ),
-                    },
-                ),
-            },
-        )
+        LogLine {
+            version: "1",
+            date_time: 2025-10-26T23:57:34.867635728Z,
+            method: "GET",
+            url: "https://static.crates.io/crates/scale-info/2.11.3/download",
+            status: 200,
+            http: Some(
+                Http {
+                    useragent: Some(
+                        "cargo/1.92.0-nightly (344c4567c 2025-10-21)",
+                    ),
+                },
+            ),
+        }
         "#);
 
         assert_eq!(

--- a/crates/crates_io_cdn_logs/src/fastly/mod.rs
+++ b/crates/crates_io_cdn_logs/src/fastly/mod.rs
@@ -66,7 +66,10 @@ pub async fn count_downloads(reader: impl AsyncBufRead + Unpin) -> anyhow::Resul
             continue;
         };
 
-        let date = json.date_time().date_naive();
+        let Some(date) = json.date() else {
+            warn!("Failed to parse date `{}`", json.date_time);
+            continue;
+        };
 
         downloads.add(name, version, date);
     }

--- a/crates/crates_io_cdn_logs/src/fastly/mod.rs
+++ b/crates/crates_io_cdn_logs/src/fastly/mod.rs
@@ -33,6 +33,11 @@ pub async fn count_downloads(reader: impl AsyncBufRead + Unpin) -> anyhow::Resul
             }
         };
 
+        if json.version() != "1" {
+            warn!("Unsupported log line version: {}", json.version());
+            continue;
+        }
+
         if json.method() != "GET" {
             // Ignore non-GET requests.
             continue;

--- a/crates/crates_io_cdn_logs/src/lib.rs
+++ b/crates/crates_io_cdn_logs/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod cloudfront;
 mod compression;
+mod date;
 mod download_map;
 pub mod fastly;
 mod paths;


### PR DESCRIPTION
These commits speed up `count_downloads()` in `crates_io_cdn_logs`. Measured with the `count_downloads` benchmark, before/after back to back on the same machine:

| case | before | after | change |
| --- | --- | --- | --- |
| cloudfront | 22.2 µs | 13.7 µs | -38% |
| fastly | 22.9 µs | 15.3 µs | -34% |

The wins come from parsing the Fastly log lines without serde's internally-tagged-enum buffering, a faster hasher for the downloads map, single-pass CloudFront field extraction, parsing only the date portion of the Fastly timestamps, and a shared fixed-format `YYYY-MM-DD` parser used by both formats. Each commit is self-contained and benchmark-verified on its own.

Two deliberate choices worth flagging:

- The downloads map switches from std's SipHash to `foldhash`, which is not HashDoS-resistant. That is fine here because the map is built by an offline background job over CDN logs, not from request-path attacker input.
- The hand-rolled date parser accepts exactly `YYYY-MM-DD` (zero-padded). That is stricter than chrono's parser but matches the format both CloudFront and Fastly emit.
