### PR TITLE
svelte: add crate content to the data access page

### DIFF
--- a/svelte/src/routes/data-access/+page.svelte
+++ b/svelte/src/routes/data-access/+page.svelte
@@ -50,6 +50,19 @@
     apply.
   </p>
 
+  <h2 id="crate-content"><a href="#crate-content">Crate content</a></h2>
+
+  <p>
+    Crates can be downloaded directly from the crates.io CDN. For example, to download <code>rand</code> version 0.10.1,
+    you can do so with a
+    <code>GET</code> request to
+    <a href="https://static.crates.io/crates/rand/rand-0.10.1.crate"
+      >https://static.crates.io/crates/rand/rand-0.10.1.crate</a
+    >.
+  </p>
+
+  <p>No rate limits apply to static.crates.io at present.</p>
+
   <h2 id="rss-feeds"><a href="#rss-feeds">RSS feeds</a></h2>
 
   <p>crates.io provides a couple of RSS feeds that contain information on new crates and crate updates:</p>


### PR DESCRIPTION
This came out of #13863 — the data access page has lots of good information on crate metadata, but doesn't actually tell the reader how to download crates without going through the API.

I picked `rand` as a hopefully uncontroversial example of a crate people will know. We could obviously do something fancy to pull the current version and/or randomise the crate used as an example, but that all feels like overkill to me right now.