### PR TITLE
Use full-length checksums in version test fixtures

### DIFF
--- a/crates/crates_io_database/src/models/default_versions.rs
+++ b/crates/crates_io_database/src/models/default_versions.rs
@@ -268,7 +268,7 @@ mod tests {
                 versions::crate_id.eq(crate_id),
                 versions::num.eq(num),
                 versions::num_no_build.eq(num),
-                versions::checksum.eq(""),
+                versions::checksum.eq("0".repeat(64)),
                 versions::crate_size.eq(0),
             ))
             .execute(&mut conn)

--- a/crates/crates_io_database/tests/reverse_dependencies.rs
+++ b/crates/crates_io_database/tests/reverse_dependencies.rs
@@ -316,7 +316,7 @@ async fn create_version(conn: &mut AsyncPgConnection, crate_id: i32, num: &str) 
             versions::crate_id.eq(crate_id),
             versions::num.eq(num),
             versions::num_no_build.eq(num),
-            versions::checksum.eq(""),
+            versions::checksum.eq("0".repeat(64)),
             versions::crate_size.eq(0),
         ))
         .returning(versions::id)

--- a/crates/crates_io_test_utils/src/builders/version.rs
+++ b/crates/crates_io_test_utils/src/builders/version.rs
@@ -42,7 +42,7 @@ impl VersionBuilder {
             num,
             size: 0,
             yanked: false,
-            checksum: String::new(),
+            checksum: "0".repeat(64),
             links: None,
             rust_version: None,
         }

--- a/src/index.rs
+++ b/src/index.rs
@@ -189,7 +189,10 @@ mod tests {
                     .created_at(created_at_2)
                     .dependency(&fooo, None),
             )
-            .version(VersionBuilder::new("1.0.1").checksum("0123456789abcdef"))
+            .version(
+                VersionBuilder::new("1.0.1")
+                    .checksum("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            )
             .expect_build(&mut conn)
             .await;
 

--- a/src/snapshots/crates_io__index__tests__index_metadata-2.snap
+++ b/src/snapshots/crates_io__index__tests__index_metadata-2.snap
@@ -7,7 +7,7 @@ expression: metadata
     "name": "bar",
     "vers": "1.0.0-beta.1",
     "deps": [],
-    "cksum": "                                                                ",
+    "cksum": "0000000000000000000000000000000000000000000000000000000000000000",
     "features": {},
     "yanked": true
   },
@@ -15,7 +15,7 @@ expression: metadata
     "name": "bar",
     "vers": "1.0.0",
     "deps": [],
-    "cksum": "                                                                ",
+    "cksum": "0000000000000000000000000000000000000000000000000000000000000000",
     "features": {},
     "yanked": false
   },
@@ -33,7 +33,7 @@ expression: metadata
         "kind": "normal"
       }
     ],
-    "cksum": "                                                                ",
+    "cksum": "0000000000000000000000000000000000000000000000000000000000000000",
     "features": {},
     "yanked": false
   },
@@ -41,7 +41,7 @@ expression: metadata
     "name": "bar",
     "vers": "1.0.1",
     "deps": [],
-    "cksum": "0123456789abcdef                                                ",
+    "cksum": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     "features": {},
     "yanked": false
   }

--- a/src/snapshots/crates_io__index__tests__index_metadata.snap
+++ b/src/snapshots/crates_io__index__tests__index_metadata.snap
@@ -7,7 +7,7 @@ expression: metadata
     "name": "foo",
     "vers": "0.1.0",
     "deps": [],
-    "cksum": "                                                                ",
+    "cksum": "0000000000000000000000000000000000000000000000000000000000000000",
     "features": {},
     "yanked": false
   }

--- a/src/snapshots/crates_io__index__tests__index_metadata_with_pubtime.snap
+++ b/src/snapshots/crates_io__index__tests__index_metadata_with_pubtime.snap
@@ -7,7 +7,7 @@ expression: metadata
     "name": "bar",
     "vers": "1.0.0",
     "deps": [],
-    "cksum": "                                                                ",
+    "cksum": "0000000000000000000000000000000000000000000000000000000000000000",
     "features": {},
     "yanked": false,
     "pubtime": "2020-01-01T00:00:00Z"
@@ -16,7 +16,7 @@ expression: metadata
     "name": "bar",
     "vers": "2.0.0",
     "deps": [],
-    "cksum": "                                                                ",
+    "cksum": "0000000000000000000000000000000000000000000000000000000000000000",
     "features": {},
     "yanked": false,
     "pubtime": "2020-02-01T00:00:00Z"

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__include_default_version-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__include_default_version-2.snap
@@ -41,7 +41,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo_default_version",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__show-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__show-2.snap
@@ -54,7 +54,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo_show",
       "crate_size": 0,
       "created_at": "[datetime]",
@@ -94,7 +94,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo_show",
       "crate_size": 0,
       "created_at": "[datetime]",
@@ -134,7 +134,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo_show",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__show_all_yanked-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__show_all_yanked-2.snap
@@ -53,7 +53,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo_show",
       "crate_size": 0,
       "created_at": "[datetime]",
@@ -93,7 +93,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo_show",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies-2.snap
@@ -24,7 +24,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "c3",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
@@ -24,7 +24,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "c2",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present-2.snap
@@ -36,7 +36,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "c3",
       "crate_size": 0,
       "created_at": "[datetime]",
@@ -76,7 +76,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "c2",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts-2.snap
@@ -24,7 +24,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "c2",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does-2.snap
@@ -24,7 +24,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "c2",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
@@ -24,7 +24,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "c2",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-9.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-9.snap
@@ -43,7 +43,7 @@ expression: json
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-9.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-9.snap
@@ -43,7 +43,7 @@ expression: json
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__list__versions-2.snap
+++ b/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__list__versions-2.snap
@@ -11,7 +11,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo_versions",
       "crate_size": 0,
       "created_at": "[datetime]",
@@ -45,7 +45,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo_versions",
       "crate_size": 0,
       "created_at": "[datetime]",
@@ -85,7 +85,7 @@ expression: response.json()
     {
       "audit_actions": [],
       "bin_names": null,
-      "checksum": "                                                                ",
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo_versions",
       "crate_size": 0,
       "created_at": "[datetime]",

--- a/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
+++ b/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
@@ -6,7 +6,7 @@ expression: json
   "version": {
     "audit_actions": [],
     "bin_names": null,
-    "checksum": "                                                                ",
+    "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
     "crate": "foo_vers_show_no_pb",
     "crate_size": 0,
     "created_at": "[datetime]",

--- a/src/tests/worker/rss/sync_crate_feed.rs
+++ b/src/tests/worker/rss/sync_crate_feed.rs
@@ -73,7 +73,7 @@ async fn create_version(
             versions::num_no_build.eq(version),
             versions::created_at.eq(publish_time),
             versions::updated_at.eq(publish_time),
-            versions::checksum.eq("checksum"),
+            versions::checksum.eq("0".repeat(64)),
             versions::crate_size.eq(0),
         ))
         .returning(versions::id)

--- a/src/tests/worker/rss/sync_updates_feed.rs
+++ b/src/tests/worker/rss/sync_updates_feed.rs
@@ -76,7 +76,7 @@ async fn create_version(
             versions::num_no_build.eq(version),
             versions::created_at.eq(publish_time),
             versions::updated_at.eq(publish_time),
-            versions::checksum.eq("checksum"),
+            versions::checksum.eq("0".repeat(64)),
             versions::crate_size.eq(0),
         ))
         .returning(versions::id)

--- a/src/worker/jobs/archive_version_downloads.rs
+++ b/src/worker/jobs/archive_version_downloads.rs
@@ -402,7 +402,7 @@ mod tests {
                 versions::crate_id.eq(crate_id),
                 versions::num.eq(num),
                 versions::num_no_build.eq(num),
-                versions::checksum.eq(""),
+                versions::checksum.eq("0".repeat(64)),
                 versions::crate_size.eq(0),
             ))
             .returning(versions::id)

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -519,7 +519,7 @@ mod tests {
                 versions::crate_id.eq(crate_id),
                 versions::num.eq(version),
                 versions::num_no_build.eq(version),
-                versions::checksum.eq("checksum"),
+                versions::checksum.eq("0".repeat(64)),
                 versions::crate_size.eq(0),
             ))
             .execute(conn)

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -262,7 +262,7 @@ mod tests {
                 versions::num_no_build.eq(version),
                 versions::created_at.eq(publish_time),
                 versions::updated_at.eq(publish_time),
-                versions::checksum.eq("checksum"),
+                versions::checksum.eq("0".repeat(64)),
                 versions::crate_size.eq(0),
             ))
             .returning(versions::id)

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -252,7 +252,7 @@ mod tests {
                 versions::num_no_build.eq(version),
                 versions::created_at.eq(publish_time),
                 versions::updated_at.eq(publish_time),
-                versions::checksum.eq("checksum"),
+                versions::checksum.eq("0".repeat(64)),
                 versions::crate_size.eq(0),
             ))
             .returning(versions::id)


### PR DESCRIPTION
Several version test fixtures used checksum values that don't resemble real data: `VersionBuilder` defaulted to an empty string (which the `char(64)` column stored as blank padding), one index test used a truncated 16-character value, and several direct inserts used placeholder strings like `"checksum"`. They now all use proper 64-character hex SHA256 strings, and the affected snapshots are updated accordingly.