### PR TITLE
Switch eslint-plugin-unicorn to the `unopinionated` preset

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,8 +56,6 @@ export default defineConfig(
       'prefer-let/prefer-let': 'error',
 
       'unicorn/explicit-length-check': ['error', { 'non-zero': 'not-equal' }],
-      // disabled because `toReversed` is not "widely supported" yet
-      'unicorn/no-array-reverse': 'off',
       // disabled because `toSorted` is not "widely supported" yet
       'unicorn/no-array-sort': 'off',
       // disabled because we are targeting only browsers at the moment

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ import svelteConfig from './svelte/svelte.config.js';
 const gitignorePath = fileURLToPath(new URL('.gitignore', import.meta.url));
 
 export default defineConfig(
-  eslintPluginUnicorn.configs.recommended,
+  eslintPluginUnicorn.configs.unopinionated,
   includeIgnoreFile(gitignorePath),
   // `crates/` (Rust workspace crates) is not in `.gitignore` but should not be
   // linted. `svelte/static/` contains vendored files like `mockServiceWorker.js`
@@ -55,24 +55,11 @@ export default defineConfig(
       'prefer-const': 'off',
       'prefer-let/prefer-let': 'error',
 
-      // disabled because it seems unnecessary
-      'unicorn/consistent-function-scoping': 'off',
-      // disabled because TypeScript already catches arity mismatches that
-      // this rule is designed to flag (e.g. `arr.map(parseInt)`)
-      'unicorn/no-array-callback-reference': 'off',
       'unicorn/explicit-length-check': ['error', { 'non-zero': 'not-equal' }],
       // disabled because `toReversed` is not "widely supported" yet
       'unicorn/no-array-reverse': 'off',
       // disabled because `toSorted` is not "widely supported" yet
       'unicorn/no-array-sort': 'off',
-      // disabled because it is annoying in some cases...
-      'unicorn/no-await-expression-member': 'off',
-      // disabled because we need `null` since JSON has no `undefined`
-      'unicorn/no-null': 'off',
-      // disabled because this rule conflicts with prettier
-      'unicorn/no-nested-ternary': 'off',
-      // disabled because of unfixable false positives
-      'unicorn/prevent-abbreviations': 'off',
       // disabled because we are targeting only browsers at the moment
       'unicorn/prefer-global-this': 'off',
       // disabled because we don't want to go all-in on ES6 modules for Node.js code yet
@@ -83,9 +70,6 @@ export default defineConfig(
       'unicorn/prefer-reflect-apply': 'off',
       // disabled because it seems unnecessary
       'unicorn/prefer-string-raw': 'off',
-      // disabled because `getElementById()` is faster than `querySelector("#id")`
-      // and expresses intent more clearly
-      'unicorn/prefer-query-selector': 'off',
       // disabled because of false positives on non-array `push()` methods
       'unicorn/prefer-single-call': 'off',
       // disabled because of Sentry issues
@@ -95,10 +79,6 @@ export default defineConfig(
       // disabled because Svelte component `<script>` blocks instantiate
       // synchronously, so top-level await is not appropriate there
       'unicorn/prefer-top-level-await': 'off',
-      // disabled because of false positives
-      'unicorn/consistent-destructuring': 'off',
-      // disabled because it does not play well with Svelte component naming conventions
-      'unicorn/filename-case': 'off',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -68,8 +68,6 @@ export default defineConfig(
       'unicorn/prefer-number-properties': 'off',
       // disabled because of false positives on non-array `push()` methods
       'unicorn/prefer-single-call': 'off',
-      // disabled because of Sentry issues
-      'unicorn/prefer-string-replace-all': 'off',
       // disabled because switch statements in JS are quite error-prone
       'unicorn/prefer-switch': 'off',
       // disabled because Svelte component `<script>` blocks instantiate

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,8 +56,6 @@ export default defineConfig(
       'prefer-let/prefer-let': 'error',
 
       'unicorn/explicit-length-check': ['error', { 'non-zero': 'not-equal' }],
-      // disabled because `toSorted` is not "widely supported" yet
-      'unicorn/no-array-sort': 'off',
       // disabled because we are targeting only browsers at the moment
       'unicorn/prefer-global-this': 'off',
       // disabled because we don't want to go all-in on ES6 modules for Node.js code yet

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,8 +66,6 @@ export default defineConfig(
       'unicorn/prefer-module': 'off',
       // disabled because it seems unnecessary
       'unicorn/prefer-number-properties': 'off',
-      // disabled because it seems unnecessary
-      'unicorn/prefer-string-raw': 'off',
       // disabled because of false positives on non-array `push()` methods
       'unicorn/prefer-single-call': 'off',
       // disabled because of Sentry issues

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,8 +56,6 @@ export default defineConfig(
       'prefer-let/prefer-let': 'error',
 
       'unicorn/explicit-length-check': ['error', { 'non-zero': 'not-equal' }],
-      // disabled because we are targeting only browsers at the moment
-      'unicorn/prefer-global-this': 'off',
       // disabled because we don't want to go all-in on ES6 modules for Node.js code yet
       'unicorn/prefer-module': 'off',
       // disabled because it seems unnecessary

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,8 +67,6 @@ export default defineConfig(
       // disabled because it seems unnecessary
       'unicorn/prefer-number-properties': 'off',
       // disabled because it seems unnecessary
-      'unicorn/prefer-reflect-apply': 'off',
-      // disabled because it seems unnecessary
       'unicorn/prefer-string-raw': 'off',
       // disabled because of false positives on non-array `push()` methods
       'unicorn/prefer-single-call': 'off',

--- a/packages/crates-io-msw/handlers/crates/get.js
+++ b/packages/crates-io-msw/handlers/crates/get.js
@@ -51,5 +51,5 @@ export default http.get('/api/v1/crates/:name', async ({ request, params }) => {
 });
 
 function toCanonicalName(name) {
-  return name.toLowerCase().replace(/-/g, '_');
+  return name.toLowerCase().replaceAll('-', '_');
 }

--- a/packages/crates-io-msw/handlers/crates/list.js
+++ b/packages/crates-io-msw/handlers/crates/list.js
@@ -68,9 +68,9 @@ export default http.get('/api/v1/crates', async ({ request }) => {
 
   let sort = url.searchParams.get('sort');
   if (sort === 'alpha') {
-    crates = crates.sort((a, b) => compare(a.name.toLowerCase(), b.name.toLowerCase()));
+    crates = crates.toSorted((a, b) => compare(a.name.toLowerCase(), b.name.toLowerCase()));
   } else if (sort === 'recent-downloads') {
-    crates = crates.sort((a, b) => b.recent_downloads - a.recent_downloads);
+    crates = crates.toSorted((a, b) => b.recent_downloads - a.recent_downloads);
   }
 
   let total = crates.length;

--- a/packages/crates-io-msw/handlers/invites/legacy-list.js
+++ b/packages/crates-io-msw/handlers/invites/legacy-list.js
@@ -15,7 +15,7 @@ export default http.get('/api/v1/me/crate_owner_invitations', () => {
 
   let inviters = invites.map(invite => invite.inviter);
   let invitees = invites.map(invite => invite.invitee);
-  let users = [...new Set([...inviters, ...invitees])].sort((a, b) => a.id - b.id);
+  let users = [...new Set([...inviters, ...invitees])].toSorted((a, b) => a.id - b.id);
 
   return HttpResponse.json({
     crate_owner_invitations: invites.map(invite => serializeInvite(invite)),

--- a/packages/crates-io-msw/handlers/invites/list.js
+++ b/packages/crates-io-msw/handlers/invites/list.js
@@ -45,7 +45,7 @@ export default http.get('/api/private/crate_owner_invitations', ({ request }) =>
 
   let inviters = invites.map(invite => invite.inviter);
   let invitees = invites.map(invite => invite.invitee);
-  let users = [...new Set([...inviters, ...invitees])].sort((a, b) => a.id - b.id);
+  let users = [...new Set([...inviters, ...invitees])].toSorted((a, b) => a.id - b.id);
 
   return HttpResponse.json({
     invitations: invites.map(invite => serializeInvite(invite)),

--- a/packages/crates-io-msw/handlers/summary.js
+++ b/packages/crates-io-msw/handlers/summary.js
@@ -10,10 +10,10 @@ export default [
   http.get('/api/v1/summary', () => {
     let crates = db.crate.findMany();
 
-    let just_updated = crates.sort((a, b) => compareDates(b.updated_at, a.updated_at)).slice(0, 10);
-    let most_downloaded = crates.sort((a, b) => b.downloads - a.downloads).slice(0, 10);
-    let new_crates = crates.sort((a, b) => b.id - a.id).slice(0, 10);
-    let most_recently_downloaded = crates.sort((a, b) => b.recent_downloads - a.recent_downloads).slice(0, 10);
+    let just_updated = crates.toSorted((a, b) => compareDates(b.updated_at, a.updated_at)).slice(0, 10);
+    let most_downloaded = crates.toSorted((a, b) => b.downloads - a.downloads).slice(0, 10);
+    let new_crates = crates.toSorted((a, b) => b.id - a.id).slice(0, 10);
+    let most_recently_downloaded = crates.toSorted((a, b) => b.recent_downloads - a.recent_downloads).slice(0, 10);
 
     let num_crates = crates.length;
     let num_downloads = crates.reduce((sum, crate) => sum + crate.downloads, 0);

--- a/packages/crates-io-msw/handlers/versions/follow-updates.js
+++ b/packages/crates-io-msw/handlers/versions/follow-updates.js
@@ -13,7 +13,7 @@ export default http.get('/api/v1/me/updates', ({ request }) => {
 
   let allVersions = user.followedCrates
     .flatMap(crate => db.version.findMany(q => q.where(version => version.crate.id === crate.id)))
-    .sort((a, b) => b.id - a.id);
+    .toSorted((a, b) => b.id - a.id);
 
   let { start, end, page, perPage } = pageParams(request);
 

--- a/packages/crates-io-msw/handlers/versions/list.js
+++ b/packages/crates-io-msw/handlers/versions/list.js
@@ -21,7 +21,9 @@ export default http.get('/api/v1/crates/:name/versions', async ({ request, param
 
   let sort = url.searchParams.get('sort');
   versions =
-    sort == 'date' ? versions.sort((a, b) => b.id - a.id) : versions.sort((a, b) => compareSemver(b.num, a.num));
+    sort == 'date'
+      ? versions.toSorted((a, b) => b.id - a.id)
+      : versions.toSorted((a, b) => compareSemver(b.num, a.num));
 
   let total = versions.length;
 

--- a/packages/crates-io-msw/models/index.js
+++ b/packages/crates-io-msw/models/index.js
@@ -85,7 +85,6 @@ export const db = {
   reset() {
     counters.reset();
 
-    // eslint-disable-next-line unicorn/no-this-outside-of-class -- `this` is the surrounding object literal
     for (let collection of Object.values(this)) {
       collection.clear?.();
     }

--- a/packages/crates-io-msw/serializers/crate.js
+++ b/packages/crates-io-msw/serializers/crate.js
@@ -44,7 +44,7 @@ export function serializeCrate(
     serialized.max_version = unyankedVersions[0] ?? '0.0.0';
     serialized.max_stable_version = unyankedVersions.find(it => !prerelease(it, { loose: true })) ?? null;
 
-    let newestVersions = versions.filter(it => !it.yanked).sort((a, b) => compareDates(b.updated_at, a.updated_at));
+    let newestVersions = versions.filter(it => !it.yanked).toSorted((a, b) => compareDates(b.updated_at, a.updated_at));
     serialized.newest_version = newestVersions[0]?.num ?? '0.0.0';
   } else {
     serialized.max_version = '0.0.0';

--- a/packages/crates-io-msw/utils/strings.js
+++ b/packages/crates-io-msw/utils/strings.js
@@ -3,9 +3,9 @@
  */
 export function dasherize(str) {
   return str
-    .replace(/([a-z\d])([A-Z])/g, '$1_$2')
+    .replaceAll(/([a-z\d])([A-Z])/g, '$1_$2')
     .toLowerCase()
-    .replace(/[ _]/g, '-');
+    .replaceAll(/[ _]/g, '-');
 }
 
 /**
@@ -13,7 +13,7 @@ export function dasherize(str) {
  */
 export function underscore(str) {
   return str
-    .replace(/([a-z\d])([A-Z]+)/g, '$1_$2')
-    .replace(/-|\s+/g, '_')
+    .replaceAll(/([a-z\d])([A-Z]+)/g, '$1_$2')
+    .replaceAll(/-|\s+/g, '_')
     .toLowerCase();
 }

--- a/svelte/src/build/favicon-ico.js
+++ b/svelte/src/build/favicon-ico.js
@@ -44,12 +44,9 @@ export default function faviconIco({ source }) {
     name: 'favicon-ico',
 
     async generateBundle() {
-      // `this` is the Rollup plugin context provided by the hook API.
-      /* eslint-disable unicorn/no-this-outside-of-class */
       // SvelteKit runs a separate SSR build that should not emit the asset.
       if (this.environment && this.environment.name !== 'client') return;
       this.emitFile({ type: 'asset', fileName: FILE_NAME, source: await build() });
-      /* eslint-enable unicorn/no-this-outside-of-class */
     },
 
     configureServer(server) {

--- a/svelte/src/hooks.client.ts
+++ b/svelte/src/hooks.client.ts
@@ -2,8 +2,8 @@ export async function init() {
   // Clear the bootstrap error handlers set in `app.html`; the app has loaded
   // successfully, so the load-failure fallback is no longer needed.
   // eslint-disable-next-line unicorn/prefer-add-event-listener
-  window.onerror = null;
-  window.onunhandledrejection = null;
+  globalThis.onerror = null;
+  globalThis.onunhandledrejection = null;
 
   if (import.meta.env.VITE_MSW_ENABLED) {
     let { http, passthrough } = await import('msw');

--- a/svelte/src/lib/components/crate-sidebar/Link.svelte.test.ts
+++ b/svelte/src/lib/components/crate-sidebar/Link.svelte.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable unicorn/prefer-https -- several tests assert that http:// URLs are preserved */
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { page } from 'vitest/browser';

--- a/svelte/src/lib/components/download-chart/data.ts
+++ b/svelte/src/lib/components/download-chart/data.ts
@@ -100,7 +100,7 @@ export function toChartData(data: DownloadChartData | null, now: Date): { datase
 
       return { data, label };
     })
-    .reverse()
+    .toReversed()
     .map(({ label, data }, index): DownloadChartDataset => {
       return {
         backgroundColor: BG_COLORS[index],

--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -69,7 +69,7 @@
     let defaultFeatures = features.default ?? [];
     return Object.keys(features)
       .filter(name => name !== 'default')
-      .sort()
+      .toSorted()
       .map(name => ({ name, isDefault: defaultFeatures.includes(name), dependencies: features[name] ?? [] }));
   });
 

--- a/svelte/src/lib/dismissed-banner-messages.svelte.ts
+++ b/svelte/src/lib/dismissed-banner-messages.svelte.ts
@@ -4,7 +4,7 @@ const BANNER_MESSAGE_STORAGE_KEY = 'dismissed-banner-messages';
 
 async function hash(content: string) {
   let input = new TextEncoder().encode(content);
-  let output = await window.crypto.subtle.digest('SHA-256', input);
+  let output = await globalThis.crypto.subtle.digest('SHA-256', input);
   return new Uint8Array(output).toHex();
 }
 

--- a/svelte/src/lib/page-title.svelte.ts
+++ b/svelte/src/lib/page-title.svelte.ts
@@ -35,7 +35,7 @@ export class PageTitleState {
   get title(): string {
     if (this.#tokens.length === 0) return BASE_TITLE;
 
-    let segments = this.#tokens.map(t => t.title).reverse();
+    let segments = this.#tokens.map(t => t.title).toReversed();
     return [...segments, BASE_TITLE].join(SEPARATOR);
   }
 

--- a/svelte/src/lib/utils/license.ts
+++ b/svelte/src/lib/utils/license.ts
@@ -758,10 +758,10 @@ export interface LicenseToken {
 export function parseLicense(text: string): LicenseToken[] {
   return text
     .trim()
-    .replace(/\//g, ' OR ')
-    .replace(/(^\(| \()/g, ' ( ')
-    .replace(/(\)$|\) )/g, ' ) ')
-    .replace(/ +/g, ' ')
+    .replaceAll('/', ' OR ')
+    .replaceAll(/(^\(| \()/g, ' ( ')
+    .replaceAll(/(\)$|\) )/g, ' ) ')
+    .replaceAll(/ +/g, ' ')
     .split(' ')
     .filter(Boolean)
     .map(text => {

--- a/svelte/src/lib/utils/session.svelte.ts
+++ b/svelte/src/lib/utils/session.svelte.ts
@@ -58,7 +58,7 @@ function waitForOAuthCallback(popup: Window): Promise<{ code: string; state: str
     let interval: ReturnType<typeof setInterval>;
 
     function onMessage(event: MessageEvent) {
-      if (event.origin !== window.location.origin || !event.data) return;
+      if (event.origin !== globalThis.location.origin || !event.data) return;
 
       let { code, state } = event.data;
       if (!code || !state) return;
@@ -224,7 +224,7 @@ export class SessionState {
       localStorage.removeItem(LOGIN_KEY);
 
       // Full page navigation to ensure all in-memory state is cleared on logout.
-      window.location.assign(resolve('/'));
+      globalThis.location.assign(resolve('/'));
     }
   }
 }

--- a/svelte/src/routes/docs/trusted-publishing/+page.svelte
+++ b/svelte/src/routes/docs/trusted-publishing/+page.svelte
@@ -5,15 +5,15 @@
 
   // Defined as a variable to avoid Svelte parsing issues with
   // curly braces and backslash escapes in inline code blocks.
-  let exchangeTokenScript = `#!/bin/bash
+  let exchangeTokenScript = String.raw`#!/bin/bash
 set -e
 
 # Exchange JWT token
 echo "Exchanging OIDC token..." >&2
-RESPONSE=$(curl -s -X POST https://crates.io/api/v1/trusted_publishing/tokens \\
-  -H "Content-Type: application/json" \\
-  -H "User-Agent: gitlab-trusted-publishing (your@email.com)" \\
-  -d "{\\"jwt\\": \\"$CRATES_IO_ID_TOKEN\\"}")
+RESPONSE=$(curl -s -X POST https://crates.io/api/v1/trusted_publishing/tokens \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: gitlab-trusted-publishing (your@email.com)" \
+  -d "{\"jwt\": \"$CRATES_IO_ID_TOKEN\"}")
 
 # Extract publish token
 CRATES_IO_PUBLISH_TOKEN=$(echo "$RESPONSE" | jq -r '.token')

--- a/svelte/src/routes/opensearch.xml/+server.ts
+++ b/svelte/src/routes/opensearch.xml/+server.ts
@@ -8,7 +8,6 @@ import icon from '$lib/assets/cargo.png?w=64&format=png&quality=80&inline&imaget
 export const prerender = true;
 
 export function GET({ url }) {
-  /* eslint-disable unicorn/prefer-https -- OpenSearch XML namespace identifier, not a fetchable URL */
   let body = `<?xml version="1.0" encoding="utf-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
     <ShortName>crates.io</ShortName>
@@ -17,7 +16,6 @@ export function GET({ url }) {
     <Url type="text/html" method="get" template="${url.origin}${base}/search?q={searchTerms}"/>
 </OpenSearchDescription>
 `;
-  /* eslint-enable unicorn/prefer-https */
 
   return new Response(body, {
     headers: { 'Content-Type': 'application/opensearchdescription+xml' },

--- a/svelte/src/routes/settings/tokens/+page.svelte
+++ b/svelte/src/routes/settings/tokens/+page.svelte
@@ -46,7 +46,7 @@
   }
 
   function sortTokens(tokens: ApiToken[]): ApiToken[] {
-    return [...tokens].sort((a, b) => {
+    return tokens.toSorted((a, b) => {
       let aExpired = isExpired(a);
       let bExpired = isExpired(b);
 


### PR DESCRIPTION
We were enabling unicorn's `recommended` preset and then switching off a growing list of opinionated style rules. `unopinionated` is the same baseline without those rules, so it matches what we actually want to enforce and lets us drop most of the overrides. The remaining commits enable a handful of the non-style rules that were previously off and adjust the affected call sites.

All rules and the `unopinionated` config already exist in the currently pinned `eslint-plugin-unicorn` (65.0.1), so this stands on its own. It also pairs with the v66 update in #13977, which is what surfaced several of these rules.

### Related
- #13977
