### PR TITLE
Stop writing `users.gh_avatar`

### DIFF
--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -96,7 +96,6 @@ pub struct NewUser<'a> {
     pub gh_login: &'a str,
     pub username: &'a str,
     pub name: Option<&'a str>,
-    pub gh_avatar: Option<&'a str>,
     pub gh_encrypted_token: &'a [u8],
 }
 
@@ -128,7 +127,6 @@ impl NewUser<'_> {
                 users::gh_login.eq(excluded(users::gh_login)),
                 users::username.eq(excluded(users::username)),
                 users::name.eq(excluded(users::name)),
-                users::gh_avatar.eq(excluded(users::gh_avatar)),
                 users::gh_encrypted_token.eq(excluded(users::gh_encrypted_token)),
             ))
             .returning(users::id)

--- a/crates/crates_io_database_dump/src/dump-db.toml
+++ b/crates/crates_io_database_dump/src/dump-db.toml
@@ -266,7 +266,7 @@ id in (
 id = "public"
 gh_login = "public"
 name = "public"
-gh_avatar = "public"
+gh_avatar = "private"
 gh_id = "public"
 username = "public"
 created_at = "public"

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
@@ -13,7 +13,7 @@ BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY;
     \copy "reserved_crate_names" ("name") TO 'data/reserved_crate_names.csv' WITH CSV HEADER
     \copy "reserved_usernames" ("username") TO 'data/reserved_usernames.csv' WITH CSV HEADER
     \copy "teams" ("avatar", "github_id", "id", "login", "name", "org_id") TO 'data/teams.csv' WITH CSV HEADER
-    \copy (SELECT "created_at", "gh_avatar", "gh_id", "gh_login", "id", "name", "username" FROM "users" WHERE id in (     SELECT owner_id AS user_id FROM crate_owners WHERE NOT deleted AND owner_kind = 0     UNION     SELECT published_by as user_id FROM versions )) TO 'data/users.csv' WITH CSV HEADER
+    \copy (SELECT "created_at", "gh_id", "gh_login", "id", "name", "username" FROM "users" WHERE id in (     SELECT owner_id AS user_id FROM crate_owners WHERE NOT deleted AND owner_kind = 0     UNION     SELECT published_by as user_id FROM versions )) TO 'data/users.csv' WITH CSV HEADER
 
     \copy "crates_categories" ("category_id", "crate_id") TO 'data/crates_categories.csv' WITH CSV HEADER
     \copy "crates_keywords" ("crate_id", "keyword_id") TO 'data/crates_keywords.csv' WITH CSV HEADER

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
@@ -67,7 +67,7 @@ BEGIN;
     \copy "reserved_crate_names" ("name") FROM 'data/reserved_crate_names.csv' WITH CSV HEADER
     \copy "reserved_usernames" ("username") FROM 'data/reserved_usernames.csv' WITH CSV HEADER
     \copy "teams" ("avatar", "github_id", "id", "login", "name", "org_id") FROM 'data/teams.csv' WITH CSV HEADER
-    \copy "users" ("created_at", "gh_avatar", "gh_id", "gh_login", "id", "name", "username") FROM 'data/users.csv' WITH CSV HEADER
+    \copy "users" ("created_at", "gh_id", "gh_login", "id", "name", "username") FROM 'data/users.csv' WITH CSV HEADER
     \copy "crates_categories" ("category_id", "crate_id") FROM 'data/crates_categories.csv' WITH CSV HEADER
     \copy "crates_keywords" ("crate_id", "keyword_id") FROM 'data/crates_keywords.csv' WITH CSV HEADER
     \copy "crate_owners" ("crate_id", "created_at", "created_by", "owner_id", "owner_kind") FROM 'data/crate_owners.csv' WITH CSV HEADER

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -169,7 +169,6 @@ async fn create_or_update_user(
             .gh_login(&user.login)
             .username(&user.login)
             .maybe_name(user.name.as_deref())
-            .maybe_gh_avatar(user.avatar_url.as_deref())
             .gh_encrypted_token(encrypted_token)
             .build();
 
@@ -184,7 +183,7 @@ async fn create_or_update_user(
             .account_id(new_user.gh_id as i64)
             .encrypted_token(new_user.gh_encrypted_token)
             .login(new_user.gh_login)
-            .maybe_avatar(new_user.gh_avatar)
+            .maybe_avatar(user.avatar_url.as_deref())
             .build();
 
         new_oauth_github.insert_or_update(conn).await?;

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -163,7 +163,7 @@ impl TestApp {
             name: new_user.name.map(str::to_string),
             gh_id: new_user.gh_id,
             gh_login: new_user.gh_login.to_string(),
-            gh_avatar: new_user.gh_avatar.map(str::to_string),
+            gh_avatar: None,
             gh_encrypted_token: new_user.gh_encrypted_token.to_vec(),
             account_lock_reason: None,
             account_lock_until: None,


### PR DESCRIPTION
User avatars are already read from `oauth_github.avatar` through the join on the `User` struct, so the `users.gh_avatar` column has no remaining readers. This removes the last writers: the field on `NewUser`, the `do_update` clause in `insert_or_update()`, and the builder call in `create_or_update_user()`, which now sources the `oauth_github` avatar straight from the GitHub response.

It also flips the column to `private` in the database dump so the now-frozen data is no longer published.

The column itself stays in place for now: dropping it has to wait until this change has been deployed, so the old code serving traffic during the release window never references a missing column.

### Related
- #13981