### PR TITLE
Heroku: Pin apt buildpack to SHA1

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/heroku/heroku-buildpack-apt
+https://github.com/heroku/heroku-buildpack-apt#224cf42df17178e69cbf64b474bd24596f364357
 https://github.com/Turbo87/heroku-buildpack-crates-io#5cf07e63f02d69537ecb02fe58fc45a7d5f0353d


### PR DESCRIPTION
This pins the `heroku-buildpack-apt` entry in `.buildpacks` to a specific commit SHA, matching the format already used for the crates-io buildpack on the line below it.

Pinning avoids unexpected behavior changes from the buildpack's `main` branch moving underneath us between deploys. The SHA `224cf42` is the current `main` HEAD of https://github.com/heroku/heroku-buildpack-apt, so this is a no-op for the next build while making future buildpack updates explicit.