### PR TITLE
Renovate: Automate buildpack SHA1 updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,20 @@
     'customManagers:dockerfileVersions',
     'customManagers:githubActionsVersions',
   ],
+  customManagers: [
+    {
+      // Track the latest commit on each buildpack's `main` branch and keep
+      // the pinned SHA1 in `.buildpacks` up to date.
+      customType: 'regex',
+      managerFilePatterns: ['/^\\.buildpacks$/'],
+      matchStrings: [
+        'https://github\\.com/(?<depName>[^#\\s]+?)#(?<currentDigest>[0-9a-f]{40})',
+      ],
+      currentValueTemplate: 'main',
+      packageNameTemplate: 'https://github.com/{{{depName}}}',
+      datasourceTemplate: 'git-refs',
+    },
+  ],
   packageRules: [
     {
       matchDepNames: ['@percy/cli', 'tj-actions/changed-files'],
@@ -46,6 +60,13 @@
     {
       matchUpdateTypes: ['digest'],
       enabled: false,
+    },
+    {
+      // Re-enable digest updates for the buildpack SHA1s tracked via `git-refs`.
+      matchManagers: ['custom.regex'],
+      matchDatasources: ['git-refs'],
+      matchUpdateTypes: ['digest'],
+      enabled: true,
     },
     {
       // This is causing various issues, so we disable it for now.


### PR DESCRIPTION
This adds a custom regex manager that tracks the pinned SHA1s in `.buildpacks` against each buildpack's `main` branch using the `git-refs` datasource, so Renovate opens PRs to bump them like any other dependency.

Digest updates are disabled globally, so this also re-enables them for the `git-refs` deps the manager produces.