### PR TITLE
Renovate: Link buildpack package and SHA1 diff in PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,11 +62,17 @@
       enabled: false,
     },
     {
-      // Re-enable digest updates for the buildpack SHA1s tracked via `git-refs`.
+      // Re-enable digest updates for the buildpack SHA1s tracked via `git-refs`,
+      // and link the package name and SHA1 diff in the PR table.
       matchManagers: ['custom.regex'],
       matchDatasources: ['git-refs'],
       matchUpdateTypes: ['digest'],
       enabled: true,
+      prBodyDefinitions: {
+        Package: '[{{{depName}}}](https://github.com/{{{depName}}})',
+        Change:
+          '[`{{{displayFrom}}}` → `{{{displayTo}}}`](https://github.com/{{{depName}}}/compare/{{{currentDigest}}}...{{{newDigest}}})',
+      },
     },
     {
       // This is causing various issues, so we disable it for now.


### PR DESCRIPTION
Renovate fetches the datasource metadata that links a package name and provides changelog links only for valid versions. The buildpack SHA1s are tracked against the `main` branch, which is not a valid version, so those links are absent from the generated PRs.

This overrides the PR table definitions for the `git-refs` deps to link the package name to its repository and turn the SHA1 change into a GitHub compare link between the two commits.

### Related

- #13989
- https://github.com/rust-lang/crates.io/pull/13990