### PR TITLE
Reject non-UTF8 paths in crate files

### DIFF
--- a/crates/crates_io_tarball/src/lib.rs
+++ b/crates/crates_io_tarball/src/lib.rs
@@ -103,6 +103,11 @@ pub async fn process_tarball<R: tokio::io::AsyncRead + Unpin>(
             return Err(TarballError::InvalidPath(entry_path.display().to_string()));
         };
 
+        // Reject any paths that are not UTF-8.
+        let Some(in_pkg_path_str) = in_pkg_path.to_str() else {
+            return Err(TarballError::InvalidPath(entry_path.display().to_string()));
+        };
+
         // Historical versions of the `tar` crate which Cargo uses internally
         // don't properly prevent hard links and symlinks from overwriting
         // arbitrary files on the filesystem. As a bit of a hammer we reject any
@@ -127,7 +132,6 @@ pub async fn process_tarball<R: tokio::io::AsyncRead + Unpin>(
 
         // Let's go hunting for the VCS info and crate manifest. The only valid place for these is
         // in the package root in the tarball.
-        let in_pkg_path_str = in_pkg_path.to_string_lossy();
         if in_pkg_path_str == ".cargo_vcs_info.json" {
             let mut contents = String::new();
             entry.read_to_string(&mut contents).await?;
@@ -227,7 +231,7 @@ impl AbstractFilesystem for PathsFileSystem {
             .iter()
             .filter_map(move |p| p.strip_prefix(rel_path).ok())
             .filter_map(|name| match name.components().next() {
-                // We can skip non-utf8 paths, since those are not checked by `crates_io_cargo_toml` anyway
+                // `process_tarball()` rejects non-utf8 paths before they reach here, so `to_str()` should always succeeds
                 Some(Component::Normal(p)) => p.to_str(),
                 _ => None,
             })
@@ -258,6 +262,28 @@ mod tests {
 
         let err = assert_err!(process_tarball("bar-0.0.1", &*tarball, MAX_SIZE).await);
         assert_snapshot!(err, @"invalid path found: foo-0.0.1/Cargo.toml");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn process_tarball_test_non_utf8_path() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let mut builder = TarballBuilder::new().add_file("foo-0.0.1/Cargo.toml", MANIFEST);
+
+        let mut header = tar::Header::new_gnu();
+        header
+            .set_path(OsStr::from_bytes(b"foo-0.0.1/\xff"))
+            .unwrap();
+        header.set_size(0);
+        header.set_cksum();
+        builder.as_mut().append(&header, b"".as_slice()).unwrap();
+
+        let tarball = builder.build();
+
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        assert_snapshot!(err, @"invalid path found: foo-0.0.1/�");
     }
 
     #[tokio::test]

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -47,6 +47,35 @@ async fn new_krate_tarball_with_hard_links() {
     assert_that!(app.stored_files().await, is_empty());
 }
 
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_tarball_with_non_utf8_path() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let (app, _, _, token) = TestApp::full().with_token().await;
+
+    let tarball = {
+        let mut builder = TarballBuilder::new();
+
+        let mut header = tar::Header::new_gnu();
+        assert_ok!(header.set_path(OsStr::from_bytes(b"foo-1.1.0/\xff")));
+        header.set_size(0);
+        header.set_cksum();
+        assert_ok!(builder.as_mut().append(&header, &[][..]));
+
+        builder.build()
+    };
+
+    let (json, _tarball) = PublishBuilder::new("foo", "1.1.0").build();
+    let body = PublishBuilder::create_publish_body(&json, &tarball);
+
+    let response = token.publish_crate(body).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"invalid path found: foo-1.1.0/�"}]}"#);
+    assert_that!(app.stored_files().await, is_empty());
+}
+
 async fn new_krate_tarball_with_device_entry(entry_type: tar::EntryType) {
     let (app, _, _, token) = TestApp::full().with_token().await;
 


### PR DESCRIPTION
Crate tarballs with file paths that aren't valid UTF-8 are now rejected during publish with a 400. This also lets `process_tarball()` reuse the validated `&str`, dropping the `to_string_lossy()` fallback.

None of the existing crates on crates.io use non-UTF8 paths, so this rejection has no compatibility impact.