### PR TITLE
Fix Prettier formatting of `renovate.json5`

### DIFF
--- a/.github/changed-files.yml
+++ b/.github/changed-files.yml
@@ -31,7 +31,7 @@ frontend_lint:
   - .github/workflows/**
   - package.json
   - pnpm-lock.yaml
-  - '**/*.{css,html,json,mjs,js,ts,svelte,yml,yaml}'
+  - '**/*.{css,html,json,json5,mjs,js,ts,svelte,yml,yaml}'
 
 msw_test:
   - .github/workflows/**

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,9 +17,7 @@
       // the pinned SHA1 in `.buildpacks` up to date.
       customType: 'regex',
       managerFilePatterns: ['/^\\.buildpacks$/'],
-      matchStrings: [
-        'https://github\\.com/(?<depName>[^#\\s]+?)#(?<currentDigest>[0-9a-f]{40})',
-      ],
+      matchStrings: ['https://github\\.com/(?<depName>[^#\\s]+?)#(?<currentDigest>[0-9a-f]{40})'],
       currentValueTemplate: 'main',
       packageNameTemplate: 'https://github.com/{{{depName}}}',
       datasourceTemplate: 'git-refs',
@@ -70,8 +68,7 @@
       enabled: true,
       prBodyDefinitions: {
         Package: '[{{{depName}}}](https://github.com/{{{depName}}})',
-        Change:
-          '[`{{{displayFrom}}}` → `{{{displayTo}}}`](https://github.com/{{{depName}}}/compare/{{{currentDigest}}}...{{{newDigest}}})',
+        Change: '[`{{{displayFrom}}}` → `{{{displayTo}}}`](https://github.com/{{{depName}}}/compare/{{{currentDigest}}}...{{{newDigest}}})',
       },
     },
     {


### PR DESCRIPTION
The `frontend_lint` CI filter gates the Prettier check on a glob that matches `.json` but not `.json5`. As a result the formatting of `.github/renovate.json5` was never verified and drifted out of line with the configured `printWidth`.

The first commit reformats the file with Prettier. The second adds `json5` to the filter glob so future changes to such files trigger the check.