### PR TITLE
Drop `sparse_index_fastly_enabled` feature flag

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -100,9 +100,6 @@ pub struct Server {
     /// Include publication timestamp in index entries (ISO8601 format).
     pub index_include_pubtime: bool,
 
-    /// Enable Fastly CDN invalidation for sparse index files.
-    pub sparse_index_fastly_enabled: bool,
-
     /// Enable enqueueing of `BuildCrateZip` jobs in the publish flow.
     pub zip_archives_enabled: bool,
 
@@ -252,8 +249,6 @@ impl Server {
             disable_token_creation,
             banner_message,
             index_include_pubtime,
-            sparse_index_fastly_enabled: var_parsed("SPARSE_INDEX_FASTLY_ENABLED")?
-                .unwrap_or(false),
             zip_archives_enabled: var_parsed("ZIP_ARCHIVES_ENABLED")?.unwrap_or(false),
             index_archive_url: var_parsed("GIT_ARCHIVE_REPO_URL")?,
             postgres_bin_dir: var_parsed("POSTGRES_BIN_DIR")?,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -610,7 +610,6 @@ fn simple_config() -> config::Server {
         disable_token_creation: None,
         banner_message: None,
         index_include_pubtime: false,
-        sparse_index_fastly_enabled: true,
         zip_archives_enabled: true,
         index_archive_url: None,
         postgres_bin_dir: None,

--- a/src/worker/jobs/index/sync.rs
+++ b/src/worker/jobs/index/sync.rs
@@ -196,9 +196,7 @@ impl BackgroundJob for SyncToSparseIndex {
 
         let path = Repository::relative_index_file_for_url(&self.krate);
 
-        if let Some(fastly) = env.fastly()
-            && env.config.sparse_index_fastly_enabled
-        {
+        if let Some(fastly) = env.fastly() {
             let domain_name = &env.config.domain_name;
             let domains = [
                 format!("index.{}", domain_name),


### PR DESCRIPTION
This enables Fastly sparse index invalidation permanently. The flag has been turned on in production for a couple of months without issues, so it is safe to remove.

It removes the config field, the `SPARSE_INDEX_FASTLY_ENABLED` env var parsing, and the conditional, so purging now runs whenever a Fastly client is configured.