### PR TITLE
admin/delete-version: Fix CDN invalidation paths

### DIFF
--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -107,10 +107,13 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
     let mut paths = Vec::new();
     for version in &opts.versions {
         debug!(%crate_name, %version, "Deleting crate file from S3");
-        if let Err(error) = store.delete_crate_file(crate_name, version).await {
-            warn!(%crate_name, %version, "Failed to delete crate file from S3: {error}");
-        } else {
-            paths.push(store.crate_location(crate_name, version));
+        match store.delete_crate_file(crate_name, version).await {
+            Err(error) => {
+                warn!(%crate_name, %version, "Failed to delete crate file from S3: {error}");
+            }
+            Ok(path) => {
+                paths.push(path);
+            }
         }
 
         debug!(%crate_name, %version, "Deleting zip source archive from S3");
@@ -119,8 +122,8 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
             Err(error) => {
                 warn!(%crate_name, %version, "Failed to delete zip source archive from S3: {error}")
             }
-            Ok(_) => {
-                paths.push(store.crate_zip_location(crate_name, version));
+            Ok(path) => {
+                paths.push(path);
             }
         }
 
@@ -130,8 +133,8 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
             Err(error) => {
                 warn!(%crate_name, %version, "Failed to delete zip source archive manifest from S3: {error}")
             }
-            Ok(_) => {
-                paths.push(store.crate_zip_manifest_location(crate_name, version));
+            Ok(path) => {
+                paths.push(path);
             }
         }
 
@@ -141,8 +144,8 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
             Err(error) => {
                 warn!(%crate_name, %version, "Failed to delete readme file from S3: {error}")
             }
-            Ok(_) => {
-                paths.push(store.readme_location(crate_name, version));
+            Ok(path) => {
+                paths.push(path);
             }
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -257,30 +257,36 @@ impl Storage {
         self.delete_all_with_prefix(&prefix).await
     }
 
+    /// Deletes a crate version's archive, returning the path that was deleted.
     #[instrument(skip(self))]
-    pub async fn delete_crate_file(&self, name: &str, version: &str) -> Result<()> {
+    pub async fn delete_crate_file(&self, name: &str, version: &str) -> Result<Path> {
         let path = crate_file_path(name, version);
-        self.store.delete(&path).await
+        self.store.delete(&path).await?;
+        Ok(path)
     }
 
-    /// Deletes a crate version's zip source archive.
+    /// Deletes a crate version's zip source archive, returning the path that was deleted.
     #[instrument(skip(self))]
-    pub async fn delete_crate_zip(&self, name: &str, version: &str) -> Result<()> {
+    pub async fn delete_crate_zip(&self, name: &str, version: &str) -> Result<Path> {
         let path = crate_zip_path(name, version);
-        self.store.delete(&path).await
+        self.store.delete(&path).await?;
+        Ok(path)
     }
 
-    /// Deletes a crate version's zip source archive manifest.
+    /// Deletes a crate version's zip source archive manifest, returning the path that was deleted.
     #[instrument(skip(self))]
-    pub async fn delete_crate_zip_manifest(&self, name: &str, version: &str) -> Result<()> {
+    pub async fn delete_crate_zip_manifest(&self, name: &str, version: &str) -> Result<Path> {
         let path = crate_zip_manifest_path(name, version);
-        self.store.delete(&path).await
+        self.store.delete(&path).await?;
+        Ok(path)
     }
 
+    /// Deletes a crate version's readme, returning the path that was deleted.
     #[instrument(skip(self))]
-    pub async fn delete_readme(&self, name: &str, version: &str) -> Result<()> {
+    pub async fn delete_readme(&self, name: &str, version: &str) -> Result<Path> {
         let path = readme_path(name, version);
-        self.store.delete(&path).await
+        self.store.delete(&path).await?;
+        Ok(path)
     }
 
     /// Deletes the Open Graph image for the given crate.


### PR DESCRIPTION
The `delete-version` admin command passed full CDN URLs from `Storage::*_location()` (e.g. `https://static.crates.io/crates/foo/foo-1.0.0.crate`, with `+` escaped to `%2B`) to the `InvalidateCdns` job.

That job's consumers expect raw storage paths, not URLs:

- Fastly's `purge()` only strips a leading slash before appending the path to the purge URL.
- CloudFront's `invalidate_many()` only prepends a slash.

So the purge targets ended up malformed (e.g. `/https://static.crates.io/crates/foo/...`), and deleted version files kept serving from the CDN until their natural TTL expiry. Every other caller of `InvalidateCdns` (`DeleteCrateFromStorage`, OG image generation, index sync) already passes raw paths.

The fix collects the raw `Path` returned by each delete call instead of the `*_location()` URLs. Using the raw path also drops the `%2B` escaping, so versions with semver build metadata invalidate correctly too.