### PR TITLE
Submit service metrics to Datadog from the background worker

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,6 +79,8 @@ The backend emits structured logs through the `tracing` framework. In production
 
 Errors and panics are additionally reported to Sentry, which groups them and captures the context needed to debug them, with sensitive headers stripped before anything is sent. The backend also exposes operational metrics in Prometheus format, such as queue depths and database pool usage, for monitoring and dashboards.
 
+Service-level metrics are also pushed to DataDog from the `background_worker` dyno via the direct HTTP submission API every few seconds.
+
 On top of all this, the `monitor` process watches for specific failure conditions and pages the on-call team through PagerDuty when it finds one, so that problems like a stalled job queue get a human's attention even outside of working hours.
 
 ## Deployment

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -95,7 +95,7 @@ fn main() -> anyhow::Result<()> {
 
     let docs_rs = RealDocsRsClient::from_environment().map(|cl| Box::new(cl) as _);
 
-    let github: Arc<dyn GitHubClient> = Arc::new(RealGitHubClient::new(http_client));
+    let github: Arc<dyn GitHubClient> = Arc::new(RealGitHubClient::new(http_client.clone()));
     let index_sync_github_app = build_index_sync_github_app(config.index_archive_url.as_ref())?;
     let sync_github_app = build_sync_github_app()?;
 
@@ -138,6 +138,11 @@ fn main() -> anyhow::Result<()> {
 
     runtime.block_on(async {
         let handle = runner.start();
+        crates_io::metrics::datadog::spawn(
+            &environment.config,
+            environment.deadpool.clone(),
+            http_client,
+        );
 
         info!("Runner booted, running jobs");
         handle.wait_for_shutdown().await

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ mod base;
 mod cdn_log_queue;
 mod cdn_log_storage;
 mod database_pools;
+mod datadog;
 mod sentry;
 mod server;
 
@@ -9,5 +10,6 @@ pub use self::base::Base;
 pub use self::cdn_log_queue::CdnLogQueueConfig;
 pub use self::cdn_log_storage::CdnLogStorageConfig;
 pub use self::database_pools::{DatabasePools, DbPoolConfig};
+pub use self::datadog::DatadogConfig;
 pub use self::sentry::SentryConfig;
 pub use self::server::Server;

--- a/src/config/datadog.rs
+++ b/src/config/datadog.rs
@@ -1,0 +1,35 @@
+use crates_io_env_vars::var;
+use secrecy::SecretString;
+
+const DEFAULT_SITE: &str = "datadoghq.com";
+
+pub struct DatadogConfig {
+    /// Datadog API key used to submit service metrics. If missing, the
+    /// background worker does not push metrics to Datadog.
+    ///
+    /// Read from the `DD_API_KEY` environment variable.
+    pub api_key: Option<SecretString>,
+
+    /// Datadog site to submit metrics to. Defaults to `datadoghq.com`.
+    ///
+    /// Read from the `DD_SITE` environment variable.
+    pub site: String,
+}
+
+impl Default for DatadogConfig {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            site: DEFAULT_SITE.into(),
+        }
+    }
+}
+
+impl DatadogConfig {
+    pub fn from_env() -> anyhow::Result<Self> {
+        let api_key = var("DD_API_KEY")?.map(SecretString::from);
+        let site = var("DD_SITE")?.unwrap_or_else(|| DEFAULT_SITE.into());
+
+        Ok(Self { api_key, site })
+    }
+}

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -9,6 +9,7 @@ use super::base::Base;
 use super::database_pools::DatabasePools;
 use crate::config::CdnLogQueueConfig;
 use crate::config::cdn_log_storage::CdnLogStorageConfig;
+use crate::config::datadog::DatadogConfig;
 use crate::middleware::{block_traffic::BlockCriteria, cargo_compat::StatusCodeConfig};
 use crate::storage::StorageConfig;
 use crates_io_env_vars::{list, list_parsed, required_var, var, var_parsed};
@@ -55,6 +56,7 @@ pub struct Server {
     pub allowed_origins: AllowedOrigins,
     pub ownership_invitations_expiration: chrono::Duration,
     pub metrics_authorization_token: Option<String>,
+    pub datadog: DatadogConfig,
     pub instance_metrics_log_every_seconds: Option<u64>,
     pub blocked_routes: HashSet<String>,
     pub cdn_user_agent: String,
@@ -220,6 +222,7 @@ impl Server {
             allowed_origins,
             ownership_invitations_expiration: chrono::Duration::days(30),
             metrics_authorization_token: var("METRICS_AUTHORIZATION_TOKEN")?,
+            datadog: DatadogConfig::from_env()?,
             instance_metrics_log_every_seconds: var_parsed("INSTANCE_METRICS_LOG_EVERY_SECONDS")?,
             blocked_routes: HashSet::from_iter(list("BLOCKED_ROUTES")?),
             cdn_user_agent: var("WEB_CDN_USER_AGENT")?

--- a/src/metrics/datadog.rs
+++ b/src/metrics/datadog.rs
@@ -1,13 +1,135 @@
-//! Encodes Prometheus metrics into the payload expected by Datadog's
+//! Submits the `cratesio_service` metrics to Datadog's
 //! [submit metrics API][api] (`POST /api/v2/series`).
+//!
+//! [`spawn`] starts a background task that periodically gathers the service
+//! metrics and submits them. The rest of the module encodes the gathered
+//! Prometheus families into the JSON payload the API expects.
 //!
 //! [api]: https://docs.datadoghq.com/api/latest/metrics/
 
-#![cfg_attr(not(test), expect(dead_code))]
-
+use crate::config::Server;
+use crate::metrics::ServiceMetrics;
+use anyhow::{Context, anyhow};
+use diesel_async::AsyncPgConnection;
+use diesel_async::pooled_connection::deadpool::Pool;
 use prometheus::proto::{MetricFamily, MetricType};
+use reqwest::Client;
+use secrecy::{ExposeSecret, SecretString};
 use serde::Serialize;
-use tracing::warn;
+use std::time::Duration;
+use tracing::{info, warn};
+
+/// Interval between metric submissions.
+const SUBMIT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Per-request timeout for a single submission.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Spawns a background task that periodically submits the service metrics to
+/// Datadog.
+///
+/// This must run in exactly one process. Today that is guaranteed by the single
+/// `background_worker` dyno; scaling the worker horizontally would make every
+/// instance submit the same series (identical host and tags per environment),
+/// causing last-write-wins collisions.
+pub fn spawn(config: &Server, deadpool: Pool<AsyncPgConnection>, http_client: Client) {
+    let Some(api_key) = config.datadog.api_key.clone() else {
+        info!("Datadog API key not configured, skipping Datadog metrics submission");
+        return;
+    };
+
+    let url = format!("https://api.{}/api/v2/series", config.datadog.site);
+
+    let domain = config.domain_name.clone();
+    let env = match domain.as_str() {
+        "staging.crates.io" => "staging",
+        _ => "prod",
+    };
+    let resources = vec![Resource {
+        kind: "host".into(),
+        name: domain,
+    }];
+
+    let mut common_tags = vec![format!("env:{env}"), "service:crates_io".into()];
+    if let Ok(Some(commit)) = crates_io_version::commit() {
+        common_tags.push(format!("version:{commit}"));
+    }
+
+    let service_metrics = match ServiceMetrics::new() {
+        Ok(metrics) => metrics,
+        Err(err) => {
+            warn!("Failed to initialize service metrics: {err}");
+            return;
+        }
+    };
+
+    tokio::spawn(async move {
+        loop {
+            let result = submit(
+                &deadpool,
+                &service_metrics,
+                &http_client,
+                &url,
+                &api_key,
+                &resources,
+                &common_tags,
+            )
+            .await;
+
+            if let Err(err) = result {
+                warn!("Failed to submit Datadog metrics: {err}");
+            }
+
+            tokio::time::sleep(SUBMIT_INTERVAL).await;
+        }
+    });
+}
+
+/// Gathers the service metrics and submits them to Datadog.
+async fn submit(
+    deadpool: &Pool<AsyncPgConnection>,
+    service_metrics: &ServiceMetrics,
+    http_client: &Client,
+    url: &str,
+    api_key: &SecretString,
+    resources: &[Resource],
+    common_tags: &[String],
+) -> anyhow::Result<()> {
+    let mut conn = deadpool
+        .get()
+        .await
+        .context("Failed to acquire database connection")?;
+
+    let families = service_metrics
+        .gather(&mut conn)
+        .await
+        .map_err(|err| anyhow!("{err}"))
+        .context("Failed to gather service metrics")?;
+
+    let timestamp = chrono::Utc::now().timestamp();
+    let series = families_to_series(&families, timestamp, resources, common_tags);
+    let body = Body { series };
+
+    let response = http_client
+        .post(url)
+        .header("DD-API-KEY", api_key.expose_secret())
+        .timeout(REQUEST_TIMEOUT)
+        .json(&body)
+        .send()
+        .await
+        .context("Failed to send request to Datadog")?;
+
+    response
+        .error_for_status()
+        .context("Datadog returned an error response")?;
+
+    Ok(())
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+struct Body {
+    series: Vec<Series>,
+}
 
 #[derive(Serialize, Debug, PartialEq)]
 struct Series {

--- a/src/metrics/datadog.rs
+++ b/src/metrics/datadog.rs
@@ -1,0 +1,140 @@
+//! Encodes Prometheus metrics into the payload expected by Datadog's
+//! [submit metrics API][api] (`POST /api/v2/series`).
+//!
+//! [api]: https://docs.datadoghq.com/api/latest/metrics/
+
+#![cfg_attr(not(test), expect(dead_code))]
+
+use prometheus::proto::{MetricFamily, MetricType};
+use serde::Serialize;
+use tracing::warn;
+
+#[derive(Serialize, Debug, PartialEq)]
+struct Series {
+    metric: String,
+    #[serde(rename = "type")]
+    kind: u32,
+    points: Vec<Point>,
+    resources: Vec<Resource>,
+    tags: Vec<String>,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+struct Point {
+    timestamp: i64,
+    value: f64,
+}
+
+#[derive(Serialize, Debug, PartialEq, Clone)]
+struct Resource {
+    #[serde(rename = "type")]
+    kind: String,
+    name: String,
+}
+
+/// Builds one Datadog [`Series`] per metric in the gathered families.
+///
+/// The `cratesio_service_` namespace prefix is rewritten to `crates_io.`, so
+/// `cratesio_service_background_jobs` becomes `crates_io.background_jobs`. Each
+/// series carries the metric's own labels concatenated with `common_tags` and
+/// the shared `resources`.
+///
+/// Unsupported metric types are logged and skipped rather than panicking: a
+/// metrics encoder must not crash the worker on an unexpected type.
+fn families_to_series(
+    families: &[MetricFamily],
+    timestamp: i64,
+    resources: &[Resource],
+    common_tags: &[String],
+) -> Vec<Series> {
+    let mut series = Vec::new();
+
+    for family in families {
+        let name = family.name();
+        let metric = match name.strip_prefix("cratesio_service_") {
+            Some(rest) => format!("crates_io.{rest}"),
+            None => name.to_string(),
+        };
+
+        for proto in family.get_metric() {
+            let (kind, value) = match family.get_field_type() {
+                MetricType::GAUGE => (3, proto.get_gauge().get_value()),
+                MetricType::COUNTER => (1, proto.get_counter().get_value()),
+                other => {
+                    warn!("unsupported metric type: {other:?}");
+                    continue;
+                }
+            };
+
+            let mut tags = proto
+                .get_label()
+                .iter()
+                .map(|l| format!("{}:{}", l.name(), l.value()))
+                .collect::<Vec<_>>();
+
+            tags.extend_from_slice(common_tags);
+
+            series.push(Series {
+                metric: metric.clone(),
+                kind,
+                points: vec![Point { timestamp, value }],
+                resources: resources.to_vec(),
+                tags,
+            });
+        }
+    }
+
+    series
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Error;
+    use prometheus::{Histogram, HistogramOpts, IntCounter, IntGaugeVec, Opts, Registry};
+
+    fn host() -> Resource {
+        Resource {
+            kind: "host".into(),
+            name: "crates.io".into(),
+        }
+    }
+
+    #[test]
+    fn test_families_to_series() -> Result<(), Error> {
+        let registry = Registry::new();
+
+        let gauge_vec = IntGaugeVec::new(
+            Opts::new("background_jobs", "queued jobs").namespace("cratesio_service"),
+            &["priority", "job"],
+        )?;
+        gauge_vec.with_label_values(&["1", "foo"]).set(42);
+        gauge_vec.with_label_values(&["2", "bar"]).set(98);
+        registry.register(Box::new(gauge_vec))?;
+
+        let counter = IntCounter::with_opts(
+            Opts::new("crates_total", "total crates").namespace("cratesio_service"),
+        )?;
+        counter.inc_by(7);
+        registry.register(Box::new(counter))?;
+
+        // A name without the `cratesio_service_` prefix passes through unchanged.
+        let other = IntCounter::with_opts(Opts::new("other_metric", "help"))?;
+        registry.register(Box::new(other))?;
+
+        // Unsupported metric types are skipped instead of producing a series.
+        let histogram = Histogram::with_opts(HistogramOpts::new("sample_histogram", "help"))?;
+        histogram.observe(1.0);
+        registry.register(Box::new(histogram))?;
+
+        let resources = [host()];
+        let common_tags = ["env:prod".to_string()];
+        let series = families_to_series(&registry.gather(), 1000, &resources, &common_tags);
+
+        // Gauges map to `type: 3`, counters to `type: 1`, and the
+        // `cratesio_service_` prefix is rewritten to `crates_io.`
+        insta::assert_json_snapshot!(series);
+
+        Ok(())
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -2,6 +2,7 @@ pub use self::instance::InstanceMetrics;
 pub use self::log_encoder::LogEncoder;
 pub use self::service::ServiceMetrics;
 
+pub mod datadog;
 mod instance;
 mod log_encoder;
 mod macros;

--- a/src/metrics/service.rs
+++ b/src/metrics/service.rs
@@ -15,7 +15,10 @@ use crate::schema::{background_jobs, crates, versions};
 use crate::util::errors::AppResult;
 use diesel::{dsl::count_star, prelude::*};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
-use prometheus::{IntGauge, IntGaugeVec, proto::MetricFamily};
+use prometheus::core::Collector;
+use prometheus::proto::{Metric, MetricFamily};
+use prometheus::{IntGauge, IntGaugeVec};
+use std::collections::HashMap;
 
 metrics! {
     pub struct ServiceMetrics {
@@ -41,7 +44,7 @@ impl ServiceMetrics {
         self.versions_total
             .set(versions::table.select(count_star()).first(conn).await?);
 
-        let background_jobs = background_jobs::table
+        let queued_jobs = background_jobs::table
             .group_by((background_jobs::job_type, background_jobs::priority))
             .select((
                 background_jobs::job_type,
@@ -51,14 +54,96 @@ impl ServiceMetrics {
             .load::<(String, i16, i64)>(conn)
             .await?;
 
-        self.background_jobs.reset();
-        for (job, priority, count) in background_jobs {
-            let priority = format!("{priority}");
+        let mut counts: HashMap<(String, String), i64> = queued_jobs
+            .into_iter()
+            .map(|(job, priority, count)| ((priority.to_string(), job), count))
+            .collect();
+
+        for family in self.background_jobs.collect() {
+            for metric in family.get_metric() {
+                let priority = label_value(metric, "priority");
+                let job = label_value(metric, "job");
+                counts.entry((priority, job)).or_insert(0);
+            }
+        }
+
+        for ((priority, job), count) in counts {
             self.background_jobs
                 .get_metric_with_label_values(&[&priority, &job])?
                 .set(count);
         }
 
         Ok(self.registry.gather())
+    }
+}
+
+/// Reads the value of a named label from a gathered metric, returning an empty
+/// string when the label is absent.
+fn label_value(metric: &Metric, name: &str) -> String {
+    metric
+        .get_label()
+        .iter()
+        .find(|label| label.name() == name)
+        .map(|label| label.value().to_string())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claims::assert_some_eq;
+    use crates_io_test_db::TestDatabase;
+
+    async fn enqueue(conn: &mut AsyncPgConnection, job: &str, priority: i16) -> AppResult<()> {
+        diesel::insert_into(background_jobs::table)
+            .values((
+                background_jobs::job_type.eq(job),
+                background_jobs::data.eq(serde_json::json!({})),
+                background_jobs::priority.eq(priority),
+            ))
+            .execute(conn)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Collects the `background_jobs` gauge into a `(priority, job) -> value` map.
+    fn job_counts(families: &[MetricFamily]) -> HashMap<(String, String), i64> {
+        families
+            .iter()
+            .find(|family| family.name() == "cratesio_service_background_jobs")
+            .into_iter()
+            .flat_map(|family| family.get_metric())
+            .map(|metric| {
+                let key = (label_value(metric, "priority"), label_value(metric, "job"));
+                (key, metric.get_gauge().get_value() as i64)
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_drained_background_jobs_report_zero() -> AppResult<()> {
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+
+        enqueue(&mut conn, "job_a", 0).await?;
+        enqueue(&mut conn, "job_b", 10).await?;
+
+        let metrics = ServiceMetrics::new()?;
+        let counts = job_counts(&metrics.gather(&mut conn).await?);
+        assert_some_eq!(counts.get(&("0".into(), "job_a".into())), &1);
+        assert_some_eq!(counts.get(&("10".into(), "job_b".into())), &1);
+
+        // Drain `job_a`, leaving `job_b` queued.
+        diesel::delete(background_jobs::table.filter(background_jobs::job_type.eq("job_a")))
+            .execute(&mut conn)
+            .await?;
+
+        // `job_a` must still be reported, now at zero, instead of disappearing.
+        let counts = job_counts(&metrics.gather(&mut conn).await?);
+        assert_some_eq!(counts.get(&("0".into(), "job_a".into())), &0);
+        assert_some_eq!(counts.get(&("10".into(), "job_b".into())), &1);
+
+        Ok(())
     }
 }

--- a/src/metrics/snapshots/crates_io__metrics__datadog__tests__families_to_series.snap
+++ b/src/metrics/snapshots/crates_io__metrics__datadog__tests__families_to_series.snap
@@ -1,0 +1,86 @@
+---
+source: src/metrics/datadog.rs
+expression: series
+---
+[
+  {
+    "metric": "crates_io.background_jobs",
+    "type": 3,
+    "points": [
+      {
+        "timestamp": 1000,
+        "value": 98.0
+      }
+    ],
+    "resources": [
+      {
+        "type": "host",
+        "name": "crates.io"
+      }
+    ],
+    "tags": [
+      "job:bar",
+      "priority:2",
+      "env:prod"
+    ]
+  },
+  {
+    "metric": "crates_io.background_jobs",
+    "type": 3,
+    "points": [
+      {
+        "timestamp": 1000,
+        "value": 42.0
+      }
+    ],
+    "resources": [
+      {
+        "type": "host",
+        "name": "crates.io"
+      }
+    ],
+    "tags": [
+      "job:foo",
+      "priority:1",
+      "env:prod"
+    ]
+  },
+  {
+    "metric": "crates_io.crates_total",
+    "type": 1,
+    "points": [
+      {
+        "timestamp": 1000,
+        "value": 7.0
+      }
+    ],
+    "resources": [
+      {
+        "type": "host",
+        "name": "crates.io"
+      }
+    ],
+    "tags": [
+      "env:prod"
+    ]
+  },
+  {
+    "metric": "other_metric",
+    "type": 1,
+    "points": [
+      {
+        "timestamp": 1000,
+        "value": 0.0
+      }
+    ],
+    "resources": [
+      {
+        "type": "host",
+        "name": "crates.io"
+      }
+    ],
+    "tags": [
+      "env:prod"
+    ]
+  }
+]

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -3,7 +3,7 @@ use crate::util::chaosproxy::ChaosProxy;
 use crate::util::github::MOCK_GITHUB_DATA;
 use claims::assert_some;
 use crates_io::config::{
-    self, Base, CdnLogQueueConfig, CdnLogStorageConfig, DatabasePools, DbPoolConfig,
+    self, Base, CdnLogQueueConfig, CdnLogStorageConfig, DatabasePools, DatadogConfig, DbPoolConfig,
 };
 use crates_io::middleware::cargo_compat::StatusCodeConfig;
 use crates_io::models::token::{CrateScope, EndpointScope};
@@ -589,6 +589,7 @@ fn simple_config() -> config::Server {
         allowed_origins: Default::default(),
         ownership_invitations_expiration: chrono::Duration::days(30),
         metrics_authorization_token: None,
+        datadog: DatadogConfig::default(),
         instance_metrics_log_every_seconds: None,
         blocked_routes: HashSet::new(),
         cdn_user_agent: "Amazon CloudFront".to_string(),


### PR DESCRIPTION
The background worker now pushes the `cratesio_service` gauges (`crates_total`, `versions_total`, `background_jobs`) to Datadog's `POST /api/v2/series` API every 5 seconds, gated on `DD_API_KEY`. The existing Prometheus scrape keeps running in parallel so the two can be compared before anything is removed.

It also fixes `ServiceMetrics::gather()`, which reset the `background_jobs` gauge and only set the combinations that currently have jobs, so a drained `(priority, job)` series stopped being reported. That is fine for Prometheus pull but freezes the value on a push backend, so `gather()` now zeroes drained combinations instead of dropping them.
