### PR TITLE
pagerduty: Store `service_key` in a `SecretString`

### DIFF
--- a/crates/crates_io_pagerduty/examples/test_pagerduty.rs
+++ b/crates/crates_io_pagerduty/examples/test_pagerduty.rs
@@ -31,8 +31,8 @@ struct Opts {
     #[arg(long, env = "PAGERDUTY_API_TOKEN", hide_env_values = true)]
     api_token: SecretString,
 
-    #[arg(long, env = "PAGERDUTY_INTEGRATION_KEY")]
-    integration_key: String,
+    #[arg(long, env = "PAGERDUTY_INTEGRATION_KEY", hide_env_values = true)]
+    integration_key: SecretString,
 
     #[arg(value_enum)]
     event_type: EventType,

--- a/crates/crates_io_pagerduty/src/lib.rs
+++ b/crates/crates_io_pagerduty/src/lib.rs
@@ -25,11 +25,11 @@ pub enum Event {
 #[derive(Clone, Debug)]
 pub struct PagerdutyClient {
     authorization: SecretString,
-    service_key: String,
+    service_key: SecretString,
 }
 
 impl PagerdutyClient {
-    pub fn new(api_token: SecretString, service_key: String) -> Self {
+    pub fn new(api_token: SecretString, service_key: SecretString) -> Self {
         Self {
             authorization: format!("Token token={}", api_token.expose_secret()).into(),
             service_key,
@@ -43,7 +43,7 @@ impl PagerdutyClient {
     /// If the variant is `Trigger`, this will page whoever is on call
     /// (potentially waking them up at 3 AM).
     pub async fn send(&self, event: &Event) -> Result<()> {
-        let service_key = &self.service_key;
+        let service_key = self.service_key.expose_secret();
 
         let client = Client::builder()
             .user_agent(crates_io_version::user_agent())

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -19,7 +19,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 #[tokio::main]
 async fn main() -> Result<()> {
     let api_token = required_var("PAGERDUTY_API_TOKEN")?.into();
-    let service_key = required_var("PAGERDUTY_INTEGRATION_KEY")?;
+    let service_key = required_var("PAGERDUTY_INTEGRATION_KEY")?.into();
     let client = PagerdutyClient::new(api_token, service_key);
 
     let conn = &mut db::oneoff_connection().await?;


### PR DESCRIPTION
The PagerDuty integration key authorizes posting events to the service via the Events API, so it is a credential in its own right. `PagerdutyClient` derives `Debug`, however, and printed it in clear text, while the sibling `authorization` field was already a `SecretString`.

This stores `service_key` in a `SecretString` too, so it stays out of debug output and is exposed only when building the request payload.