### PR TITLE
config: Store `metrics_authorization_token` in a `SecretString`

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -1,4 +1,5 @@
 use oauth2::{ClientId, ClientSecret};
+use secrecy::SecretString;
 use url::Url;
 
 use crate::Env;
@@ -55,7 +56,7 @@ pub struct Server {
     pub domain_name: String,
     pub allowed_origins: AllowedOrigins,
     pub ownership_invitations_expiration: chrono::Duration,
-    pub metrics_authorization_token: Option<String>,
+    pub metrics_authorization_token: Option<SecretString>,
     pub datadog: DatadogConfig,
     pub instance_metrics_log_every_seconds: Option<u64>,
     pub blocked_routes: HashSet<String>,
@@ -221,7 +222,7 @@ impl Server {
             domain_name,
             allowed_origins,
             ownership_invitations_expiration: chrono::Duration::days(30),
-            metrics_authorization_token: var("METRICS_AUTHORIZATION_TOKEN")?,
+            metrics_authorization_token: var("METRICS_AUTHORIZATION_TOKEN")?.map(Into::into),
             datadog: DatadogConfig::from_env()?,
             instance_metrics_log_every_seconds: var_parsed("INSTANCE_METRICS_LOG_EVERY_SECONDS")?,
             blocked_routes: HashSet::from_iter(list("BLOCKED_ROUTES")?),

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -8,6 +8,7 @@ use axum_extra::headers::CacheControl;
 use http::request::Parts;
 use http::{StatusCode, header};
 use prometheus::TextEncoder;
+use secrecy::ExposeSecret;
 
 /// Handles the `GET /api/private/metrics/{kind}` endpoint.
 pub async fn prometheus(
@@ -22,7 +23,7 @@ pub async fn prometheus(
             .and_then(|value| value.to_str().ok())
             .and_then(|value| value.strip_prefix("Bearer "));
 
-        if provided_token != Some(expected_token.as_str()) {
+        if provided_token != Some(expected_token.expose_secret()) {
             return Err(forbidden("invalid or missing authorization token"));
         }
     } else {


### PR DESCRIPTION
The metrics authorization token is a bearer credential used to gate the `/api/private/metrics/{kind}` endpoint. This stores it in a `secrecy::SecretString` instead of a plain `String`, so it stays out of any debug output and is exposed only for the comparison in the metrics controller.

Matches how other secrets in the config are handled (e.g. `gh_client_secret`, database URLs, storage keys).