### PR TITLE
pagerduty: Remove redundant `Authorization` header and API token

### DIFF
--- a/crates/crates_io_pagerduty/examples/test_pagerduty.rs
+++ b/crates/crates_io_pagerduty/examples/test_pagerduty.rs
@@ -28,9 +28,6 @@ impl FromStr for EventType {
 #[derive(clap::Parser, Debug)]
 #[command(name = "test-pagerduty", about = "Send a test event to pagerduty")]
 struct Opts {
-    #[arg(long, env = "PAGERDUTY_API_TOKEN", hide_env_values = true)]
-    api_token: SecretString,
-
     #[arg(long, env = "PAGERDUTY_INTEGRATION_KEY", hide_env_values = true)]
     integration_key: SecretString,
 
@@ -45,7 +42,7 @@ async fn main() -> Result<()> {
 
     let opts = Opts::parse();
 
-    let client = PagerdutyClient::new(opts.api_token, opts.integration_key);
+    let client = PagerdutyClient::new(opts.integration_key);
 
     let event = match opts.event_type {
         EventType::Trigger => pagerduty::Event::Trigger {

--- a/crates/crates_io_pagerduty/src/lib.rs
+++ b/crates/crates_io_pagerduty/src/lib.rs
@@ -24,16 +24,12 @@ pub enum Event {
 
 #[derive(Clone, Debug)]
 pub struct PagerdutyClient {
-    authorization: SecretString,
     service_key: SecretString,
 }
 
 impl PagerdutyClient {
-    pub fn new(api_token: SecretString, service_key: SecretString) -> Self {
-        Self {
-            authorization: format!("Token token={}", api_token.expose_secret()).into(),
-            service_key,
-        }
+    pub fn new(service_key: SecretString) -> Self {
+        Self { service_key }
     }
 }
 
@@ -52,7 +48,6 @@ impl PagerdutyClient {
         let response = client
             .post("https://events.pagerduty.com/generic/2010-04-15/create_event.json")
             .header(header::ACCEPT, "application/vnd.pagerduty+json;version=2")
-            .header(header::AUTHORIZATION, self.authorization.expose_secret())
             .json(&FullEvent { service_key, event })
             .send()
             .await?;

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -18,9 +18,8 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let api_token = required_var("PAGERDUTY_API_TOKEN")?.into();
     let service_key = required_var("PAGERDUTY_INTEGRATION_KEY")?.into();
-    let client = PagerdutyClient::new(api_token, service_key);
+    let client = PagerdutyClient::new(service_key);
 
     let conn = &mut db::oneoff_connection().await?;
 


### PR DESCRIPTION
The `Authorization: Token token=<api_token>` header appears to be a PagerDuty REST API authentication mechanism. `PagerdutyClient`, however, posts to the Events API v1 endpoint (`.../generic/2010-04-15/create_event.json`), which is not part of the REST API and authenticates solely via the `service_key` in the JSON request body. The header was therefore ignored.

This drops the header along with the now-unused `api_token` parameter, the `authorization` field, and the `PAGERDUTY_API_TOKEN` environment variable read in `monitor.rs`.

The Events API v1 docs list `service_key` as a body parameter and make no mention of an `Authorization` header, and the endpoint has no `401` response code:

- https://developer.pagerduty.com/docs/events-api-v1-overview
- https://developer.pagerduty.com/docs/send-v1-event

The `Token token=` header belongs to the REST API instead:

- https://developer.pagerduty.com/docs/authentication