### PR TITLE
msw: Serve zip archives from the static CDN host

### DIFF
--- a/packages/crates-io-msw/handlers/cdn.js
+++ b/packages/crates-io-msw/handlers/cdn.js
@@ -2,6 +2,8 @@ import { http, HttpResponse } from 'msw';
 
 import { db } from '../index.js';
 
+const ENCODER = new TextEncoder();
+
 export default [
   http.get('https://static.crates.io/readmes/:name/:filename', async ({ params }) => {
     let crate = db.crate.findFirst(q => q.where({ name: params.name }));
@@ -16,4 +18,102 @@ export default [
 
     return HttpResponse.html(found.readme);
   }),
+
+  http.get('https://static.crates.io/crates/:name/:filename', async ({ params, request }) => {
+    let { name, filename } = params;
+
+    let suffix = filename.endsWith('.zip.json') ? '.zip.json' : filename.endsWith('.zip') ? '.zip' : null;
+    if (!suffix) return;
+
+    // The expected filename is `${name}-${version}${suffix}`. This recovers the
+    // version and decodes the `%2B` applied to versions with build metadata.
+    let version = decodeURIComponent(filename.slice(`${name}-`.length, -suffix.length));
+
+    let sourceFiles = findSourceFiles(name, version);
+    if (!sourceFiles) {
+      // The S3-backed CDN reports a not-yet-built archive as `403`.
+      return new HttpResponse(null, { status: 403 });
+    }
+
+    let { body, manifest } = await buildArchive(sourceFiles);
+
+    if (suffix === '.zip.json') {
+      return HttpResponse.json(manifest);
+    }
+
+    let range = request.headers.get('Range');
+    if (range) {
+      let slice = sliceRange(body, range);
+      if (slice) {
+        return new HttpResponse(slice, { status: 206 });
+      }
+    }
+
+    return new HttpResponse(body, { status: 200 });
+  }),
 ];
+
+/** Looks up the `source_files` of a crate version, or `undefined` if there are none. */
+function findSourceFiles(name, version) {
+  let crate = db.crate.findFirst(q => q.where({ name }));
+  if (!crate) return;
+
+  let found = db.version.findFirst(q => q.where(v => v.crate.id === crate.id && v.num === version));
+  return found?.source_files ?? undefined;
+}
+
+/**
+ * Builds a seekable archive body and its manifest from a map of source files.
+ *
+ * The client locates each entry purely by the manifest's byte offsets plus a
+ * range request, so the body is a plain concatenation of the compressed entries
+ * rather than a real ZIP container, which is good enough for our purposes.
+ */
+async function buildArchive(sourceFiles) {
+  let files = [];
+  let chunks = [];
+  let offset = 0;
+
+  for (let path of Object.keys(sourceFiles).toSorted()) {
+    let uncompressed = ENCODER.encode(sourceFiles[path]);
+    let compressed = await deflateRaw(uncompressed);
+    files.push({
+      path,
+      data_offset: offset,
+      compressed_size: compressed.length,
+      uncompressed_size: uncompressed.length,
+      compression: 'deflate',
+      sha256: await sha256Hex(uncompressed),
+    });
+    chunks.push(compressed);
+    offset += compressed.length;
+  }
+
+  let body = new Uint8Array(offset);
+  let position = 0;
+  for (let chunk of chunks) {
+    body.set(chunk, position);
+    position += chunk.length;
+  }
+
+  return { body, manifest: { files } };
+}
+
+/** Compresses bytes as a raw `DEFLATE` stream, matching how zip entries are stored. */
+async function deflateRaw(data) {
+  let stream = new Blob([data]).stream().pipeThrough(new CompressionStream('deflate-raw'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/** Returns the hex-encoded SHA-256 digest of the given bytes. */
+async function sha256Hex(data) {
+  let digest = await crypto.subtle.digest('SHA-256', data);
+  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+/** Slices a `bytes=<start>-<end>` range out of the body, or `null` if malformed. */
+function sliceRange(body, range) {
+  let match = /^bytes=(\d+)-(\d+)$/.exec(range);
+  if (!match) return null;
+  return body.slice(Number(match[1]), Number(match[2]) + 1);
+}

--- a/packages/crates-io-msw/handlers/cdn.test.js
+++ b/packages/crates-io-msw/handlers/cdn.test.js
@@ -1,59 +1,168 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import { db } from '../index.js';
 
-test('returns 403 for unknown crates', async function () {
-  let response = await fetch('https://static.crates.io/readmes/foo/foo-1.0.0.html');
-  expect(response.status).toBe(403);
-  expect(await response.text()).toBe('');
+async function inflateRaw(data) {
+  let stream = new Blob([data]).stream().pipeThrough(new DecompressionStream('deflate-raw'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+describe('GET /readmes/:name/:filename', () => {
+  test('returns 403 for unknown crates', async function () {
+    let response = await fetch('https://static.crates.io/readmes/foo/foo-1.0.0.html');
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('');
+  });
+
+  test('returns 403 for unknown versions', async function () {
+    await db.crate.create({ name: 'rand' });
+
+    let response = await fetch('https://static.crates.io/readmes/rand/rand-1.0.0.html');
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('');
+  });
+
+  test('returns 403 for versions without README', async function () {
+    let crate = await db.crate.create({ name: 'rand' });
+    await db.version.create({ crate, num: '1.0.0' });
+
+    let response = await fetch('https://static.crates.io/readmes/rand/rand-1.0.0.html');
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('');
+  });
+
+  test('returns the README as raw HTML', async function () {
+    let readme = 'lorem ipsum <i>est</i> dolor!';
+
+    let crate = await db.crate.create({ name: 'rand' });
+    await db.version.create({ crate, num: '1.0.0', readme });
+
+    let response = await fetch('https://static.crates.io/readmes/rand/rand-1.0.0.html');
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(readme);
+  });
+
+  test('recovers the version for crate names containing dashes', async function () {
+    let readme = 'serde readme';
+
+    let crate = await db.crate.create({ name: 'serde-json' });
+    await db.version.create({ crate, num: '1.0.0', readme });
+
+    let response = await fetch('https://static.crates.io/readmes/serde-json/serde-json-1.0.0.html');
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(readme);
+  });
+
+  test('decodes the version from the encoded filename', async function () {
+    let readme = 'build metadata readme';
+
+    let crate = await db.crate.create({ name: 'rand' });
+    await db.version.create({ crate, num: '1.0.0+foo', readme });
+
+    let response = await fetch('https://static.crates.io/readmes/rand/rand-1.0.0%2Bfoo.html');
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(readme);
+  });
 });
 
-test('returns 403 for unknown versions', async function () {
-  await db.crate.create({ name: 'rand' });
+describe('GET /crates/:name/:filename', () => {
+  test('returns 403 for unknown crates', async function () {
+    let response = await fetch('https://static.crates.io/crates/foo/foo-1.0.0.zip.json');
+    expect(response.status).toBe(403);
+  });
 
-  let response = await fetch('https://static.crates.io/readmes/rand/rand-1.0.0.html');
-  expect(response.status).toBe(403);
-  expect(await response.text()).toBe('');
-});
+  test('returns 403 for a version without a source archive', async function () {
+    let crate = await db.crate.create({ name: 'rand' });
+    await db.version.create({ crate, num: '1.0.0' });
 
-test('returns 403 for versions without README', async function () {
-  let crate = await db.crate.create({ name: 'rand' });
-  await db.version.create({ crate, num: '1.0.0' });
+    let response = await fetch('https://static.crates.io/crates/rand/rand-1.0.0.zip.json');
+    expect(response.status).toBe(403);
+  });
 
-  let response = await fetch('https://static.crates.io/readmes/rand/rand-1.0.0.html');
-  expect(response.status).toBe(403);
-  expect(await response.text()).toBe('');
-});
+  test('serves a manifest describing the source files', async function () {
+    let crate = await db.crate.create({ name: 'rand' });
+    await db.version.create({
+      crate,
+      num: '1.0.0',
+      source_files: { 'src/lib.rs': 'fn main() {}\n', 'Cargo.toml': 'name = "rand"\n' },
+    });
 
-test('returns the README as raw HTML', async function () {
-  let readme = 'lorem ipsum <i>est</i> dolor!';
+    let response = await fetch('https://static.crates.io/crates/rand/rand-1.0.0.zip.json');
+    expect(response.status).toBe(200);
 
-  let crate = await db.crate.create({ name: 'rand' });
-  await db.version.create({ crate, num: '1.0.0', readme });
+    let manifest = await response.json();
+    expect(manifest).toMatchInlineSnapshot(`
+      {
+        "files": [
+          {
+            "compressed_size": 16,
+            "compression": "deflate",
+            "data_offset": 0,
+            "path": "Cargo.toml",
+            "sha256": "80eee9505e19fcad456f0d08ed5792ed10046f7042aa0adc87e37eb9a6bccf80",
+            "uncompressed_size": 14,
+          },
+          {
+            "compressed_size": 15,
+            "compression": "deflate",
+            "data_offset": 16,
+            "path": "src/lib.rs",
+            "sha256": "536e506bb90914c243a12b397b9a998f85ae2cbd9ba02dfd03a9e155ca5ca0f4",
+            "uncompressed_size": 13,
+          },
+        ],
+      }
+    `);
+  });
 
-  let response = await fetch('https://static.crates.io/readmes/rand/rand-1.0.0.html');
-  expect(response.status).toBe(200);
-  expect(await response.text()).toBe(readme);
-});
+  test('serves a file via a range request that inflates to its contents', async function () {
+    let content = 'fn main() { println!("hi"); }\n';
 
-test('recovers the version for crate names containing dashes', async function () {
-  let readme = 'serde readme';
+    let crate = await db.crate.create({ name: 'rand' });
+    await db.version.create({ crate, num: '1.0.0', source_files: { 'src/lib.rs': content } });
 
-  let crate = await db.crate.create({ name: 'serde-json' });
-  await db.version.create({ crate, num: '1.0.0', readme });
+    let manifestResponse = await fetch('https://static.crates.io/crates/rand/rand-1.0.0.zip.json');
+    let manifest = await manifestResponse.json();
+    let entry = manifest.files.find(file => file.path === 'src/lib.rs');
 
-  let response = await fetch('https://static.crates.io/readmes/serde-json/serde-json-1.0.0.html');
-  expect(response.status).toBe(200);
-  expect(await response.text()).toBe(readme);
-});
+    let start = entry.data_offset;
+    let end = entry.data_offset + entry.compressed_size - 1;
+    let response = await fetch('https://static.crates.io/crates/rand/rand-1.0.0.zip', {
+      headers: { Range: `bytes=${start}-${end}` },
+    });
+    expect(response.status).toBe(206);
 
-test('decodes the version from the encoded filename', async function () {
-  let readme = 'build metadata readme';
+    let compressed = new Uint8Array(await response.arrayBuffer());
+    let text = new TextDecoder().decode(await inflateRaw(compressed));
+    expect(text).toBe(content);
+  });
 
-  let crate = await db.crate.create({ name: 'rand' });
-  await db.version.create({ crate, num: '1.0.0+foo', readme });
+  test('serves the whole archive when no range header is sent', async function () {
+    let sourceFiles = { 'Cargo.toml': 'name = "rand"\n', 'src/lib.rs': 'fn main() {}\n' };
 
-  let response = await fetch('https://static.crates.io/readmes/rand/rand-1.0.0%2Bfoo.html');
-  expect(response.status).toBe(200);
-  expect(await response.text()).toBe(readme);
+    let crate = await db.crate.create({ name: 'rand' });
+    await db.version.create({ crate, num: '1.0.0', source_files: sourceFiles });
+
+    let manifestResponse = await fetch('https://static.crates.io/crates/rand/rand-1.0.0.zip.json');
+    let manifest = await manifestResponse.json();
+    let entry = manifest.files.find(file => file.path === 'src/lib.rs');
+
+    // Without a range header the whole archive comes back, and the client can slice
+    // an entry out of it by its manifest offset.
+    let response = await fetch('https://static.crates.io/crates/rand/rand-1.0.0.zip');
+    expect(response.status).toBe(200);
+
+    let body = new Uint8Array(await response.arrayBuffer());
+    let compressed = body.slice(entry.data_offset, entry.data_offset + entry.compressed_size);
+    let text = new TextDecoder().decode(await inflateRaw(compressed));
+    expect(text).toBe('fn main() {}\n');
+  });
+
+  test('recovers the version when the crate name and version contain dashes', async function () {
+    let crate = await db.crate.create({ name: 'serde-json' });
+    await db.version.create({ crate, num: '1.0.0-beta.1', source_files: { 'Cargo.toml': 'name = "serde_json"\n' } });
+
+    let response = await fetch('https://static.crates.io/crates/serde-json/serde-json-1.0.0-beta.1.zip.json');
+    expect(response.status).toBe(200);
+  });
 });

--- a/packages/crates-io-msw/models/dependency.test.js
+++ b/packages/crates-io-msw/models/dependency.test.js
@@ -92,6 +92,7 @@ test('happy path', async ({ expect }) => {
         "publishedBy": null,
         "readme": null,
         "rust_version": null,
+        "source_files": null,
         "trustpub_data": null,
         "updated_at": "2017-02-24T12:34:56Z",
         "yank_message": null,

--- a/packages/crates-io-msw/models/version-download.test.js
+++ b/packages/crates-io-msw/models/version-download.test.js
@@ -62,6 +62,7 @@ test('happy path', async ({ expect }) => {
         "publishedBy": null,
         "readme": null,
         "rust_version": null,
+        "source_files": null,
         "trustpub_data": null,
         "updated_at": "2017-02-24T12:34:56Z",
         "yank_message": null,

--- a/packages/crates-io-msw/models/version.js
+++ b/packages/crates-io-msw/models/version.js
@@ -25,6 +25,11 @@ const schema = v.pipe(
     trustpub_data: v.optional(v.any(), null),
     linecounts: v.optional(v.any()),
 
+    // Maps a source file path to its text contents. When set, the CDN handler
+    // serves a synthesized `.zip` archive and `.zip.json` manifest for the
+    // version. `null` simulates an archive that has not been built yet.
+    source_files: v.optional(v.nullable(v.record(v.string(), v.string())), null),
+
     crate: v.any(),
     publishedBy: v.optional(v.any(), null),
   }),

--- a/packages/crates-io-msw/models/version.test.js
+++ b/packages/crates-io-msw/models/version.test.js
@@ -57,6 +57,7 @@ test('happy path', async ({ expect }) => {
       "publishedBy": null,
       "readme": null,
       "rust_version": null,
+      "source_files": null,
       "trustpub_data": null,
       "updated_at": "2017-02-24T12:34:56Z",
       "yank_message": null,

--- a/packages/crates-io-msw/serializers/version.js
+++ b/packages/crates-io-msw/serializers/version.js
@@ -16,6 +16,7 @@ export function serializeVersion(version) {
   serialized.published_by = version.publishedBy ? serializeUser(version.publishedBy) : null;
 
   delete serialized.readme;
+  delete serialized.source_files;
 
   return serialized;
 }


### PR DESCRIPTION
This adds handlers for the seekable `.zip` archive and its `.zip.json` manifest served from the CDN. A new `source_files` field on the version model maps each source path to its contents. When it is set, the handler synthesizes a manifest and a matching archive body and honors range requests for individual entries. A `null` field reports `403`, simulating an archive that has not been built yet.

The archive body is a plain concatenation of the compressed entries rather than a real ZIP container, since a client locates each file purely by the manifest's byte offsets plus a range request.

`source_files` is internal mock state, so the version serializer strips it from API responses.

### Related

- https://github.com/rust-lang/crates.io/pull/13978
