### PR TITLE
Add a source code viewer for crate versions

### DIFF
--- a/e2e/acceptance/crate-code.spec.ts
+++ b/e2e/acceptance/crate-code.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@/e2e/helper';
+
+const SOURCE_FILES = {
+  'Cargo.toml': '[package]\nname = "serde"\n',
+  'src/lib.rs': '// serde crate root\npub fn answer() -> u32 { 42 }\n',
+  'src/de.rs': '// serde deserializer\npub struct Deserializer;\n',
+  'docs/guide.md': '# Guide\n\nWelcome.\n',
+  'examples/icon.png': `PNG${String.fromCodePoint(0)}binary data`,
+};
+
+test.describe('Acceptance | crate code viewer', { tag: '@acceptance' }, () => {
+  test('redirects `/code` to the default file and renders it', async ({ page, msw, percy }) => {
+    let crate = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate, num: '1.0.0', source_files: SOURCE_FILES });
+
+    await page.goto('/crates/serde/1.0.0/code');
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/lib.rs');
+    await expect(page.locator('[data-test-code-viewer]')).toContainText('// serde crate root');
+    await expect(page.getByRole('treeitem', { name: 'lib.rs', selected: true })).toBeVisible();
+
+    await percy.snapshot();
+    await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
+  });
+
+  test('redirects a directory to its first file', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate, num: '1.0.0', source_files: SOURCE_FILES });
+
+    await page.goto('/crates/serde/1.0.0/code/docs');
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/docs/guide.md');
+    await expect(page.locator('[data-test-code-viewer]')).toContainText('Welcome.');
+  });
+
+  test('navigates between files via the tree and browser history', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate, num: '1.0.0', source_files: SOURCE_FILES });
+
+    await page.goto('/crates/serde/1.0.0/code/src/lib.rs');
+    await expect(page.locator('[data-test-code-viewer]')).toContainText('// serde crate root');
+
+    await page.getByRole('treeitem', { name: 'de.rs' }).click();
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/de.rs');
+    await expect(page.locator('[data-test-code-viewer]')).toContainText('// serde deserializer');
+
+    await page.goBack();
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/lib.rs');
+    await expect(page.locator('[data-test-code-viewer]')).toContainText('// serde crate root');
+  });
+
+  test('shows a message for binary files', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate, num: '1.0.0', source_files: SOURCE_FILES });
+
+    await page.goto('/crates/serde/1.0.0/code/examples/icon.png');
+    await expect(page.locator('[data-test-binary-file]')).toBeVisible();
+  });
+
+  test('shows a not-available message when the archive is missing', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate, num: '1.0.0' });
+
+    await page.goto('/crates/serde/1.0.0/code');
+    await expect(page.locator('[data-test-archive-unavailable]')).toBeVisible();
+  });
+
+  test('shows an error for an unknown file path', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate, num: '1.0.0', source_files: SOURCE_FILES });
+
+    await page.goto('/crates/serde/1.0.0/code/src/missing.rs');
+    await expect(page.locator('[data-test-load-error]')).toBeVisible();
+  });
+});

--- a/e2e/acceptance/crate-code.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/crate-code.spec.ts-snapshots/aria.yml
@@ -1,0 +1,100 @@
+- banner:
+  - link "crates.io":
+    - /url: /
+  - search:
+    - textbox "Search":
+      - /placeholder: Type 'S' or '/' to search
+    - button "Search"
+  - navigation:
+    - 'button "Change color scheme. Current: system"'
+    - button "Log in with GitHub"
+- main:
+  - heading "serde v1.0.0" [level=1]
+  - text: This is the description for the crate called "serde"
+  - navigation "serde crate subpages":
+    - list:
+      - listitem:
+        - link "Readme":
+          - /url: /crates/serde/1.0.0
+      - listitem:
+        - link "1 Version":
+          - /url: /crates/serde/versions
+      - listitem:
+        - link "Dependencies":
+          - /url: /crates/serde/1.0.0/dependencies
+      - listitem:
+        - link "Dependents":
+          - /url: /crates/serde/reverse_dependencies
+      - listitem:
+        - link "Security":
+          - /url: /crates/serde/security
+  - complementary "File tree":
+    - tree:
+      - textbox "Search…"
+      - treeitem "docs" [level=1]
+      - treeitem "examples" [level=1]: exam ples
+      - treeitem "src" [expanded] [level=1]
+      - treeitem "de.rs" [level=2]: de. rs
+      - treeitem "lib.rs" [level=2] [selected]: lib. rs
+      - treeitem "Cargo.toml" [level=1]: Cargo. toml
+  - region "File contents":
+    - img
+    - text: /src\/lib\.rs \d+ B/
+    - code: "/1 2 \\/\\/ serde crate root pub fn answer\\(\\) -> u32 \\{ \\d+ \\}/"
+- contentinfo:
+  - heading "Rust" [level=2]
+  - list:
+    - listitem:
+      - link "rust-lang.org":
+        - /url: https://www.rust-lang.org/
+    - listitem:
+      - link "Rust Foundation":
+        - /url: https://foundation.rust-lang.org/
+    - listitem:
+      - link "The crates.io team":
+        - /url: https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io
+  - heading "Get Help" [level=2]
+  - list:
+    - listitem:
+      - link "The Cargo Book":
+        - /url: https://doc.rust-lang.org/cargo/
+    - listitem:
+      - link "Support":
+        - /url: /support
+    - listitem:
+      - link "System Status":
+        - /url: https://status.crates.io/
+    - listitem:
+      - link "Report a bug":
+        - /url: https://github.com/rust-lang/crates.io/issues/new/choose
+  - heading "Policies" [level=2]
+  - list:
+    - listitem:
+      - link "Usage Policy":
+        - /url: /policies
+    - listitem:
+      - link "Security":
+        - /url: /policies/security
+    - listitem:
+      - link "Privacy Policy":
+        - /url: https://foundation.rust-lang.org/policies/privacy-policy/
+    - listitem:
+      - link "Code of Conduct":
+        - /url: https://www.rust-lang.org/policies/code-of-conduct
+    - listitem:
+      - link "Data Access":
+        - /url: /data-access
+    - listitem:
+      - link "Rate Limits":
+        - /url: /docs/rate-limits
+  - heading "Social" [level=2]
+  - list:
+    - listitem:
+      - 'link "GitHub: rust-lang/crates.io"':
+        - /url: https://github.com/rust-lang/crates.io/
+    - listitem:
+      - 'link "Zulip: #t-crates-io"':
+        - /url: https://rust-lang.zulipchat.com/#streams/318791/t-crates-io
+    - listitem:
+      - 'link "X: @cratesiostatus"':
+        - /url: https://twitter.com/cratesiostatus

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,19 +20,19 @@ importers:
         version: link:packages/crates-io-msw
       '@eslint/compat':
         specifier: 2.1.0
-        version: 2.1.0(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))
+        version: 2.1.0(eslint@10.5.0(jiti@2.7.0))
       '@eslint/js':
         specifier: 10.0.1
-        version: 10.0.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))
+        version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
       '@ianvs/prettier-plugin-sort-imports':
         specifier: 4.7.1
-        version: 4.7.1(prettier@3.8.4)(supports-color@10.2.2)
+        version: 4.7.1(prettier@3.8.4)
       '@msw/playwright':
         specifier: 0.6.7
         version: 0.6.7(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))
       '@percy/cli':
         specifier: 1.31.14
-        version: 1.31.14(supports-color@10.2.2)(typescript@6.0.3)
+        version: 1.31.14(typescript@6.0.3)
       '@percy/playwright':
         specifier: 1.1.0
         version: 1.1.0(playwright-core@1.61.0)
@@ -50,22 +50,22 @@ importers:
         version: 15.0.1
       eslint:
         specifier: 10.5.0
-        version: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+        version: 10.5.0(jiti@2.7.0)
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))
+        version: 10.1.8(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-prefer-let:
         specifier: 4.2.2
         version: 4.2.2
       eslint-plugin-storybook:
         specifier: 10.4.6
-        version: 10.4.6(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+        version: 10.4.6(eslint@10.5.0(jiti@2.7.0))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
       eslint-plugin-svelte:
         specifier: 3.19.0
-        version: 3.19.0(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(svelte@5.56.3(@typescript-eslint/types@8.61.1))
+        version: 3.19.0(eslint@10.5.0(jiti@2.7.0))(svelte@5.56.3(@typescript-eslint/types@8.61.1))
       eslint-plugin-unicorn:
         specifier: 65.0.1
-        version: 65.0.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))
+        version: 65.0.1(eslint@10.5.0(jiti@2.7.0))
       globals:
         specifier: 17.6.0
         version: 17.6.0
@@ -83,7 +83,7 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: 8.61.1
-        version: 8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+        version: 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
 
   packages/crates-io-api-client:
     dependencies:
@@ -140,6 +140,12 @@ importers:
       '@fontsource/fira-sans':
         specifier: 5.2.7
         version: 5.2.7
+      '@pierre/diffs':
+        specifier: 1.2.11
+        version: 1.2.11(@shikijs/themes@4.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@pierre/trees':
+        specifier: 1.0.0-beta.4
+        version: 1.0.0-beta.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@shikijs/langs':
         specifier: 4.2.0
         version: 4.2.0
@@ -157,7 +163,7 @@ importers:
         version: 11.15.0
       micromark:
         specifier: 4.0.2
-        version: 4.0.2(supports-color@10.2.2)
+        version: 4.0.2
       micromark-extension-gfm:
         specifier: 3.0.0
         version: 3.0.0
@@ -1381,6 +1387,42 @@ packages:
     resolution: {integrity: sha512-2V4yxf60mXsDAUz+GFOePcfSNF9mSbrV1WH+sUWDItFUjV14QSVNuBcZRKO8Etgi7bFSCPz1Z1jXrxmopBFpbg==}
     engines: {node: '>=14'}
 
+  '@pierre/diffs@1.2.11':
+    resolution: {integrity: sha512-lSkl5C7eb8Zq7Ote0+J5ZdVOlI72r2EU3vW4+06wULSQqkIMP8mkxG70lVj593b1XYlsM2hCvuyt0cKTA96plQ==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
+  '@pierre/theme@1.0.3':
+    resolution: {integrity: sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==}
+    engines: {vscode: ^1.0.0}
+
+  '@pierre/theming@0.0.1':
+    resolution: {integrity: sha512-1thlEtJbqdyLzc1ZS2KQa1q7FzDGHT4dTEdKHoyQjOMeWWOmbVG5/ndEfOKfAb5Fzkz8cNJrOjFLiZoDH/A03A==}
+    peerDependencies:
+      '@pierre/theme': ^1.0.0
+      '@shikijs/themes': ^3.0.0 || ^4.0.0
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+      shiki: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@pierre/theme':
+        optional: true
+      '@shikijs/themes':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      shiki:
+        optional: true
+
+  '@pierre/trees@1.0.0-beta.4':
+    resolution: {integrity: sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
   '@playwright/test@1.61.0':
     resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
     engines: {node: '>=18'}
@@ -1531,6 +1573,10 @@ packages:
 
   '@shikijs/themes@4.2.0':
     resolution: {integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==}
+    engines: {node: '>=20'}
+
+  '@shikijs/transformers@4.2.0':
+    resolution: {integrity: sha512-pKrYVNUr1oPjJvs76gkPPirDySx3GKG9O88P2Y3AQ+7AjSFws9Y+Ry/Q/6Yg6QpyigzjdQ6H5JAMNAvLXZ63dw==}
     engines: {node: '>=20'}
 
   '@shikijs/types@4.2.0':
@@ -2588,6 +2634,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+    engines: {node: '>=0.3.1'}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
@@ -3194,6 +3244,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -3564,6 +3617,14 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@6.6.5:
+    resolution: {integrity: sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+
+  preact@11.0.0-beta.0:
+    resolution: {integrity: sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -4296,7 +4357,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7(supports-color@10.2.2)':
+  '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -4443,20 +4504,20 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.5.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@2.1.0(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))':
+  '@eslint/compat@2.1.0(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
       '@eslint/core': 1.2.1
     optionalDependencies:
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.5.0(jiti@2.7.0)
 
-  '@eslint/config-array@0.23.5(supports-color@10.2.2)':
+  '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@10.2.2)
@@ -4472,9 +4533,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))':
+  '@eslint/js@10.0.1(eslint@10.5.0(jiti@2.7.0))':
     optionalDependencies:
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.5.0(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -4514,11 +4575,11 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.8.4)(supports-color@10.2.2)':
+  '@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.8.4)':
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       prettier: 3.8.4
       semver: 7.8.4
@@ -5012,10 +5073,7 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.14(typescript@6.0.3)
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-command@1.31.14(typescript@6.0.3)':
     dependencies:
@@ -5032,15 +5090,12 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.14(typescript@6.0.3)
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-doctor@1.31.14(typescript@6.0.3)':
     dependencies:
       '@percy/cli-command': 1.31.14(typescript@6.0.3)
-      '@percy/client': 1.31.14(supports-color@10.2.2)(typescript@6.0.3)
+      '@percy/client': 1.31.14(typescript@6.0.3)
       '@percy/config': 1.31.14(typescript@6.0.3)
       '@percy/core': 1.31.14(typescript@6.0.3)
       '@percy/env': 1.31.14
@@ -5071,10 +5126,7 @@ snapshots:
       '@percy/cli-command': 1.31.14(typescript@6.0.3)
       yaml: 2.9.0
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-upload@1.31.14(typescript@6.0.3)':
     dependencies:
@@ -5082,12 +5134,9 @@ snapshots:
       fast-glob: 3.3.3
       image-size: 1.2.1
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
-  '@percy/cli@1.31.14(supports-color@10.2.2)(typescript@6.0.3)':
+  '@percy/cli@1.31.14(typescript@6.0.3)':
     dependencies:
       '@percy/cli-app': 1.31.14(typescript@6.0.3)
       '@percy/cli-build': 1.31.14(typescript@6.0.3)
@@ -5097,7 +5146,7 @@ snapshots:
       '@percy/cli-exec': 1.31.14(typescript@6.0.3)
       '@percy/cli-snapshot': 1.31.14(typescript@6.0.3)
       '@percy/cli-upload': 1.31.14(typescript@6.0.3)
-      '@percy/client': 1.31.14(supports-color@10.2.2)(typescript@6.0.3)
+      '@percy/client': 1.31.14(typescript@6.0.3)
       '@percy/logger': 1.31.14
     transitivePeerDependencies:
       - bufferutil
@@ -5105,12 +5154,12 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/client@1.31.14(supports-color@10.2.2)(typescript@6.0.3)':
+  '@percy/client@1.31.14(typescript@6.0.3)':
     dependencies:
       '@percy/config': 1.31.14(typescript@6.0.3)
       '@percy/env': 1.31.14
       '@percy/logger': 1.31.14
-      pac-proxy-agent: 7.2.0(supports-color@10.2.2)
+      pac-proxy-agent: 7.2.0
       pako: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -5127,7 +5176,7 @@ snapshots:
 
   '@percy/core@1.31.14(typescript@6.0.3)':
     dependencies:
-      '@percy/client': 1.31.14(supports-color@10.2.2)(typescript@6.0.3)
+      '@percy/client': 1.31.14(typescript@6.0.3)
       '@percy/config': 1.31.14(typescript@6.0.3)
       '@percy/dom': 1.31.14
       '@percy/logger': 1.31.14
@@ -5176,7 +5225,7 @@ snapshots:
 
   '@percy/sdk-utils@1.31.14':
     dependencies:
-      pac-proxy-agent: 7.2.0(supports-color@10.2.2)
+      pac-proxy-agent: 7.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5187,6 +5236,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@pierre/diffs@1.2.11(@shikijs/themes@4.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@pierre/theme': 1.0.3
+      '@pierre/theming': 0.0.1(@pierre/theme@1.0.3)(@shikijs/themes@4.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.2.0)
+      '@shikijs/transformers': 4.2.0
+      diff: 8.0.3
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      shiki: 4.2.0
+    transitivePeerDependencies:
+      - '@shikijs/themes'
+
+  '@pierre/theme@1.0.3': {}
+
+  '@pierre/theming@0.0.1(@pierre/theme@1.0.3)(@shikijs/themes@4.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.2.0)':
+    optionalDependencies:
+      '@pierre/theme': 1.0.3
+      '@shikijs/themes': 4.2.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      shiki: 4.2.0
+
+  '@pierre/trees@1.0.0-beta.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      preact: 11.0.0-beta.0
+      preact-render-to-string: 6.6.5(preact@11.0.0-beta.0)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@playwright/test@1.61.0':
     dependencies:
@@ -5309,6 +5389,11 @@ snapshots:
 
   '@shikijs/themes@4.2.0':
     dependencies:
+      '@shikijs/types': 4.2.0
+
+  '@shikijs/transformers@4.2.0':
+    dependencies:
+      '@shikijs/core': 4.2.0
       '@shikijs/types': 4.2.0
 
   '@shikijs/types@4.2.0':
@@ -5725,15 +5810,15 @@ snapshots:
       '@types/node': 24.13.2
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/type-utils': 8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.1
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.5.0(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -5741,14 +5826,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.1
       debug: 4.4.3(supports-color@10.2.2)
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.5.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5771,13 +5856,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3(supports-color@10.2.2)
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.5.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5800,13 +5885,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.5.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6460,6 +6545,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff@8.0.3: {}
+
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
@@ -6527,28 +6614,28 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.5.0(jiti@2.7.0)
 
   eslint-plugin-prefer-let@4.2.2:
     dependencies:
       requireindex: 1.2.0
 
-  eslint-plugin-storybook@10.4.6(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3):
+  eslint-plugin-storybook@10.4.6(eslint@10.5.0(jiti@2.7.0))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(typescript@6.0.3)
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.5.0(jiti@2.7.0)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-svelte@3.19.0(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(svelte@5.56.3(@typescript-eslint/types@8.61.1)):
+  eslint-plugin-svelte@3.19.0(eslint@10.5.0(jiti@2.7.0))(svelte@5.56.3(@typescript-eslint/types@8.61.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@jridgewell/sourcemap-codec': 1.5.5
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.5.0(jiti@2.7.0)
       esutils: 2.0.3
       globals: 16.5.0
       known-css-properties: 0.37.0
@@ -6562,15 +6649,15 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  eslint-plugin-unicorn@65.0.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-unicorn@65.0.1(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       change-case: 5.4.4
       ci-info: 4.4.0
       core-js-compat: 3.49.0
       detect-indent: 7.0.2
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint: 10.5.0(jiti@2.7.0)
       find-up-simple: 1.0.1
       globals: 17.6.0
       indent-string: 5.0.0
@@ -6599,11 +6686,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2):
+  eslint@10.5.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@10.2.2)
+      '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.6.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -6771,7 +6858,7 @@ snapshots:
     dependencies:
       pump: 3.0.4
 
-  get-uri@6.0.5(supports-color@10.2.2):
+  get-uri@6.0.5:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
@@ -6840,7 +6927,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  http-proxy-agent@7.0.2(supports-color@10.2.2):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
@@ -7063,6 +7150,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru_map@0.4.1: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -7283,7 +7372,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@10.2.2):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@10.2.2)
@@ -7488,16 +7577,16 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  pac-proxy-agent@7.2.0(supports-color@10.2.2):
+  pac-proxy-agent@7.2.0:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
-      get-uri: 6.0.5(supports-color@10.2.2)
-      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5(supports-color@10.2.2)
+      socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
 
@@ -7595,6 +7684,12 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-render-to-string@6.6.5(preact@11.0.0-beta.0):
+    dependencies:
+      preact: 11.0.0-beta.0
+
+  preact@11.0.0-beta.0: {}
 
   prelude-ls@1.2.1: {}
 
@@ -7832,7 +7927,7 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socks-proxy-agent@8.0.5(supports-color@10.2.2):
+  socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
@@ -8043,13 +8138,13 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript-eslint@8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
+  typescript-eslint@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0)(supports-color@10.2.2))(typescript@6.0.3)
-      eslint: 10.5.0(jiti@2.7.0)(supports-color@10.2.2)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.5.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -25,6 +25,8 @@
     "@floating-ui/dom": "1.7.6",
     "@fontsource/fira-mono": "5.2.7",
     "@fontsource/fira-sans": "5.2.7",
+    "@pierre/diffs": "1.2.11",
+    "@pierre/trees": "1.0.0-beta.4",
     "@shikijs/langs": "4.2.0",
     "@shikijs/themes": "4.2.0",
     "chart.js": "4.5.1",

--- a/svelte/src/lib/components/SearchForm.svelte
+++ b/svelte/src/lib/components/SearchForm.svelte
@@ -35,8 +35,11 @@
   }
 
   function handleKeydown(event: KeyboardEvent) {
-    // Don't trigger if user is typing in an input/textarea or if modifier keys are pressed
-    let target = event.target as HTMLElement;
+    // Don't trigger if user is typing in an input/textarea or if modifier keys are pressed.
+    // `event.target` is retargeted to the shadow host for events originating
+    // inside a shadow root (e.g. an input within a web component), so read the
+    // real innermost element from the composed path instead.
+    let target = event.composedPath()[0] as HTMLElement;
     if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
       return;
     }

--- a/svelte/src/lib/components/SearchForm.svelte.test.ts
+++ b/svelte/src/lib/components/SearchForm.svelte.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+import SearchFormTestWrapper from './SearchFormTestWrapper.svelte';
+
+function pressKey(target: EventTarget, key: string) {
+  target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, composed: true }));
+}
+
+describe('SearchForm', () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it('focuses the search input when pressing "S" outside any input', async () => {
+    // The large input carrying `data-test-search-input` is hidden below 820px,
+    // so widen the viewport to make it focusable.
+    await page.viewport(1280, 800);
+    render(SearchFormTestWrapper);
+    let input = page.getByCSS('[data-test-search-input]').element() as HTMLInputElement;
+    expect(document.activeElement).not.toBe(input);
+
+    pressKey(document.body, 'S');
+
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('does not steal focus while typing in an input inside a shadow root', () => {
+    render(SearchFormTestWrapper);
+    let searchInput = page.getByCSS('[data-test-search-input]').element() as HTMLInputElement;
+
+    // An input inside a shadow root: a keydown from it is retargeted to the
+    // shadow host by the time it reaches the window listener.
+    let host = document.createElement('div');
+    document.body.append(host);
+    let shadowInput = document.createElement('input');
+    host.attachShadow({ mode: 'open' }).append(shadowInput);
+    shadowInput.focus();
+    cleanup = () => host.remove();
+
+    pressKey(shadowInput, 'S');
+
+    expect(document.activeElement).toBe(host);
+    expect(document.activeElement).not.toBe(searchInput);
+  });
+});

--- a/svelte/src/lib/components/SearchFormTestWrapper.svelte
+++ b/svelte/src/lib/components/SearchFormTestWrapper.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { SearchFormContext, setSearchFormContext } from '$lib/search-form.svelte';
+  import SearchForm from './SearchForm.svelte';
+
+  setSearchFormContext(new SearchFormContext());
+</script>
+
+<SearchForm />

--- a/svelte/src/lib/utils/syntax-language.test.ts
+++ b/svelte/src/lib/utils/syntax-language.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { languageForPath } from './syntax-language';
+
+describe('languageForPath', () => {
+  it('maps a file extension to its Shiki language id', () => {
+    expect(languageForPath('src/lib.rs')).toBe('rust');
+    expect(languageForPath('Cargo.toml')).toBe('toml');
+    expect(languageForPath('README.md')).toBe('markdown');
+    expect(languageForPath('build.js')).toBe('javascript');
+  });
+
+  it('resolves the language from the file name, ignoring directories', () => {
+    expect(languageForPath('src/core/de.rs')).toBe('rust');
+  });
+
+  it('matches extensions case-insensitively', () => {
+    expect(languageForPath('SRC/LIB.RS')).toBe('rust');
+  });
+
+  it('maps well-known file names whose extension is not a language', () => {
+    expect(languageForPath('Cargo.lock')).toBe('toml');
+    expect(languageForPath('vendor/Cargo.toml.orig')).toBe('toml');
+  });
+
+  it('falls back to plain text for an unknown extension', () => {
+    expect(languageForPath('assets/icon.bin')).toBe('text');
+  });
+
+  it('falls back to plain text for a file without an extension', () => {
+    expect(languageForPath('LICENSE')).toBe('text');
+    expect(languageForPath('Makefile')).toBe('text');
+  });
+});

--- a/svelte/src/lib/utils/syntax-language.ts
+++ b/svelte/src/lib/utils/syntax-language.ts
@@ -1,0 +1,53 @@
+/**
+ * Resolves the Shiki language id used to highlight a source file, based on its
+ * extension or a few well-known filenames.
+ */
+
+/** The default plain-text language used when no mapping matches. */
+const PLAIN_TEXT_LANGUAGE = 'text';
+
+/** Maps file extensions to Shiki language ids. */
+const LANGUAGE_BY_EXTENSION: Record<string, string> = {
+  bash: 'shellscript',
+  c: 'c',
+  cc: 'cpp',
+  cjs: 'javascript',
+  cpp: 'cpp',
+  css: 'css',
+  cxx: 'cpp',
+  h: 'c',
+  hpp: 'cpp',
+  html: 'html',
+  ini: 'ini',
+  js: 'javascript',
+  json: 'json',
+  markdown: 'markdown',
+  md: 'markdown',
+  mjs: 'javascript',
+  py: 'python',
+  rs: 'rust',
+  sh: 'shellscript',
+  svg: 'xml',
+  toml: 'toml',
+  ts: 'typescript',
+  xml: 'xml',
+  yaml: 'yaml',
+  yml: 'yaml',
+};
+
+/** Maps well-known filenames to Shiki language ids. */
+const LANGUAGE_BY_FILENAME: Record<string, string> = {
+  'Cargo.lock': 'toml',
+  'Cargo.toml.orig': 'toml',
+};
+
+/** Resolves the Shiki language id for a file path, defaulting to plain text. */
+export function languageForPath(path: string): string {
+  let filename = path.slice(path.lastIndexOf('/') + 1);
+  if (filename in LANGUAGE_BY_FILENAME) {
+    return LANGUAGE_BY_FILENAME[filename];
+  }
+
+  let extension = filename.slice(filename.lastIndexOf('.') + 1).toLowerCase();
+  return LANGUAGE_BY_EXTENSION[extension] ?? PLAIN_TEXT_LANGUAGE;
+}

--- a/svelte/src/lib/utils/zip-archive.test.ts
+++ b/svelte/src/lib/utils/zip-archive.test.ts
@@ -1,0 +1,265 @@
+import type { ManifestFile } from './zip-archive';
+
+import { db, handlers } from '@crates-io/msw';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { archiveUrl, loadFile, loadManifest, manifestUrl } from './zip-archive';
+
+const BASE = 'https://static.crates.io';
+const CRATE = 'serde';
+const VERSION = '1.0.228';
+const ARCHIVE = `${BASE}/crates/${CRATE}/${CRATE}-${VERSION}.zip`;
+const MANIFEST = `${ARCHIVE}.json`;
+
+let server = setupServer(...handlers);
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterEach(() => db.reset());
+afterAll(() => server.close());
+
+const ENCODER = new TextEncoder();
+
+function encode(text: string): Uint8Array {
+  return ENCODER.encode(text);
+}
+
+/** Compresses bytes as a raw DEFLATE stream, mirroring how zip entries are stored. */
+async function deflateRaw(data: Uint8Array): Promise<Uint8Array> {
+  let stream = new Blob([data as BlobPart]).stream().pipeThrough(new CompressionStream('deflate-raw'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/** Returns the lowercase hex SHA-256 of the given bytes, matching the manifest format. */
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  let digest = await crypto.subtle.digest('SHA-256', bytes as BufferSource);
+  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function manifestFile(overrides: Partial<ManifestFile> = {}): ManifestFile {
+  return {
+    path: 'src/lib.rs',
+    data_offset: 0,
+    compressed_size: 0,
+    uncompressed_size: 0,
+    compression: 'deflate',
+    sha256: '',
+    ...overrides,
+  };
+}
+
+/** Publishes a crate version whose source archive the CDN mock will serve. */
+async function publishSource(sourceFiles: Record<string, string>) {
+  let crate = await db.crate.create({ name: CRATE });
+  await db.version.create({ crate, num: VERSION, source_files: sourceFiles });
+}
+
+/** Loads a single file through the CDN mock, resolving its manifest entry first. */
+async function loadServedFile(path: string) {
+  let manifest = await loadManifest(fetch, BASE, CRATE, VERSION);
+  let entry = manifest?.files.find(file => file.path === path);
+  if (!entry) throw new Error(`manifest is missing "${path}"`);
+  return loadFile(fetch, BASE, CRATE, VERSION, entry);
+}
+
+describe('archiveUrl()', () => {
+  it('builds the archive URL from the CDN base', () => {
+    let url = archiveUrl('https://static.crates.io', 'serde', '1.0.228');
+    expect(url).toBe('https://static.crates.io/crates/serde/serde-1.0.228.zip');
+  });
+
+  it('produces a same-origin relative URL for an empty base', () => {
+    let url = archiveUrl('', 'serde', '1.0.228');
+    expect(url).toBe('/crates/serde/serde-1.0.228.zip');
+  });
+});
+
+describe('manifestUrl()', () => {
+  it('appends `.json` to the archive URL', () => {
+    let url = manifestUrl('https://static.crates.io', 'serde', '1.0.228');
+    expect(url).toBe('https://static.crates.io/crates/serde/serde-1.0.228.zip.json');
+  });
+});
+
+describe('loadManifest()', () => {
+  it('returns the manifest served by the CDN', async () => {
+    await publishSource({ 'src/lib.rs': 'fn main() {}\n', 'Cargo.toml': 'name = "serde"\n' });
+
+    let manifest = await loadManifest(fetch, BASE, CRATE, VERSION);
+    expect(manifest).toMatchInlineSnapshot(`
+      {
+        "files": [
+          {
+            "compressed_size": 17,
+            "compression": "deflate",
+            "data_offset": 0,
+            "path": "Cargo.toml",
+            "sha256": "be3701dbfa0e482cdc1e8679e59cc8d9df3655562f4d8c4edba7bf9d906b1846",
+            "uncompressed_size": 15,
+          },
+          {
+            "compressed_size": 15,
+            "compression": "deflate",
+            "data_offset": 17,
+            "path": "src/lib.rs",
+            "sha256": "536e506bb90914c243a12b397b9a998f85ae2cbd9ba02dfd03a9e155ca5ca0f4",
+            "uncompressed_size": 13,
+          },
+        ],
+      }
+    `);
+  });
+
+  it('returns null when the CDN returns 404', async () => {
+    server.use(http.get(MANIFEST, () => new HttpResponse(null, { status: 404 })));
+    expect(await loadManifest(fetch, BASE, CRATE, VERSION)).toBeNull();
+  });
+
+  it('returns null when the CDN returns 403', async () => {
+    let crate = await db.crate.create({ name: CRATE });
+    await db.version.create({ crate, num: VERSION });
+
+    expect(await loadManifest(fetch, BASE, CRATE, VERSION)).toBeNull();
+  });
+
+  it('throws on any other error status', async () => {
+    server.use(http.get(MANIFEST, () => new HttpResponse(null, { status: 500 })));
+    await expect(loadManifest(fetch, BASE, CRATE, VERSION)).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: Failed to load archive manifest (500 Internal Server Error)]`,
+    );
+  });
+});
+
+describe('loadFile()', () => {
+  it('loads and inflates a file served by the CDN', async () => {
+    let contents = 'fn main() { println!("hi"); }\n';
+    await publishSource({ 'src/lib.rs': contents });
+
+    expect(await loadServedFile('src/lib.rs')).toEqual({ kind: 'text', text: contents });
+  });
+
+  it('reads a stored (uncompressed) entry from a 206 range response', async () => {
+    let text = 'name = "serde"\n';
+    let stored = encode(text);
+    let file = manifestFile({
+      compression: 'store',
+      compressed_size: stored.length,
+      uncompressed_size: stored.length,
+      sha256: await sha256Hex(stored),
+    });
+
+    server.use(http.get(ARCHIVE, () => new HttpResponse(stored, { status: 206 })));
+
+    expect(await loadFile(fetch, BASE, CRATE, VERSION, file)).toEqual({ kind: 'text', text });
+  });
+
+  it('slices the entry out of a full 200 response', async () => {
+    let text = 'pub fn answer() -> u32 { 42 }\n';
+    let raw = encode(text);
+    let compressed = await deflateRaw(raw);
+    let offset = 64;
+
+    // A range request can come back `200` with the whole archive. The entry's
+    // compressed bytes sit at `data_offset`, surrounded by other entries.
+    let archive = new Uint8Array(offset + compressed.length + 32);
+    archive.fill(0xff);
+    archive.set(compressed, offset);
+
+    let file = manifestFile({
+      data_offset: offset,
+      compression: 'deflate',
+      compressed_size: compressed.length,
+      uncompressed_size: raw.length,
+      sha256: await sha256Hex(raw),
+    });
+
+    server.use(http.get(ARCHIVE, () => new HttpResponse(archive, { status: 200 })));
+
+    expect(await loadFile(fetch, BASE, CRATE, VERSION, file)).toEqual({ kind: 'text', text });
+  });
+
+  it('throws when the decompressed size differs from the manifest', async () => {
+    let stored = encode('name = "serde"\n');
+    let file = manifestFile({
+      compression: 'store',
+      compressed_size: stored.length,
+      uncompressed_size: stored.length + 5,
+      sha256: await sha256Hex(stored),
+    });
+
+    server.use(http.get(ARCHIVE, () => new HttpResponse(stored, { status: 206 })));
+
+    await expect(loadFile(fetch, BASE, CRATE, VERSION, file)).rejects.toMatchInlineSnapshot(
+      `[Error: Integrity check failed for "src/lib.rs": expected 20 bytes, got 15]`,
+    );
+  });
+
+  it('throws when the SHA-256 differs from the manifest', async () => {
+    let stored = encode('name = "serde"\n');
+    let file = manifestFile({
+      compression: 'store',
+      compressed_size: stored.length,
+      uncompressed_size: stored.length,
+      sha256: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+    });
+
+    server.use(http.get(ARCHIVE, () => new HttpResponse(stored, { status: 206 })));
+
+    await expect(loadFile(fetch, BASE, CRATE, VERSION, file)).rejects.toMatchInlineSnapshot(
+      `[Error: Integrity check failed for "src/lib.rs": SHA-256 mismatch]`,
+    );
+  });
+
+  it('throws on an unsupported compression method', async () => {
+    let bytes = encode('fn main() {}\n');
+    let file = {
+      ...manifestFile({
+        compressed_size: bytes.length,
+        uncompressed_size: bytes.length,
+        sha256: await sha256Hex(bytes),
+      }),
+      compression: 'brotli',
+    } as unknown as ManifestFile;
+
+    server.use(http.get(ARCHIVE, () => new HttpResponse(bytes, { status: 206 })));
+
+    await expect(loadFile(fetch, BASE, CRATE, VERSION, file)).rejects.toMatchInlineSnapshot(
+      `[Error: Unsupported compression method "brotli"]`,
+    );
+  });
+
+  it('reports a file containing a NUL byte as binary', async () => {
+    let bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0x00, 0x1a, 0x0a]);
+    let file = manifestFile({
+      path: 'icon.png',
+      compression: 'store',
+      compressed_size: bytes.length,
+      uncompressed_size: bytes.length,
+      sha256: await sha256Hex(bytes),
+    });
+
+    server.use(http.get(ARCHIVE, () => new HttpResponse(bytes, { status: 206 })));
+
+    expect(await loadFile(fetch, BASE, CRATE, VERSION, file)).toEqual({ kind: 'binary' });
+  });
+
+  it('returns null when the CDN returns 404', async () => {
+    server.use(http.get(ARCHIVE, () => new HttpResponse(null, { status: 404 })));
+    expect(await loadFile(fetch, BASE, CRATE, VERSION, manifestFile())).toBeNull();
+  });
+
+  it('returns null when the CDN returns 403', async () => {
+    let crate = await db.crate.create({ name: CRATE });
+    await db.version.create({ crate, num: VERSION });
+
+    expect(await loadFile(fetch, BASE, CRATE, VERSION, manifestFile())).toBeNull();
+  });
+
+  it('throws on any other error status', async () => {
+    server.use(http.get(ARCHIVE, () => new HttpResponse(null, { status: 500 })));
+    await expect(loadFile(fetch, BASE, CRATE, VERSION, manifestFile())).rejects.toMatchInlineSnapshot(
+      `[Error: Failed to load file "src/lib.rs" (500 Internal Server Error)]`,
+    );
+  });
+});

--- a/svelte/src/lib/utils/zip-archive.ts
+++ b/svelte/src/lib/utils/zip-archive.ts
@@ -1,0 +1,164 @@
+/**
+ * Utilities for reading published crate source files directly from the `.zip`
+ * archives on the CDN, using the companion `.zip.json` manifest and HTTP range
+ * requests.
+ *
+ * Each crate version is available as a seekable `.zip` archive at
+ * `<base>/crates/<name>/<name>-<version>.zip`, with a manifest at the same URL
+ * plus a `.json` suffix. The manifest lists every file along with the byte
+ * offset and size of its compressed data inside the archive, which lets us fetch
+ * and decode a single file without downloading the whole archive.
+ */
+
+/** The parsed contents of a `.zip.json` manifest. */
+export interface Manifest {
+  files: ManifestFile[];
+}
+
+/** A single file entry from the `.zip.json` manifest. */
+export interface ManifestFile {
+  /** Path of the file inside the archive, e.g. `src/lib.rs`. */
+  path: string;
+  /** Byte offset of the entry's compressed data within the `.zip` archive. */
+  data_offset: number;
+  /** Size of the compressed file in bytes. */
+  compressed_size: number;
+  /** Size of the decompressed file in bytes. */
+  uncompressed_size: number;
+  /** Compression method used for this entry. */
+  compression: 'deflate' | 'store';
+  /** Hex-encoded SHA-256 of the decompressed file contents. */
+  sha256: string;
+}
+
+export type LoadedFile = { kind: 'text'; text: string } | { kind: 'binary' };
+
+/** Returns the URL of the `.zip` archive for a crate version. */
+export function archiveUrl(base: string, crateName: string, versionNum: string): string {
+  return `${base}/crates/${crateName}/${crateName}-${versionNum}.zip`;
+}
+
+/** Returns the URL of the `.zip.json` manifest for a crate version. */
+export function manifestUrl(base: string, crateName: string, versionNum: string): string {
+  return `${archiveUrl(base, crateName, versionNum)}.json`;
+}
+
+/**
+ * Loads and parses the `.zip.json` manifest for a crate version.
+ *
+ * @returns The parsed manifest, or `null` if no archive exists yet (404/403).
+ * @throws Error If the request fails with any other non-success status.
+ */
+export async function loadManifest(
+  fetch: typeof globalThis.fetch,
+  base: string,
+  crate: string,
+  version: string,
+): Promise<Manifest | null> {
+  let response = await fetch(manifestUrl(base, crate, version));
+
+  // The S3-backed CDN reports a not-yet-built archive as `404` or `403`.
+  if (response.status === 404 || response.status === 403) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load archive manifest (${response.status} ${response.statusText})`);
+  }
+
+  return (await response.json()) as Manifest;
+}
+
+/**
+ * Loads a single file from the archive via a range request.
+ *
+ * Only the bytes of the requested entry are fetched, then decompressed locally
+ * using the browser's `DecompressionStream`. Binary files are detected and
+ * reported as such instead of being decoded into mojibake.
+ *
+ * @returns The decoded text or a binary marker, or `null` if the archive is not
+ *   available yet (404/403), mirroring {@link loadManifest}.
+ * @throws Error If the request fails with any other non-success status.
+ */
+export async function loadFile(
+  fetch: typeof globalThis.fetch,
+  base: string,
+  crateName: string,
+  versionNum: string,
+  file: ManifestFile,
+): Promise<LoadedFile | null> {
+  let start = file.data_offset;
+  let end = file.data_offset + file.compressed_size - 1;
+
+  let response = await fetch(archiveUrl(base, crateName, versionNum), {
+    headers: { Range: `bytes=${start}-${end}` },
+  });
+
+  // The S3-backed CDN reports a not-yet-built archive as `404` or `403`.
+  if (response.status === 404 || response.status === 403) {
+    return null;
+  }
+
+  if (response.status !== 206 && response.status !== 200) {
+    throw new Error(`Failed to load file "${file.path}" (${response.status} ${response.statusText})`);
+  }
+
+  let body = await response.arrayBuffer();
+  let compressed =
+    response.status === 206 ? body : body.slice(file.data_offset, file.data_offset + file.compressed_size);
+
+  let bytes = await decompress(compressed, file.compression);
+  await verifyIntegrity(bytes, file);
+
+  if (looksBinary(bytes)) {
+    return { kind: 'binary' };
+  }
+
+  return { kind: 'text', text: new TextDecoder().decode(bytes) };
+}
+
+/** Decompresses the raw entry bytes according to the manifest's method. */
+async function decompress(compressed: ArrayBuffer, compression: ManifestFile['compression']): Promise<Uint8Array> {
+  if (compression === 'store') {
+    return new Uint8Array(compressed);
+  }
+
+  if (compression === 'deflate') {
+    let stream = new Blob([compressed]).stream().pipeThrough(new DecompressionStream('deflate-raw'));
+    return new Uint8Array(await new Response(stream).arrayBuffer());
+  }
+
+  throw new Error(`Unsupported compression method "${compression}"`);
+}
+
+/**
+ * Verifies the decompressed bytes against the size and SHA-256 recorded in the
+ * manifest, throwing if either differs.
+ */
+async function verifyIntegrity(bytes: Uint8Array, file: ManifestFile): Promise<void> {
+  if (bytes.length !== file.uncompressed_size) {
+    throw new Error(
+      `Integrity check failed for "${file.path}": expected ${file.uncompressed_size} bytes, got ${bytes.length}`,
+    );
+  }
+
+  let digest = await crypto.subtle.digest('SHA-256', bytes as BufferSource);
+  let hex = [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+  if (hex !== file.sha256) {
+    throw new Error(`Integrity check failed for "${file.path}": SHA-256 mismatch`);
+  }
+}
+
+/**
+ * Heuristic for whether a file is binary rather than displayable text: a NUL
+ * byte within the first 8000 bytes, the same signal git uses.
+ */
+function looksBinary(bytes: Uint8Array): boolean {
+  let limit = Math.min(bytes.length, 8000);
+  for (let i = 0; i < limit; i++) {
+    if (bytes[i] === 0) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/code/+layout.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/code/+layout.ts
@@ -1,0 +1,17 @@
+import { createClient } from '@crates-io/api-client';
+
+import { cdnBase } from '$lib/utils/cdn';
+import { loadSiteMetadata } from '$lib/utils/site-metadata';
+import { loadManifest } from '$lib/utils/zip-archive';
+
+export async function load({ fetch, params }) {
+  let { data } = await loadSiteMetadata(createClient({ fetch }));
+  if (!data) {
+    throw new Error('Failed to load site metadata');
+  }
+
+  let base = cdnBase(data);
+  let manifest = await loadManifest(fetch, base, params.crate_id, params.version_num);
+
+  return { cdnBase: base, manifest };
+}

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
@@ -1,0 +1,300 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
+  import { File as FileView } from '@pierre/diffs';
+  import { FileTree } from '@pierre/trees';
+  import prettyBytes from 'pretty-bytes';
+
+  import { getColorScheme } from '$lib/color-scheme.svelte';
+  import CrateHeader from '$lib/components/CrateHeader.svelte';
+  import { languageForPath } from '$lib/utils/syntax-language';
+  import { loadFile } from '$lib/utils/zip-archive';
+
+  const THEMES = { light: 'github-light', dark: 'github-dark' } as const;
+
+  // The mutually exclusive display states of the code panel.
+  type FileState =
+    | { kind: 'content' }
+    | { kind: 'binary' }
+    | { kind: 'unavailable' }
+    | { kind: 'error'; message: string };
+
+  let { data } = $props();
+
+  let crate = $derived(data.crate);
+  let version = $derived(data.version);
+  let manifest = $derived(data.manifest);
+  let cdnBase = $derived(data.cdnBase);
+  let selectedPath = $derived(data.selectedPath);
+
+  let filesByPath = $derived(new Map((manifest?.files ?? []).map(file => [file.path, file])));
+
+  let colorScheme = getColorScheme();
+
+  let tree = $state.raw<FileTree>();
+  let treeContainer = $state.raw<HTMLElement>();
+
+  let fileView = $state.raw<FileView>();
+  let fileContainer = $state.raw<HTMLElement>();
+
+  let fileState = $state<FileState>({ kind: 'content' });
+
+  // Canonical ancestor directory paths (trailing slash) for a file path,
+  // e.g. `src/core/de.rs` -> [`src/`, `src/core/`]. Used to reveal a file in an
+  // otherwise-collapsed tree.
+  function ancestorDirectories(path: string): string[] {
+    let segments = path.split('/').slice(0, -1);
+    return segments.map((_, index) => segments.slice(0, index + 1).join('/') + '/');
+  }
+
+  onMount(() => {
+    if (!manifest || !treeContainer || !fileContainer) return;
+
+    tree = new FileTree({
+      paths: manifest.files.map(file => file.path),
+      initialExpansion: 'closed',
+      initialExpandedPaths: selectedPath ? ancestorDirectories(selectedPath) : [],
+      flattenEmptyDirectories: true,
+      search: true,
+      stickyFolders: true,
+      onSelectionChange(paths) {
+        let path = paths[0];
+        if (path && path !== selectedPath && filesByPath.has(path)) {
+          let href = resolve('/crates/[crate_id]/[version_num]/code/[...path]', {
+            crate_id: crate.id,
+            version_num: version.num,
+            path,
+          });
+          void goto(href, { keepFocus: true, noScroll: true });
+        }
+      },
+    });
+
+    tree.render({ containerWrapper: treeContainer });
+
+    fileView = new FileView({
+      theme: THEMES,
+      themeType: colorScheme.scheme,
+      overflow: 'wrap',
+      // Show the uncompressed file size in the built-in header. The callback
+      // receives the file whose `name` is its archive path.
+      renderHeaderMetadata: file => {
+        let entry = filesByPath.get(file.name);
+        return entry ? prettyBytes(entry.uncompressed_size, { binary: true }) : null;
+      },
+    });
+
+    return () => {
+      tree?.cleanUp();
+      fileView?.cleanUp();
+    };
+  });
+
+  // Load and display whichever file the URL points at and keep the tree's
+  // selection in sync (so back/forward navigation highlights the right row).
+  $effect(() => {
+    let path = selectedPath;
+    if (!path) return;
+
+    void showFile(path);
+    syncTreeSelection(path);
+  });
+
+  // Keep the code view and file tree in sync with the user's color scheme.
+  $effect(() => {
+    fileView?.setThemeType(colorScheme.scheme);
+
+    let fileTreeContainer = tree?.getFileTreeContainer();
+    if (fileTreeContainer) {
+      fileTreeContainer.style.colorScheme = colorScheme.resolvedScheme;
+    }
+  });
+
+  async function showFile(path: string) {
+    if (!fileView || !fileContainer) return;
+
+    let file = filesByPath.get(path);
+    if (!file) {
+      fileState = { kind: 'error', message: `File "${path}" was not found in this archive.` };
+      return;
+    }
+
+    try {
+      let result = await loadFile(fetch, cdnBase, crate.name, version.num, file);
+
+      // Drop a stale result if a newer navigation superseded this
+      // load while it was in flight.
+      if (selectedPath !== path) return;
+
+      if (result === null) {
+        fileState = { kind: 'unavailable' };
+        return;
+      }
+
+      if (result.kind === 'binary') {
+        fileState = { kind: 'binary' };
+        return;
+      }
+
+      fileState = { kind: 'content' };
+
+      fileView.render({
+        file: { name: path, contents: result.text, lang: languageForPath(path) },
+        containerWrapper: fileContainer,
+      });
+    } catch (error) {
+      if (selectedPath !== path) return;
+
+      let message = error instanceof Error ? error.message : String(error);
+      fileState = { kind: 'error', message };
+    }
+  }
+
+  function syncTreeSelection(path: string) {
+    if (!tree) return;
+
+    let current = tree.getSelectedPaths();
+    if (current.length === 1 && current[0] === path) return;
+
+    // Reveal the file by expanding its ancestor directories.
+    // `scrollToPath()` only works once the target row is visible.
+    for (let dir of ancestorDirectories(path)) {
+      let item = tree.getItem(dir);
+      if (item && 'expand' in item) item.expand();
+    }
+
+    for (let other of current) {
+      tree.getItem(other)?.deselect();
+    }
+    tree.getItem(path)?.select();
+    tree.scrollToPath(path, { focus: false, offset: 'center' });
+  }
+</script>
+
+{#snippet unavailableMessage()}
+  <div class="unavailable" data-test-archive-unavailable>
+    <p>The source code for this version is not available yet.</p>
+    <p>
+      Archives are built shortly after a version is published. This usually only takes a few seconds, so please try
+      again in a couple of minutes.
+    </p>
+  </div>
+{/snippet}
+
+<CrateHeader {crate} {version} versionNum={version.num} keywords={data.keywords} ownersPromise={data.ownersPromise} />
+
+{#if !manifest}
+  {@render unavailableMessage()}
+{:else}
+  <div class="viewer">
+    <aside class="tree-panel" aria-label="File tree">
+      <div class="tree" bind:this={treeContainer}></div>
+    </aside>
+
+    <section class="code-panel" aria-label="File contents">
+      {#if fileState.kind === 'unavailable'}
+        {@render unavailableMessage()}
+      {:else if fileState.kind === 'binary'}
+        <div class="message" data-test-binary-file>
+          <p>This file is binary and can't be displayed.</p>
+        </div>
+      {:else if fileState.kind === 'error'}
+        <div class="error" data-test-load-error>Failed to load file: {fileState.message}</div>
+      {/if}
+
+      <div
+        class="code"
+        class:hidden={fileState.kind !== 'content'}
+        bind:this={fileContainer}
+        data-test-code-viewer
+      ></div>
+    </section>
+  </div>
+{/if}
+
+<style>
+  .unavailable,
+  .message {
+    padding: var(--space-m);
+    color: var(--main-color-light);
+    line-height: 1.4;
+
+    p {
+      margin: 0 0 var(--space-2xs);
+    }
+  }
+
+  .error {
+    padding: var(--space-s);
+    color: light-dark(oklch(0.5 0.15 24), oklch(0.8 0.07 24));
+  }
+
+  .hidden {
+    display: none;
+  }
+
+  .viewer {
+    display: grid;
+    grid-template-columns: minmax(200px, 280px) 1fr;
+    gap: var(--space-s);
+    height: 70vh;
+    min-height: 400px;
+  }
+
+  .tree-panel {
+    background-color: light-dark(white, #141413);
+    border-radius: var(--space-3xs);
+    box-shadow: 0 2px 3px light-dark(hsla(51, 50%, 44%, 0.35), #232321);
+    overflow: hidden;
+  }
+
+  .tree {
+    height: 100%;
+  }
+
+  .tree :global(file-tree-container) {
+    --trees-bg-override: light-dark(white, #141413);
+    padding-top: var(--space-xs);
+  }
+
+  .code-panel {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    background-color: light-dark(white, #141413);
+    border-radius: var(--space-3xs);
+    box-shadow: 0 2px 3px light-dark(hsla(51, 50%, 44%, 0.35), #232321);
+    overflow: hidden;
+  }
+
+  .code {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    font-size: calc(0.85 * var(--space-s));
+    background-color: light-dark(white, #141413);
+  }
+
+  .code :global(diffs-container) {
+    --diffs-font-family: var(--font-monospace);
+    --diffs-header-font-family: var(--font-body);
+    --diffs-light-bg: white;
+    --diffs-dark-bg: #141413;
+  }
+
+  @media only screen and (max-width: 750px) {
+    .viewer {
+      grid-template-columns: 1fr;
+      height: auto;
+    }
+
+    .tree-panel {
+      height: 240px;
+    }
+
+    .code-panel {
+      height: 60vh;
+    }
+  }
+</style>

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.ts
@@ -1,0 +1,27 @@
+import { resolve } from '$app/paths';
+import { redirect } from '@sveltejs/kit';
+
+import { redirectTarget } from './redirect-target';
+
+export async function load({ params, parent }) {
+  let { crate, version, manifest } = await parent();
+
+  // The selected file always lives in the URL (so the browser back button can
+  // navigate between files). `/code` with no path redirects to the default
+  // file, and a directory path redirects to the first file inside it.
+  if (manifest) {
+    let target = redirectTarget(manifest.files, params.path);
+    if (target) {
+      redirect(
+        307,
+        resolve('/crates/[crate_id]/[version_num]/code/[...path]', {
+          crate_id: crate.id,
+          version_num: version.num,
+          path: target.path,
+        }),
+      );
+    }
+  }
+
+  return { selectedPath: params.path || null };
+}

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/redirect-target.test.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/redirect-target.test.ts
@@ -1,0 +1,69 @@
+import type { ManifestFile } from '$lib/utils/zip-archive';
+
+import { describe, expect, it } from 'vitest';
+
+import { redirectTarget } from './redirect-target';
+
+function files(...paths: string[]): ManifestFile[] {
+  return paths.map(path => ({
+    path,
+    data_offset: 0,
+    compressed_size: 0,
+    uncompressed_size: 0,
+    compression: 'deflate',
+    sha256: '',
+  }));
+}
+
+describe('redirectTarget()', () => {
+  it('returns undefined when the path is already a file', () => {
+    expect(redirectTarget(files('src/lib.rs', 'Cargo.toml'), 'Cargo.toml')).toBeUndefined();
+  });
+
+  describe('default file (no path)', () => {
+    it('prefers src/lib.rs', () => {
+      let target = redirectTarget(files('Cargo.toml', 'src/main.rs', 'src/lib.rs'), '');
+      expect(target?.path).toBe('src/lib.rs');
+    });
+
+    it('falls back to src/main.rs when src/lib.rs is absent', () => {
+      let target = redirectTarget(files('Cargo.toml', 'src/main.rs'), '');
+      expect(target?.path).toBe('src/main.rs');
+    });
+
+    it('falls back to Cargo.toml when neither src file exists', () => {
+      let target = redirectTarget(files('Cargo.toml', 'README.md'), '');
+      expect(target?.path).toBe('Cargo.toml');
+    });
+
+    it('falls back to the lexicographically first file when no priority file matches', () => {
+      let target = redirectTarget(files('src/util.rs', 'README.md'), '');
+      expect(target?.path).toBe('README.md');
+    });
+
+    it('returns undefined when the archive has no files', () => {
+      expect(redirectTarget(files(), '')).toBeUndefined();
+    });
+  });
+
+  describe('directory path', () => {
+    it('redirects to the lexicographically first file in the directory', () => {
+      let target = redirectTarget(files('src/util.rs', 'src/de.rs', 'src/lib.rs'), 'src');
+      expect(target?.path).toBe('src/de.rs');
+    });
+
+    it('treats a trailing-slash path as a directory', () => {
+      let target = redirectTarget(files('docs/guide.md', 'docs/api.md'), 'docs/');
+      expect(target?.path).toBe('docs/api.md');
+    });
+
+    it('does not match files whose name merely shares the path as a prefix', () => {
+      let target = redirectTarget(files('src_helpers.rs', 'src/lib.rs'), 'src');
+      expect(target?.path).toBe('src/lib.rs');
+    });
+
+    it('returns undefined for a path that is neither a file nor a directory', () => {
+      expect(redirectTarget(files('src/lib.rs'), 'does/not/exist')).toBeUndefined();
+    });
+  });
+});

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/redirect-target.ts
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/redirect-target.ts
@@ -1,0 +1,46 @@
+import type { ManifestFile } from '$lib/utils/zip-archive';
+
+/** Files preferred as the initial selection, in priority order. */
+const DEFAULT_FILE_PRIORITY = ['src/lib.rs', 'src/main.rs', 'Cargo.toml'];
+
+/** Picks the file to redirect to, or `undefined` when the path is a file already. */
+export function redirectTarget(files: ManifestFile[], path: string | undefined): ManifestFile | undefined {
+  if (!path) {
+    return pickDefaultFile(files);
+  }
+
+  if (files.some(file => file.path === path)) {
+    return undefined;
+  }
+
+  // Not a file, so treat the path as a directory and jump to its first file.
+  return firstFileInDirectory(files, path);
+}
+
+function pickDefaultFile(files: ManifestFile[]): ManifestFile | undefined {
+  for (let path of DEFAULT_FILE_PRIORITY) {
+    let match = files.find(file => file.path === path);
+    if (match) {
+      return match;
+    }
+  }
+
+  // No preferred file exists, so fall back to the first file in the archive.
+  return firstFile(files);
+}
+
+function firstFileInDirectory(files: ManifestFile[], dirPath: string): ManifestFile | undefined {
+  let prefix = dirPath.endsWith('/') ? dirPath : `${dirPath}/`;
+  return firstFile(files.filter(file => file.path.startsWith(prefix)));
+}
+
+/** Returns the file with the lexicographically smallest path. */
+function firstFile(files: ManifestFile[]): ManifestFile | undefined {
+  let first: ManifestFile | undefined;
+  for (let file of files) {
+    if (first === undefined || file.path < first.path) {
+      first = file;
+    }
+  }
+  return first;
+}


### PR DESCRIPTION
This adds a "Code" route on crate version pages that browses a published version's source directly from the CDN, with no new backend. Individual files are range-fetched out of the seekable `.zip` archive and its `.zip.json` manifest and inflated client-side with `DecompressionStream`, so only the viewed file is downloaded. The file tree renders with `@pierre/trees` and a single highlighted file with `@pierre/diffs`.

It is reachable by direct URL (`/crates/<name>/<version>/code/...`). The crate navigation does not link to it yet in this PR so that we can run a public beta test for this feature first.

<img width="991" height="847" alt="Bildschirmfoto 2026-06-21 um 16 04 38" src="https://github.com/user-attachments/assets/9e76cedd-412b-4de1-95b6-3f9f42a4b196" />


### Related

- https://github.com/rust-lang/crates.io/pull/13978
- https://github.com/rust-lang/crates.io/pull/14019
