### PR TITLE
Redirect `[crate_id]/code` to default version's code viewer

### DIFF
--- a/e2e/acceptance/crate-code.spec.ts
+++ b/e2e/acceptance/crate-code.spec.ts
@@ -22,6 +22,24 @@ test.describe('Acceptance | crate code viewer', { tag: '@acceptance' }, () => {
     await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
   });
 
+  test('redirects `/code` without a version to the default version', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate, num: '1.0.0', source_files: SOURCE_FILES });
+
+    await page.goto('/crates/serde/code');
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/lib.rs');
+    await expect(page.locator('[data-test-code-viewer]')).toContainText('// serde crate root');
+  });
+
+  test('forwards the requested path when redirecting to the default version', async ({ page, msw }) => {
+    let crate = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate, num: '1.0.0', source_files: SOURCE_FILES });
+
+    await page.goto('/crates/serde/code/src/de.rs');
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/de.rs');
+    await expect(page.locator('[data-test-code-viewer]')).toContainText('// serde deserializer');
+  });
+
   test('redirects a directory to its first file', async ({ page, msw }) => {
     let crate = await msw.db.crate.create({ name: 'serde' });
     await msw.db.version.create({ crate, num: '1.0.0', source_files: SOURCE_FILES });

--- a/svelte/src/routes/crates/[crate_id]/code/[...path]/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/code/[...path]/+page.ts
@@ -1,0 +1,10 @@
+import { resolve } from '$app/paths';
+import { redirect } from '@sveltejs/kit';
+
+export async function load({ parent, params }) {
+  let { defaultVersion } = await parent();
+  let crate_id = params.crate_id;
+  let version_num = defaultVersion.num;
+  let path = params.path;
+  redirect(307, resolve('/crates/[crate_id]/[version_num]/code/[...path]', { crate_id, version_num, path }));
+}


### PR DESCRIPTION
The code viewer route only exists under a version-pinned URL. This adds a crate-level `code/[...path]/+page.ts` that resolves the default version and redirects `/crates/[crate_id]/code` to `/crates/[crate_id]/[version_num]/code`, forwarding any requested file path.