### PR TITLE
CrateHeader: Add a Code tab

### DIFF
--- a/e2e/acceptance/crate-navtabs.spec.ts
+++ b/e2e/acceptance/crate-navtabs.spec.ts
@@ -6,7 +6,11 @@ test.describe('Acceptance | crate navigation tabs', { tag: '@acceptance' }, () =
     let crate = await msw.db.crate.create({ name: 'nanomsg' });
     await msw.db.version.create({ crate, num: '0.6.1' });
 
+    let user = await msw.db.user.create({ isAdmin: true });
+    await msw.authenticateAs(user);
+
     let tabReadme = page.locator('[data-test-readme-tab] a');
+    let tabCode = page.locator('[data-test-code-tab] a');
     let tabVersions = page.locator('[data-test-versions-tab] a');
     let tabDeps = page.locator('[data-test-deps-tab] a');
     let tabRevDeps = page.locator('[data-test-rev-deps-tab] a');
@@ -15,6 +19,8 @@ test.describe('Acceptance | crate navigation tabs', { tag: '@acceptance' }, () =
     async function checkLinks(version: string = '') {
       let readmeLink = version ? `/crates/nanomsg/${version}` : '/crates/nanomsg';
       await expect(tabReadme).toHaveAttribute('href', readmeLink);
+      let codeLink = version ? `/crates/nanomsg/${version}/code` : '/crates/nanomsg/code';
+      await expect(tabCode).toHaveAttribute('href', codeLink);
       await expect(tabVersions).toHaveAttribute('href', '/crates/nanomsg/versions');
       let depsLink = version ? `/crates/nanomsg/${version}/dependencies` : '/crates/nanomsg/dependencies';
       await expect(tabDeps).toHaveAttribute('href', depsLink);
@@ -23,7 +29,7 @@ test.describe('Acceptance | crate navigation tabs', { tag: '@acceptance' }, () =
 
     async function checkTabActiveState(currentTab: Locator) {
       await expect(currentTab).toHaveAttribute('data-test-active');
-      let otherTabs = [tabReadme, tabVersions, tabDeps, tabRevDeps].filter(tab => tab !== currentTab);
+      let otherTabs = [tabReadme, tabCode, tabVersions, tabDeps, tabRevDeps].filter(tab => tab !== currentTab);
       for (let tab of otherTabs) {
         await expect(tab).not.toHaveAttribute('data-test-active');
       }
@@ -34,6 +40,14 @@ test.describe('Acceptance | crate navigation tabs', { tag: '@acceptance' }, () =
     await page.goto('/crates/nanomsg');
     await expect(page).toHaveURL('/crates/nanomsg');
     await checkLinks();
+    await checkTabActiveState(currentTab);
+    await expect(tabSettings).toHaveCount(0);
+
+    // Code
+    currentTab = tabCode;
+    await currentTab.click();
+    await expect(page).toHaveURL('/crates/nanomsg/0.6.1/code');
+    await checkLinks('0.6.1');
     await checkTabActiveState(currentTab);
     await expect(tabSettings).toHaveCount(0);
 

--- a/svelte/src/lib/components/CrateHeader.svelte
+++ b/svelte/src/lib/components/CrateHeader.svelte
@@ -2,6 +2,7 @@
   import type { components } from '@crates-io/api-client';
 
   import { resolve } from '$app/paths';
+  import { page } from '$app/state';
 
   import CrateFollowButton from '$lib/components/CrateFollowButton.svelte';
   import * as NavTabs from '$lib/components/nav-tabs';
@@ -46,6 +47,16 @@
       ? resolve('/crates/[crate_id]/[version_num]', { crate_id, version_num })
       : resolve('/crates/[crate_id]', { crate_id }),
   );
+
+  let codeHref = $derived(
+    version_num
+      ? resolve('/crates/[crate_id]/[version_num]/code/[...path]', { crate_id, version_num, path: '' })
+      : resolve('/crates/[crate_id]/code/[...path]', { crate_id, path: '' }),
+  );
+
+  // The selected file lives in the URL (e.g. `/code/src/lib.rs`), so match the
+  // Code tab as active for any path under the base `/code` route.
+  let codeActive = $derived(page.url.pathname === codeHref || page.url.pathname.startsWith(`${codeHref}/`));
 
   let versionsHref = $derived(resolve('/crates/[crate_id]/versions', { crate_id }));
 
@@ -110,6 +121,9 @@
 
 <NavTabs.Root aria-label="{crate.name} crate subpages" style="margin-bottom: var(--space-s)">
   <NavTabs.Tab href={readmeHref} data-test-readme-tab>Readme</NavTabs.Tab>
+  {#if session.currentUser?.is_admin}
+    <NavTabs.Tab href={codeHref} active={codeActive} data-test-code-tab>Code</NavTabs.Tab>
+  {/if}
   <NavTabs.Tab href={versionsHref} data-test-versions-tab>
     {crate.num_versions}
     {crate.num_versions === 1 ? 'Version' : 'Versions'}


### PR DESCRIPTION
This adds a Code tab to the crate header, between Readme and Versions, linking to the source viewer for the current or default version. It stays active for any path under `/code`, since the selected file lives in the URL.

> [!note]
> The tab is restricted to admin users for beta testing the source viewer.