### PR TITLE
Extract `CodeViewer` and `FileTree` components

### DIFF
--- a/svelte/src/lib/components/CodeViewer.stories.svelte
+++ b/svelte/src/lib/components/CodeViewer.stories.svelte
@@ -1,0 +1,62 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import CodeViewer from './CodeViewer.svelte';
+
+  const { Story } = defineMeta({
+    title: 'CodeViewer',
+    component: CodeViewer,
+    tags: ['autodocs'],
+    argTypes: {
+      colorScheme: { control: 'inline-radio', options: ['light', 'dark'] },
+    },
+    args: {
+      colorScheme: 'light',
+    },
+  });
+
+  const FILES = [
+    {
+      path: 'Cargo.toml',
+      text: '[package]\nname = "example"\nversion = "0.1.0"\nedition = "2021"\n\n[dependencies]\nserde = "1"\nserde_json = "1"\n',
+      meta: '88 B',
+    },
+    {
+      path: 'src/main.rs',
+      text: 'fn main() {\n    println!("Hello, world!");\n}\n',
+      meta: '42 B',
+    },
+    {
+      path: 'README.md',
+      text: '# Example\n\nA sample crate used in the CodeViewer story.\n',
+      meta: '52 B',
+    },
+  ];
+</script>
+
+<script>
+</script>
+
+<Story name="Default">
+  {#snippet template(args: { colorScheme: 'light' | 'dark' })}
+    <div class="viewer">
+      <CodeViewer content={FILES[0]} colorScheme={args.colorScheme} />
+    </div>
+
+    <div class="viewer">
+      <CodeViewer content={FILES[1]} colorScheme={args.colorScheme} />
+    </div>
+
+    <div class="viewer">
+      <CodeViewer content={FILES[2]} colorScheme={args.colorScheme} />
+    </div>
+  {/snippet}
+</Story>
+
+<style>
+  .viewer {
+    display: flex;
+    height: 200px;
+    margin-bottom: var(--space-m);
+  }
+</style>

--- a/svelte/src/lib/components/CodeViewer.svelte
+++ b/svelte/src/lib/components/CodeViewer.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { File as FileView } from '@pierre/diffs';
+
+  import { languageForPath } from '$lib/utils/syntax-language';
+
+  interface Props {
+    content: { path: string; text: string; meta: string | null } | null;
+    colorScheme: 'light' | 'dark';
+  }
+
+  let { content, colorScheme }: Props = $props();
+
+  const THEMES = { light: 'github-light', dark: 'github-dark' } as const;
+
+  let container = $state.raw<HTMLElement>();
+  let view = $state.raw<FileView>();
+
+  onMount(() => {
+    view = new FileView({
+      theme: THEMES,
+      themeType: colorScheme,
+      overflow: 'wrap',
+      renderHeaderMetadata: () => content?.meta ?? null,
+    });
+    return () => view?.cleanUp();
+  });
+
+  $effect(() => view?.setThemeType(colorScheme));
+
+  $effect(() => {
+    if (!container || !content) return;
+    view?.render({
+      file: { name: content.path, contents: content.text, lang: languageForPath(content.path) },
+      containerWrapper: container,
+    });
+  });
+</script>
+
+<div class="code" class:hidden={content === null} bind:this={container} data-test-code-viewer></div>
+
+<style>
+  .hidden {
+    display: none;
+  }
+
+  .code {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    font-size: calc(0.85 * var(--space-s));
+    background-color: light-dark(white, #141413);
+  }
+
+  .code :global(diffs-container) {
+    --diffs-font-family: var(--font-monospace);
+    --diffs-header-font-family: var(--font-body);
+    --diffs-light-bg: white;
+    --diffs-dark-bg: #141413;
+  }
+</style>

--- a/svelte/src/lib/components/FileTree.stories.svelte
+++ b/svelte/src/lib/components/FileTree.stories.svelte
@@ -1,0 +1,62 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import { fn } from 'storybook/test';
+
+  import FileTree from './FileTree.svelte';
+
+  const PATHS = [
+    '.cargo_vcs_info.json',
+    'Cargo.toml',
+    'Cargo.toml.orig',
+    'Cargo.lock',
+    'README.md',
+    'src/lib.rs',
+    'src/main.rs',
+    'src/core/mod.rs',
+    'src/core/de.rs',
+    'src/core/ser.rs',
+    'src/utils/mod.rs',
+    'tests/integration.rs',
+  ];
+
+  const { Story } = defineMeta({
+    title: 'FileTree',
+    component: FileTree,
+    tags: ['autodocs'],
+    argTypes: {
+      colorScheme: { control: 'inline-radio', options: ['light', 'dark'] },
+    },
+    args: {
+      paths: PATHS,
+      colorScheme: 'light',
+      onselect: fn(),
+    },
+  });
+</script>
+
+<script lang="ts">
+  let selectedPath = $state<string | null>('src/lib.rs');
+</script>
+
+<Story name="Default">
+  {#snippet template(args)}
+    <div class="container">
+      <FileTree
+        paths={args.paths}
+        {selectedPath}
+        onselect={path => {
+          args.onselect(path);
+          selectedPath = path;
+        }}
+        colorScheme={args.colorScheme}
+      />
+    </div>
+  {/snippet}
+</Story>
+
+<style>
+  .container {
+    height: 500px;
+    width: 300px;
+  }
+</style>

--- a/svelte/src/lib/components/FileTree.svelte
+++ b/svelte/src/lib/components/FileTree.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { FileTree as PierreFileTree } from '@pierre/trees';
+
+  interface Props {
+    paths: string[];
+    selectedPath: string | null;
+    onselect: (path: string) => void;
+    colorScheme: 'light' | 'dark';
+  }
+
+  let { paths, selectedPath, onselect, colorScheme }: Props = $props();
+
+  let container = $state.raw<HTMLElement>();
+  let tree = $state.raw<PierreFileTree>();
+
+  // Returns ancestor directory paths for a file path,
+  // e.g. `src/core/de.rs` -> [`src/`, `src/core/`].
+  function ancestorDirectories(path: string): string[] {
+    let segments = path.split('/').slice(0, -1);
+    return segments.map((_, index) => segments.slice(0, index + 1).join('/') + '/');
+  }
+
+  onMount(() => {
+    if (!container) return;
+    tree = new PierreFileTree({
+      paths,
+      initialExpansion: 'closed',
+      initialExpandedPaths: selectedPath ? ancestorDirectories(selectedPath) : [],
+      flattenEmptyDirectories: true,
+      search: true,
+      stickyFolders: true,
+      onSelectionChange(p) {
+        let path = p[0];
+        if (path && path !== selectedPath) {
+          onselect(path);
+        }
+      },
+    });
+    tree.render({ containerWrapper: container });
+    return () => tree?.cleanUp();
+  });
+
+  $effect(() => {
+    let path = selectedPath;
+    if (!tree || !path) return;
+
+    let current = tree.getSelectedPaths();
+    if (current.length === 1 && current[0] === path) return;
+
+    // `scrollToPath()` only works once the target row is visible.
+    for (let dir of ancestorDirectories(path)) {
+      let item = tree.getItem(dir);
+      if (item && 'expand' in item) {
+        item.expand();
+      }
+    }
+
+    for (let other of current) {
+      tree.getItem(other)?.deselect();
+    }
+    tree.getItem(path)?.select();
+    tree.scrollToPath(path, { focus: false, offset: 'center' });
+  });
+
+  $effect(() => {
+    let container = tree?.getFileTreeContainer();
+    if (container) {
+      container.style.colorScheme = colorScheme;
+    }
+  });
+</script>
+
+<div class="tree" bind:this={container}></div>
+
+<style>
+  .tree {
+    height: 100%;
+  }
+
+  .tree :global(file-tree-container) {
+    --trees-bg-override: light-dark(white, #141413);
+    padding-top: var(--space-xs);
+  }
+</style>

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
-  import { FileTree } from '@pierre/trees';
   import prettyBytes from 'pretty-bytes';
 
   import { getColorScheme } from '$lib/color-scheme.svelte';
   import CodeViewer from '$lib/components/CodeViewer.svelte';
   import CrateHeader from '$lib/components/CrateHeader.svelte';
+  import FileTree from '$lib/components/FileTree.svelte';
   import { loadFile } from '$lib/utils/zip-archive';
 
   type FileState =
@@ -29,9 +28,6 @@
 
   let colorScheme = getColorScheme();
 
-  let tree = $state.raw<FileTree>();
-  let treeContainer = $state.raw<HTMLElement>();
-
   let fileState = $state<FileState>({ kind: 'loading' });
 
   let content = $derived.by(() => {
@@ -44,58 +40,11 @@
     };
   });
 
-  // Canonical ancestor directory paths (trailing slash) for a file path,
-  // e.g. `src/core/de.rs` -> [`src/`, `src/core/`]. Used to reveal a file in an
-  // otherwise-collapsed tree.
-  function ancestorDirectories(path: string): string[] {
-    let segments = path.split('/').slice(0, -1);
-    return segments.map((_, index) => segments.slice(0, index + 1).join('/') + '/');
-  }
-
-  onMount(() => {
-    if (!manifest || !treeContainer) return;
-
-    tree = new FileTree({
-      paths: manifest.files.map(file => file.path),
-      initialExpansion: 'closed',
-      initialExpandedPaths: selectedPath ? ancestorDirectories(selectedPath) : [],
-      flattenEmptyDirectories: true,
-      search: true,
-      stickyFolders: true,
-      onSelectionChange(paths) {
-        let path = paths[0];
-        if (path && path !== selectedPath && filesByPath.has(path)) {
-          let href = resolve('/crates/[crate_id]/[version_num]/code/[...path]', {
-            crate_id: crate.id,
-            version_num: version.num,
-            path,
-          });
-          void goto(href, { keepFocus: true, noScroll: true });
-        }
-      },
-    });
-
-    tree.render({ containerWrapper: treeContainer });
-
-    return () => tree?.cleanUp();
-  });
-
-  // Load and display whichever file the URL points at and keep the tree's
-  // selection in sync (so back/forward navigation highlights the right row).
   $effect(() => {
     let path = selectedPath;
     if (!path) return;
 
     void showFile(path);
-    syncTreeSelection(path);
-  });
-
-  // Keep the file tree in sync with the user's color scheme.
-  $effect(() => {
-    let fileTreeContainer = tree?.getFileTreeContainer();
-    if (fileTreeContainer) {
-      fileTreeContainer.style.colorScheme = colorScheme.resolvedScheme;
-    }
   });
 
   async function showFile(path: string) {
@@ -127,24 +76,16 @@
     }
   }
 
-  function syncTreeSelection(path: string) {
-    if (!tree) return;
+  function navigateTo(path: string) {
+    if (!filesByPath.has(path)) return;
 
-    let current = tree.getSelectedPaths();
-    if (current.length === 1 && current[0] === path) return;
+    let href = resolve('/crates/[crate_id]/[version_num]/code/[...path]', {
+      crate_id: crate.id,
+      version_num: version.num,
+      path,
+    });
 
-    // Reveal the file by expanding its ancestor directories.
-    // `scrollToPath()` only works once the target row is visible.
-    for (let dir of ancestorDirectories(path)) {
-      let item = tree.getItem(dir);
-      if (item && 'expand' in item) item.expand();
-    }
-
-    for (let other of current) {
-      tree.getItem(other)?.deselect();
-    }
-    tree.getItem(path)?.select();
-    tree.scrollToPath(path, { focus: false, offset: 'center' });
+    void goto(href, { keepFocus: true, noScroll: true });
   }
 </script>
 
@@ -165,7 +106,12 @@
 {:else}
   <div class="viewer">
     <aside class="tree-panel" aria-label="File tree">
-      <div class="tree" bind:this={treeContainer}></div>
+      <FileTree
+        paths={manifest.files.map(file => file.path)}
+        {selectedPath}
+        onselect={navigateTo}
+        colorScheme={colorScheme.resolvedScheme}
+      />
     </aside>
 
     <section class="code-panel" aria-label="File contents">
@@ -214,15 +160,6 @@
     border-radius: var(--space-3xs);
     box-shadow: 0 2px 3px light-dark(hsla(51, 50%, 44%, 0.35), #232321);
     overflow: hidden;
-  }
-
-  .tree {
-    height: 100%;
-  }
-
-  .tree :global(file-tree-container) {
-    --trees-bg-override: light-dark(white, #141413);
-    padding-top: var(--space-xs);
   }
 
   .code-panel {

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
@@ -2,20 +2,17 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
-  import { File as FileView } from '@pierre/diffs';
   import { FileTree } from '@pierre/trees';
   import prettyBytes from 'pretty-bytes';
 
   import { getColorScheme } from '$lib/color-scheme.svelte';
+  import CodeViewer from '$lib/components/CodeViewer.svelte';
   import CrateHeader from '$lib/components/CrateHeader.svelte';
-  import { languageForPath } from '$lib/utils/syntax-language';
   import { loadFile } from '$lib/utils/zip-archive';
 
-  const THEMES = { light: 'github-light', dark: 'github-dark' } as const;
-
-  // The mutually exclusive display states of the code panel.
   type FileState =
-    | { kind: 'content' }
+    | { kind: 'loading' }
+    | { kind: 'content'; path: string; text: string }
     | { kind: 'binary' }
     | { kind: 'unavailable' }
     | { kind: 'error'; message: string };
@@ -35,10 +32,17 @@
   let tree = $state.raw<FileTree>();
   let treeContainer = $state.raw<HTMLElement>();
 
-  let fileView = $state.raw<FileView>();
-  let fileContainer = $state.raw<HTMLElement>();
+  let fileState = $state<FileState>({ kind: 'loading' });
 
-  let fileState = $state<FileState>({ kind: 'content' });
+  let content = $derived.by(() => {
+    if (fileState.kind !== 'content') return null;
+    let entry = filesByPath.get(fileState.path);
+    return {
+      path: fileState.path,
+      text: fileState.text,
+      meta: entry ? prettyBytes(entry.uncompressed_size, { binary: true }) : null,
+    };
+  });
 
   // Canonical ancestor directory paths (trailing slash) for a file path,
   // e.g. `src/core/de.rs` -> [`src/`, `src/core/`]. Used to reveal a file in an
@@ -49,7 +53,7 @@
   }
 
   onMount(() => {
-    if (!manifest || !treeContainer || !fileContainer) return;
+    if (!manifest || !treeContainer) return;
 
     tree = new FileTree({
       paths: manifest.files.map(file => file.path),
@@ -73,22 +77,7 @@
 
     tree.render({ containerWrapper: treeContainer });
 
-    fileView = new FileView({
-      theme: THEMES,
-      themeType: colorScheme.scheme,
-      overflow: 'wrap',
-      // Show the uncompressed file size in the built-in header. The callback
-      // receives the file whose `name` is its archive path.
-      renderHeaderMetadata: file => {
-        let entry = filesByPath.get(file.name);
-        return entry ? prettyBytes(entry.uncompressed_size, { binary: true }) : null;
-      },
-    });
-
-    return () => {
-      tree?.cleanUp();
-      fileView?.cleanUp();
-    };
+    return () => tree?.cleanUp();
   });
 
   // Load and display whichever file the URL points at and keep the tree's
@@ -101,10 +90,8 @@
     syncTreeSelection(path);
   });
 
-  // Keep the code view and file tree in sync with the user's color scheme.
+  // Keep the file tree in sync with the user's color scheme.
   $effect(() => {
-    fileView?.setThemeType(colorScheme.scheme);
-
     let fileTreeContainer = tree?.getFileTreeContainer();
     if (fileTreeContainer) {
       fileTreeContainer.style.colorScheme = colorScheme.resolvedScheme;
@@ -112,8 +99,6 @@
   });
 
   async function showFile(path: string) {
-    if (!fileView || !fileContainer) return;
-
     let file = filesByPath.get(path);
     if (!file) {
       fileState = { kind: 'error', message: `File "${path}" was not found in this archive.` };
@@ -129,20 +114,11 @@
 
       if (result === null) {
         fileState = { kind: 'unavailable' };
-        return;
-      }
-
-      if (result.kind === 'binary') {
+      } else if (result.kind === 'binary') {
         fileState = { kind: 'binary' };
-        return;
+      } else {
+        fileState = { kind: 'content', path, text: result.text };
       }
-
-      fileState = { kind: 'content' };
-
-      fileView.render({
-        file: { name: path, contents: result.text, lang: languageForPath(path) },
-        containerWrapper: fileContainer,
-      });
     } catch (error) {
       if (selectedPath !== path) return;
 
@@ -203,12 +179,7 @@
         <div class="error" data-test-load-error>Failed to load file: {fileState.message}</div>
       {/if}
 
-      <div
-        class="code"
-        class:hidden={fileState.kind !== 'content'}
-        bind:this={fileContainer}
-        data-test-code-viewer
-      ></div>
+      <CodeViewer {content} colorScheme={colorScheme.resolvedScheme} />
     </section>
   </div>
 {/if}
@@ -228,10 +199,6 @@
   .error {
     padding: var(--space-s);
     color: light-dark(oklch(0.5 0.15 24), oklch(0.8 0.07 24));
-  }
-
-  .hidden {
-    display: none;
   }
 
   .viewer {
@@ -266,21 +233,6 @@
     border-radius: var(--space-3xs);
     box-shadow: 0 2px 3px light-dark(hsla(51, 50%, 44%, 0.35), #232321);
     overflow: hidden;
-  }
-
-  .code {
-    flex: 1;
-    min-height: 0;
-    overflow: auto;
-    font-size: calc(0.85 * var(--space-s));
-    background-color: light-dark(white, #141413);
-  }
-
-  .code :global(diffs-container) {
-    --diffs-font-family: var(--font-monospace);
-    --diffs-header-font-family: var(--font-body);
-    --diffs-light-bg: white;
-    --diffs-dark-bg: #141413;
   }
 
   @media only screen and (max-width: 750px) {


### PR DESCRIPTION
This is a follow-up to #14020 that pulls the two widgets out of the code viewer page route into reusable components under `$lib/components`.

The page now derives a single `content` value and delegates rendering to a prop-driven `CodeViewer`, while the directory tree moves into a fully controlled `FileTree` that takes a `selectedPath` and emits an `onselect` intent instead of navigating itself. The page keeps the URL as the single source of truth, so with both widgets extracted the route is a thin shell that owns routing, file loading, and the display-state machine.

Each component comes with a Storybook story.

### Related

- https://github.com/rust-lang/crates.io/pull/14020
