### PR TITLE
frontend: Render `CodeViewer` with virtualized `CodeView`

### DIFF
--- a/svelte/src/lib/components/CodeViewer.svelte
+++ b/svelte/src/lib/components/CodeViewer.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import type { CodeViewOptions } from '@pierre/diffs';
+
   import { onMount } from 'svelte';
-  import { File as FileView } from '@pierre/diffs';
+  import { CodeView } from '@pierre/diffs';
 
   import { languageForPath } from '$lib/utils/syntax-language';
 
@@ -14,26 +16,37 @@
   const THEMES = { light: 'github-light', dark: 'github-dark' } as const;
 
   let container = $state.raw<HTMLElement>();
-  let view = $state.raw<FileView>();
+  let view = $state.raw<CodeView>();
 
-  onMount(() => {
-    view = new FileView({
+  function options(): CodeViewOptions<undefined> {
+    return {
       theme: THEMES,
       themeType: colorScheme,
       overflow: 'wrap',
+      layout: {
+        paddingTop: 0,
+        paddingBottom: 0,
+        gap: 0,
+      },
       renderHeaderMetadata: () => content?.meta ?? null,
-    });
+    };
+  }
+
+  onMount(() => {
+    view = new CodeView(options());
+    view.setup(container!);
     return () => view?.cleanUp();
   });
 
-  $effect(() => view?.setThemeType(colorScheme));
+  $effect(() => view?.setOptions(options()));
 
   $effect(() => {
-    if (!container || !content) return;
-    view?.render({
-      file: { name: content.path, contents: content.text, lang: languageForPath(content.path) },
-      containerWrapper: container,
-    });
+    let items = [];
+    if (content) {
+      let file = { name: content.path, contents: content.text, lang: languageForPath(content.path) };
+      items.push({ id: content.path, type: 'file' as const, file });
+    }
+    view?.setItems(items);
   });
 </script>
 


### PR DESCRIPTION
The `File` component renders the entire file's DOM up front, which is slow for large generated files. `CodeView` virtualizes rendering and only mounts the rows currently in view.

Rendering `typos-dict`'s 9.42 MiB `word_codegen.rs` drops from ~19s to ~3s, and the mounted row count stays bounded while scrolling.

`CodeView` has no `setThemeType()` and replaces rather than merges its options, so theme changes go through `setOptions()` with the full options object.