### PR TITLE
crates_io_api_types: add `created_at` to `EncodablePublicUser`

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -718,6 +718,13 @@ pub struct EncodablePrivateUser {
     /// Whether the user has opted in to receive publish notifications via email.
     #[schema(example = true)]
     pub publish_notifications: bool,
+
+    /// The date and time the user was created.
+    ///
+    /// For users created before June 19, 2026, the creation time will be the
+    /// time the user's GitHub account was created. If the GitHub account was
+    /// deleted before June 19, 2026, this field will be empty.
+    pub created_at: Option<DateTime<Utc>>,
 }
 
 impl EncodablePrivateUser {
@@ -735,6 +742,7 @@ impl EncodablePrivateUser {
             gh_avatar,
             is_admin,
             publish_notifications,
+            created_at,
             ..
         } = user;
         let url = format!("https://github.com/{gh_login}");
@@ -750,6 +758,7 @@ impl EncodablePrivateUser {
             url: Some(url),
             is_admin,
             publish_notifications,
+            created_at,
         }
     }
 }
@@ -776,6 +785,13 @@ pub struct EncodablePublicUser {
     /// The user's GitHub profile URL.
     #[schema(example = "https://github.com/ghost")]
     pub url: String,
+
+    /// The date and time the user was created.
+    ///
+    /// For users created before June 19, 2026, the creation time will be the
+    /// time the user's GitHub account was created. If the GitHub account was
+    /// deleted before June 19, 2026, this field will be empty.
+    pub created_at: Option<DateTime<Utc>>,
 }
 
 /// Converts a `User` model into an `EncodablePublicUser` for JSON serialization.
@@ -786,6 +802,7 @@ impl From<User> for EncodablePublicUser {
             name,
             gh_login,
             gh_avatar,
+            created_at,
             ..
         } = user;
         let url = format!("https://github.com/{gh_login}");
@@ -795,6 +812,7 @@ impl From<User> for EncodablePublicUser {
             login: gh_login,
             name,
             url,
+            created_at,
         }
     }
 }
@@ -1152,6 +1170,7 @@ mod tests {
                     name: None,
                     avatar: None,
                     url: String::new(),
+                    created_at: None,
                 },
                 time: NaiveDate::from_ymd_opt(2017, 1, 6)
                     .unwrap()

--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -1039,6 +1039,15 @@ export interface components {
              */
             avatar?: string | null;
             /**
+             * Format: date-time
+             * @description The date and time the user was created.
+             *
+             *     For users created before June 19, 2026, the creation time will be the
+             *     time the user's GitHub account was created. If the GitHub account was
+             *     deleted before June 19, 2026, this field will be empty.
+             */
+            created_at?: string | null;
+            /**
              * @description The user's email address, if set.
              * @example kate@morgan.dev
              */
@@ -1580,6 +1589,15 @@ export interface components {
              * @example https://avatars2.githubusercontent.com/u/1234567?v=4
              */
             avatar?: string | null;
+            /**
+             * Format: date-time
+             * @description The date and time the user was created.
+             *
+             *     For users created before June 19, 2026, the creation time will be the
+             *     time the user's GitHub account was created. If the GitHub account was
+             *     deleted before June 19, 2026, this field will be empty.
+             */
+            created_at?: string | null;
             /**
              * Format: int32
              * @description An opaque identifier for the user.

--- a/src/tests/krate/publish/edition.rs
+++ b/src/tests/krate/publish/edition.rs
@@ -30,8 +30,10 @@ async fn test_edition_is_saved() {
         ".version.id" => any_id_redaction(),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
+        ".version.published_by.created_at" => "[datetime]",
         ".version.published_by.id" => id_redaction(token.as_model().user_id),
         ".version.audit_actions[].time" => "[datetime]",
+        ".version.audit_actions[].user.created_at" => "[datetime]",
         ".version.audit_actions[].user.id" => id_redaction(token.as_model().user_id),
     });
 }

--- a/src/tests/krate/publish/links.rs
+++ b/src/tests/krate/publish/links.rs
@@ -30,6 +30,8 @@ async fn test_crate_with_links_field() {
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
         ".version.audit_actions[].time" => "[datetime]",
+        ".version.audit_actions[].user.created_at" => "[datetime]",
+        ".version.published_by.created_at" => "[datetime]",
         ".version.published_by.id" => insta::any_id_redaction(),
     });
     assert_snapshot!(response.status(), @"200 OK");

--- a/src/tests/krate/publish/manifest.rs
+++ b/src/tests/krate/publish/manifest.rs
@@ -43,8 +43,10 @@ async fn boolean_readme() {
         ".version.id" => any_id_redaction(),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
+        ".version.published_by.created_at" => "[datetime]",
         ".version.published_by.id" => id_redaction(token.as_model().user_id),
         ".version.audit_actions[].time" => "[datetime]",
+        ".version.audit_actions[].user.created_at" => "[datetime]",
         ".version.audit_actions[].user.id" => id_redaction(token.as_model().user_id),
     });
 }
@@ -201,8 +203,10 @@ async fn test_lib_and_bin_crate() {
         ".version.id" => any_id_redaction(),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
+        ".version.published_by.created_at" => "[datetime]",
         ".version.published_by.id" => id_redaction(token.as_model().user_id),
         ".version.audit_actions[].time" => "[datetime]",
+        ".version.audit_actions[].user.created_at" => "[datetime]",
         ".version.audit_actions[].user.id" => id_redaction(token.as_model().user_id),
     });
 

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__edition__edition_is_saved-4.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__edition__edition_is_saved-4.snap
@@ -10,6 +10,7 @@ expression: response.json()
         "time": "[datetime]",
         "user": {
           "avatar": null,
+          "created_at": "[datetime]",
           "id": "[id]",
           "login": "foo",
           "name": null,
@@ -46,6 +47,7 @@ expression: response.json()
     "num": "1.0.0",
     "published_by": {
       "avatar": null,
+      "created_at": "[datetime]",
       "id": "[id]",
       "login": "foo",
       "name": null,

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__links__crate_with_links_field-3.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__links__crate_with_links_field-3.snap
@@ -10,6 +10,7 @@ expression: response.json()
         "time": "[datetime]",
         "user": {
           "avatar": null,
+          "created_at": "[datetime]",
           "id": 1,
           "login": "foo",
           "name": null,
@@ -46,6 +47,7 @@ expression: response.json()
     "num": "1.0.0",
     "published_by": {
       "avatar": null,
+      "created_at": "[datetime]",
       "id": "[id]",
       "login": "foo",
       "name": null,

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__boolean_readme-4.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__boolean_readme-4.snap
@@ -10,6 +10,7 @@ expression: response.json()
         "time": "[datetime]",
         "user": {
           "avatar": null,
+          "created_at": "[datetime]",
           "id": "[id]",
           "login": "foo",
           "name": null,
@@ -46,6 +47,7 @@ expression: response.json()
     "num": "1.0.0",
     "published_by": {
       "avatar": null,
+      "created_at": "[datetime]",
       "id": "[id]",
       "login": "foo",
       "name": null,

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__lib_and_bin_crate-4.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__lib_and_bin_crate-4.snap
@@ -10,6 +10,7 @@ expression: response.json()
         "time": "[datetime]",
         "user": {
           "avatar": null,
+          "created_at": "[datetime]",
           "id": "[id]",
           "login": "foo",
           "name": null,
@@ -55,6 +56,7 @@ expression: response.json()
     "num": "1.0.0",
     "published_by": {
       "avatar": null,
+      "created_at": "[datetime]",
       "id": "[id]",
       "login": "foo",
       "name": null,

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-2.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-2.snap
@@ -28,7 +28,8 @@ expression: json
       "login": "foo",
       "name": null,
       "avatar": null,
-      "url": "https://github.com/foo"
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
     },
     "audit_actions": [
       {
@@ -38,7 +39,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -49,7 +51,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       }

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-3.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-3.snap
@@ -28,7 +28,8 @@ expression: json
       "login": "foo",
       "name": null,
       "avatar": null,
-      "url": "https://github.com/foo"
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
     },
     "audit_actions": [
       {
@@ -38,7 +39,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -49,7 +51,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -60,7 +63,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       }

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-4.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-4.snap
@@ -28,7 +28,8 @@ expression: json
       "login": "foo",
       "name": null,
       "avatar": null,
-      "url": "https://github.com/foo"
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
     },
     "audit_actions": [
       {
@@ -38,7 +39,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -49,7 +51,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -60,7 +63,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       }

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-5.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-5.snap
@@ -28,7 +28,8 @@ expression: json
       "login": "foo",
       "name": null,
       "avatar": null,
-      "url": "https://github.com/foo"
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
     },
     "audit_actions": [
       {
@@ -38,7 +39,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -49,7 +51,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -60,7 +63,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -71,7 +75,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       }

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-6.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-6.snap
@@ -28,7 +28,8 @@ expression: json
       "login": "foo",
       "name": null,
       "avatar": null,
-      "url": "https://github.com/foo"
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
     },
     "audit_actions": [
       {
@@ -38,7 +39,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -49,7 +51,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -60,7 +63,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -71,7 +75,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       }

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank.snap
@@ -28,7 +28,8 @@ expression: json
       "login": "foo",
       "name": null,
       "avatar": null,
-      "url": "https://github.com/foo"
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
     },
     "audit_actions": [
       {
@@ -38,7 +39,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       },
@@ -49,7 +51,8 @@ expression: json
           "login": "foo",
           "name": null,
           "avatar": null,
-          "url": "https://github.com/foo"
+          "url": "https://github.com/foo",
+          "created_at": "[datetime]"
         },
         "time": "[datetime]"
       }

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -248,7 +248,9 @@ async fn patch_version_yank_unyank() {
         assert_json_snapshot!(json, {
             ".version.created_at" => "[datetime]",
             ".version.updated_at" => "[datetime]",
+            ".version.published_by.created_at" => "[datetime]",
             ".version.audit_actions[].time" => "[datetime]",
+            ".version.audit_actions[].user.created_at" => "[datetime]",
         });
     };
 

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -11,8 +11,8 @@ use chrono::Utc;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::StatusCode;
-use insta::assert_snapshot;
-use serde::Deserialize;
+use insta::{assert_json_snapshot, assert_snapshot};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 #[derive(Deserialize)]
@@ -23,7 +23,7 @@ struct TeamResponse {
 struct UserResponse {
     users: Vec<EncodableOwner>,
 }
-#[derive(Deserialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 struct InvitationListResponse {
     crate_owner_invitations: Vec<EncodableCrateOwnerInvitationV1>,
     users: Vec<EncodablePublicUser>,
@@ -431,7 +431,7 @@ async fn invitations_list_v1() {
     let mut conn = app.db_conn().await;
     let owner = owner.as_model();
 
-    let krate = CrateBuilder::new("invited_crate", owner.id)
+    let _krate = CrateBuilder::new("invited_crate", owner.id)
         .expect_build(&mut conn)
         .await;
 
@@ -445,23 +445,11 @@ async fn invitations_list_v1() {
     assert_snapshot!(response.status(), @"200 OK");
 
     let invitations = user.list_invitations().await;
-    assert_eq!(
-        invitations,
-        InvitationListResponse {
-            crate_owner_invitations: vec![EncodableCrateOwnerInvitationV1 {
-                crate_id: krate.id,
-                crate_name: krate.name,
-                invited_by_username: owner.gh_login.clone(),
-                invitee_id: user.as_model().id,
-                inviter_id: owner.id,
-                // This value changes with each test run so we can't use a fixed value here
-                created_at: invitations.crate_owner_invitations[0].created_at,
-                // This value changes with each test run so we can't use a fixed value here
-                expires_at: invitations.crate_owner_invitations[0].expires_at,
-            }],
-            users: vec![owner.clone().into(), user.as_model().clone().into()],
-        }
-    );
+    assert_json_snapshot!(invitations, {
+        ".crate_owner_invitations[].created_at" => "[datetime]",
+        ".crate_owner_invitations[].expires_at" => "[datetime]",
+        ".users[].created_at" => "[datetime]",
+    });
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -475,7 +463,7 @@ async fn invitations_list_does_not_include_expired_invites_v1() {
     let krate1 = CrateBuilder::new("invited_crate_1", owner.id)
         .expect_build(&mut conn)
         .await;
-    let krate2 = CrateBuilder::new("invited_crate_2", owner.id)
+    let _krate2 = CrateBuilder::new("invited_crate_2", owner.id)
         .expect_build(&mut conn)
         .await;
     token
@@ -491,23 +479,11 @@ async fn invitations_list_does_not_include_expired_invites_v1() {
     expire_invitation(&app, krate1.id).await;
 
     let invitations = user.list_invitations().await;
-    assert_eq!(
-        invitations,
-        InvitationListResponse {
-            crate_owner_invitations: vec![EncodableCrateOwnerInvitationV1 {
-                crate_id: krate2.id,
-                crate_name: krate2.name,
-                invited_by_username: owner.gh_login.clone(),
-                invitee_id: user.as_model().id,
-                inviter_id: owner.id,
-                // This value changes with each test run so we can't use a fixed value here
-                created_at: invitations.crate_owner_invitations[0].created_at,
-                // This value changes with each test run so we can't use a fixed value here
-                expires_at: invitations.crate_owner_invitations[0].expires_at,
-            }],
-            users: vec![owner.clone().into(), user.as_model().clone().into()],
-        }
-    );
+    assert_json_snapshot!(invitations, {
+        ".crate_owner_invitations[].created_at" => "[datetime]",
+        ".crate_owner_invitations[].expires_at" => "[datetime]",
+        ".users[].created_at" => "[datetime]",
+    });
 }
 
 /// Given a user inviting a different user to be a crate

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -44,6 +44,7 @@ async fn show() {
         ".keywords[].created_at" => "[datetime]",
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 }
 
@@ -102,6 +103,7 @@ async fn show_all_yanked() {
         ".keywords[].created_at" => "[datetime]",
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 }
 
@@ -207,6 +209,7 @@ async fn test_include_default_version() {
         ".crate.updated_at" => "[datetime]",
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 
     let resp_versions = anon

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -29,6 +29,7 @@ async fn reverse_dependencies() {
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 
     // c1 has no dependent crates.
@@ -39,6 +40,7 @@ async fn reverse_dependencies() {
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 }
 
@@ -66,6 +68,7 @@ async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 }
 
@@ -93,6 +96,7 @@ async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 }
 
@@ -125,6 +129,7 @@ async fn prerelease_versions_not_included_in_reverse_dependencies() {
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 }
 
@@ -152,6 +157,7 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 
     use crates_io::schema::versions;
@@ -171,6 +177,7 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 }
 
@@ -217,6 +224,7 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 }
 
@@ -246,6 +254,7 @@ async fn reverse_dependencies_query_supports_u64_version_number_parts() {
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 }
 

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__include_default_version-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__include_default_version-2.snap
@@ -65,6 +65,7 @@ expression: response.json()
       "num": "0.5.1",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__show-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__show-2.snap
@@ -78,6 +78,7 @@ expression: response.json()
       "num": "0.5.1",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,
@@ -118,6 +119,7 @@ expression: response.json()
       "num": "0.5.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__show_all_yanked-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__show_all_yanked-2.snap
@@ -77,6 +77,7 @@ expression: response.json()
       "num": "0.5.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,
@@ -117,6 +118,7 @@ expression: response.json()
       "num": "1.0.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies-2.snap
@@ -48,6 +48,7 @@ expression: response.json()
       "num": "1.0.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
@@ -48,6 +48,7 @@ expression: response.json()
       "num": "1.1.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present-2.snap
@@ -60,6 +60,7 @@ expression: response.json()
       "num": "3.0.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts-2.snap
@@ -48,6 +48,7 @@ expression: response.json()
       "num": "1.0.18446744073709551615",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does-2.snap
@@ -48,6 +48,7 @@ expression: response.json()
       "num": "2.0.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
@@ -48,6 +48,7 @@ expression: response.json()
       "num": "2.0.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-9.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-9.snap
@@ -67,6 +67,7 @@ expression: json
       "num": "0.99.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-9.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-9.snap
@@ -67,6 +67,7 @@ expression: json
       "num": "0.99.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/update.rs
+++ b/src/tests/routes/crates/update.rs
@@ -48,6 +48,7 @@ async fn test_enable_trustpub_only() {
         ".crate.updated_at" => "[datetime]",
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 
     assert_snapshot!(app.emails_snapshot().await);
@@ -99,6 +100,7 @@ async fn test_disable_trustpub_only() {
         ".crate.updated_at" => "[datetime]",
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 
     assert_snapshot!(app.emails_snapshot().await);

--- a/src/tests/routes/crates/versions/list.rs
+++ b/src/tests/routes/crates/versions/list.rs
@@ -36,6 +36,7 @@ async fn versions() -> anyhow::Result<()> {
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
+        ".versions[].published_by.created_at" => "[datetime]",
     });
 
     Ok(())

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -28,6 +28,7 @@ async fn show_by_crate_name_and_version() {
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
         ".version.published_by.id" => insta::id_redaction(user.id),
+        ".version.published_by.created_at" => "[datetime]",
     });
 }
 

--- a/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__list__versions-2.snap
+++ b/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__list__versions-2.snap
@@ -69,6 +69,7 @@ expression: response.json()
       "num": "0.5.1",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,
@@ -109,6 +110,7 @@ expression: response.json()
       "num": "0.5.0",
       "published_by": {
         "avatar": null,
+        "created_at": "[datetime]",
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__read__show_by_crate_name_and_version.snap
+++ b/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__read__show_by_crate_name_and_version.snap
@@ -30,6 +30,7 @@ expression: json
     "num": "2.0.0",
     "published_by": {
       "avatar": null,
+      "created_at": "[datetime]",
       "id": "[id]",
       "login": "foo",
       "name": null,

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -28,7 +28,9 @@ async fn me() {
 
     let response = user.get::<()>("/api/v1/me").await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_json_snapshot!(response.json());
+    assert_json_snapshot!(response.json(), {
+        ".user.created_at" => "[datetime]",
+    });
 
     CrateBuilder::new("foo_my_packages", user.as_model().id)
         .expect_build(&mut conn)
@@ -36,7 +38,9 @@ async fn me() {
 
     let response = user.get::<()>("/api/v1/me").await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_json_snapshot!(response.json());
+    assert_json_snapshot!(response.json(), {
+        ".user.created_at" => "[datetime]",
+    });
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/me/snapshots/integration__routes__me__get__me-4.snap
+++ b/src/tests/routes/me/snapshots/integration__routes__me__get__me-4.snap
@@ -6,6 +6,7 @@ expression: response.json()
   "owned_crates": [],
   "user": {
     "avatar": null,
+    "created_at": "[datetime]",
     "email": "foo@example.com",
     "email_verification_sent": true,
     "email_verified": true,

--- a/src/tests/routes/me/snapshots/integration__routes__me__get__me-6.snap
+++ b/src/tests/routes/me/snapshots/integration__routes__me__get__me-6.snap
@@ -12,6 +12,7 @@ expression: response.json()
   ],
   "user": {
     "avatar": null,
+    "created_at": "[datetime]",
     "email": "foo@example.com",
     "email_verification_sent": true,
     "email_verified": true,

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -4,16 +4,17 @@ use crate::builders::CrateBuilder;
 use crate::util::{MockCookieUser, RequestHelper, TestApp};
 use crates_io::views::{EncodableCrateOwnerInvitation, EncodablePublicUser};
 use http::StatusCode;
-use serde::Deserialize;
+use insta::assert_json_snapshot;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-#[derive(Deserialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 struct CrateOwnerInvitationsResponse {
     invitations: Vec<EncodableCrateOwnerInvitation>,
     users: Vec<EncodablePublicUser>,
     meta: CrateOwnerInvitationsMeta,
 }
-#[derive(Deserialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 struct CrateOwnerInvitationsMeta {
     next_page: Option<String>,
 }
@@ -32,10 +33,10 @@ async fn invitation_list() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn().await;
 
-    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
+    let _crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
         .expect_build(&mut conn)
         .await;
-    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
+    let _crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
         .expect_build(&mut conn)
         .await;
 
@@ -47,125 +48,43 @@ async fn invitation_list() {
 
     // user1 has invites for both crates
     let invitations = get_invitations(&user1, &format!("invitee_id={}", user1.as_model().id)).await;
-    assert_eq!(
-        invitations,
-        CrateOwnerInvitationsResponse {
-            invitations: vec![
-                EncodableCrateOwnerInvitation {
-                    crate_id: crate1.id,
-                    crate_name: crate1.name.clone(),
-                    invitee_id: user1.as_model().id,
-                    inviter_id: owner.as_model().id,
-                    // The timestamps depend on when the test is run.
-                    created_at: invitations.invitations[0].created_at,
-                    expires_at: invitations.invitations[0].expires_at,
-                },
-                EncodableCrateOwnerInvitation {
-                    crate_id: crate2.id,
-                    crate_name: crate2.name.clone(),
-                    invitee_id: user1.as_model().id,
-                    inviter_id: owner.as_model().id,
-                    // The timestamps depend on when the test is run.
-                    created_at: invitations.invitations[1].created_at,
-                    expires_at: invitations.invitations[1].expires_at,
-                },
-            ],
-            users: vec![
-                owner.as_model().clone().into(),
-                user1.as_model().clone().into()
-            ],
-            meta: CrateOwnerInvitationsMeta { next_page: None },
-        }
-    );
+    assert_json_snapshot!(invitations, {
+        ".invitations[].created_at" => "[datetime]",
+        ".invitations[].expires_at" => "[datetime]",
+        ".users[].created_at" => "[datetime]",
+    });
 
     // user2 is only invited to a single crate
     let invitations = get_invitations(&user2, &format!("invitee_id={}", user2.as_model().id)).await;
-    assert_eq!(
-        invitations,
-        CrateOwnerInvitationsResponse {
-            invitations: vec![EncodableCrateOwnerInvitation {
-                crate_id: crate1.id,
-                crate_name: crate1.name.clone(),
-                invitee_id: user2.as_model().id,
-                inviter_id: owner.as_model().id,
-                // The timestamps depend on when the test is run.
-                created_at: invitations.invitations[0].created_at,
-                expires_at: invitations.invitations[0].expires_at,
-            }],
-            users: vec![
-                owner.as_model().clone().into(),
-                user2.as_model().clone().into(),
-            ],
-            meta: CrateOwnerInvitationsMeta { next_page: None },
-        }
-    );
+    assert_json_snapshot!(invitations, {
+        ".invitations[].created_at" => "[datetime]",
+        ".invitations[].expires_at" => "[datetime]",
+        ".users[].created_at" => "[datetime]",
+    });
 
     // owner has no invites
     let invitations = get_invitations(&owner, &format!("invitee_id={}", owner.as_model().id)).await;
-    assert_eq!(
-        invitations,
-        CrateOwnerInvitationsResponse {
-            invitations: vec![],
-            users: vec![],
-            meta: CrateOwnerInvitationsMeta { next_page: None },
-        }
-    );
+    assert_json_snapshot!(invitations, {
+        ".invitations[].created_at" => "[datetime]",
+        ".invitations[].expires_at" => "[datetime]",
+        ".users[].created_at" => "[datetime]",
+    });
 
     // crate1 has two available invitations
     let invitations = get_invitations(&owner, "crate_name=crate_1").await;
-    assert_eq!(
-        invitations,
-        CrateOwnerInvitationsResponse {
-            invitations: vec![
-                EncodableCrateOwnerInvitation {
-                    crate_id: crate1.id,
-                    crate_name: crate1.name.clone(),
-                    invitee_id: user1.as_model().id,
-                    inviter_id: owner.as_model().id,
-                    // The timestamps depend on when the test is run.
-                    created_at: invitations.invitations[0].created_at,
-                    expires_at: invitations.invitations[0].expires_at,
-                },
-                EncodableCrateOwnerInvitation {
-                    crate_id: crate1.id,
-                    crate_name: crate1.name,
-                    invitee_id: user2.as_model().id,
-                    inviter_id: owner.as_model().id,
-                    // The timestamps depend on when the test is run.
-                    created_at: invitations.invitations[1].created_at,
-                    expires_at: invitations.invitations[1].expires_at,
-                },
-            ],
-            users: vec![
-                owner.as_model().clone().into(),
-                user1.as_model().clone().into(),
-                user2.as_model().clone().into(),
-            ],
-            meta: CrateOwnerInvitationsMeta { next_page: None },
-        }
-    );
+    assert_json_snapshot!(invitations, {
+        ".invitations[].created_at" => "[datetime]",
+        ".invitations[].expires_at" => "[datetime]",
+        ".users[].created_at" => "[datetime]",
+    });
 
     // crate2 has one available invitation
     let invitations = get_invitations(&owner, "crate_name=crate_2").await;
-    assert_eq!(
-        invitations,
-        CrateOwnerInvitationsResponse {
-            invitations: vec![EncodableCrateOwnerInvitation {
-                crate_id: crate2.id,
-                crate_name: crate2.name,
-                invitee_id: user1.as_model().id,
-                inviter_id: owner.as_model().id,
-                // The timestamps depend on when the test is run.
-                created_at: invitations.invitations[0].created_at,
-                expires_at: invitations.invitations[0].expires_at,
-            }],
-            users: vec![
-                owner.as_model().clone().into(),
-                user1.as_model().clone().into(),
-            ],
-            meta: CrateOwnerInvitationsMeta { next_page: None },
-        }
-    );
+    assert_json_snapshot!(invitations, {
+        ".invitations[].created_at" => "[datetime]",
+        ".invitations[].expires_at" => "[datetime]",
+        ".users[].created_at" => "[datetime]",
+    });
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -177,7 +96,7 @@ async fn invitations_list_does_not_include_expired_invites() {
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
         .expect_build(&mut conn)
         .await;
-    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
+    let _crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
         .expect_build(&mut conn)
         .await;
 
@@ -195,25 +114,11 @@ async fn invitations_list_does_not_include_expired_invites() {
 
     // user1 has an invite just for crate 2
     let invitations = get_invitations(&user, &format!("invitee_id={}", user.as_model().id)).await;
-    assert_eq!(
-        invitations,
-        CrateOwnerInvitationsResponse {
-            invitations: vec![EncodableCrateOwnerInvitation {
-                crate_id: crate2.id,
-                crate_name: crate2.name,
-                invitee_id: user.as_model().id,
-                inviter_id: owner.as_model().id,
-                // The timestamps depend on when the test is run.
-                created_at: invitations.invitations[0].created_at,
-                expires_at: invitations.invitations[0].expires_at,
-            }],
-            users: vec![
-                owner.as_model().clone().into(),
-                user.as_model().clone().into(),
-            ],
-            meta: CrateOwnerInvitationsMeta { next_page: None },
-        }
-    );
+    assert_json_snapshot!(invitations, {
+        ".invitations[].created_at" => "[datetime]",
+        ".invitations[].expires_at" => "[datetime]",
+        ".users[].created_at" => "[datetime]",
+    });
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -222,10 +127,10 @@ async fn invitations_list_paginated() {
     let mut conn = app.db_conn().await;
     let user = app.db_new_user("invited_user").await;
 
-    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
+    let _crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
         .expect_build(&mut conn)
         .await;
-    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
+    let _crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
         .expect_build(&mut conn)
         .await;
 
@@ -244,28 +149,11 @@ async fn invitations_list_paginated() {
         &format!("per_page=1&invitee_id={}", user.as_model().id),
     )
     .await;
-    assert_eq!(
-        invitations,
-        CrateOwnerInvitationsResponse {
-            invitations: vec![EncodableCrateOwnerInvitation {
-                crate_id: crate1.id,
-                crate_name: crate1.name,
-                invitee_id: user.as_model().id,
-                inviter_id: owner.as_model().id,
-                // The timestamps depend on when the test is run.
-                created_at: invitations.invitations[0].created_at,
-                expires_at: invitations.invitations[0].expires_at,
-            }],
-            users: vec![
-                owner.as_model().clone().into(),
-                user.as_model().clone().into(),
-            ],
-            meta: CrateOwnerInvitationsMeta {
-                // This unwraps and then wraps again in Some() to ensure it's not None
-                next_page: Some(invitations.meta.next_page.clone().unwrap()),
-            },
-        }
-    );
+    assert_json_snapshot!(invitations, {
+        ".invitations[].created_at" => "[datetime]",
+        ".invitations[].expires_at" => "[datetime]",
+        ".users[].created_at" => "[datetime]",
+    });
 
     // Fetch the second page of results
     let invitations = get_invitations(
@@ -273,25 +161,11 @@ async fn invitations_list_paginated() {
         invitations.meta.next_page.unwrap().trim_start_matches('?'),
     )
     .await;
-    assert_eq!(
-        invitations,
-        CrateOwnerInvitationsResponse {
-            invitations: vec![EncodableCrateOwnerInvitation {
-                crate_id: crate2.id,
-                crate_name: crate2.name,
-                invitee_id: user.as_model().id,
-                inviter_id: owner.as_model().id,
-                // The timestamps depend on when the test is run.
-                created_at: invitations.invitations[0].created_at,
-                expires_at: invitations.invitations[0].expires_at,
-            }],
-            users: vec![
-                owner.as_model().clone().into(),
-                user.as_model().clone().into(),
-            ],
-            meta: CrateOwnerInvitationsMeta { next_page: None },
-        }
-    );
+    assert_json_snapshot!(invitations, {
+        ".invitations[].created_at" => "[datetime]",
+        ".invitations[].expires_at" => "[datetime]",
+        ".users[].created_at" => "[datetime]",
+    });
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-2.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-2.snap
@@ -1,0 +1,37 @@
+---
+source: src/tests/routes/private/crate_owner_invitations.rs
+expression: invitations
+---
+{
+  "invitations": [
+    {
+      "invitee_id": 3,
+      "inviter_id": 1,
+      "crate_id": 1,
+      "crate_name": "crate_1",
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "login": "foo",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
+    },
+    {
+      "id": 3,
+      "login": "user_2",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/user_2",
+      "created_at": "[datetime]"
+    }
+  ],
+  "meta": {
+    "next_page": null
+  }
+}

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-3.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-3.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/private/crate_owner_invitations.rs
+expression: invitations
+---
+{
+  "invitations": [],
+  "users": [],
+  "meta": {
+    "next_page": null
+  }
+}

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-4.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-4.snap
@@ -1,0 +1,53 @@
+---
+source: src/tests/routes/private/crate_owner_invitations.rs
+expression: invitations
+---
+{
+  "invitations": [
+    {
+      "invitee_id": 2,
+      "inviter_id": 1,
+      "crate_id": 1,
+      "crate_name": "crate_1",
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    },
+    {
+      "invitee_id": 3,
+      "inviter_id": 1,
+      "crate_id": 1,
+      "crate_name": "crate_1",
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "login": "foo",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
+    },
+    {
+      "id": 2,
+      "login": "user_1",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/user_1",
+      "created_at": "[datetime]"
+    },
+    {
+      "id": 3,
+      "login": "user_2",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/user_2",
+      "created_at": "[datetime]"
+    }
+  ],
+  "meta": {
+    "next_page": null
+  }
+}

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-5.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-5.snap
@@ -1,0 +1,37 @@
+---
+source: src/tests/routes/private/crate_owner_invitations.rs
+expression: invitations
+---
+{
+  "invitations": [
+    {
+      "invitee_id": 2,
+      "inviter_id": 1,
+      "crate_id": 2,
+      "crate_name": "crate_2",
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "login": "foo",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
+    },
+    {
+      "id": 2,
+      "login": "user_1",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/user_1",
+      "created_at": "[datetime]"
+    }
+  ],
+  "meta": {
+    "next_page": null
+  }
+}

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list.snap
@@ -1,0 +1,45 @@
+---
+source: src/tests/routes/private/crate_owner_invitations.rs
+expression: invitations
+---
+{
+  "invitations": [
+    {
+      "invitee_id": 2,
+      "inviter_id": 1,
+      "crate_id": 1,
+      "crate_name": "crate_1",
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    },
+    {
+      "invitee_id": 2,
+      "inviter_id": 1,
+      "crate_id": 2,
+      "crate_name": "crate_2",
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "login": "foo",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
+    },
+    {
+      "id": 2,
+      "login": "user_1",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/user_1",
+      "created_at": "[datetime]"
+    }
+  ],
+  "meta": {
+    "next_page": null
+  }
+}

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_does_not_include_expired_invites.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_does_not_include_expired_invites.snap
@@ -1,0 +1,37 @@
+---
+source: src/tests/routes/private/crate_owner_invitations.rs
+expression: invitations
+---
+{
+  "invitations": [
+    {
+      "invitee_id": 2,
+      "inviter_id": 1,
+      "crate_id": 2,
+      "crate_name": "crate_2",
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "login": "foo",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
+    },
+    {
+      "id": 2,
+      "login": "invited_user",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/invited_user",
+      "created_at": "[datetime]"
+    }
+  ],
+  "meta": {
+    "next_page": null
+  }
+}

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_paginated-2.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_paginated-2.snap
@@ -1,0 +1,37 @@
+---
+source: src/tests/routes/private/crate_owner_invitations.rs
+expression: invitations
+---
+{
+  "invitations": [
+    {
+      "invitee_id": 2,
+      "inviter_id": 1,
+      "crate_id": 2,
+      "crate_name": "crate_2",
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "login": "foo",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
+    },
+    {
+      "id": 2,
+      "login": "invited_user",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/invited_user",
+      "created_at": "[datetime]"
+    }
+  ],
+  "meta": {
+    "next_page": null
+  }
+}

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_paginated.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_paginated.snap
@@ -1,0 +1,37 @@
+---
+source: src/tests/routes/private/crate_owner_invitations.rs
+expression: invitations
+---
+{
+  "invitations": [
+    {
+      "invitee_id": 2,
+      "inviter_id": 1,
+      "crate_id": 1,
+      "crate_name": "crate_1",
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "login": "foo",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
+    },
+    {
+      "id": 2,
+      "login": "invited_user",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/invited_user",
+      "created_at": "[datetime]"
+    }
+  ],
+  "meta": {
+    "next_page": "?per_page=1&invitee_id=2&seek=WzEsMl0"
+  }
+}

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -107,6 +107,14 @@ expression: response.json()
               "null"
             ]
           },
+          "created_at": {
+            "description": "The date and time the user was created.\n\nFor users created before June 19, 2026, the creation time will be the\ntime the user's GitHub account was created. If the GitHub account was\ndeleted before June 19, 2026, this field will be empty.",
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "email": {
             "description": "The user's email address, if set.",
             "example": "kate@morgan.dev",
@@ -950,6 +958,14 @@ expression: response.json()
           "avatar": {
             "description": "The user's avatar URL, if set.",
             "example": "https://avatars2.githubusercontent.com/u/1234567?v=4",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "description": "The date and time the user was created.\n\nFor users created before June 19, 2026, the creation time will be the\ntime the user's GitHub account was created. If the GitHub account was\ndeleted before June 19, 2026, this field will be empty.",
+            "format": "date-time",
             "type": [
               "string",
               "null"

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -107,6 +107,14 @@ expression: response.json()
               "null"
             ]
           },
+          "created_at": {
+            "description": "The date and time the user was created.\n\nFor users created before June 19, 2026, the creation time will be the\ntime the user's GitHub account was created. If the GitHub account was\ndeleted before June 19, 2026, this field will be empty.",
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "email": {
             "description": "The user's email address, if set.",
             "example": "kate@morgan.dev",
@@ -950,6 +958,14 @@ expression: response.json()
           "avatar": {
             "description": "The user's avatar URL, if set.",
             "example": "https://avatars2.githubusercontent.com/u/1234567?v=4",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "description": "The date and time the user was created.\n\nFor users created before June 19, 2026, the creation time will be the\ntime the user's GitHub account was created. If the GitHub account was\ndeleted before June 19, 2026, this field will be empty.",
+            "format": "date-time",
             "type": [
               "string",
               "null"

--- a/src/tests/snapshots/integration__owners__invitations_list_does_not_include_expired_invites_v1.snap
+++ b/src/tests/snapshots/integration__owners__invitations_list_does_not_include_expired_invites_v1.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/owners.rs
+expression: invitations
+---
+{
+  "crate_owner_invitations": [
+    {
+      "invitee_id": 2,
+      "inviter_id": 1,
+      "invited_by_username": "foo",
+      "crate_name": "invited_crate_2",
+      "crate_id": 2,
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "login": "foo",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
+    },
+    {
+      "id": 2,
+      "login": "invited_user",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/invited_user",
+      "created_at": "[datetime]"
+    }
+  ]
+}

--- a/src/tests/snapshots/integration__owners__invitations_list_v1-2.snap
+++ b/src/tests/snapshots/integration__owners__invitations_list_v1-2.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/owners.rs
+expression: invitations
+---
+{
+  "crate_owner_invitations": [
+    {
+      "invitee_id": 2,
+      "inviter_id": 1,
+      "invited_by_username": "foo",
+      "crate_name": "invited_crate",
+      "crate_id": 1,
+      "created_at": "[datetime]",
+      "expires_at": "[datetime]"
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "login": "foo",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/foo",
+      "created_at": "[datetime]"
+    },
+    {
+      "id": 2,
+      "login": "invited_user",
+      "name": null,
+      "avatar": null,
+      "url": "https://github.com/invited_user",
+      "created_at": "[datetime]"
+    }
+  ]
+}


### PR DESCRIPTION
Now that we have `users.created_at` and have backfilled it, the final step is to expose it in the public API.

The only actual changes are in `crates/crates_io_api_types/src/lib.rs`; everything else is updating tests, mostly snapshots. I've converted some integration tests that predate our use of `insta` to use `insta` along the way, since that allows us to use insta's redaction functionality like other parts of the codebase.

Finishes, and therefore closes #13867.