### PR TITLE
CodeViewer: Speed up scrolling on large files

### DIFF
--- a/svelte/src/lib/components/CodeViewer.stories.svelte
+++ b/svelte/src/lib/components/CodeViewer.stories.svelte
@@ -20,16 +20,19 @@
       path: 'Cargo.toml',
       text: '[package]\nname = "example"\nversion = "0.1.0"\nedition = "2021"\n\n[dependencies]\nserde = "1"\nserde_json = "1"\n',
       meta: '88 B',
+      cacheKey: 'cargo-toml',
     },
     {
       path: 'src/main.rs',
       text: 'fn main() {\n    println!("Hello, world!");\n}\n',
       meta: '42 B',
+      cacheKey: 'main-rs',
     },
     {
       path: 'README.md',
       text: '# Example\n\nA sample crate used in the CodeViewer story.\n',
       meta: '52 B',
+      cacheKey: 'readme-md',
     },
   ];
 </script>

--- a/svelte/src/lib/components/CodeViewer.svelte
+++ b/svelte/src/lib/components/CodeViewer.svelte
@@ -10,7 +10,7 @@
   import { languageForPath } from '$lib/utils/syntax-language';
 
   interface Props {
-    content: { path: string; text: string; meta: string | null } | null;
+    content: { path: string; text: string; meta: string } | null;
     colorScheme: 'light' | 'dark';
   }
 

--- a/svelte/src/lib/components/CodeViewer.svelte
+++ b/svelte/src/lib/components/CodeViewer.svelte
@@ -10,7 +10,7 @@
   import { languageForPath } from '$lib/utils/syntax-language';
 
   interface Props {
-    content: { path: string; text: string; meta: string } | null;
+    content: { path: string; text: string; meta: string; cacheKey: string } | null;
     colorScheme: 'light' | 'dark';
   }
 
@@ -59,7 +59,12 @@
   $effect(() => {
     let items = [];
     if (content) {
-      let file = { name: content.path, contents: content.text, lang: languageForPath(content.path) };
+      let file = {
+        name: content.path,
+        contents: content.text,
+        lang: languageForPath(content.path),
+        cacheKey: content.cacheKey,
+      };
       items.push({ id: content.path, type: 'file' as const, file });
     }
     view?.setItems(items);

--- a/svelte/src/lib/components/CodeViewer.svelte
+++ b/svelte/src/lib/components/CodeViewer.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import type { CodeViewOptions } from '@pierre/diffs';
+  import type { WorkerPoolManager } from '@pierre/diffs/worker';
 
   import { onMount } from 'svelte';
   import { CodeView } from '@pierre/diffs';
+  import { getOrCreateWorkerPoolSingleton } from '@pierre/diffs/worker';
+  import WorkerUrl from '@pierre/diffs/worker/worker.js?worker&url';
 
   import { languageForPath } from '$lib/utils/syntax-language';
 
@@ -32,8 +35,21 @@
     };
   }
 
+  function getHighlighterPool(): WorkerPoolManager {
+    return getOrCreateWorkerPoolSingleton({
+      poolOptions: {
+        workerFactory: () => new Worker(WorkerUrl, { type: 'module' }),
+        poolSize: 1,
+      },
+      highlighterOptions: {
+        theme: THEMES,
+        langs: ['rust', 'toml'],
+      },
+    });
+  }
+
   onMount(() => {
-    view = new CodeView(options());
+    view = new CodeView(options(), getHighlighterPool());
     view.setup(container!);
     return () => view?.cleanUp();
   });

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
@@ -38,6 +38,7 @@
       path: fileState.file.path,
       text: fileState.text,
       meta: prettyBytes(fileState.file.uncompressed_size, { binary: true }),
+      cacheKey: fileState.file.sha256,
     };
   });
 

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { ManifestFile } from '$lib/utils/zip-archive';
+
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import prettyBytes from 'pretty-bytes';
@@ -11,7 +13,7 @@
 
   type FileState =
     | { kind: 'loading' }
-    | { kind: 'content'; path: string; text: string }
+    | { kind: 'content'; file: ManifestFile; text: string }
     | { kind: 'binary' }
     | { kind: 'unavailable' }
     | { kind: 'error'; message: string };
@@ -32,11 +34,10 @@
 
   let content = $derived.by(() => {
     if (fileState.kind !== 'content') return null;
-    let entry = filesByPath.get(fileState.path);
     return {
-      path: fileState.path,
+      path: fileState.file.path,
       text: fileState.text,
-      meta: entry ? prettyBytes(entry.uncompressed_size, { binary: true }) : null,
+      meta: prettyBytes(fileState.file.uncompressed_size, { binary: true }),
     };
   });
 
@@ -66,7 +67,7 @@
       } else if (result.kind === 'binary') {
         fileState = { kind: 'binary' };
       } else {
-        fileState = { kind: 'content', path, text: result.text };
+        fileState = { kind: 'content', file, text: result.text };
       }
     } catch (error) {
       if (selectedPath !== path) return;


### PR DESCRIPTION
The code viewer scrolled very slowly on large files. On `typos-dict`'s 9.42 MiB `word_codegen.rs` (253k lines), scrolling ran at around 3fps with the main thread blocked for nearly the whole scroll.

`@pierre/diffs` only takes its windowed render path, where just the visible lines are built into the DOM, when a worker pool is passed to `CodeView`. Without one it reprocesses the entire file on every scroll frame, even for files that exceed the highlight size limit and render as plain text. Passing a worker pool switches `CodeView` to the windowed path and moves any tokenization off the main thread. The file's `sha256`, threaded through as a `cacheKey`, then stops `FileRenderer` from re-splitting the whole file into lines on every frame.

### Performance

Measured on `/crates/typos-dict/0.13.30/code/src/word_codegen.rs` with a 6 second programmatic scroll, using Playwright to record `longtask` entries and frame timing.

| | scroll FPS | main thread blocked (of 6s scroll) | load to first paint |
| --- | --- | --- | --- |
| before | ~3 | ~6.0s | ~2.4s |
| after | 120 | 0s | ~1.0s |

### Related

- https://github.com/rust-lang/crates.io/pull/14033
- https://github.com/rust-lang/crates.io/pull/14030
- https://github.com/rust-lang/crates.io/pull/14020
