### PR TITLE
CodeViewer: Use highlighter inference with custom extension overrides

### DIFF
--- a/svelte/src/lib/components/CodeViewer.svelte
+++ b/svelte/src/lib/components/CodeViewer.svelte
@@ -7,7 +7,7 @@
   import { getOrCreateWorkerPoolSingleton } from '@pierre/diffs/worker';
   import WorkerUrl from '@pierre/diffs/worker/worker.js?worker&url';
 
-  import { languageForPath } from '$lib/utils/syntax-language';
+  import { registerCustomExtensions } from '$lib/utils/syntax-language';
 
   interface Props {
     content: { path: string; text: string; meta: string; cacheKey: string } | null;
@@ -49,6 +49,7 @@
   }
 
   onMount(() => {
+    registerCustomExtensions();
     view = new CodeView(options(), getHighlighterPool());
     view.setup(container!);
     return () => view?.cleanUp();
@@ -62,7 +63,6 @@
       let file = {
         name: content.path,
         contents: content.text,
-        lang: languageForPath(content.path),
         cacheKey: content.cacheKey,
       };
       items.push({ id: content.path, type: 'file' as const, file });

--- a/svelte/src/lib/utils/syntax-language.test.ts
+++ b/svelte/src/lib/utils/syntax-language.test.ts
@@ -1,34 +1,25 @@
+import { getFiletypeFromFileName } from '@pierre/diffs';
 import { describe, expect, it } from 'vitest';
 
-import { languageForPath } from './syntax-language';
+import { registerCustomExtensions } from './syntax-language';
 
-describe('languageForPath', () => {
-  it('maps a file extension to its Shiki language id', () => {
-    expect(languageForPath('src/lib.rs')).toBe('rust');
-    expect(languageForPath('Cargo.toml')).toBe('toml');
-    expect(languageForPath('README.md')).toBe('markdown');
-    expect(languageForPath('build.js')).toBe('javascript');
+describe('registerCustomExtensions', () => {
+  registerCustomExtensions();
+
+  it('highlights `Cargo.lock` as TOML', () => {
+    expect(getFiletypeFromFileName('Cargo.lock')).toBe('toml');
   });
 
-  it('resolves the language from the file name, ignoring directories', () => {
-    expect(languageForPath('src/core/de.rs')).toBe('rust');
+  it('highlights `*.toml.orig` as TOML, ignoring directories', () => {
+    expect(getFiletypeFromFileName('Cargo.toml.orig')).toBe('toml');
+    expect(getFiletypeFromFileName('vendor/Cargo.toml.orig')).toBe('toml');
   });
 
-  it('matches extensions case-insensitively', () => {
-    expect(languageForPath('SRC/LIB.RS')).toBe('rust');
+  it('highlights SVG files as XML', () => {
+    expect(getFiletypeFromFileName('icon.svg')).toBe('xml');
   });
 
-  it('maps well-known file names whose extension is not a language', () => {
-    expect(languageForPath('Cargo.lock')).toBe('toml');
-    expect(languageForPath('vendor/Cargo.toml.orig')).toBe('toml');
-  });
-
-  it('falls back to plain text for an unknown extension', () => {
-    expect(languageForPath('assets/icon.bin')).toBe('text');
-  });
-
-  it('falls back to plain text for a file without an extension', () => {
-    expect(languageForPath('LICENSE')).toBe('text');
-    expect(languageForPath('Makefile')).toBe('text');
+  it('leaves other files to the highlighter to infer', () => {
+    expect(getFiletypeFromFileName('src/lib.rs')).toBe('rust');
   });
 });

--- a/svelte/src/lib/utils/syntax-language.ts
+++ b/svelte/src/lib/utils/syntax-language.ts
@@ -1,53 +1,17 @@
+import { setCustomExtension } from '@pierre/diffs';
+
 /**
- * Resolves the Shiki language id used to highlight a source file, based on its
- * extension or a few well-known filenames.
+ * File names and extensions whose syntax highlighting language the `@pierre/diffs`
+ * highlighter cannot infer on its own, mapped to their Shiki language id:
  */
-
-/** The default plain-text language used when no mapping matches. */
-const PLAIN_TEXT_LANGUAGE = 'text';
-
-/** Maps file extensions to Shiki language ids. */
-const LANGUAGE_BY_EXTENSION: Record<string, string> = {
-  bash: 'shellscript',
-  c: 'c',
-  cc: 'cpp',
-  cjs: 'javascript',
-  cpp: 'cpp',
-  css: 'css',
-  cxx: 'cpp',
-  h: 'c',
-  hpp: 'cpp',
-  html: 'html',
-  ini: 'ini',
-  js: 'javascript',
-  json: 'json',
-  markdown: 'markdown',
-  md: 'markdown',
-  mjs: 'javascript',
-  py: 'python',
-  rs: 'rust',
-  sh: 'shellscript',
-  svg: 'xml',
-  toml: 'toml',
-  ts: 'typescript',
-  xml: 'xml',
-  yaml: 'yaml',
-  yml: 'yaml',
-};
-
-/** Maps well-known filenames to Shiki language ids. */
-const LANGUAGE_BY_FILENAME: Record<string, string> = {
+const CUSTOM_EXTENSIONS: Record<string, string> = {
   'Cargo.lock': 'toml',
-  'Cargo.toml.orig': 'toml',
+  'toml.orig': 'toml',
+  svg: 'xml',
 };
 
-/** Resolves the Shiki language id for a file path, defaulting to plain text. */
-export function languageForPath(path: string): string {
-  let filename = path.slice(path.lastIndexOf('/') + 1);
-  if (filename in LANGUAGE_BY_FILENAME) {
-    return LANGUAGE_BY_FILENAME[filename];
+export function registerCustomExtensions() {
+  for (let [name, lang] of Object.entries(CUSTOM_EXTENSIONS)) {
+    setCustomExtension(name, lang);
   }
-
-  let extension = filename.slice(filename.lastIndexOf('.') + 1).toLowerCase();
-  return LANGUAGE_BY_EXTENSION[extension] ?? PLAIN_TEXT_LANGUAGE;
 }


### PR DESCRIPTION
The `CodeViewer` set `FileContents.lang` from a hand-rolled extension map, which `@pierre/diffs` documents against since it already infers the language from the file name.

This drops that map and registers only the overrides the highlighter gets wrong for crate files via `setCustomExtension()`: `Cargo.lock` and `*.toml.orig` are TOML, and `.svg` is highlighted as XML. Everything else, including `.h` and `.sh`, falls back to the highlighter's own inference, so file types beyond the previous curated list now get highlighted too.