### PR TITLE
Delegate README grammar loading to a shiki shorthand

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,9 +146,6 @@ importers:
       '@pierre/trees':
         specifier: 1.0.0-beta.4
         version: 1.0.0-beta.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@shikijs/langs':
-        specifier: 4.2.0
-        version: 4.2.0
       '@shikijs/themes':
         specifier: 4.2.0
         version: 4.2.0

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -27,7 +27,6 @@
     "@fontsource/fira-sans": "5.2.7",
     "@pierre/diffs": "1.2.11",
     "@pierre/trees": "1.0.0-beta.4",
-    "@shikijs/langs": "4.2.0",
     "@shikijs/themes": "4.2.0",
     "chart.js": "4.5.1",
     "date-fns": "4.4.0",

--- a/svelte/src/lib/attachments/highlight.svelte.test.ts
+++ b/svelte/src/lib/attachments/highlight.svelte.test.ts
@@ -12,15 +12,15 @@ function codeBlock(language: string | undefined, source: string): HTMLElement {
 }
 
 describe('highlightSyntax', () => {
-  it('highlights Rust synchronously', () => {
+  it('highlights Rust', async () => {
     let source = 'fn main() {\n    println!("hello");\n}';
     let code = codeBlock('rust', source);
 
     highlightSyntax()(code);
 
-    // Rust is bundled eagerly, so it is highlighted without awaiting anything.
     // shiki's `<pre><code>` wrapper is stripped and the tokens carry inline
     // `light-dark()` colors.
+    await expect.poll(() => code.innerHTML).toContain('light-dark(');
     expect(code.innerHTML).toMatchInlineSnapshot(`
       "<span class="line"><span style="color:light-dark(#D73A49, #F97583)">fn</span><span style="color:light-dark(#6F42C1, #B392F0)"> main</span><span style="color:light-dark(#24292E, #E1E4E8)">() {</span></span>
       <span class="line"><span style="color:light-dark(#6F42C1, #B392F0)">    println!</span><span style="color:light-dark(#24292E, #E1E4E8)">(</span><span style="color:light-dark(#032F62, #9ECBFF)">"hello"</span><span style="color:light-dark(#24292E, #E1E4E8)">);</span></span>
@@ -39,12 +39,22 @@ describe('highlightSyntax', () => {
     await expect.poll(() => code.innerHTML).toContain('light-dark(');
   });
 
-  it('resolves language aliases (protobuf)', async () => {
+  it('resolves shiki built-in aliases (protobuf)', async () => {
     let code = codeBlock('protobuf', 'message Foo { int32 id = 1; }');
 
     highlightSyntax()(code);
 
     await expect.poll(() => code.innerHTML).toContain('light-dark(');
+  });
+
+  it('resolves Prism aliases (clike, markup)', async () => {
+    let clike = codeBlock('clike', 'int main() { return 0; }');
+    highlightSyntax()(clike);
+    await expect.poll(() => clike.innerHTML).toContain('light-dark(');
+
+    let markup = codeBlock('markup', '<a href="example">link</a>');
+    highlightSyntax()(markup);
+    await expect.poll(() => markup.innerHTML).toContain('light-dark(');
   });
 
   it('leaves code blocks without a known language untouched', async () => {

--- a/svelte/src/lib/attachments/highlight.ts
+++ b/svelte/src/lib/attachments/highlight.ts
@@ -1,90 +1,53 @@
-import type { LanguageInput } from 'shiki/core';
-
-import rust from '@shikijs/langs/rust';
-import githubDark from '@shikijs/themes/github-dark';
-import githubLight from '@shikijs/themes/github-light';
-import { createHighlighterCoreSync } from 'shiki/core';
+import { createBundledHighlighter, createSingletonShorthands } from 'shiki/core';
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+import { bundledLanguages } from 'shiki/langs';
 
 /** Theme keys passed to shiki, rendered as inline `light-dark()` colors. */
 const THEMES = { light: 'github-light', dark: 'github-dark' } as const;
 
-interface Grammar {
-  /** Language id passed to shiki, matching the loaded grammar's canonical name. */
-  lang: string;
-  /** Returns the grammar. Lazy entries import it into a separate bundle chunk. */
-  load: () => LanguageInput;
-}
-
-/** A code block paired with the grammar it should be highlighted with. */
-interface Block {
-  el: Element;
-  grammar: Grammar;
-}
-
 /**
- * Maps the `language-*` class names emitted by the backend Markdown renderer to
- * shiki grammars. Keys cover the allow-list in `crates_io_markdown` plus the
- * `clike`/`markup`/`rs` aliases. `mermaid` is intentionally absent because it
- * is rendered by a separate attachment.
+ * Prism.js `language-*` names emitted by the backend Markdown renderer that
+ * shiki does not recognize, mapped to their shiki language id.
  */
-const GRAMMARS: Record<string, Grammar> = {
-  bash: { lang: 'shellscript', load: () => import('@shikijs/langs/shellscript') },
-  c: { lang: 'c', load: () => import('@shikijs/langs/c') },
-  clike: { lang: 'c', load: () => import('@shikijs/langs/c') },
-  cpp: { lang: 'cpp', load: () => import('@shikijs/langs/cpp') },
-  csharp: { lang: 'csharp', load: () => import('@shikijs/langs/csharp') },
-  glsl: { lang: 'glsl', load: () => import('@shikijs/langs/glsl') },
-  go: { lang: 'go', load: () => import('@shikijs/langs/go') },
-  ini: { lang: 'ini', load: () => import('@shikijs/langs/ini') },
-  javascript: { lang: 'javascript', load: () => import('@shikijs/langs/javascript') },
-  json: { lang: 'json', load: () => import('@shikijs/langs/json') },
-  markup: { lang: 'xml', load: () => import('@shikijs/langs/xml') },
-  protobuf: { lang: 'proto', load: () => import('@shikijs/langs/proto') },
-  ruby: { lang: 'ruby', load: () => import('@shikijs/langs/ruby') },
-  rs: { lang: 'rust', load: () => rust },
-  rust: { lang: 'rust', load: () => rust },
-  scss: { lang: 'scss', load: () => import('@shikijs/langs/scss') },
-  sql: { lang: 'sql', load: () => import('@shikijs/langs/sql') },
-  toml: { lang: 'toml', load: () => import('@shikijs/langs/toml') },
-  xml: { lang: 'xml', load: () => import('@shikijs/langs/xml') },
-  yaml: { lang: 'yaml', load: () => import('@shikijs/langs/yaml') },
+const ALIASES: Record<string, string> = {
+  clike: 'c',
+  markup: 'xml',
 };
 
-/**
- * Long-lived highlighter, created synchronously so eagerly bundled grammars can
- * be applied before the first paint. Rust and the two themes are loaded upfront
- * since crate sources are predominantly Rust, while every other grammar is
- * loaded on demand.
- */
-const highlighter = createHighlighterCoreSync({
-  themes: [githubLight, githubDark],
-  langs: [rust],
-  engine: createJavaScriptRegexEngine(),
-});
+const { codeToHtml } = createSingletonShorthands(
+  createBundledHighlighter({
+    langs: bundledLanguages,
+    themes: {
+      'github-light': () => import('@shikijs/themes/github-light'),
+      'github-dark': () => import('@shikijs/themes/github-dark'),
+    },
+    engine: () => createJavaScriptRegexEngine(),
+  }),
+);
 
-/** Returns the grammar for the first recognized `language-*` class, if any. */
-function grammarFor(element: Element): Grammar | undefined {
+/** Returns the shiki language id for the first highlightable `language-*` class. */
+function langFor(element: Element): string | undefined {
   for (let cls of element.classList) {
     let match = /^language-(.+)$/.exec(cls);
     if (!match) continue;
 
-    let grammar = GRAMMARS[match[1]];
-    if (grammar) {
-      return grammar;
+    let lang = ALIASES[match[1]] ?? match[1];
+    if (Object.hasOwn(bundledLanguages, lang)) {
+      return lang;
     }
   }
   return undefined;
 }
 
 /** Replaces a code block's content with shiki's tokenized spans. */
-function applyHighlight({ el, grammar }: Block) {
-  let html = highlighter.codeToHtml(el.textContent ?? '', {
-    lang: grammar.lang,
+async function applyHighlight(el: Element, lang: string, isCancelled: () => boolean) {
+  let html = await codeToHtml(el.textContent ?? '', {
+    lang,
     themes: THEMES,
     defaultColor: 'light-dark()',
     colorsRendering: 'none',
   });
+  if (isCancelled()) return;
 
   // shiki wraps the output in its own `<pre><code>`, so we inject only the
   // inner tokens to preserve the existing `<pre><code>` styling.
@@ -96,47 +59,16 @@ function applyHighlight({ el, grammar }: Block) {
   }
 }
 
-/**
- * Highlights the given code blocks. Blocks whose language is already loaded are
- * highlighted synchronously, so eagerly bundled grammars (Rust) render without a
- * flash of unstyled code. Any remaining languages are loaded and applied later.
- */
-function highlight(elements: Element[], isCancelled: () => boolean) {
-  let blocks: Block[] = [];
+/** Highlights the given code blocks, loading each grammar on demand. */
+async function highlight(elements: Element[], isCancelled: () => boolean) {
+  let pending = [];
   for (let el of elements) {
-    let grammar = grammarFor(el);
-    if (grammar) {
-      blocks.push({ el, grammar });
+    let lang = langFor(el);
+    if (lang) {
+      pending.push(applyHighlight(el, lang, isCancelled));
     }
   }
-
-  let loaded = new Set(highlighter.getLoadedLanguages());
-  let pending: Block[] = [];
-  for (let block of blocks) {
-    if (loaded.has(block.grammar.lang)) {
-      applyHighlight(block);
-    } else {
-      pending.push(block);
-    }
-  }
-
-  if (pending.length !== 0) {
-    // The attachment must return its cleanup synchronously, so we don't await
-    // the lazy grammar loads. `void` marks the promise as intentionally
-    // unhandled. Stale runs are discarded via the `cancelled` flag.
-    void loadPending(pending, isCancelled);
-  }
-}
-
-/** Loads the grammars needed by `blocks`, then highlights them. */
-async function loadPending(blocks: Block[], isCancelled: () => boolean) {
-  let grammars = [...new Set(blocks.map(block => block.grammar))];
-  await Promise.allSettled(grammars.map(grammar => highlighter.loadLanguage(grammar.load())));
-  if (isCancelled()) return;
-
-  for (let block of blocks) {
-    applyHighlight(block);
-  }
+  await Promise.allSettled(pending);
 }
 
 /**
@@ -152,7 +84,7 @@ export function highlightSyntax(html?: string, selector?: string) {
 
     let cancelled = false;
     let elements = selector ? [...element.querySelectorAll(selector)] : [element];
-    highlight(elements, () => cancelled);
+    void highlight(elements, () => cancelled);
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
The README highlighter maintained its own async grammar loading: a curated `language-*` map, an eagerly created highlighter, and a hand-written load-then-highlight pipeline that needed a new entry and import for every language.

A `createSingletonShorthands()` shorthand handles loading itself, so this drops the bespoke pipeline. It builds on `createBundledHighlighter()`, the JavaScript regex engine, and the full `bundledLanguages` registry from `shiki/langs`, with that registry doubling as the allow-list. Any language the backend permits now highlights without a frontend change. Only the Prism.js `clike` and `markup` names still need an explicit alias.

Highlighting is now fully asynchronous, so Rust blocks no longer paint synchronously on first render.