### PR TITLE
CodeViewer: Disable word wrapping

### DIFF
--- a/svelte/src/lib/components/CodeViewer.svelte
+++ b/svelte/src/lib/components/CodeViewer.svelte
@@ -25,7 +25,7 @@
     return {
       theme: THEMES,
       themeType: colorScheme,
-      overflow: 'wrap',
+      overflow: 'scroll',
       layout: {
         paddingTop: 0,
         paddingBottom: 0,


### PR DESCRIPTION
`@pierre/diffs` wrap mode issues `scrollTo()` corrections on every scroll event to keep wrapped-line layout stable. Chromium mishandles a programmatic scroll during a native scrollbar-thumb drag, so the scrollbar thumb lags behind the cursor. Firefox is unaffected. The same bug reproduces on diffshub.com, so it stems from the library rather than our integration.

Scroll overflow keeps line heights uniform, fires no corrections, and drags smoothly.
