### PR TITLE
middleware/common_headers: Cache only successful responses

### DIFF
--- a/src/middleware/common_headers.rs
+++ b/src/middleware/common_headers.rs
@@ -14,8 +14,6 @@ const ONE_YEAR: Duration = Duration::from_secs(365 * 24 * 60 * 60);
 pub async fn add_common_headers(request: Request, next: Next) -> impl IntoResponse {
     let v = HeaderValue::from_static;
 
-    let mut headers = HeaderMap::new();
-
     let path = request.uri().path();
 
     const STATIC_FILES: [&str; 6] = [
@@ -26,18 +24,25 @@ pub async fn add_common_headers(request: Request, next: Next) -> impl IntoRespon
         "/opensearch.xml",
         "/.well-known/security.txt",
     ];
-    if STATIC_FILES.contains(&path) {
-        expires(&mut headers, ONE_DAY);
-    }
-
-    if path.starts_with("/_app/immutable/") {
-        expires(&mut headers, 10 * ONE_YEAR);
-    }
+    let cache_duration = if STATIC_FILES.contains(&path) {
+        Some(ONE_DAY)
+    } else if path.starts_with("/_app/immutable/") {
+        Some(10 * ONE_YEAR)
+    } else {
+        None
+    };
 
     let response = next.run(request).await;
 
+    let mut headers = HeaderMap::new();
     headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, v("*"));
     headers.insert(header::STRICT_TRANSPORT_SECURITY, v("max-age=31536000"));
+
+    if let Some(cache_duration) = cache_duration
+        && response.status().is_success()
+    {
+        expires(&mut headers, cache_duration);
+    }
 
     if NGINX_SUCCESS_CODES.contains(&response.status().as_u16()) {
         headers.insert(header::X_CONTENT_TYPE_OPTIONS, v("nosniff"));

--- a/src/tests/caching.rs
+++ b/src/tests/caching.rs
@@ -180,3 +180,11 @@ async fn public_endpoint_is_cacheable_for_authenticated_users() {
     let response = user.get::<()>("/api/v1/categories").await;
     response.assert_no_cache_control();
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_immutable_asset_is_not_cached() {
+    let (_, anon) = TestApp::init().empty().await;
+    let response = anon.get::<()>("/_app/immutable/missing.js").await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    response.assert_no_cache_control();
+}


### PR DESCRIPTION
The `Cache-Control` and `Expires` headers for static files and `/_app/immutable/` assets were applied before the response ran, so they attached to every response regardless of status. A 404 for a missing hashed asset path was therefore cached for ten years, which prevented that path from ever resolving once the asset existed.

This computes the cache duration from the request path but only sets the headers when the response status is 2xx.

### Related

- Resolves https://github.com/rust-lang/crates.io/issues/14043
- Resolves https://github.com/rust-lang/crates.io/issues/14036