### PR TITLE
Fix inaccurate doc comments

### DIFF
--- a/crates/crates_io_database_dump/src/gen_scripts.rs
+++ b/crates/crates_io_database_dump/src/gen_scripts.rs
@@ -11,7 +11,7 @@ pub fn gen_scripts(export_script: &Path, import_script: &Path) -> anyhow::Result
     config.gen_psql_scripts(export_sql, import_sql)
 }
 
-/// Subset of the configuration data to be passed on to the Handlbars template.
+/// Subset of the configuration data to be passed on to the template.
 #[derive(Debug, Serialize)]
 struct HandlebarsTableContext<'a> {
     name: &'a str,
@@ -57,7 +57,7 @@ impl TableConfig {
     }
 }
 
-/// Subset of the configuration data to be passed on to the Handlbars template.
+/// Subset of the configuration data to be passed on to the template.
 #[derive(Debug, Serialize)]
 struct TemplateContext<'a> {
     tables: Vec<HandlebarsTableContext<'a>>,

--- a/crates/crates_io_linecount/src/lib.rs
+++ b/crates/crates_io_linecount/src/lib.rs
@@ -48,8 +48,8 @@ impl LinecountStats {
 
     /// Add a single file to the statistics
     ///
-    /// The caller can use `should_count_path()` to check if a file should be processed
-    /// before decompressing to avoid unnecessary work.
+    /// The caller can use `PathDetails::should_ignore()` to skip files that should
+    /// not be processed before decompressing to avoid unnecessary work.
     pub fn add_file(&mut self, language_type: LanguageType, content: &[u8]) {
         let file_stats = language_type.parse_from_slice(content, &TOKEI_CONFIG);
 

--- a/crates/crates_io_session/src/lib.rs
+++ b/crates/crates_io_session/src/lib.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 pub static COOKIE_NAME: &str = "cargo_session";
 static MAX_AGE_DAYS: i64 = 90;
 
+/// Request extension holding the session data
 #[derive(Clone, FromRequestParts)]
 #[from_request(via(Extension))]
 pub struct SessionExtension(Arc<RwLock<Session>>);
@@ -71,7 +72,6 @@ pub async fn attach_session(jar: SignedCookieJar, mut req: Request, next: Next) 
     }
 }
 
-/// Request extension holding the session data
 pub struct Session {
     data: HashMap<String, String>,
     dirty: bool,

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -279,8 +279,8 @@ fn run_migrations(conn: &mut PgConnection) -> diesel::migration::Result<()> {
 ///   `batch_execute` can't run.
 /// - Lines starting with `\` (psql meta-commands like `\restrict`/
 ///   `\unrestrict`, emitted by `pg_dump` 17+) are stripped.
-/// - SETs for configuration that `pg_dump` 17+ emit that PostgreSQL 16 can't
-///   handle.
+/// - SETs for configuration that `pg_dump` 17+ emit but PostgreSQL 16 can't
+///   handle are stripped.
 /// - A trailing `RESET ALL` clears any session state the preamble's
 ///   `SET` / `set_config('search_path', …)` calls left behind so it
 ///   doesn't leak to the next checkout of the pooled connection.

--- a/crates/crates_io_test_utils/src/builders/dependency.rs
+++ b/crates/crates_io_test_utils/src/builders/dependency.rs
@@ -34,10 +34,6 @@ impl DependencyBuilder {
     }
 
     /// Set the version requirement for this dependency.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the `version_req` string specified isn't a valid `semver::VersionReq`.
     #[track_caller]
     pub fn version_req(mut self, version_req: &str) -> Self {
         self.version_req = version_req.to_string();

--- a/crates/crates_io_trustpub/src/gitlab/claims.rs
+++ b/crates/crates_io_trustpub/src/gitlab/claims.rs
@@ -44,8 +44,8 @@ impl GitLabClaims {
         Ok(claims)
     }
 
-    /// Extract the workflow filename from the [`ci_config_ref_uri`](Self::ci_config_ref_uri)
-    /// field or return `None` if the filename cannot be extracted.
+    /// Extract the workflow filepath from the [`ci_config_ref_uri`](Self::ci_config_ref_uri)
+    /// field or return `None` if the filepath cannot be extracted.
     pub fn workflow_filepath(&self) -> Option<&str> {
         extract_workflow_filepath(&self.ci_config_ref_uri)
     }

--- a/crates/crates_io_worker/src/runner.rs
+++ b/crates/crates_io_worker/src/runner.rs
@@ -68,7 +68,7 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context> {
 
     /// Start the background workers.
     ///
-    /// This returns a `RunningRunner` which can be used to wait for the workers to shutdown.
+    /// This returns a `RunHandle` which can be used to wait for the workers to shutdown.
     pub fn start(&self) -> RunHandle {
         // Workers wait on this to be woken up when a new job is enqueued.
         let notify = Arc::new(Notify::new());

--- a/crates/crates_io_worker/src/util.rs
+++ b/crates/crates_io_worker/src/util.rs
@@ -31,7 +31,7 @@ where
     result
 }
 
-/// Try to figure out what's in the box, and print it if we can.
+/// Tries to figure out what's in the box, and wraps it in an error if we can.
 ///
 /// The actual error type we will get from `panic::catch_unwind` is really poorly documented.
 /// However, the `panic::set_hook` functions deal with a `PanicHookInfo` type, and its payload is

--- a/src/app.rs
+++ b/src/app.rs
@@ -102,7 +102,7 @@ impl<S: app_builder::State> AppBuilder<S> {
     /// This method configures the OIDC key stores for the specified providers
     /// and expects a list of provider names as input.
     ///
-    /// Currently, only "github" is supported as a provider.
+    /// Currently, "github" and "gitlab" are supported as providers.
     pub fn trustpub_providers(
         self,
         providers: &[String],

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -179,8 +179,8 @@ fn build_index_sync_github_app(
 }
 
 /// Builds the GitHub App client used to authenticate requests to
-/// the users API. `GH_SYNC_APP_ORG`,`GH_SYNC_APP_CLIENT_ID`, and `GH_SYNC_APP_PRIVATE_KEY` must
-/// all be present.
+/// the users API. Returns `None` when `GH_SYNC_APP_CLIENT_ID` is unset. When it
+/// is set, `GH_SYNC_APP_ORG` and `GH_SYNC_APP_PRIVATE_KEY` must also be present.
 fn build_sync_github_app() -> anyhow::Result<Option<Arc<dyn GitHubApp>>> {
     let Some(client_id) = var("GH_SYNC_APP_CLIENT_ID")? else {
         return Ok(None);

--- a/src/config/database_pools.rs
+++ b/src/config/database_pools.rs
@@ -65,9 +65,9 @@ impl DatabasePools {
 impl DatabasePools {
     /// Load settings for one or more database pools from the environment
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function panics if `DB_OFFLINE=leader` but `READ_ONLY_REPLICA_URL` is unset.
+    /// This function returns an error if `DB_OFFLINE=leader` but `READ_ONLY_REPLICA_URL` is unset.
     pub fn full_from_environment(base: &Base) -> anyhow::Result<Self> {
         let leader_url = required_var("DATABASE_URL")?.into();
         let follower_url = var("READ_ONLY_REPLICA_URL")?.map(Into::into);

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -91,8 +91,6 @@ impl Server {
     /// - `GITHUB_TOKEN_ENCRYPTION_KEY`: Key for encrypting GitHub access tokens (64 hex characters).
     /// - `WEB_MAX_ALLOWED_PAGE_OFFSET`: Page offsets larger than this value are rejected. Defaults
     ///   to 200.
-    /// - `FORCE_UNCONDITIONAL_REDIRECTS`: Whether to force unconditional redirects in the download
-    ///   endpoint even with a healthy database pool.
     /// - `DISABLE_TOKEN_CREATION`: If set to any non-empty value, disables API token creation
     ///   and uses the value as the error message returned to users.
     /// - `GIT_ARCHIVE_REPO_URL`: HTTPS URL (e.g. `https://github.com/<org>/<repo>.git`) of a git

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -82,8 +82,8 @@ impl Server {
     ///
     /// Sets the following default values:
     ///
-    /// - `Config::max_upload_size`: 10MiB
-    /// - `Config::ownership_invitations_expiration_days`: 30
+    /// - `PublishLimitsConfig::upload_size`: 10MiB
+    /// - `Server::ownership_invitations_expiration`: 30 days
     ///
     /// Pulls values from the following environment variables:
     ///

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -499,7 +499,7 @@ async fn is_gh_org_owner(
     Ok(membership.is_some_and(|m| m.is_active_admin()))
 }
 
-/// Error results from a [`add_owner()`] model call.
+/// Error results from an [`add_owner()`] call.
 #[derive(Debug, Error)]
 enum OwnerAddError {
     #[error(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 //! This crate implements the backend server for <https://crates.io/>
 //!
-//! All implemented routes are defined in the [middleware](fn.middleware.html) function and
-//! implemented in the [category](category/index.html), [keyword](keyword/index.html),
-//! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
+//! All implemented routes are defined in the [`router`] module and implemented
+//! in the [`controllers`] module.
 
 pub use crate::{app::App, email::Emails};
 pub use crates_io_api_types as views;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,9 @@ pub mod worker;
 /// Used for setting different values depending on whether the app is being run in production,
 /// in development, or for testing.
 ///
-/// The app's `config.env` value is set in *src/bin/server.rs* to `Production` if the environment
-/// variable `HEROKU` is set and `Development` otherwise. `config.env` is set to `Test`
-/// unconditionally in *src/test/all.rs*.
+/// The app's `config.env` value is set by [`Base::from_environment()`](crate::config::Base::from_environment)
+/// to `Production` if the environment variable `HEROKU` is set and `Development` otherwise. It is
+/// set to `Test` unconditionally by the test harness.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum Env {
     Development,

--- a/src/metrics/log_encoder.rs
+++ b/src/metrics/log_encoder.rs
@@ -140,9 +140,9 @@ fn families_to_json_events(families: &[MetricFamily]) -> Vec<VectorEvent<'_>> {
 /// do that, so we need to do the splitting ourselves.
 ///
 /// This function takes an iterator of serializable items and returns the serialized version,
-/// possibly split into multiple chunks. Each chunk is *at least* `max_size_hint` long, as the
-/// function stops serializing new items in the same chunk only when the size limit is reached
-/// after serializing an item.
+/// possibly split into multiple chunks. Every chunk except the last is *at least* `max_size_hint`
+/// long, as the function stops serializing new items in the same chunk only when the size limit is
+/// reached after serializing an item.
 ///
 /// Because of that `max_size_hint` should be lower than the upper bound we can't cross.
 fn serialize_and_split_list<'a, S: Serialize + 'a>(

--- a/src/sentry/mod.rs
+++ b/src/sentry/mod.rs
@@ -11,9 +11,11 @@ use tracing::warn;
 /// otherwise it is required to be a valid DSN string. `SENTRY_ENV_API` must
 /// be set if a DSN is provided.
 ///
-/// `HEROKU_SLUG_COMMIT`, if present, will be used as the `release` property
-/// on all events. This environment variable is provided by Heroku when the
-/// `runtime-dyno-metadata` Labs feature is enabled.
+/// `HEROKU_BUILD_COMMIT`, if present, will be used as the `release` property
+/// on all events, falling back to the deprecated `HEROKU_SLUG_COMMIT`. These
+/// environment variables are provided by Heroku when the
+/// `runtime-dyno-build-metadata` and `runtime-dyno-metadata` Labs features are
+/// enabled, respectively.
 pub fn init() -> Option<ClientInitGuard> {
     let config = match SentryConfig::from_environment() {
         Ok(config) => config,

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -1,4 +1,4 @@
-//! Tests for the `GET /api/private/crate-owners-invitations` endpoint
+//! Tests for the `GET /api/private/crate_owner_invitations` endpoint
 
 use crate::builders::CrateBuilder;
 use crate::util::{MockCookieUser, RequestHelper, TestApp};

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -74,7 +74,7 @@ async fn test_ignore_nulls() {
 /// Check to make sure that neither other signed in users nor anonymous users can edit another
 /// user's email address.
 ///
-/// If an attempt is made, `update_user.rs` will return an error indicating that the current user
+/// If an attempt is made, the endpoint will return an error indicating that the current user
 /// does not match the requested user.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_other_users_cannot_change_my_email() {

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -6,7 +6,7 @@
 //! `MockAnonymousUser`.  The `MockAnonymousUser` can be used to issue requests in an
 //! unauthenticated session.
 //!
-//! A `TestApp` value provides raw access to the database through the `db` function and can
+//! A `TestApp` value provides raw access to the database through the `db_conn` function and can
 //! construct new users via the `db_new_user` function.  This function returns a
 //! `MockCookieUser`, which can be used to generate one or more tokens via its `db_new_token`
 //! function, which in turn returns a `MockTokenUser`.

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -251,7 +251,7 @@ pub trait RequestHelper {
         self.delete_with_body(&url, body).await
     }
 
-    /// Remove a single owner to the specified crate.
+    /// Remove a single owner from the specified crate.
     async fn remove_named_owner(&self, krate_name: &str, owner: &str) -> Response<OwnerResp> {
         self.remove_named_owners(krate_name, &[owner]).await
     }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -1,6 +1,6 @@
 //! This module provides utility types and traits for managing a test session
 //!
-//! Tests start by using one of the `TestApp` constructors: `init`, `with_proxy`, or `full`.  This returns a
+//! Tests start by using one of the `TestApp` constructors: `init` or `full`.  This returns a
 //! `TestAppBuilder` which provides convenience methods for creating up to one user, optionally with
 //! a token.  The builder methods all return at least an initialized `TestApp` and a
 //! `MockAnonymousUser`.  The `MockAnonymousUser` can be used to issue requests in an

--- a/src/typosquat/cache.rs
+++ b/src/typosquat/cache.rs
@@ -23,8 +23,8 @@ impl Cache {
     /// Instantiates a new [`Cache`] from the environment.
     ///
     /// This reads the `NOTIFICATION_EMAILS_ENV` environment variable to get the list of e-mail
-    /// addresses to send notifications to, then invokes [`Cache::new`] to read popular crates from
-    /// the database.
+    /// addresses to send notifications to. If any addresses are configured, it invokes
+    /// [`Cache::new`] to read popular crates from the database. Otherwise, it builds an empty cache.
     #[instrument(skip_all, err)]
     pub async fn from_env(conn: &mut AsyncPgConnection) -> Result<Self, Error> {
         let emails: Vec<String> = crates_io_env_vars::var(NOTIFICATION_EMAILS_ENV)

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -2,12 +2,12 @@
 //!
 //! The suggested usage in returned results is as follows:
 //!
-//! * The concrete `util::concrete::Error` type (re-exported as `util::Error`) is great for code
-//!   that is not part of the request/response lifecycle.  It avoids pulling in the unnecessary
-//!   infrastructure to convert errors into a user facing JSON responses (relative to `AppError`).
+//! * The `anyhow::Error` type is great for code that is not part of the request/response
+//!   lifecycle.  It avoids pulling in the unnecessary infrastructure to convert errors into a user
+//!   facing JSON responses (relative to `AppError`).
 //! * `diesel::QueryResult` - There is a lot of code that only deals with query errors.  If only
 //!   one type of error is possible in a function, using that specific error is preferable to the
-//!   more general `util::Error`.  This is especially common in model code.
+//!   more general `anyhow::Error`.  This is especially common in model code.
 //! * `util::errors::AppResult` - Some failures should be converted into user facing JSON
 //!   responses.  This error type is more dynamic and is box allocated.  Low-level errors are
 //!   typically not converted to user facing errors and most usage is within the models,

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -94,7 +94,7 @@ fn build_store(
 }
 
 /// Loads the given log file from the object store and counts the number of
-/// downloads for each crate and version. The results are printed to the log.
+/// downloads for each crate and version. The results are saved to the database.
 ///
 /// This function is separate from the [`BackgroundJob`] trait method so that
 /// it can be tested without having to construct a full [`Environment`]

--- a/src/worker/jobs/index_version_downloads_archive/mod.rs
+++ b/src/worker/jobs/index_version_downloads_archive/mod.rs
@@ -12,7 +12,7 @@ use tracing::{info, warn};
 const INDEX_PATH: &str = "archive/version-downloads/index.html";
 const INDEX_JSON_PATH: &str = "archive/version-downloads/index.json";
 
-/// Generate an index.html for the version download CSVs exported to S3.
+/// Generates `index.html` and `index.json` for the version download CSVs exported to S3.
 #[derive(Serialize, Deserialize, Default)]
 pub struct IndexVersionDownloadsArchive;
 


### PR DESCRIPTION
This fixes documentation comments across the workspace that no longer matched the code. The issues fall into two groups:

- Stale references to renamed or removed items: functions, types, fields, environment variables, source file paths, and route paths that no longer exist under the documented name.
- Descriptions that contradicted the actual behavior, such as a `# Panics` section on a function that returns an error instead, docs claiming results are printed to the log when they are saved to the database, and a provider list that omitted GitLab.

The findings came from a systematic review of every doc comment in the workspace. Each fix is a separate commit scoped to the item it corrects. The changes are documentation only and do not touch any runtime code.
