### PR TITLE
crates-admin/sync-index: Resolve crate names case-insensitively

### DIFF
--- a/src/bin/crates-admin/snapshots/crates_admin__sync_index__tests__enqueue_sync_jobs_batch_mode.snap
+++ b/src/bin/crates-admin/snapshots/crates_admin__sync_index__tests__enqueue_sync_jobs_batch_mode.snap
@@ -1,0 +1,65 @@
+---
+source: src/bin/crates-admin/sync_index.rs
+expression: all_jobs(&mut conn).await
+---
+[
+  {
+    "job_type": "bulk_sync_to_git_index",
+    "data": {
+      "commit_message": "bulk sync",
+      "crate_names": [
+        "crate-0",
+        "crate-1"
+      ]
+    }
+  },
+  {
+    "job_type": "bulk_sync_to_git_index",
+    "data": {
+      "commit_message": "bulk sync",
+      "crate_names": [
+        "crate-2",
+        "crate-3"
+      ]
+    }
+  },
+  {
+    "job_type": "bulk_sync_to_git_index",
+    "data": {
+      "commit_message": "bulk sync",
+      "crate_names": [
+        "crate-4"
+      ]
+    }
+  },
+  {
+    "job_type": "sync_to_sparse_index",
+    "data": {
+      "krate": "crate-0"
+    }
+  },
+  {
+    "job_type": "sync_to_sparse_index",
+    "data": {
+      "krate": "crate-1"
+    }
+  },
+  {
+    "job_type": "sync_to_sparse_index",
+    "data": {
+      "krate": "crate-2"
+    }
+  },
+  {
+    "job_type": "sync_to_sparse_index",
+    "data": {
+      "krate": "crate-3"
+    }
+  },
+  {
+    "job_type": "sync_to_sparse_index",
+    "data": {
+      "krate": "crate-4"
+    }
+  }
+]

--- a/src/bin/crates-admin/snapshots/crates_admin__sync_index__tests__enqueue_sync_jobs_git_and_sparse.snap
+++ b/src/bin/crates-admin/snapshots/crates_admin__sync_index__tests__enqueue_sync_jobs_git_and_sparse.snap
@@ -1,0 +1,30 @@
+---
+source: src/bin/crates-admin/sync_index.rs
+expression: all_jobs(&mut conn).await
+---
+[
+  {
+    "job_type": "sync_to_git_index",
+    "data": {
+      "krate": "foo"
+    }
+  },
+  {
+    "job_type": "sync_to_git_index",
+    "data": {
+      "krate": "bar"
+    }
+  },
+  {
+    "job_type": "sync_to_sparse_index",
+    "data": {
+      "krate": "foo"
+    }
+  },
+  {
+    "job_type": "sync_to_sparse_index",
+    "data": {
+      "krate": "bar"
+    }
+  }
+]

--- a/src/bin/crates-admin/snapshots/crates_admin__sync_index__tests__enqueue_sync_jobs_no_git.snap
+++ b/src/bin/crates-admin/snapshots/crates_admin__sync_index__tests__enqueue_sync_jobs_no_git.snap
@@ -1,0 +1,12 @@
+---
+source: src/bin/crates-admin/sync_index.rs
+expression: all_jobs(&mut conn).await
+---
+[
+  {
+    "job_type": "sync_to_sparse_index",
+    "data": {
+      "krate": "foo"
+    }
+  }
+]

--- a/src/bin/crates-admin/snapshots/crates_admin__sync_index__tests__enqueue_sync_jobs_no_sparse.snap
+++ b/src/bin/crates-admin/snapshots/crates_admin__sync_index__tests__enqueue_sync_jobs_no_sparse.snap
@@ -1,0 +1,12 @@
+---
+source: src/bin/crates-admin/sync_index.rs
+expression: all_jobs(&mut conn).await
+---
+[
+  {
+    "job_type": "sync_to_git_index",
+    "data": {
+      "krate": "foo"
+    }
+  }
+]

--- a/src/bin/crates-admin/sync_index.rs
+++ b/src/bin/crates-admin/sync_index.rs
@@ -95,45 +95,7 @@ pub async fn run(opts: Opts) -> Result<()> {
         return Ok(());
     }
 
-    conn.transaction(async |conn| {
-        // Handle git index sync
-        if opts.git {
-            if let Some(batch_size) = opts.batch_size
-                && let Some(commit_message) = opts.commit_message.as_ref()
-            {
-                let priority = opts.priority.unwrap_or(jobs::BulkSyncToGitIndex::PRIORITY);
-
-                let jobs: Vec<_> = crate_names
-                    .chunks(batch_size)
-                    .map(|chunk| jobs::BulkSyncToGitIndex::new(chunk.to_vec(), commit_message))
-                    .collect();
-
-                println!("Enqueueing {} BulkSyncToGitIndex jobs", jobs.len());
-                enqueue_jobs(conn, &jobs, priority).await?;
-            } else {
-                let priority = opts.priority.unwrap_or(jobs::SyncToGitIndex::PRIORITY);
-                let jobs: Vec<_> = crate_names.iter().map(jobs::SyncToGitIndex::new).collect();
-
-                println!("Enqueueing {} SyncToGitIndex jobs", jobs.len());
-                enqueue_jobs(conn, &jobs, priority).await?;
-            }
-        }
-
-        // Handle sparse index sync (always per-crate)
-        if opts.sparse {
-            let priority = opts.priority.unwrap_or(jobs::SyncToSparseIndex::PRIORITY);
-            let jobs: Vec<_> = crate_names
-                .iter()
-                .map(jobs::SyncToSparseIndex::new)
-                .collect();
-
-            println!("Enqueueing {} SyncToSparseIndex jobs", jobs.len());
-            enqueue_jobs(conn, &jobs, priority).await?;
-        }
-
-        Ok(())
-    })
-    .await
+    enqueue_sync_jobs(&mut conn, &crate_names, &opts).await
 }
 
 /// Determines which crate names to sync based on the provided options.
@@ -207,4 +169,51 @@ async fn confirm_sync(opts: &Opts, num_crates: usize) -> Result<bool> {
 
     println!("{}", prompt_parts.join("\n"));
     dialoguer::confirm("Do you want to continue?").await
+}
+
+/// Enqueues git and/or sparse index sync jobs for the given crate names.
+async fn enqueue_sync_jobs(
+    conn: &mut AsyncPgConnection,
+    crate_names: &[String],
+    opts: &Opts,
+) -> Result<()> {
+    conn.transaction(async |conn| {
+        // Handle git index sync
+        if opts.git {
+            if let Some(batch_size) = opts.batch_size
+                && let Some(commit_message) = opts.commit_message.as_ref()
+            {
+                let priority = opts.priority.unwrap_or(jobs::BulkSyncToGitIndex::PRIORITY);
+
+                let jobs: Vec<_> = crate_names
+                    .chunks(batch_size)
+                    .map(|chunk| jobs::BulkSyncToGitIndex::new(chunk.to_vec(), commit_message))
+                    .collect();
+
+                println!("Enqueueing {} BulkSyncToGitIndex jobs", jobs.len());
+                enqueue_jobs(conn, &jobs, priority).await?;
+            } else {
+                let priority = opts.priority.unwrap_or(jobs::SyncToGitIndex::PRIORITY);
+                let jobs: Vec<_> = crate_names.iter().map(jobs::SyncToGitIndex::new).collect();
+
+                println!("Enqueueing {} SyncToGitIndex jobs", jobs.len());
+                enqueue_jobs(conn, &jobs, priority).await?;
+            }
+        }
+
+        // Handle sparse index sync (always per-crate)
+        if opts.sparse {
+            let priority = opts.priority.unwrap_or(jobs::SyncToSparseIndex::PRIORITY);
+            let jobs: Vec<_> = crate_names
+                .iter()
+                .map(jobs::SyncToSparseIndex::new)
+                .collect();
+
+            println!("Enqueueing {} SyncToSparseIndex jobs", jobs.len());
+            enqueue_jobs(conn, &jobs, priority).await?;
+        }
+
+        Ok(())
+    })
+    .await
 }

--- a/src/bin/crates-admin/sync_index.rs
+++ b/src/bin/crates-admin/sync_index.rs
@@ -5,10 +5,12 @@ use clap::builder::ArgAction;
 use crates_io::db;
 use crates_io::schema::crates;
 use crates_io::worker::jobs;
+use crates_io_database::fns::canon_crate_name;
 use crates_io_worker::BackgroundJob;
 use crates_io_worker::schema::background_jobs;
 use diesel::prelude::*;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use std::collections::HashMap;
 use tracing::warn;
 
 const BATCH_SIZE: usize = 1000;
@@ -119,21 +121,39 @@ async fn resolve_crate_names(conn: &mut AsyncPgConnection, opts: &Opts) -> Resul
 
     // Check which crates exist in the database. Crates that don't
     // exist will still be synced, which removes them from the index.
+    let canon_names = opts.names.iter().map(|name| canon(name));
     let existing_crates: Vec<String> = crates::table
-        .filter(crates::name.eq_any(&opts.names))
+        .filter(canon_crate_name(crates::name).eq_any(canon_names))
         .select(crates::name)
         .load(conn)
         .await?;
 
+    let by_canon: HashMap<String, String> = existing_crates
+        .into_iter()
+        .map(|name| (canon(&name), name))
+        .collect();
+
+    let mut crate_names = Vec::with_capacity(opts.names.len());
     for name in &opts.names {
-        if !existing_crates.contains(name) {
-            warn!(
-                "Crate `{name}` does not exist in the database and will be removed from the index."
-            );
+        match by_canon.get(&canon(name)) {
+            Some(stored_name) => crate_names.push(stored_name.clone()),
+            None => {
+                warn!(
+                    "Crate `{name}` does not exist in the database and will be removed from the index."
+                );
+                crate_names.push(name.clone());
+            }
         }
     }
 
-    Ok(opts.names.clone())
+    Ok(crate_names)
+}
+
+/// Normalizes a crate name the same way the database's `canon_crate_name()`
+/// function does, allowing user-provided names to be matched against the
+/// stored names regardless of case or `-`/`_` differences.
+fn canon(name: &str) -> String {
+    name.to_lowercase().replace('-', "_")
 }
 
 /// Shows a confirmation prompt when batch mode is used.
@@ -297,6 +317,24 @@ mod tests {
         let opts = opts_for_names(&["foo", "deleted-crate"]);
         let result = resolve_crate_names(&mut conn, &opts).await.unwrap();
         assert_eq!(result, vec!["foo", "deleted-crate"]);
+    }
+
+    #[tokio::test]
+    async fn resolve_crate_names_normalizes_to_stored_name() {
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+        let user_id = create_user(&conn).await;
+
+        CrateBuilder::new("NULL", user_id)
+            .expect_build(&mut conn)
+            .await;
+        CrateBuilder::new("foo-bar", user_id)
+            .expect_build(&mut conn)
+            .await;
+
+        let opts = opts_for_names(&["null", "foo_bar"]);
+        let result = resolve_crate_names(&mut conn, &opts).await.unwrap();
+        assert_eq!(result, vec!["NULL", "foo-bar"]);
     }
 
     #[tokio::test]

--- a/src/bin/crates-admin/sync_index.rs
+++ b/src/bin/crates-admin/sync_index.rs
@@ -82,35 +82,7 @@ pub struct Opts {
 pub async fn run(opts: Opts) -> Result<()> {
     let mut conn = db::oneoff_connection().await?;
 
-    // Determine which crates to sync
-    let crate_names: Vec<String> = if let Some(date) = opts.updated_before {
-        let datetime = Utc.from_utc_datetime(&date.and_time(NaiveTime::MIN));
-
-        crates::table
-            .filter(crates::updated_at.lt(datetime))
-            .select(crates::name)
-            .order(crates::name)
-            .load(&mut conn)
-            .await?
-    } else {
-        // Check which crates exist in the database. Crates that don't
-        // exist will still be synced, which removes them from the index.
-        let existing_crates: Vec<String> = crates::table
-            .filter(crates::name.eq_any(&opts.names))
-            .select(crates::name)
-            .load(&mut conn)
-            .await?;
-
-        for name in &opts.names {
-            if !existing_crates.contains(name) {
-                warn!(
-                    "Crate `{name}` does not exist in the database and will be removed from the index."
-                );
-            }
-        }
-
-        opts.names
-    };
+    let crate_names = resolve_crate_names(&mut conn, &opts).await?;
 
     let num_crates = crate_names.len();
 
@@ -186,4 +158,42 @@ pub async fn run(opts: Opts) -> Result<()> {
         Ok(())
     })
     .await
+}
+
+/// Determines which crate names to sync based on the provided options.
+///
+/// When `updated_before` is set, queries for all crates updated before
+/// that date. Otherwise, uses the explicitly provided names, warning
+/// about any that don't exist in the database.
+async fn resolve_crate_names(conn: &mut AsyncPgConnection, opts: &Opts) -> Result<Vec<String>> {
+    if let Some(date) = opts.updated_before {
+        let datetime = Utc.from_utc_datetime(&date.and_time(NaiveTime::MIN));
+
+        let names = crates::table
+            .filter(crates::updated_at.lt(datetime))
+            .select(crates::name)
+            .order(crates::name)
+            .load(conn)
+            .await?;
+
+        return Ok(names);
+    }
+
+    // Check which crates exist in the database. Crates that don't
+    // exist will still be synced, which removes them from the index.
+    let existing_crates: Vec<String> = crates::table
+        .filter(crates::name.eq_any(&opts.names))
+        .select(crates::name)
+        .load(conn)
+        .await?;
+
+    for name in &opts.names {
+        if !existing_crates.contains(name) {
+            warn!(
+                "Crate `{name}` does not exist in the database and will be removed from the index."
+            );
+        }
+    }
+
+    Ok(opts.names.clone())
 }

--- a/src/bin/crates-admin/sync_index.rs
+++ b/src/bin/crates-admin/sync_index.rs
@@ -224,6 +224,8 @@ mod tests {
     use crates_io_database::models::NewUser;
     use crates_io_test_db::TestDatabase;
     use crates_io_test_utils::builders::CrateBuilder;
+    use insta::assert_json_snapshot;
+    use serde::Serialize;
 
     fn opts_for_names(names: &[&str]) -> Opts {
         Opts {
@@ -248,6 +250,20 @@ mod tests {
         .insert(conn)
         .await
         .unwrap()
+    }
+
+    #[derive(HasQuery, Serialize)]
+    #[diesel(
+        table_name = background_jobs,
+        base_query = background_jobs::table.order(background_jobs::id)
+    )]
+    struct Job {
+        job_type: String,
+        data: serde_json::Value,
+    }
+
+    async fn all_jobs(conn: &mut AsyncPgConnection) -> Vec<Job> {
+        Job::query().get_results(conn).await.unwrap()
     }
 
     #[tokio::test]
@@ -313,5 +329,63 @@ mod tests {
 
         let result = resolve_crate_names(&mut conn, &opts).await.unwrap();
         assert_eq!(result, vec!["old-crate"]);
+    }
+
+    #[tokio::test]
+    async fn enqueue_sync_jobs_git_and_sparse() {
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+
+        let names = vec!["foo".to_string(), "bar".to_string()];
+        let opts = opts_for_names(&["foo", "bar"]);
+        enqueue_sync_jobs(&mut conn, &names, &opts).await.unwrap();
+
+        assert_json_snapshot!(all_jobs(&mut conn).await);
+    }
+
+    #[tokio::test]
+    async fn enqueue_sync_jobs_no_git() {
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+
+        let names = vec!["foo".to_string()];
+        let mut opts = opts_for_names(&["foo"]);
+        opts.git = false;
+        enqueue_sync_jobs(&mut conn, &names, &opts).await.unwrap();
+
+        assert_json_snapshot!(all_jobs(&mut conn).await);
+    }
+
+    #[tokio::test]
+    async fn enqueue_sync_jobs_no_sparse() {
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+
+        let names = vec!["foo".to_string()];
+        let mut opts = opts_for_names(&["foo"]);
+        opts.sparse = false;
+        enqueue_sync_jobs(&mut conn, &names, &opts).await.unwrap();
+
+        assert_json_snapshot!(all_jobs(&mut conn).await);
+    }
+
+    #[tokio::test]
+    async fn enqueue_sync_jobs_batch_mode() {
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+
+        let names: Vec<String> = (0..5).map(|i| format!("crate-{i}")).collect();
+        let opts = Opts {
+            names: names.clone(),
+            git: true,
+            sparse: true,
+            batch_size: Some(2),
+            commit_message: Some("bulk sync".to_string()),
+            updated_before: None,
+            priority: None,
+        };
+        enqueue_sync_jobs(&mut conn, &names, &opts).await.unwrap();
+
+        assert_json_snapshot!(all_jobs(&mut conn).await);
     }
 }

--- a/src/bin/crates-admin/sync_index.rs
+++ b/src/bin/crates-admin/sync_index.rs
@@ -217,3 +217,101 @@ async fn enqueue_sync_jobs(
     })
     .await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crates_io_database::models::NewUser;
+    use crates_io_test_db::TestDatabase;
+    use crates_io_test_utils::builders::CrateBuilder;
+
+    fn opts_for_names(names: &[&str]) -> Opts {
+        Opts {
+            names: names.iter().map(|s| s.to_string()).collect(),
+            git: true,
+            sparse: true,
+            batch_size: None,
+            commit_message: None,
+            updated_before: None,
+            priority: None,
+        }
+    }
+
+    async fn create_user(conn: &AsyncPgConnection) -> i32 {
+        NewUser {
+            gh_id: 1,
+            gh_login: "testuser",
+            username: "testuser",
+            name: None,
+            gh_encrypted_token: b"token",
+        }
+        .insert(conn)
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn resolve_crate_names_returns_existing_names() {
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+        let user_id = create_user(&conn).await;
+
+        CrateBuilder::new("foo", user_id)
+            .expect_build(&mut conn)
+            .await;
+        CrateBuilder::new("bar", user_id)
+            .expect_build(&mut conn)
+            .await;
+
+        let opts = opts_for_names(&["foo", "bar"]);
+        let result = resolve_crate_names(&mut conn, &opts).await.unwrap();
+        assert_eq!(result, vec!["foo", "bar"]);
+    }
+
+    #[tokio::test]
+    async fn resolve_crate_names_includes_nonexistent_names() {
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+        let user_id = create_user(&conn).await;
+
+        CrateBuilder::new("foo", user_id)
+            .expect_build(&mut conn)
+            .await;
+
+        let opts = opts_for_names(&["foo", "deleted-crate"]);
+        let result = resolve_crate_names(&mut conn, &opts).await.unwrap();
+        assert_eq!(result, vec!["foo", "deleted-crate"]);
+    }
+
+    #[tokio::test]
+    async fn resolve_crate_names_with_updated_before() {
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+        let user_id = create_user(&conn).await;
+
+        let old_date = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+        let recent_date = Utc.with_ymd_and_hms(2025, 6, 1, 0, 0, 0).unwrap();
+
+        CrateBuilder::new("old-crate", user_id)
+            .updated_at(old_date)
+            .expect_build(&mut conn)
+            .await;
+        CrateBuilder::new("recent-crate", user_id)
+            .updated_at(recent_date)
+            .expect_build(&mut conn)
+            .await;
+
+        let opts = Opts {
+            names: vec![],
+            git: true,
+            sparse: true,
+            batch_size: Some(100),
+            commit_message: Some("test".to_string()),
+            updated_before: Some(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()),
+            priority: None,
+        };
+
+        let result = resolve_crate_names(&mut conn, &opts).await.unwrap();
+        assert_eq!(result, vec!["old-crate"]);
+    }
+}

--- a/src/bin/crates-admin/sync_index.rs
+++ b/src/bin/crates-admin/sync_index.rs
@@ -91,32 +91,8 @@ pub async fn run(opts: Opts) -> Result<()> {
         return Ok(());
     }
 
-    // Show confirmation prompt when batch mode is used
-    if let Some(batch_size) = opts.batch_size {
-        let mut prompt_parts = Vec::new();
-
-        if opts.git {
-            let num_batches = num_crates.div_ceil(batch_size);
-            prompt_parts.push(format!(
-                "This will sync {num_crates} crate{} to the git index in {num_batches} batch{}.",
-                if num_crates == 1 { "" } else { "s" },
-                if num_batches == 1 { "" } else { "es" }
-            ));
-        }
-
-        if opts.sparse {
-            prompt_parts.push(format!(
-                "This will enqueue {num_crates} sparse index sync job{}.",
-                if num_crates == 1 { "" } else { "s" }
-            ));
-        }
-
-        if !prompt_parts.is_empty() {
-            println!("{}", prompt_parts.join("\n"));
-            if !dialoguer::confirm("Do you want to continue?").await? {
-                return Ok(());
-            }
-        }
+    if !confirm_sync(&opts, num_crates).await? {
+        return Ok(());
     }
 
     conn.transaction(async |conn| {
@@ -196,4 +172,39 @@ async fn resolve_crate_names(conn: &mut AsyncPgConnection, opts: &Opts) -> Resul
     }
 
     Ok(opts.names.clone())
+}
+
+/// Shows a confirmation prompt when batch mode is used.
+///
+/// Returns `true` if the sync should proceed, `false` if the user
+/// declined or no confirmation was needed but nothing to do.
+async fn confirm_sync(opts: &Opts, num_crates: usize) -> Result<bool> {
+    let Some(batch_size) = opts.batch_size else {
+        return Ok(true);
+    };
+
+    let mut prompt_parts = Vec::new();
+
+    if opts.git {
+        let num_batches = num_crates.div_ceil(batch_size);
+        prompt_parts.push(format!(
+            "This will sync {num_crates} crate{} to the git index in {num_batches} batch{}.",
+            if num_crates == 1 { "" } else { "s" },
+            if num_batches == 1 { "" } else { "es" }
+        ));
+    }
+
+    if opts.sparse {
+        prompt_parts.push(format!(
+            "This will enqueue {num_crates} sparse index sync job{}.",
+            if num_crates == 1 { "" } else { "s" }
+        ));
+    }
+
+    if prompt_parts.is_empty() {
+        return Ok(true);
+    }
+
+    println!("{}", prompt_parts.join("\n"));
+    dialoguer::confirm("Do you want to continue?").await
 }


### PR DESCRIPTION
This updates `crates-admin sync-index` so explicitly requested crate names are matched using canonical crate-name rules before sync jobs are enqueued. It returns the stored crate name for matches, so inputs like `null` and `foo_bar` resolve to `NULL` and `foo-bar`.

We first extract the command flow into `resolve_crate_names()`, `confirm_sync()`, and `enqueue_sync_jobs()` fns so the name resolution and job enqueueing behavior can be tested directly.

We then add database-backed tests for crate-name resolution and snapshot tests for git and sparse index job payloads, including batch mode. Missing crates continue to be enqueued with the requested name so stale index entries can still be removed.