### PR TITLE
CodeViewer: Add GitHub-style line selection

### DIFF
--- a/e2e/acceptance/crate-code.spec.ts
+++ b/e2e/acceptance/crate-code.spec.ts
@@ -85,6 +85,74 @@ test.describe('Acceptance | crate code viewer', { tag: '@acceptance' }, () => {
     await expect.poll(() => viewer.evaluate(el => el.scrollTop)).toBe(0);
   });
 
+  test('selects code lines from GitHub-style URL hashes', async ({ page, msw }) => {
+    let sourceFiles = {
+      ...SOURCE_FILES,
+      'src/lib.rs': ['// line 1', '// line 2', '// line 3', '// line 4', '// line 5'].join('\n'),
+    };
+
+    let crate = await msw.db.crate.create({ name: 'serde' });
+    await msw.db.version.create({ crate, num: '1.0.0', source_files: sourceFiles });
+
+    await page.goto('/crates/serde/1.0.0/code/src/lib.rs#L2-L4');
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/lib.rs#L2-L4');
+    await expect.poll(() => page.evaluate(() => globalThis.history.length)).toBe(2);
+
+    let line = (number: number) => page.locator(`[data-line="${number}"]`).first();
+    let expectSelectedLines = async (selectedLines: number[]) => {
+      let selected = new Set(selectedLines);
+
+      for (let number of [1, 2, 3, 4, 5]) {
+        let expectation = expect(line(number));
+
+        // eslint-disable-next-line unicorn/prefer-ternary
+        if (selected.has(number)) {
+          await expectation.toHaveAttribute('data-selected-line');
+        } else {
+          await expectation.not.toHaveAttribute('data-selected-line');
+        }
+      }
+    };
+
+    // Assert that lines 2-4 are selected.
+    await expectSelectedLines([2, 3, 4]);
+
+    // Mouse down on line 1 selects it.
+    let line1 = await page.locator('[data-column-number="1"]').first().boundingBox();
+    expect(line1).not.toBeNull();
+    await page.mouse.move(line1!.x + line1!.width / 2, line1!.y + line1!.height / 2);
+    await page.mouse.down();
+    await expectSelectedLines([1]);
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/lib.rs#L2-L4');
+    await expect.poll(() => page.evaluate(() => globalThis.history.length)).toBe(2);
+
+    // Moving the mouse to line 5 selects the 1-5 range.
+    let line5 = await page.locator('[data-column-number="5"]').first().boundingBox();
+    expect(line5).not.toBeNull();
+    await page.mouse.move(line5!.x + line5!.width / 2, line5!.y + line5!.height / 2);
+    await expectSelectedLines([1, 2, 3, 4, 5]);
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/lib.rs#L2-L4');
+    await expect.poll(() => page.evaluate(() => globalThis.history.length)).toBe(2);
+
+    // Mouse up updates the URL hash.
+    await page.mouse.up();
+    await expectSelectedLines([1, 2, 3, 4, 5]);
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/lib.rs#L1-L5');
+    await expect.poll(() => page.evaluate(() => globalThis.history.length)).toBe(2);
+
+    // Navigate to a different file.
+    await page.getByRole('treeitem', { name: 'de.rs' }).click();
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/de.rs');
+    await expect.poll(() => page.evaluate(() => globalThis.history.length)).toBe(3);
+    await expect(page.locator('[data-test-code-viewer]')).toContainText('// serde deserializer');
+
+    // Navigate back to the previous file and ensure that line 1-5 is selected.
+    await page.goBack();
+    await expect(page).toHaveURL('/crates/serde/1.0.0/code/src/lib.rs#L1-L5');
+    await expectSelectedLines([1, 2, 3, 4, 5]);
+    await expect(page.locator('[data-test-code-viewer]')).toContainText('// line 1');
+  });
+
   test('shows a message for binary files', async ({ page, msw }) => {
     let crate = await msw.db.crate.create({ name: 'serde' });
     await msw.db.version.create({ crate, num: '1.0.0', source_files: SOURCE_FILES });

--- a/svelte/src/lib/components/CodeViewer.svelte
+++ b/svelte/src/lib/components/CodeViewer.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import type { CodeViewOptions } from '@pierre/diffs';
+  import type { CodeViewOptions, SelectedLineRange } from '@pierre/diffs';
   import type { WorkerPoolManager } from '@pierre/diffs/worker';
 
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { CodeView } from '@pierre/diffs';
   import { getOrCreateWorkerPoolSingleton } from '@pierre/diffs/worker';
   import WorkerUrl from '@pierre/diffs/worker/worker.js?worker&url';
@@ -12,14 +12,19 @@
   interface Props {
     content: { path: string; text: string; meta: string; cacheKey: string } | null;
     colorScheme: 'light' | 'dark';
+    lineHash?: string;
+    onLineHashChange?: (hash: string) => void;
   }
 
-  let { content, colorScheme }: Props = $props();
+  let { content, colorScheme, lineHash = '', onLineHashChange }: Props = $props();
 
   const THEMES = { light: 'github-light', dark: 'github-dark' } as const;
 
+  const LINE_HASH_PATTERN = /^L([1-9]\d*)(?:-L([1-9]\d*))?$/;
+
   let container = $state.raw<HTMLElement>();
   let view = $state.raw<CodeView>();
+  let selectedRange = $derived(parseLineHash(lineHash));
 
   function options(): CodeViewOptions<undefined> {
     return {
@@ -30,6 +35,11 @@
         paddingTop: 0,
         paddingBottom: 0,
         gap: 0,
+      },
+      enableLineSelection: true,
+      onLineSelectionEnd: selection => {
+        let hash = formatLineHash(selection) ?? '';
+        onLineHashChange?.(hash);
       },
       renderHeaderMetadata: () => content?.meta ?? null,
     };
@@ -46,6 +56,24 @@
         langs: ['rust', 'toml'],
       },
     });
+  }
+
+  function parseLineHash(hash: string): SelectedLineRange | null {
+    let match = LINE_HASH_PATTERN.exec(hash.startsWith('#') ? hash.slice(1) : hash);
+    if (!match) return null;
+
+    let start = Number.parseInt(match[1]!, 10);
+    let end = match[2] ? Number.parseInt(match[2], 10) : start;
+
+    return { start, end };
+  }
+
+  function formatLineHash(range: SelectedLineRange | null): string | null {
+    if (!range) return null;
+
+    let start = Math.min(range.start, range.end);
+    let end = Math.max(range.start, range.end);
+    return start === end ? `#L${start}` : `#L${start}-L${end}`;
   }
 
   onMount(() => {
@@ -69,8 +97,24 @@
     }
     view?.setItems(items);
 
+    // Render immediately to avoid `scrollTo()` resolution warnings
+    view?.render(true);
+
     if (content) {
-      view?.scrollTo({ type: 'position', position: 0, behavior: 'instant' });
+      let range = untrack(() => selectedRange);
+      if (range) {
+        view?.scrollTo({ type: 'range', id: content.path, range });
+      } else {
+        view?.scrollTo({ type: 'position', position: 0, behavior: 'instant' });
+      }
+    }
+  });
+
+  $effect(() => {
+    if (content && selectedRange) {
+      view?.setSelectedLines({ id: content.path, range: selectedRange }, { notify: false });
+    } else {
+      view?.clearSelectedLines({ notify: false });
     }
   });
 </script>

--- a/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/[version_num]/code/[...path]/+page.svelte
@@ -3,6 +3,7 @@
 
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
+  import { page } from '$app/state';
   import prettyBytes from 'pretty-bytes';
 
   import { getColorScheme } from '$lib/color-scheme.svelte';
@@ -25,6 +26,7 @@
   let manifest = $derived(data.manifest);
   let cdnBase = $derived(data.cdnBase);
   let selectedPath = $derived(data.selectedPath);
+  let lineHash = $derived(page.url.hash);
 
   let filesByPath = $derived(new Map((manifest?.files ?? []).map(file => [file.path, file])));
 
@@ -89,6 +91,19 @@
 
     void goto(href, { keepFocus: true, noScroll: true });
   }
+
+  function updateLineHash(hash: string) {
+    if (page.url.hash === hash) return;
+
+    let href = resolve('/crates/[crate_id]/[version_num]/code/[...path]', {
+      crate_id: crate.id,
+      version_num: version.num,
+      path: selectedPath ?? '',
+    });
+    let lineHref = (hash ? `${href}${hash}` : href) as typeof href;
+
+    void goto(lineHref, { keepFocus: true, noScroll: true, replaceState: true });
+  }
 </script>
 
 {#snippet unavailableMessage()}
@@ -127,7 +142,7 @@
         <div class="error" data-test-load-error>Failed to load file: {fileState.message}</div>
       {/if}
 
-      <CodeViewer {content} colorScheme={colorScheme.resolvedScheme} />
+      <CodeViewer {content} colorScheme={colorScheme.resolvedScheme} {lineHash} onLineHashChange={updateLineHash} />
     </section>
   </div>
 {/if}


### PR DESCRIPTION
The code viewer now reads `#L2` and `#L2-L4` URL hashes to highlight and scroll to a line range when a file loads. Selecting lines with the mouse updates the URL hash via `replaceState`, so the selection survives back and forward navigation without polluting the history stack.

<img width="683" height="243" alt="Bildschirmfoto 2026-06-25 um 12 49 30" src="https://github.com/user-attachments/assets/9326b2b9-3c12-43e0-bc2a-cc7032f2ff89" />

