### PR TITLE
Remove unused `DOWNLOADS_ARCHIVE_*` env vars from `.env.sample`

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -58,13 +58,6 @@ export TEST_DATABASE_URL=
 # export CDN_LOG_QUEUE_URL=
 # export CDN_LOG_QUEUE_REGION=
 
-# Configuration for the version downloads data archive.
-# You can leave these commented out if you're not using the archival process.
-# export DOWNLOADS_ARCHIVE_ACCESS_KEY=
-# export DOWNLOADS_ARCHIVE_SECRET_KEY=
-# export DOWNLOADS_ARCHIVE_REGION=
-# export DOWNLOADS_ARCHIVE_BUCKET=
-
 # Upstream location of the registry index. Background jobs will push to
 # this URL. The default points to a local index for development.
 # Run `./script/init-local-index.sh` to initialize this repo.


### PR DESCRIPTION
These variables configured a dedicated S3 bucket for the version downloads archive. The archival job now writes to the shared `static` bucket via the `Storage` struct (#9180), so the code reading these variables was removed but the `.env.sample` entries were missed.