### PR TITLE
Remove redundant `OG_IMAGE_BASE_URL` env var

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -89,8 +89,3 @@ export GITHUB_TOKEN_ENCRYPTION_KEY=0af877502cf11413eaa64af985fe1f8ed250ac9168a3b
 # Credentials for connecting to the Sentry error reporting service.
 # export SENTRY_DSN_API=
 export SENTRY_ENV_API=local
-
-# Base URL for the service from which the OpenGraph images
-# for crates are loaded. Make sure the URL ends
-# with a `/`.
-export OG_IMAGE_BASE_URL="http://localhost:3000/og/"

--- a/src/config/frontend.rs
+++ b/src/config/frontend.rs
@@ -1,5 +1,4 @@
 use crates_io_env_vars::var_parsed;
-use url::Url;
 
 #[derive(Debug)]
 pub struct FrontendConfig {
@@ -9,13 +8,6 @@ pub struct FrontendConfig {
     /// Should the server serve the frontend `index.html` for all
     /// non-API requests?
     pub serve_html: bool,
-
-    /// Base URL for the service from which the OpenGraph images
-    /// for crates are loaded. Required if
-    /// [`Self::serve_html`] is set.
-    ///
-    /// Read from the `OG_IMAGE_BASE_URL` environment variable.
-    pub og_image_base_url: Option<Url>,
 
     /// Maximum number of items that the HTML render
     /// cache in `crate::middleware::frontend_html::serve`
@@ -30,7 +22,6 @@ impl FrontendConfig {
         Ok(Self {
             serve_dist: true,
             serve_html: true,
-            og_image_base_url: var_parsed("OG_IMAGE_BASE_URL")?,
             html_render_cache_max_capacity: var_parsed("HTML_RENDER_CACHE_CAP")?.unwrap_or(1024),
         })
     }

--- a/src/middleware/frontend_html.rs
+++ b/src/middleware/frontend_html.rs
@@ -17,7 +17,6 @@ use axum::response::{IntoResponse, Response};
 use futures_util::FutureExt;
 use futures_util::future::{BoxFuture, Shared};
 use http::{HeaderMap, HeaderValue, Method, StatusCode, header};
-use url::Url;
 
 use crate::app::AppState;
 
@@ -80,13 +79,9 @@ pub async fn serve(state: AppState, request: Request, next: Next) -> Response {
             return (StatusCode::METHOD_NOT_ALLOWED, headers).into_response();
         }
 
-        // `state.config.frontend.og_image_base_url` will always be `Some` as that's required
-        // if `state.config.frontend.serve_html` is `true`, and otherwise this
-        // middleware won't be executed; see `crate::middleware::apply_axum_middleware`.
-        let og_image_url =
-            generate_og_image_url(path, state.config.frontend.og_image_base_url.as_ref())
-                .map(|url| Cow::Owned(url.to_string()))
-                .unwrap_or(Cow::Borrowed(OG_IMAGE_FALLBACK_URL));
+        let og_image_url = extract_crate_name(path)
+            .map(|krate| Cow::Owned(state.storage.og_image_location(krate)))
+            .unwrap_or(Cow::Borrowed(OG_IMAGE_FALLBACK_URL));
 
         // Fetch the HTML from cache given `og_image_url` as key or render it
         let html_cache = RENDERED_HTML_CACHE
@@ -139,24 +134,11 @@ fn extract_crate_name(path: &str) -> Option<&str> {
     krate.is_empty().not().then_some(krate)
 }
 
-/// Comes up with an Open Graph image URL. In case a crate page is requested,
-/// we use the crate's name as extracted from the request path and the OG image
-/// base URL from config to generate one, otherwise we use the fallback image.
-fn generate_og_image_url(path: &str, og_image_base_url: Option<&Url>) -> Option<Url> {
-    let og_image_base_url = og_image_base_url?;
-
-    let krate = extract_crate_name(path)?;
-
-    let filename = format!("{krate}.png");
-    og_image_base_url.join(&filename).ok()
-}
-
 #[cfg(test)]
 mod tests {
     use googletest::{assert_that, prelude::eq};
-    use url::Url;
 
-    use crate::middleware::frontend_html::{extract_crate_name, generate_og_image_url};
+    use crate::middleware::frontend_html::extract_crate_name;
 
     #[test]
     fn test_extract_crate_name() {
@@ -173,33 +155,6 @@ mod tests {
 
         for (path, expected) in PATHS.iter().copied() {
             assert_that!(extract_crate_name(path), eq(expected));
-        }
-    }
-
-    #[test]
-    fn test_generate_og_image_url() {
-        const PATHS: &[(&str, Option<&str>)] = &[
-            ("/crates/tokio", Some("http://localhost:3000/og/tokio.png")),
-            (
-                "/crates/tokio/versions",
-                Some("http://localhost:3000/og/tokio.png"),
-            ),
-            ("/crates/tokio/", Some("http://localhost:3000/og/tokio.png")),
-            ("/", None),
-            ("/crates", None),
-            ("/crates/", None),
-            ("/dashboard/", None),
-            ("/settings/profile", None),
-        ];
-
-        let og_image_base_url: Url = "http://localhost:3000/og/".parse().unwrap();
-        let og_image_base_url = Some(&og_image_base_url);
-
-        for (path, expected) in PATHS.iter() {
-            assert_eq!(
-                generate_og_image_url(path, og_image_base_url),
-                expected.map(|url| Url::parse(url).unwrap())
-            );
         }
     }
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -606,7 +606,6 @@ fn simple_config() -> config::Server {
         frontend: FrontendConfig {
             serve_dist: false,
             serve_html: false,
-            og_image_base_url: None,
             html_render_cache_max_capacity: 1024,
         },
         trustpub_audience: AUDIENCE.to_string(),


### PR DESCRIPTION
`Storage::og_image_location()` already produces the URL for a crate's OG image, so the separate `OG_IMAGE_BASE_URL` config was duplicating that functionality. This switches the frontend HTML middleware over to the storage method and drops the env var.