### PR TITLE
storage: Accept `&Path` in `upload_feed()`

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -418,13 +418,7 @@ impl Storage {
     }
 
     #[instrument(skip(self, channel))]
-    pub async fn upload_feed(
-        &self,
-        feed_id: &FeedId<'_>,
-        channel: &rss::Channel,
-    ) -> anyhow::Result<()> {
-        let path = feed_id.into();
-
+    pub async fn upload_feed(&self, path: &Path, channel: &rss::Channel) -> anyhow::Result<()> {
         let mut buffer = Vec::new();
         let mut cursor = Cursor::new(&mut buffer);
         channel.pretty_write_to(&mut cursor, b' ', 4)?;
@@ -432,7 +426,7 @@ impl Storage {
 
         let attributes = self.attrs([(Attribute::ContentType, "text/xml; charset=UTF-8")]);
         let opts = attributes.into();
-        self.store.put_opts(&path, payload, opts).await?;
+        self.store.put_opts(path, payload, opts).await?;
         Ok(())
     }
 

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -77,11 +77,12 @@ impl BackgroundJob for SyncCrateFeed {
             ..Default::default()
         };
 
+        let path = object_store::path::Path::from(&feed_id);
+
         info!("Uploading feed to storage…");
-        ctx.storage.upload_feed(&feed_id, &channel).await?;
+        ctx.storage.upload_feed(&path, &channel).await?;
 
         let dist = CloudFrontDistribution::Static;
-        let path = object_store::path::Path::from(&feed_id);
         if let Err(error) = ctx.invalidate_cdns(&conn, dist, path.as_ref()).await {
             warn!("Failed to invalidate CDN caches: {error}");
         }

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -64,11 +64,12 @@ impl BackgroundJob for SyncCratesFeed {
             ..Default::default()
         };
 
+        let path = object_store::path::Path::from(&feed_id);
+
         info!("Uploading feed to storage…");
-        ctx.storage.upload_feed(&feed_id, &channel).await?;
+        ctx.storage.upload_feed(&path, &channel).await?;
 
         let dist = CloudFrontDistribution::Static;
-        let path = object_store::path::Path::from(&feed_id);
         if let Err(error) = ctx.invalidate_cdns(&conn, dist, path.as_ref()).await {
             warn!("Failed to invalidate CDN caches: {error}");
         }

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -64,11 +64,12 @@ impl BackgroundJob for SyncUpdatesFeed {
             ..Default::default()
         };
 
+        let path = object_store::path::Path::from(&feed_id);
+
         info!("Uploading feed to storage…");
-        ctx.storage.upload_feed(&feed_id, &channel).await?;
+        ctx.storage.upload_feed(&path, &channel).await?;
 
         let dist = CloudFrontDistribution::Static;
-        let path = object_store::path::Path::from(&feed_id);
         if let Err(error) = ctx.invalidate_cdns(&conn, dist, path.as_ref()).await {
             warn!("Failed to invalidate CDN caches: {error}");
         }


### PR DESCRIPTION
This drops the `FeedId` dependency from `upload_feed()` and takes the storage `Path` directly. Each caller already builds the `Path` for CDN invalidation, so it now constructs it once and passes it to both `upload_feed()` and `invalidate_cdns()`.