### PR TITLE
storage: Replace the per-file-type API with `StorageKey`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ unescaped_backticks = "warn"
 dbg_macro = "warn"
 doc_link_with_quotes = "warn"
 doc_markdown = "warn"
+# The `.then(...).unwrap_or_default()` form is often more compact than the
+# `if`/`else` that rustfmt produces for the equivalent condition.
+obfuscated_if_else = "allow"
 todo = "warn"
 too_long_first_doc_paragraph = "warn"
 

--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -2,7 +2,7 @@ use crate::dialoguer;
 use anyhow::Context;
 use crates_io::models::update_default_version;
 use crates_io::schema::crates;
-use crates_io::storage::Storage;
+use crates_io::storage::{Storage, StorageKey};
 use crates_io::worker::jobs;
 use crates_io::{db, schema::versions};
 use crates_io_worker::BackgroundJob;
@@ -139,13 +139,14 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         }
 
         debug!(%crate_name, %version, "Deleting readme file from S3");
-        match store.delete_readme(crate_name, version).await {
+        let readme_key = StorageKey::for_readme(crate_name, version);
+        match store.delete(&readme_key).await {
             Err(object_store::Error::NotFound { .. }) => {}
             Err(error) => {
                 warn!(%crate_name, %version, "Failed to delete readme file from S3: {error}")
             }
-            Ok(path) => {
-                paths.push(path);
+            Ok(()) => {
+                paths.push(readme_key.path());
             }
         }
     }

--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -107,12 +107,13 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
     let mut paths = Vec::new();
     for version in &opts.versions {
         debug!(%crate_name, %version, "Deleting crate file from S3");
-        match store.delete_crate_file(crate_name, version).await {
+        let crate_file_key = StorageKey::for_crate_file(crate_name, version);
+        match store.delete(&crate_file_key).await {
             Err(error) => {
                 warn!(%crate_name, %version, "Failed to delete crate file from S3: {error}");
             }
-            Ok(path) => {
-                paths.push(path);
+            Ok(()) => {
+                paths.push(crate_file_key.path());
             }
         }
 

--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -118,24 +118,26 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         }
 
         debug!(%crate_name, %version, "Deleting zip source archive from S3");
-        match store.delete_crate_zip(crate_name, version).await {
+        let zip_key = StorageKey::for_crate_zip(crate_name, version);
+        match store.delete(&zip_key).await {
             Err(object_store::Error::NotFound { .. }) => {}
             Err(error) => {
                 warn!(%crate_name, %version, "Failed to delete zip source archive from S3: {error}")
             }
-            Ok(path) => {
-                paths.push(path);
+            Ok(()) => {
+                paths.push(zip_key.path());
             }
         }
 
         debug!(%crate_name, %version, "Deleting zip source archive manifest from S3");
-        match store.delete_crate_zip_manifest(crate_name, version).await {
+        let manifest_key = StorageKey::for_crate_zip_manifest(crate_name, version);
+        match store.delete(&manifest_key).await {
             Err(object_store::Error::NotFound { .. }) => {}
             Err(error) => {
                 warn!(%crate_name, %version, "Failed to delete zip source archive manifest from S3: {error}")
             }
-            Ok(path) => {
-                paths.push(path);
+            Ok(()) => {
+                paths.push(manifest_key.path());
             }
         }
 

--- a/src/bin/crates-admin/render_readmes.rs
+++ b/src/bin/crates-admin/render_readmes.rs
@@ -153,7 +153,8 @@ async fn get_readme(
 ) -> anyhow::Result<String> {
     let pkg_name = format!("{}-{}", krate_name, version.num);
 
-    let location = storage.crate_location(krate_name, &version.num.to_string());
+    let key = StorageKey::for_crate_file(krate_name, &version.num);
+    let location = storage.location(&key);
 
     let mut extra_headers = header::HeaderMap::new();
     extra_headers.insert(

--- a/src/bin/crates-admin/render_readmes.rs
+++ b/src/bin/crates-admin/render_readmes.rs
@@ -10,7 +10,7 @@ use tokio_util::io::StreamReader;
 
 use async_compression::tokio::bufread::GzipDecoder;
 use chrono::{NaiveDateTime, Utc};
-use crates_io::storage::Storage;
+use crates_io::storage::{Storage, StorageKey};
 use crates_io::tasks::spawn_blocking;
 use crates_io_markdown::text_to_html;
 use crates_io_tarball::{Manifest, StringOrBool};
@@ -121,8 +121,9 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
                 println!("[{}-{}] Rendering README...", krate_name, version.num);
                 let readme = get_readme(&storage, &client, &version, &krate_name).await?;
                 if !readme.is_empty() {
+                    let key = StorageKey::for_readme(&krate_name, &version.num);
                     storage
-                        .upload_readme(&krate_name, &version.num, readme.into())
+                        .upload(&key, readme.into())
                         .await
                         .context("Failed to upload rendered README file to S3")?;
                 }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -41,6 +41,7 @@ use crate::middleware::log_request::RequestLogExt;
 use crate::models::token::EndpointScope;
 use crate::rate_limiter::LimitedAction;
 use crate::schema::*;
+use crate::storage::StorageKey;
 use crate::util::errors::{AppResult, BoxedAppError, bad_request, custom, forbidden, internal};
 use crate::views::{
     EncodableCrate, EncodableCrateDependency, GoodCrate, PublishMetadata, PublishWarnings,
@@ -636,7 +637,8 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
         }
 
         // Upload crate tarball
-        app.storage.upload_crate_file(&krate.name, &version_string, tarball_bytes)
+        let key = StorageKey::for_crate_file(&krate.name, &version_string);
+        app.storage.upload(&key, tarball_bytes.into())
             .await
             .map_err(|e| internal(format!("failed to upload crate: {e}")))?;
 

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -6,6 +6,7 @@ use super::CrateVersionPath;
 use crate::app::AppState;
 use crate::models::VersionDownload;
 use crate::schema::*;
+use crate::storage::StorageKey;
 use crate::util::errors::AppResult;
 use crate::util::{RequestUtils, redirect};
 use crate::views::EncodableVersionDownload;
@@ -46,7 +47,8 @@ pub async fn download_version(
     req: Parts,
 ) -> AppResult<Response> {
     let wants_json = req.wants_json();
-    let redirect_url = app.storage.crate_location(&path.name, &path.version);
+    let key = StorageKey::for_crate_file(&path.name, &path.version);
+    let redirect_url = app.storage.location(&key);
     let response = if wants_json {
         json!({ "url": redirect_url }).into_response()
     } else {

--- a/src/controllers/version/readme.rs
+++ b/src/controllers/version/readme.rs
@@ -1,5 +1,6 @@
 use crate::app::AppState;
 use crate::controllers::version::CrateVersionPath;
+use crate::storage::StorageKey;
 use crate::util::{RequestUtils, redirect};
 use axum::Json;
 use axum::response::{IntoResponse, Response};
@@ -26,7 +27,8 @@ pub struct UrlResponse {
     ),
 )]
 pub async fn get_version_readme(app: AppState, path: CrateVersionPath, req: Parts) -> Response {
-    let url = app.storage.readme_location(&path.name, &path.version);
+    let key = StorageKey::for_readme(&path.name, &path.version);
+    let url = app.storage.location(&key);
     let response = if req.wants_json() {
         Json(UrlResponse { url }).into_response()
     } else {

--- a/src/middleware/frontend_html.rs
+++ b/src/middleware/frontend_html.rs
@@ -19,6 +19,7 @@ use futures_util::future::{BoxFuture, Shared};
 use http::{HeaderMap, HeaderValue, Method, StatusCode, header};
 
 use crate::app::AppState;
+use crate::storage::StorageKey;
 
 const OG_IMAGE_FALLBACK_URL: &str = "https://crates.io/assets/og-image.png";
 const PATH_PREFIX_CRATES: &str = "/crates/";
@@ -79,8 +80,10 @@ pub async fn serve(state: AppState, request: Request, next: Next) -> Response {
             return (StatusCode::METHOD_NOT_ALLOWED, headers).into_response();
         }
 
-        let og_image_url = extract_crate_name(path)
-            .map(|krate| Cow::Owned(state.storage.og_image_location(krate)))
+        let crate_name = extract_crate_name(path);
+        let key = crate_name.map(StorageKey::for_og_image);
+        let og_image_url = key
+            .map(|key| Cow::Owned(state.storage.location(&key)))
             .unwrap_or(Cow::Borrowed(OG_IMAGE_FALLBACK_URL));
 
         // Fetch the HTML from cache given `og_image_url` as key or render it

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -206,22 +206,6 @@ impl Storage {
         }
     }
 
-    /// Returns the URL of an uploaded crate version's zip source archive.
-    ///
-    /// The function doesn't check for the existence of the file.
-    pub fn crate_zip_location(&self, name: &str, version: &str) -> String {
-        self.apply_cdn_prefix(&crate_zip_path(name, version))
-            .replace('+', "%2B")
-    }
-
-    /// Returns the URL of an uploaded crate version's zip source archive manifest.
-    ///
-    /// The function doesn't check for the existence of the file.
-    pub fn crate_zip_manifest_location(&self, name: &str, version: &str) -> String {
-        self.apply_cdn_prefix(&crate_zip_manifest_path(name, version))
-            .replace('+', "%2B")
-    }
-
     /// Returns the public URL of the file identified by `key`.
     ///
     /// The function doesn't check for the existence of the file.
@@ -233,10 +217,6 @@ impl Storage {
     /// `https://static.crates.io`.
     pub fn cdn_base(&self) -> &str {
         &self.cdn_base
-    }
-
-    fn apply_cdn_prefix(&self, path: &Path) -> String {
-        format!("{}/{path}", self.cdn_base)
     }
 
     /// Deletes all crate files for the given crate, returning the paths that were deleted.
@@ -251,22 +231,6 @@ impl Storage {
     pub async fn delete_all_readmes(&self, name: &str) -> Result<Vec<Path>> {
         let prefix = format!("{PREFIX_READMES}/{name}").into();
         self.delete_all_with_prefix(&prefix).await
-    }
-
-    /// Deletes a crate version's zip source archive, returning the path that was deleted.
-    #[instrument(skip(self))]
-    pub async fn delete_crate_zip(&self, name: &str, version: &str) -> Result<Path> {
-        let path = crate_zip_path(name, version);
-        self.store.delete(&path).await?;
-        Ok(path)
-    }
-
-    /// Deletes a crate version's zip source archive manifest, returning the path that was deleted.
-    #[instrument(skip(self))]
-    pub async fn delete_crate_zip_manifest(&self, name: &str, version: &str) -> Result<Path> {
-        let path = crate_zip_manifest_path(name, version);
-        self.store.delete(&path).await?;
-        Ok(path)
     }
 
     #[instrument(skip(self))]
@@ -294,18 +258,16 @@ impl Storage {
     #[instrument(skip(self, reader))]
     pub async fn upload_crate_zip(
         &self,
-        name: &str,
-        version: &str,
+        key: &StorageKey<'_>,
         mut reader: impl AsyncRead + Unpin,
     ) -> anyhow::Result<()> {
-        let path = crate_zip_path(name, version);
-        let attributes = self.attrs([
-            (Attribute::ContentType, CONTENT_TYPE_ZIP),
-            (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
-        ]);
+        let attributes = self
+            .supports_attributes
+            .then(|| key.attributes())
+            .unwrap_or_default();
 
         // Set up a streaming upload
-        let mut writer = object_store::buffered::BufWriter::new(self.store.clone(), path)
+        let mut writer = object_store::buffered::BufWriter::new(self.store.clone(), key.path())
             .with_attributes(attributes);
 
         // Upload the archive contents
@@ -318,24 +280,6 @@ impl Storage {
         // ... or finalize upload
         writer.shutdown().await?;
 
-        Ok(())
-    }
-
-    /// Uploads a crate version's zip source archive manifest.
-    #[instrument(skip(self, bytes))]
-    pub async fn upload_crate_zip_manifest(
-        &self,
-        name: &str,
-        version: &str,
-        bytes: Bytes,
-    ) -> Result<()> {
-        let path = crate_zip_manifest_path(name, version);
-        let attributes = self.attrs([
-            (Attribute::ContentType, CONTENT_TYPE_JSON),
-            (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
-        ]);
-        let opts = attributes.into();
-        self.store.put_opts(&path, bytes.into(), opts).await?;
         Ok(())
     }
 
@@ -450,17 +394,11 @@ fn build_s3(config: &S3Config, client_options: ClientOptions) -> AmazonS3 {
         .unwrap()
 }
 
-fn crate_zip_path(name: &str, version: &str) -> Path {
-    format!("{PREFIX_CRATES}/{name}/{name}-{version}.zip").into()
-}
-
-fn crate_zip_manifest_path(name: &str, version: &str) -> Path {
-    format!("{PREFIX_CRATES}/{name}/{name}-{version}.zip.json").into()
-}
-
 #[derive(Debug)]
 pub enum StorageKey<'a> {
     CrateFile { name: &'a str, version: &'a str },
+    CrateZip { name: &'a str, version: &'a str },
+    CrateZipManifest { name: &'a str, version: &'a str },
     Readme { name: &'a str, version: &'a str },
     OgImage { name: &'a str },
     CrateFeed { name: &'a str },
@@ -472,6 +410,16 @@ impl<'a> StorageKey<'a> {
     /// Builds a [`StorageKey::CrateFile`] key for the given crate version.
     pub fn for_crate_file(name: &'a str, version: &'a str) -> Self {
         StorageKey::CrateFile { name, version }
+    }
+
+    /// Builds a [`StorageKey::CrateZip`] key for the given crate version.
+    pub fn for_crate_zip(name: &'a str, version: &'a str) -> Self {
+        StorageKey::CrateZip { name, version }
+    }
+
+    /// Builds a [`StorageKey::CrateZipManifest`] key for the given crate version.
+    pub fn for_crate_zip_manifest(name: &'a str, version: &'a str) -> Self {
+        StorageKey::CrateZipManifest { name, version }
     }
 
     /// Builds a [`StorageKey::Readme`] key for the given crate version.
@@ -489,6 +437,12 @@ impl<'a> StorageKey<'a> {
         match self {
             StorageKey::CrateFile { name, version } => {
                 format!("{PREFIX_CRATES}/{name}/{name}-{version}.crate").into()
+            }
+            StorageKey::CrateZip { name, version } => {
+                format!("{PREFIX_CRATES}/{name}/{name}-{version}.zip").into()
+            }
+            StorageKey::CrateZipManifest { name, version } => {
+                format!("{PREFIX_CRATES}/{name}/{name}-{version}.zip.json").into()
             }
             StorageKey::Readme { name, version } => {
                 format!("{PREFIX_READMES}/{name}/{name}-{version}.html").into()
@@ -511,6 +465,14 @@ impl<'a> StorageKey<'a> {
         match self {
             StorageKey::CrateFile { .. } => Attributes::from_iter([
                 (Attribute::ContentType, CONTENT_TYPE_CRATE),
+                (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
+            ]),
+            StorageKey::CrateZip { .. } => Attributes::from_iter([
+                (Attribute::ContentType, CONTENT_TYPE_ZIP),
+                (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
+            ]),
+            StorageKey::CrateZipManifest { .. } => Attributes::from_iter([
+                (Attribute::ContentType, CONTENT_TYPE_JSON),
                 (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
             ]),
             StorageKey::Readme { .. } => Attributes::from_iter([
@@ -599,7 +561,8 @@ mod tests {
             ),
         ];
         for (name, version, expected) in crate_zip_tests {
-            assert_eq!(storage.crate_zip_location(name, version), expected);
+            let key = StorageKey::for_crate_zip(name, version);
+            assert_eq!(storage.location(&key), expected);
         }
 
         let crate_zip_manifest_tests = vec![
@@ -615,7 +578,8 @@ mod tests {
             ),
         ];
         for (name, version, expected) in crate_zip_manifest_tests {
-            assert_eq!(storage.crate_zip_manifest_location(name, version), expected);
+            let key = StorageKey::for_crate_zip_manifest(name, version);
+            assert_eq!(storage.location(&key), expected);
         }
 
         let readme_tests = vec![
@@ -656,24 +620,20 @@ mod tests {
             Storage::from_config(&config)
         }
 
-        assert_eq!(storage(None).apply_cdn_prefix(&"foo".into()), "/foo");
-        assert_eq!(
-            storage(Some("static.crates.io")).apply_cdn_prefix(&"foo".into()),
-            "https://static.crates.io/foo"
-        );
-        assert_eq!(
-            storage(Some("https://fastly-static.crates.io")).apply_cdn_prefix(&"foo".into()),
-            "https://fastly-static.crates.io/foo"
-        );
+        let key = StorageKey::for_og_image("foo");
 
+        assert_eq!(storage(None).location(&key), "/og-images/foo.png");
         assert_eq!(
-            storage(Some("static.crates.io")).apply_cdn_prefix(&"/foo/bar".into()),
-            "https://static.crates.io/foo/bar"
+            storage(Some("https://fastly-static.crates.io")).location(&key),
+            "https://fastly-static.crates.io/og-images/foo.png"
         );
-
         assert_eq!(
-            storage(Some("static.crates.io/")).apply_cdn_prefix(&"/foo/bar".into()),
-            "https://static.crates.io//foo/bar"
+            storage(Some("static.crates.io")).location(&key),
+            "https://static.crates.io/og-images/foo.png"
+        );
+        assert_eq!(
+            storage(Some("static.crates.io/")).location(&key),
+            "https://static.crates.io//og-images/foo.png"
         );
     }
 
@@ -754,16 +714,15 @@ mod tests {
             storage.store.put(&path.into(), payload).await.unwrap();
         }
 
-        storage.delete_crate_zip("foo", "1.2.3").await.unwrap();
+        let zip_key = StorageKey::for_crate_zip("foo", "1.2.3");
+        storage.delete(&zip_key).await.unwrap();
         assert_eq!(
             stored_files(&storage.store).await,
             vec!["crates/foo/foo-1.2.3.zip.json"]
         );
 
-        storage
-            .delete_crate_zip_manifest("foo", "1.2.3")
-            .await
-            .unwrap();
+        let manifest_key = StorageKey::for_crate_zip_manifest("foo", "1.2.3");
+        storage.delete(&manifest_key).await.unwrap();
         assert!(stored_files(&storage.store).await.is_empty());
     }
 
@@ -808,14 +767,16 @@ mod tests {
     async fn upload_crate_zip() {
         let s = Storage::from_config(&StorageConfig::in_memory());
 
-        s.upload_crate_zip("foo", "1.2.3", &b"fake zip data"[..])
+        let key = StorageKey::for_crate_zip("foo", "1.2.3");
+        s.upload_crate_zip(&key, &b"fake zip data"[..])
             .await
             .unwrap();
 
         let expected_files = vec!["crates/foo/foo-1.2.3.zip"];
         assert_eq!(stored_files(&s.store).await, expected_files);
 
-        s.upload_crate_zip("foo", "2.0.0+foo", &b"fake zip data"[..])
+        let key = StorageKey::for_crate_zip("foo", "2.0.0+foo");
+        s.upload_crate_zip(&key, &b"fake zip data"[..])
             .await
             .unwrap();
 
@@ -828,16 +789,14 @@ mod tests {
         let s = Storage::from_config(&StorageConfig::in_memory());
 
         let bytes = Bytes::from_static(b"{\"files\":[]}");
-        s.upload_crate_zip_manifest("foo", "1.2.3", bytes.clone())
-            .await
-            .unwrap();
+        let key = StorageKey::for_crate_zip_manifest("foo", "1.2.3");
+        s.upload(&key, bytes.clone().into()).await.unwrap();
 
         let expected_files = vec!["crates/foo/foo-1.2.3.zip.json"];
         assert_eq!(stored_files(&s.store).await, expected_files);
 
-        s.upload_crate_zip_manifest("foo", "2.0.0+foo", bytes)
-            .await
-            .unwrap();
+        let key = StorageKey::for_crate_zip_manifest("foo", "2.0.0+foo");
+        s.upload(&key, bytes.into()).await.unwrap();
 
         let expected_files = vec![
             "crates/foo/foo-1.2.3.zip.json",

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -206,14 +206,6 @@ impl Storage {
         }
     }
 
-    /// Returns the URL of an uploaded crate's version archive.
-    ///
-    /// The function doesn't check for the existence of the file.
-    pub fn crate_location(&self, name: &str, version: &str) -> String {
-        self.apply_cdn_prefix(&crate_file_path(name, version))
-            .replace('+', "%2B")
-    }
-
     /// Returns the URL of an uploaded crate version's zip source archive.
     ///
     /// The function doesn't check for the existence of the file.
@@ -261,14 +253,6 @@ impl Storage {
         self.delete_all_with_prefix(&prefix).await
     }
 
-    /// Deletes a crate version's archive, returning the path that was deleted.
-    #[instrument(skip(self))]
-    pub async fn delete_crate_file(&self, name: &str, version: &str) -> Result<Path> {
-        let path = crate_file_path(name, version);
-        self.store.delete(&path).await?;
-        Ok(path)
-    }
-
     /// Deletes a crate version's zip source archive, returning the path that was deleted.
     #[instrument(skip(self))]
     pub async fn delete_crate_zip(&self, name: &str, version: &str) -> Result<Path> {
@@ -302,18 +286,6 @@ impl Storage {
 
         let opts = attributes.into();
         self.store.put_opts(&key.path(), payload, opts).await?;
-        Ok(())
-    }
-
-    #[instrument(skip(self, bytes))]
-    pub async fn upload_crate_file(&self, name: &str, version: &str, bytes: Bytes) -> Result<()> {
-        let path = crate_file_path(name, version);
-        let attributes = self.attrs([
-            (Attribute::ContentType, CONTENT_TYPE_CRATE),
-            (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
-        ]);
-        let opts = attributes.into();
-        self.store.put_opts(&path, bytes.into(), opts).await?;
         Ok(())
     }
 
@@ -370,11 +342,9 @@ impl Storage {
     #[instrument(skip(self))]
     pub async fn download_crate_file(
         &self,
-        name: &str,
-        version: &str,
+        key: &StorageKey<'_>,
     ) -> Result<BoxStream<'_, Result<Bytes>>> {
-        let path = crate_file_path(name, version);
-        let result = self.store.get(&path).await?;
+        let result = self.store.get(&key.path()).await?;
         Ok(result.into_stream())
     }
 
@@ -480,10 +450,6 @@ fn build_s3(config: &S3Config, client_options: ClientOptions) -> AmazonS3 {
         .unwrap()
 }
 
-fn crate_file_path(name: &str, version: &str) -> Path {
-    format!("{PREFIX_CRATES}/{name}/{name}-{version}.crate").into()
-}
-
 fn crate_zip_path(name: &str, version: &str) -> Path {
     format!("{PREFIX_CRATES}/{name}/{name}-{version}.zip").into()
 }
@@ -494,6 +460,7 @@ fn crate_zip_manifest_path(name: &str, version: &str) -> Path {
 
 #[derive(Debug)]
 pub enum StorageKey<'a> {
+    CrateFile { name: &'a str, version: &'a str },
     Readme { name: &'a str, version: &'a str },
     OgImage { name: &'a str },
     CrateFeed { name: &'a str },
@@ -502,6 +469,11 @@ pub enum StorageKey<'a> {
 }
 
 impl<'a> StorageKey<'a> {
+    /// Builds a [`StorageKey::CrateFile`] key for the given crate version.
+    pub fn for_crate_file(name: &'a str, version: &'a str) -> Self {
+        StorageKey::CrateFile { name, version }
+    }
+
     /// Builds a [`StorageKey::Readme`] key for the given crate version.
     pub fn for_readme(name: &'a str, version: &'a str) -> Self {
         StorageKey::Readme { name, version }
@@ -515,6 +487,9 @@ impl<'a> StorageKey<'a> {
     /// Object-store path used for put/get/delete operations.
     pub fn path(&self) -> Path {
         match self {
+            StorageKey::CrateFile { name, version } => {
+                format!("{PREFIX_CRATES}/{name}/{name}-{version}.crate").into()
+            }
             StorageKey::Readme { name, version } => {
                 format!("{PREFIX_READMES}/{name}/{name}-{version}.html").into()
             }
@@ -534,6 +509,10 @@ impl<'a> StorageKey<'a> {
     /// The intended attribute set (content-type + cache-control) for the file.
     pub fn attributes(&self) -> Attributes {
         match self {
+            StorageKey::CrateFile { .. } => Attributes::from_iter([
+                (Attribute::ContentType, CONTENT_TYPE_CRATE),
+                (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
+            ]),
             StorageKey::Readme { .. } => Attributes::from_iter([
                 (Attribute::ContentType, CONTENT_TYPE_README),
                 (Attribute::CacheControl, CACHE_CONTROL_README),
@@ -603,7 +582,8 @@ mod tests {
             ),
         ];
         for (name, version, expected) in crate_tests {
-            assert_eq!(storage.crate_location(name, version), expected);
+            let key = StorageKey::for_crate_file(name, version);
+            assert_eq!(storage.location(&key), expected);
         }
 
         let crate_zip_tests = vec![
@@ -752,7 +732,8 @@ mod tests {
     async fn delete_crate_file() {
         let storage = prepare().await;
 
-        storage.delete_crate_file("foo", "1.2.3").await.unwrap();
+        let key = StorageKey::for_crate_file("foo", "1.2.3");
+        storage.delete(&key).await.unwrap();
 
         let expected_files = vec![
             "crates/bar/bar-2.0.0.crate",
@@ -807,16 +788,14 @@ mod tests {
     async fn upload_crate_file() {
         let s = Storage::from_config(&StorageConfig::in_memory());
 
-        s.upload_crate_file("foo", "1.2.3", Bytes::new())
-            .await
-            .unwrap();
+        let key = StorageKey::for_crate_file("foo", "1.2.3");
+        s.upload(&key, Bytes::new().into()).await.unwrap();
 
         let expected_files = vec!["crates/foo/foo-1.2.3.crate"];
         assert_eq!(stored_files(&s.store).await, expected_files);
 
-        s.upload_crate_file("foo", "2.0.0+foo", Bytes::new())
-            .await
-            .unwrap();
+        let key = StorageKey::for_crate_file("foo", "2.0.0+foo");
+        s.upload(&key, Bytes::new().into()).await.unwrap();
 
         let expected_files = vec![
             "crates/foo/foo-1.2.3.crate",

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -408,34 +408,49 @@ impl<'a> StorageKey<'a> {
         self.path().as_ref().replace('+', "%2B")
     }
 
+    /// The content-type the file should be stored with, or `None` to rely on
+    /// the store's default.
+    pub fn content_type(&self) -> Option<&'static str> {
+        match self {
+            StorageKey::CrateFile { .. } => Some("application/gzip"),
+            StorageKey::CrateZip { .. } => Some("application/zip"),
+            StorageKey::CrateZipManifest { .. } => Some("application/json"),
+            StorageKey::Readme { .. } => Some("text/html"),
+            StorageKey::OgImage { .. } => Some("image/png"),
+            StorageKey::CrateFeed { .. } | StorageKey::CratesFeed | StorageKey::UpdatesFeed => {
+                Some("text/xml; charset=UTF-8")
+            }
+            StorageKey::DbDumpTar | StorageKey::DbDumpZip => None,
+        }
+    }
+
+    /// The cache-control the file should be stored with, or `None` for no
+    /// override.
+    pub fn cache_control(&self) -> Option<&'static str> {
+        match self {
+            StorageKey::CrateFile { .. }
+            | StorageKey::CrateZip { .. }
+            | StorageKey::CrateZipManifest { .. } => Some(CACHE_CONTROL_IMMUTABLE),
+            StorageKey::Readme { .. } => Some(CACHE_CONTROL_README),
+            StorageKey::OgImage { .. } => Some(CACHE_CONTROL_OG_IMAGE),
+            StorageKey::CrateFeed { .. }
+            | StorageKey::CratesFeed
+            | StorageKey::UpdatesFeed
+            | StorageKey::DbDumpTar
+            | StorageKey::DbDumpZip => None,
+        }
+    }
+
     /// The intended attribute set (content-type + cache-control) for the file.
     pub fn attributes(&self) -> Attributes {
-        match self {
-            StorageKey::CrateFile { .. } => Attributes::from_iter([
-                (Attribute::ContentType, "application/gzip"),
-                (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
-            ]),
-            StorageKey::CrateZip { .. } => Attributes::from_iter([
-                (Attribute::ContentType, "application/zip"),
-                (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
-            ]),
-            StorageKey::CrateZipManifest { .. } => Attributes::from_iter([
-                (Attribute::ContentType, "application/json"),
-                (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
-            ]),
-            StorageKey::Readme { .. } => Attributes::from_iter([
-                (Attribute::ContentType, "text/html"),
-                (Attribute::CacheControl, CACHE_CONTROL_README),
-            ]),
-            StorageKey::OgImage { .. } => Attributes::from_iter([
-                (Attribute::ContentType, "image/png"),
-                (Attribute::CacheControl, CACHE_CONTROL_OG_IMAGE),
-            ]),
-            StorageKey::CrateFeed { .. } | StorageKey::CratesFeed | StorageKey::UpdatesFeed => {
-                Attributes::from_iter([(Attribute::ContentType, "text/xml; charset=UTF-8")])
-            }
-            StorageKey::DbDumpTar | StorageKey::DbDumpZip => Attributes::new(),
+        let mut attributes = Attributes::new();
+        if let Some(content_type) = self.content_type() {
+            attributes.insert(Attribute::ContentType, content_type.into());
         }
+        if let Some(cache_control) = self.cache_control() {
+            attributes.insert(Attribute::CacheControl, cache_control.into());
+        }
+        attributes
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -253,10 +253,10 @@ impl Storage {
         Ok(())
     }
 
-    /// Uploads a crate version's zip source archive, streaming it from `reader`
-    /// so the whole archive is never buffered in memory.
+    /// Uploads the contents of `reader` to the location identified by `key`,
+    /// streaming it so the whole file is never buffered in memory.
     #[instrument(skip(self, reader))]
-    pub async fn upload_crate_zip(
+    pub async fn upload_stream(
         &self,
         key: &StorageKey<'_>,
         mut reader: impl AsyncRead + Unpin,
@@ -337,25 +337,8 @@ impl Storage {
         key: &StorageKey<'_>,
         local_path: &StdPath,
     ) -> anyhow::Result<()> {
-        let store = self.store.clone();
-
-        // Open the local tarball file
-        let mut local_file = File::open(local_path).await?;
-
-        // Set up a multipart upload
-        let mut writer = object_store::buffered::BufWriter::new(store, key.path());
-
-        // Upload file contents
-        if let Err(error) = tokio::io::copy(&mut local_file, &mut writer).await {
-            // Abort the upload if something failed
-            writer.abort().await?;
-            return Err(error.into());
-        }
-
-        // ... or finalize upload
-        writer.shutdown().await?;
-
-        Ok(())
+        let local_file = File::open(local_path).await?;
+        self.upload_stream(key, local_file).await
     }
 
     /// This should only be used for assertions in the test suite!
@@ -776,17 +759,13 @@ mod tests {
         let s = Storage::from_config(&StorageConfig::in_memory());
 
         let key = StorageKey::for_crate_zip("foo", "1.2.3");
-        s.upload_crate_zip(&key, &b"fake zip data"[..])
-            .await
-            .unwrap();
+        s.upload_stream(&key, &b"fake zip data"[..]).await.unwrap();
 
         let expected_files = vec!["crates/foo/foo-1.2.3.zip"];
         assert_eq!(stored_files(&s.store).await, expected_files);
 
         let key = StorageKey::for_crate_zip("foo", "2.0.0+foo");
-        s.upload_crate_zip(&key, &b"fake zip data"[..])
-            .await
-            .unwrap();
+        s.upload_stream(&key, &b"fake zip data"[..]).await.unwrap();
 
         let expected_files = vec!["crates/foo/foo-1.2.3.zip", "crates/foo/foo-2.0.0+foo.zip"];
         assert_eq!(stored_files(&s.store).await, expected_files);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -22,13 +22,6 @@ const PREFIX_CRATES: &str = "crates";
 const PREFIX_READMES: &str = "readmes";
 const PREFIX_OG_IMAGES: &str = "og-images";
 const DEFAULT_REGION: &str = "us-west-1";
-const CONTENT_TYPE_CRATE: &str = "application/gzip";
-const CONTENT_TYPE_GZIP: &str = "application/gzip";
-const CONTENT_TYPE_ZIP: &str = "application/zip";
-const CONTENT_TYPE_JSON: &str = "application/json";
-const CONTENT_TYPE_INDEX: &str = "text/plain";
-const CONTENT_TYPE_README: &str = "text/html";
-const CONTENT_TYPE_OG_IMAGE: &str = "image/png";
 const CACHE_CONTROL_IMMUTABLE: &str = "public,max-age=31536000,immutable";
 const CACHE_CONTROL_INDEX: &str = "public,max-age=600";
 const CACHE_CONTROL_README: &str = "public,max-age=604800";
@@ -141,8 +134,8 @@ impl Storage {
                     // The `BufWriter::new()` API currently does not allow
                     // specifying any file attributes, so we need to set the
                     // content type here instead for the database dump upload.
-                    .with_content_type_for_suffix("gz", CONTENT_TYPE_GZIP)
-                    .with_content_type_for_suffix("zip", CONTENT_TYPE_ZIP);
+                    .with_content_type_for_suffix("gz", "application/gzip")
+                    .with_content_type_for_suffix("zip", "application/zip");
 
                 let store = build_s3(default, options);
 
@@ -293,7 +286,7 @@ impl Storage {
         let path = crates_io_index::Repository::relative_index_file_for_url(name).into();
         if let Some(content) = content {
             let attributes = self.attrs([
-                (Attribute::ContentType, CONTENT_TYPE_INDEX),
+                (Attribute::ContentType, "text/plain"),
                 (Attribute::CacheControl, CACHE_CONTROL_INDEX),
             ]);
             let payload = content.into();
@@ -419,23 +412,23 @@ impl<'a> StorageKey<'a> {
     pub fn attributes(&self) -> Attributes {
         match self {
             StorageKey::CrateFile { .. } => Attributes::from_iter([
-                (Attribute::ContentType, CONTENT_TYPE_CRATE),
+                (Attribute::ContentType, "application/gzip"),
                 (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
             ]),
             StorageKey::CrateZip { .. } => Attributes::from_iter([
-                (Attribute::ContentType, CONTENT_TYPE_ZIP),
+                (Attribute::ContentType, "application/zip"),
                 (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
             ]),
             StorageKey::CrateZipManifest { .. } => Attributes::from_iter([
-                (Attribute::ContentType, CONTENT_TYPE_JSON),
+                (Attribute::ContentType, "application/json"),
                 (Attribute::CacheControl, CACHE_CONTROL_IMMUTABLE),
             ]),
             StorageKey::Readme { .. } => Attributes::from_iter([
-                (Attribute::ContentType, CONTENT_TYPE_README),
+                (Attribute::ContentType, "text/html"),
                 (Attribute::CacheControl, CACHE_CONTROL_README),
             ]),
             StorageKey::OgImage { .. } => Attributes::from_iter([
-                (Attribute::ContentType, CONTENT_TYPE_OG_IMAGE),
+                (Attribute::ContentType, "image/png"),
                 (Attribute::CacheControl, CACHE_CONTROL_OG_IMAGE),
             ]),
             StorageKey::CrateFeed { .. } | StorageKey::CratesFeed | StorageKey::UpdatesFeed => {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -230,14 +230,6 @@ impl Storage {
             .replace('+', "%2B")
     }
 
-    /// Returns the URL of an uploaded crate's version readme.
-    ///
-    /// The function doesn't check for the existence of the file.
-    pub fn readme_location(&self, name: &str, version: &str) -> String {
-        self.apply_cdn_prefix(&readme_path(name, version))
-            .replace('+', "%2B")
-    }
-
     /// Returns the public URL of the file identified by `key`.
     ///
     /// The function doesn't check for the existence of the file.
@@ -289,14 +281,6 @@ impl Storage {
     #[instrument(skip(self))]
     pub async fn delete_crate_zip_manifest(&self, name: &str, version: &str) -> Result<Path> {
         let path = crate_zip_manifest_path(name, version);
-        self.store.delete(&path).await?;
-        Ok(path)
-    }
-
-    /// Deletes a crate version's readme, returning the path that was deleted.
-    #[instrument(skip(self))]
-    pub async fn delete_readme(&self, name: &str, version: &str) -> Result<Path> {
-        let path = readme_path(name, version);
         self.store.delete(&path).await?;
         Ok(path)
     }
@@ -392,18 +376,6 @@ impl Storage {
         let path = crate_file_path(name, version);
         let result = self.store.get(&path).await?;
         Ok(result.into_stream())
-    }
-
-    #[instrument(skip(self, bytes))]
-    pub async fn upload_readme(&self, name: &str, version: &str, bytes: Bytes) -> Result<()> {
-        let path = readme_path(name, version);
-        let attributes = self.attrs([
-            (Attribute::ContentType, CONTENT_TYPE_README),
-            (Attribute::CacheControl, CACHE_CONTROL_README),
-        ]);
-        let opts = attributes.into();
-        self.store.put_opts(&path, bytes.into(), opts).await?;
-        Ok(())
     }
 
     #[instrument(skip(self, channel))]
@@ -520,12 +492,9 @@ fn crate_zip_manifest_path(name: &str, version: &str) -> Path {
     format!("{PREFIX_CRATES}/{name}/{name}-{version}.zip.json").into()
 }
 
-fn readme_path(name: &str, version: &str) -> Path {
-    format!("{PREFIX_READMES}/{name}/{name}-{version}.html").into()
-}
-
 #[derive(Debug)]
 pub enum StorageKey<'a> {
+    Readme { name: &'a str, version: &'a str },
     OgImage { name: &'a str },
     CrateFeed { name: &'a str },
     CratesFeed,
@@ -533,6 +502,11 @@ pub enum StorageKey<'a> {
 }
 
 impl<'a> StorageKey<'a> {
+    /// Builds a [`StorageKey::Readme`] key for the given crate version.
+    pub fn for_readme(name: &'a str, version: &'a str) -> Self {
+        StorageKey::Readme { name, version }
+    }
+
     /// Builds a [`StorageKey::OgImage`] key for the given crate.
     pub fn for_og_image(name: &'a str) -> Self {
         StorageKey::OgImage { name }
@@ -541,6 +515,9 @@ impl<'a> StorageKey<'a> {
     /// Object-store path used for put/get/delete operations.
     pub fn path(&self) -> Path {
         match self {
+            StorageKey::Readme { name, version } => {
+                format!("{PREFIX_READMES}/{name}/{name}-{version}.html").into()
+            }
             StorageKey::OgImage { name } => format!("{PREFIX_OG_IMAGES}/{name}.png").into(),
             StorageKey::CrateFeed { name } => format!("rss/crates/{name}.xml").into(),
             StorageKey::CratesFeed => "rss/crates.xml".into(),
@@ -557,6 +534,10 @@ impl<'a> StorageKey<'a> {
     /// The intended attribute set (content-type + cache-control) for the file.
     pub fn attributes(&self) -> Attributes {
         match self {
+            StorageKey::Readme { .. } => Attributes::from_iter([
+                (Attribute::ContentType, CONTENT_TYPE_README),
+                (Attribute::CacheControl, CACHE_CONTROL_README),
+            ]),
             StorageKey::OgImage { .. } => Attributes::from_iter([
                 (Attribute::ContentType, CONTENT_TYPE_OG_IMAGE),
                 (Attribute::CacheControl, CACHE_CONTROL_OG_IMAGE),
@@ -670,7 +651,8 @@ mod tests {
             ),
         ];
         for (name, version, expected) in readme_tests {
-            assert_eq!(storage.readme_location(name, version), expected);
+            let key = StorageKey::for_readme(name, version);
+            assert_eq!(storage.location(&key), expected);
         }
 
         let og_image_tests = vec![
@@ -808,7 +790,8 @@ mod tests {
     async fn delete_readme() {
         let storage = prepare().await;
 
-        storage.delete_readme("foo", "1.2.3").await.unwrap();
+        let key = StorageKey::for_readme("foo", "1.2.3");
+        storage.delete(&key).await.unwrap();
 
         let expected_files = vec![
             "crates/bar/bar-2.0.0.crate",
@@ -889,14 +872,14 @@ mod tests {
         let s = Storage::from_config(&StorageConfig::in_memory());
 
         let bytes = Bytes::from_static(b"hello world");
-        s.upload_readme("foo", "1.2.3", bytes.clone())
-            .await
-            .unwrap();
+        let key = StorageKey::for_readme("foo", "1.2.3");
+        s.upload(&key, bytes.clone().into()).await.unwrap();
 
         let expected_files = vec!["readmes/foo/foo-1.2.3.html"];
         assert_eq!(stored_files(&s.store).await, expected_files);
 
-        s.upload_readme("foo", "2.0.0+foo", bytes).await.unwrap();
+        let key = StorageKey::for_readme("foo", "2.0.0+foo");
+        s.upload(&key, bytes.into()).await.unwrap();
 
         let expected_files = vec![
             "readmes/foo/foo-1.2.3.html",

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -547,6 +547,12 @@ impl StorageKey<'_> {
             StorageKey::UpdatesFeed => "rss/updates.xml".into(),
         }
     }
+
+    /// [`Self::path()`] rendered for a public URL, with `+` percent-encoded as
+    /// `%2B`.
+    pub fn cdn_path(&self) -> String {
+        self.path().as_ref().replace('+', "%2B")
+    }
 }
 
 #[cfg(test)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -321,6 +321,20 @@ impl Storage {
         self.store.delete(&path).await
     }
 
+    /// Uploads `payload` to the location identified by `key`, storing it with
+    /// the key's intended attributes.
+    #[instrument(skip(self, payload))]
+    pub async fn upload(&self, key: &StorageKey<'_>, payload: PutPayload) -> Result<()> {
+        let attributes = self
+            .supports_attributes
+            .then(|| key.attributes())
+            .unwrap_or_default();
+
+        let opts = attributes.into();
+        self.store.put_opts(&key.path(), payload, opts).await?;
+        Ok(())
+    }
+
     #[instrument(skip(self, bytes))]
     pub async fn upload_crate_file(&self, name: &str, version: &str, bytes: Bytes) -> Result<()> {
         let path = crate_file_path(name, version);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -247,7 +247,7 @@ impl Storage {
 
     /// Returns the URL of an uploaded RSS feed.
     pub fn feed_url(&self, key: &StorageKey<'_>) -> String {
-        self.apply_cdn_prefix(&key.into()).replace('+', "%2B")
+        self.apply_cdn_prefix(&key.path()).replace('+', "%2B")
     }
 
     /// Returns the base URL that crate files are served from, e.g.
@@ -315,7 +315,7 @@ impl Storage {
 
     #[instrument(skip(self))]
     pub async fn delete_feed(&self, key: &StorageKey<'_>) -> Result<()> {
-        let path = key.into();
+        let path = key.path();
         self.store.delete(&path).await
     }
 
@@ -538,9 +538,10 @@ pub enum StorageKey<'a> {
     UpdatesFeed,
 }
 
-impl From<&StorageKey<'_>> for Path {
-    fn from(key: &StorageKey<'_>) -> Path {
-        match key {
+impl StorageKey<'_> {
+    /// Object-store path used for put/get/delete operations.
+    pub fn path(&self) -> Path {
+        match self {
             StorageKey::CrateFeed { name } => format!("rss/crates/{name}.xml").into(),
             StorageKey::CratesFeed => "rss/crates.xml".into(),
             StorageKey::UpdatesFeed => "rss/updates.xml".into(),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -252,11 +252,6 @@ impl Storage {
         format!("{}/{}", self.cdn_base, key.cdn_path())
     }
 
-    /// Returns the URL of an uploaded RSS feed.
-    pub fn feed_url(&self, key: &StorageKey<'_>) -> String {
-        self.apply_cdn_prefix(&key.path()).replace('+', "%2B")
-    }
-
     /// Returns the base URL that crate files are served from, e.g.
     /// `https://static.crates.io`.
     pub fn cdn_base(&self) -> &str {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -130,12 +130,7 @@ impl Storage {
                     // Apply default content types for the version downloads archive
                     .with_content_type_for_suffix("html", "text/html")
                     .with_content_type_for_suffix("json", "application/json")
-                    .with_content_type_for_suffix("csv", "text/csv")
-                    // The `BufWriter::new()` API currently does not allow
-                    // specifying any file attributes, so we need to set the
-                    // content type here instead for the database dump upload.
-                    .with_content_type_for_suffix("gz", "application/gzip")
-                    .with_content_type_for_suffix("zip", "application/zip");
+                    .with_content_type_for_suffix("csv", "text/csv");
 
                 let store = build_s3(default, options);
 
@@ -420,7 +415,8 @@ impl<'a> StorageKey<'a> {
             StorageKey::CrateFeed { .. } | StorageKey::CratesFeed | StorageKey::UpdatesFeed => {
                 Some("text/xml; charset=UTF-8")
             }
-            StorageKey::DbDumpTar | StorageKey::DbDumpZip => None,
+            StorageKey::DbDumpTar => Some("application/gzip"),
+            StorageKey::DbDumpZip => Some("application/zip"),
         }
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -246,8 +246,8 @@ impl Storage {
     }
 
     /// Returns the URL of an uploaded RSS feed.
-    pub fn feed_url(&self, feed_id: &FeedId<'_>) -> String {
-        self.apply_cdn_prefix(&feed_id.into()).replace('+', "%2B")
+    pub fn feed_url(&self, key: &StorageKey<'_>) -> String {
+        self.apply_cdn_prefix(&key.into()).replace('+', "%2B")
     }
 
     /// Returns the base URL that crate files are served from, e.g.
@@ -314,8 +314,8 @@ impl Storage {
     }
 
     #[instrument(skip(self))]
-    pub async fn delete_feed(&self, feed_id: &FeedId<'_>) -> Result<()> {
-        let path = feed_id.into();
+    pub async fn delete_feed(&self, key: &StorageKey<'_>) -> Result<()> {
+        let path = key.into();
         self.store.delete(&path).await
     }
 
@@ -532,18 +532,18 @@ fn og_image_path(name: &str) -> Path {
 }
 
 #[derive(Debug)]
-pub enum FeedId<'a> {
-    Crate { name: &'a str },
-    Crates,
-    Updates,
+pub enum StorageKey<'a> {
+    CrateFeed { name: &'a str },
+    CratesFeed,
+    UpdatesFeed,
 }
 
-impl From<&FeedId<'_>> for Path {
-    fn from(feed_id: &FeedId<'_>) -> Path {
-        match feed_id {
-            FeedId::Crate { name } => format!("rss/crates/{name}.xml").into(),
-            FeedId::Crates => "rss/crates.xml".into(),
-            FeedId::Updates => "rss/updates.xml".into(),
+impl From<&StorageKey<'_>> for Path {
+    fn from(key: &StorageKey<'_>) -> Path {
+        match key {
+            StorageKey::CrateFeed { name } => format!("rss/crates/{name}.xml").into(),
+            StorageKey::CratesFeed => "rss/crates.xml".into(),
+            StorageKey::UpdatesFeed => "rss/updates.xml".into(),
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,7 +13,6 @@ use object_store::{
 };
 use secrecy::{ExposeSecret, SecretString};
 use std::fs;
-use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWriteExt};
@@ -287,27 +286,6 @@ impl Storage {
     ) -> Result<BoxStream<'_, Result<Bytes>>> {
         let result = self.store.get(&key.path()).await?;
         Ok(result.into_stream())
-    }
-
-    #[instrument(skip(self, channel))]
-    pub async fn upload_feed(
-        &self,
-        key: &StorageKey<'_>,
-        channel: &rss::Channel,
-    ) -> anyhow::Result<()> {
-        let mut buffer = Vec::new();
-        let mut cursor = Cursor::new(&mut buffer);
-        channel.pretty_write_to(&mut cursor, b' ', 4)?;
-        let payload = PutPayload::from_bytes(buffer.into());
-
-        let attributes = self
-            .supports_attributes
-            .then(|| key.attributes())
-            .unwrap_or_default();
-
-        let opts = attributes.into();
-        self.store.put_opts(&key.path(), payload, opts).await?;
-        Ok(())
     }
 
     #[instrument(skip(self, content))]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -284,7 +284,7 @@ impl Storage {
     }
 
     #[instrument(skip(self))]
-    pub async fn download_crate_file(
+    pub async fn download_stream(
         &self,
         key: &StorageKey<'_>,
     ) -> Result<BoxStream<'_, Result<Bytes>>> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -316,7 +316,7 @@ impl Storage {
     }
 
     #[instrument(skip(self))]
-    pub async fn delete_feed(&self, key: &StorageKey<'_>) -> Result<()> {
+    pub async fn delete(&self, key: &StorageKey<'_>) -> Result<()> {
         let path = key.path();
         self.store.delete(&path).await
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -420,15 +420,23 @@ impl Storage {
     }
 
     #[instrument(skip(self, channel))]
-    pub async fn upload_feed(&self, path: &Path, channel: &rss::Channel) -> anyhow::Result<()> {
+    pub async fn upload_feed(
+        &self,
+        key: &StorageKey<'_>,
+        channel: &rss::Channel,
+    ) -> anyhow::Result<()> {
         let mut buffer = Vec::new();
         let mut cursor = Cursor::new(&mut buffer);
         channel.pretty_write_to(&mut cursor, b' ', 4)?;
         let payload = PutPayload::from_bytes(buffer.into());
 
-        let attributes = self.attrs([(Attribute::ContentType, "text/xml; charset=UTF-8")]);
+        let attributes = self
+            .supports_attributes
+            .then(|| key.attributes())
+            .unwrap_or_default();
+
         let opts = attributes.into();
-        self.store.put_opts(path, payload, opts).await?;
+        self.store.put_opts(&key.path(), payload, opts).await?;
         Ok(())
     }
 
@@ -554,6 +562,15 @@ impl StorageKey<'_> {
     /// `%2B`.
     pub fn cdn_path(&self) -> String {
         self.path().as_ref().replace('+', "%2B")
+    }
+
+    /// The intended attribute set (content-type + cache-control) for the file.
+    pub fn attributes(&self) -> Attributes {
+        match self {
+            StorageKey::CrateFeed { .. } | StorageKey::CratesFeed | StorageKey::UpdatesFeed => {
+                Attributes::from_iter([(Attribute::ContentType, "text/xml; charset=UTF-8")])
+            }
+        }
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -238,13 +238,6 @@ impl Storage {
             .replace('+', "%2B")
     }
 
-    /// Returns the URL of an uploaded crate's Open Graph image.
-    ///
-    /// The function doesn't check for the existence of the file.
-    pub fn og_image_location(&self, name: &str) -> String {
-        self.apply_cdn_prefix(&og_image_path(name))
-    }
-
     /// Returns the public URL of the file identified by `key`.
     ///
     /// The function doesn't check for the existence of the file.
@@ -306,13 +299,6 @@ impl Storage {
         let path = readme_path(name, version);
         self.store.delete(&path).await?;
         Ok(path)
-    }
-
-    /// Deletes the Open Graph image for the given crate.
-    #[instrument(skip(self))]
-    pub async fn delete_og_image(&self, name: &str) -> Result<()> {
-        let path = og_image_path(name);
-        self.store.delete(&path).await
     }
 
     #[instrument(skip(self))]
@@ -414,19 +400,6 @@ impl Storage {
         let attributes = self.attrs([
             (Attribute::ContentType, CONTENT_TYPE_README),
             (Attribute::CacheControl, CACHE_CONTROL_README),
-        ]);
-        let opts = attributes.into();
-        self.store.put_opts(&path, bytes.into(), opts).await?;
-        Ok(())
-    }
-
-    /// Uploads an Open Graph image for the given crate.
-    #[instrument(skip(self, bytes))]
-    pub async fn upload_og_image(&self, name: &str, bytes: Bytes) -> Result<()> {
-        let path = og_image_path(name);
-        let attributes = self.attrs([
-            (Attribute::ContentType, CONTENT_TYPE_OG_IMAGE),
-            (Attribute::CacheControl, CACHE_CONTROL_OG_IMAGE),
         ]);
         let opts = attributes.into();
         self.store.put_opts(&path, bytes.into(), opts).await?;
@@ -551,21 +524,24 @@ fn readme_path(name: &str, version: &str) -> Path {
     format!("{PREFIX_READMES}/{name}/{name}-{version}.html").into()
 }
 
-fn og_image_path(name: &str) -> Path {
-    format!("{PREFIX_OG_IMAGES}/{name}.png").into()
-}
-
 #[derive(Debug)]
 pub enum StorageKey<'a> {
+    OgImage { name: &'a str },
     CrateFeed { name: &'a str },
     CratesFeed,
     UpdatesFeed,
 }
 
-impl StorageKey<'_> {
+impl<'a> StorageKey<'a> {
+    /// Builds a [`StorageKey::OgImage`] key for the given crate.
+    pub fn for_og_image(name: &'a str) -> Self {
+        StorageKey::OgImage { name }
+    }
+
     /// Object-store path used for put/get/delete operations.
     pub fn path(&self) -> Path {
         match self {
+            StorageKey::OgImage { name } => format!("{PREFIX_OG_IMAGES}/{name}.png").into(),
             StorageKey::CrateFeed { name } => format!("rss/crates/{name}.xml").into(),
             StorageKey::CratesFeed => "rss/crates.xml".into(),
             StorageKey::UpdatesFeed => "rss/updates.xml".into(),
@@ -581,6 +557,10 @@ impl StorageKey<'_> {
     /// The intended attribute set (content-type + cache-control) for the file.
     pub fn attributes(&self) -> Attributes {
         match self {
+            StorageKey::OgImage { .. } => Attributes::from_iter([
+                (Attribute::ContentType, CONTENT_TYPE_OG_IMAGE),
+                (Attribute::CacheControl, CACHE_CONTROL_OG_IMAGE),
+            ]),
             StorageKey::CrateFeed { .. } | StorageKey::CratesFeed | StorageKey::UpdatesFeed => {
                 Attributes::from_iter([(Attribute::ContentType, "text/xml; charset=UTF-8")])
             }
@@ -701,7 +681,8 @@ mod tests {
             ),
         ];
         for (name, expected) in og_image_tests {
-            assert_eq!(storage.og_image_location(name), expected);
+            let key = StorageKey::for_og_image(name);
+            assert_eq!(storage.location(&key), expected);
         }
     }
 
@@ -960,14 +941,14 @@ mod tests {
         let s = Storage::from_config(&StorageConfig::in_memory());
 
         let bytes = Bytes::from_static(b"fake png data");
-        s.upload_og_image("foo", bytes.clone()).await.unwrap();
+        let key = StorageKey::for_og_image("foo");
+        s.upload(&key, bytes.clone().into()).await.unwrap();
 
         let expected_files = vec!["og-images/foo.png"];
         assert_eq!(stored_files(&s.store).await, expected_files);
 
-        s.upload_og_image("some-long-crate-name", bytes)
-            .await
-            .unwrap();
+        let key = StorageKey::for_og_image("some-long-crate-name");
+        s.upload(&key, bytes.into()).await.unwrap();
 
         let expected_files = vec!["og-images/foo.png", "og-images/some-long-crate-name.png"];
         assert_eq!(stored_files(&s.store).await, expected_files);
@@ -978,13 +959,16 @@ mod tests {
         let s = Storage::from_config(&StorageConfig::in_memory());
 
         let bytes = Bytes::from_static(b"fake png data");
-        s.upload_og_image("foo", bytes.clone()).await.unwrap();
-        s.upload_og_image("bar", bytes).await.unwrap();
+
+        let foo_key = StorageKey::for_og_image("foo");
+        s.upload(&foo_key, bytes.clone().into()).await.unwrap();
+        let bar_key = StorageKey::for_og_image("bar");
+        s.upload(&bar_key, bytes.into()).await.unwrap();
 
         let expected_files = vec!["og-images/bar.png", "og-images/foo.png"];
         assert_eq!(stored_files(&s.store).await, expected_files);
 
-        s.delete_og_image("foo").await.unwrap();
+        s.delete(&foo_key).await.unwrap();
 
         let expected_files = vec!["og-images/bar.png"];
         assert_eq!(stored_files(&s.store).await, expected_files);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -16,7 +16,6 @@ use std::fs;
 use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::fs::File;
 use tokio::io::{AsyncRead, AsyncWriteExt};
 use tracing::{instrument, warn};
 
@@ -35,8 +34,6 @@ const CACHE_CONTROL_IMMUTABLE: &str = "public,max-age=31536000,immutable";
 const CACHE_CONTROL_INDEX: &str = "public,max-age=600";
 const CACHE_CONTROL_README: &str = "public,max-age=604800";
 const CACHE_CONTROL_OG_IMAGE: &str = "public,max-age=86400";
-
-type StdPath = std::path::Path;
 
 #[derive(Debug)]
 pub struct StorageConfig {
@@ -331,16 +328,6 @@ impl Storage {
         Ok(())
     }
 
-    #[instrument(skip(self))]
-    pub async fn upload_db_dump(
-        &self,
-        key: &StorageKey<'_>,
-        local_path: &StdPath,
-    ) -> anyhow::Result<()> {
-        let local_file = File::open(local_path).await?;
-        self.upload_stream(key, local_file).await
-    }
-
     /// This should only be used for assertions in the test suite!
     pub fn as_inner(&self) -> Arc<dyn ObjectStore> {
         self.store.clone()
@@ -485,7 +472,6 @@ impl<'a> StorageKey<'a> {
 mod tests {
     use super::*;
     use hyper::body::Bytes;
-    use tempfile::NamedTempFile;
 
     pub async fn prepare() -> Storage {
         let storage = Storage::from_config(&StorageConfig::in_memory());
@@ -837,8 +823,7 @@ mod tests {
         assert!(stored_files(&s.store).await.is_empty());
 
         let key = StorageKey::DbDumpTar;
-        let file = NamedTempFile::new().unwrap();
-        s.upload_db_dump(&key, file.path()).await.unwrap();
+        s.upload_stream(&key, &b"fake db dump"[..]).await.unwrap();
 
         let expected_files = vec!["db-dump.tar.gz"];
         assert_eq!(stored_files(&s.store).await, expected_files);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -245,6 +245,13 @@ impl Storage {
         self.apply_cdn_prefix(&og_image_path(name))
     }
 
+    /// Returns the public URL of the file identified by `key`.
+    ///
+    /// The function doesn't check for the existence of the file.
+    pub fn location(&self, key: &StorageKey<'_>) -> String {
+        format!("{}/{}", self.cdn_base, key.cdn_path())
+    }
+
     /// Returns the URL of an uploaded RSS feed.
     pub fn feed_url(&self, key: &StorageKey<'_>) -> String {
         self.apply_cdn_prefix(&key.path()).replace('+', "%2B")

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -332,15 +332,18 @@ impl Storage {
     }
 
     #[instrument(skip(self))]
-    pub async fn upload_db_dump(&self, target: &str, local_path: &StdPath) -> anyhow::Result<()> {
+    pub async fn upload_db_dump(
+        &self,
+        key: &StorageKey<'_>,
+        local_path: &StdPath,
+    ) -> anyhow::Result<()> {
         let store = self.store.clone();
 
         // Open the local tarball file
         let mut local_file = File::open(local_path).await?;
 
         // Set up a multipart upload
-        let path = target.into();
-        let mut writer = object_store::buffered::BufWriter::new(store, path);
+        let mut writer = object_store::buffered::BufWriter::new(store, key.path());
 
         // Upload file contents
         if let Err(error) = tokio::io::copy(&mut local_file, &mut writer).await {
@@ -404,6 +407,8 @@ pub enum StorageKey<'a> {
     CrateFeed { name: &'a str },
     CratesFeed,
     UpdatesFeed,
+    DbDumpTar,
+    DbDumpZip,
 }
 
 impl<'a> StorageKey<'a> {
@@ -451,6 +456,8 @@ impl<'a> StorageKey<'a> {
             StorageKey::CrateFeed { name } => format!("rss/crates/{name}.xml").into(),
             StorageKey::CratesFeed => "rss/crates.xml".into(),
             StorageKey::UpdatesFeed => "rss/updates.xml".into(),
+            StorageKey::DbDumpTar => "db-dump.tar.gz".into(),
+            StorageKey::DbDumpZip => "db-dump.zip".into(),
         }
     }
 
@@ -486,6 +493,7 @@ impl<'a> StorageKey<'a> {
             StorageKey::CrateFeed { .. } | StorageKey::CratesFeed | StorageKey::UpdatesFeed => {
                 Attributes::from_iter([(Attribute::ContentType, "text/xml; charset=UTF-8")])
             }
+            StorageKey::DbDumpTar | StorageKey::DbDumpZip => Attributes::new(),
         }
     }
 }
@@ -849,11 +857,11 @@ mod tests {
 
         assert!(stored_files(&s.store).await.is_empty());
 
-        let target = "db-dump.tar.gz";
+        let key = StorageKey::DbDumpTar;
         let file = NamedTempFile::new().unwrap();
-        s.upload_db_dump(target, file.path()).await.unwrap();
+        s.upload_db_dump(&key, file.path()).await.unwrap();
 
-        let expected_files = vec![target];
+        let expected_files = vec!["db-dump.tar.gz"];
         assert_eq!(stored_files(&s.store).await, expected_files);
     }
 

--- a/src/worker/jobs/analyze_crate_file.rs
+++ b/src/worker/jobs/analyze_crate_file.rs
@@ -94,7 +94,7 @@ async fn analyze_crate_tarball(
     storage: &Storage,
 ) -> anyhow::Result<LinecountStats> {
     let key = StorageKey::for_crate_file(krate, version);
-    let result = storage.download_crate_file(&key).await;
+    let result = storage.download_stream(&key).await;
     let stream = result.context("Failed to download crate file")?;
     let reader = StreamReader::new(stream);
     let reader = BufReader::new(reader);

--- a/src/worker/jobs/analyze_crate_file.rs
+++ b/src/worker/jobs/analyze_crate_file.rs
@@ -1,5 +1,5 @@
 use crate::schema::{crates, versions};
-use crate::storage::Storage;
+use crate::storage::{Storage, StorageKey};
 use crate::worker::Environment;
 use crate::worker::jobs::GenerateOgImage;
 use anyhow::Context;
@@ -93,7 +93,8 @@ async fn analyze_crate_tarball(
     version: &str,
     storage: &Storage,
 ) -> anyhow::Result<LinecountStats> {
-    let result = storage.download_crate_file(krate, version).await;
+    let key = StorageKey::for_crate_file(krate, version);
+    let result = storage.download_crate_file(&key).await;
     let stream = result.context("Failed to download crate file")?;
     let reader = StreamReader::new(stream);
     let reader = BufReader::new(reader);

--- a/src/worker/jobs/build_crate_zip.rs
+++ b/src/worker/jobs/build_crate_zip.rs
@@ -1,4 +1,5 @@
 use crate::schema::{crates, versions};
+use crate::storage::StorageKey;
 use crate::worker::Environment;
 use anyhow::Context;
 use chrono::{DateTime, Datelike, Timelike, Utc};
@@ -141,8 +142,9 @@ async fn download_to_tempfile(
     let file = tempfile::tempfile().context("Failed to create temporary file")?;
     let mut writer = tokio::fs::File::from_std(file);
 
+    let key = StorageKey::for_crate_file(krate, version);
     let mut stream = storage
-        .download_crate_file(krate, version)
+        .download_crate_file(&key)
         .await
         .context("Failed to download crate file")?;
 

--- a/src/worker/jobs/build_crate_zip.rs
+++ b/src/worker/jobs/build_crate_zip.rs
@@ -66,7 +66,7 @@ impl BackgroundJob for BuildCrateZip {
 
         let zip_key = StorageKey::for_crate_zip(name, version);
         env.storage
-            .upload_crate_zip(&zip_key, tokio::fs::File::from_std(artifacts.zip))
+            .upload_stream(&zip_key, tokio::fs::File::from_std(artifacts.zip))
             .await
             .context("Failed to upload zip archive")?;
 

--- a/src/worker/jobs/build_crate_zip.rs
+++ b/src/worker/jobs/build_crate_zip.rs
@@ -146,7 +146,7 @@ async fn download_to_tempfile(
 
     let key = StorageKey::for_crate_file(krate, version);
     let mut stream = storage
-        .download_crate_file(&key)
+        .download_stream(&key)
         .await
         .context("Failed to download crate file")?;
 

--- a/src/worker/jobs/build_crate_zip.rs
+++ b/src/worker/jobs/build_crate_zip.rs
@@ -64,13 +64,15 @@ impl BackgroundJob for BuildCrateZip {
             .await
             .context("Zip build task panicked")??;
 
+        let zip_key = StorageKey::for_crate_zip(name, version);
         env.storage
-            .upload_crate_zip(name, version, tokio::fs::File::from_std(artifacts.zip))
+            .upload_crate_zip(&zip_key, tokio::fs::File::from_std(artifacts.zip))
             .await
             .context("Failed to upload zip archive")?;
 
+        let manifest_key = StorageKey::for_crate_zip_manifest(name, version);
         env.storage
-            .upload_crate_zip_manifest(name, version, artifacts.manifest_json.into())
+            .upload(&manifest_key, artifacts.manifest_json.into())
             .await
             .context("Failed to upload zip manifest")?;
 

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -43,7 +43,7 @@ impl BackgroundJob for DeleteCrateFromStorage {
             },
             async {
                 info!("{name}: Deleting RSS feed from S3…");
-                let result = ctx.storage.delete_feed(&key).await;
+                let result = ctx.storage.delete(&key).await;
                 result.context("Failed to delete RSS feed from S3")
             },
             async {

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -28,7 +28,8 @@ impl BackgroundJob for DeleteCrateFromStorage {
 
     async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
         let name = &self.name;
-        let key = StorageKey::CrateFeed { name };
+        let og_image_key = StorageKey::for_og_image(name);
+        let feed_key = StorageKey::CrateFeed { name };
 
         let (crate_file_paths, readme_paths, _, _) = try_join!(
             async {
@@ -43,12 +44,12 @@ impl BackgroundJob for DeleteCrateFromStorage {
             },
             async {
                 info!("{name}: Deleting RSS feed from S3…");
-                let result = ctx.storage.delete(&key).await;
+                let result = ctx.storage.delete(&feed_key).await;
                 result.context("Failed to delete RSS feed from S3")
             },
             async {
                 info!("{name}: Deleting OG image from S3…");
-                let result = ctx.storage.delete_og_image(name).await;
+                let result = ctx.storage.delete(&og_image_key).await;
                 result.context("Failed to delete OG image from S3")
             }
         )?;
@@ -62,8 +63,8 @@ impl BackgroundJob for DeleteCrateFromStorage {
             crate_file_paths
                 .into_iter()
                 .chain(readme_paths)
-                .chain(std::iter::once(format!("og-images/{name}.png").into()))
-                .chain(std::iter::once(key.path())),
+                .chain(std::iter::once(og_image_key.path()))
+                .chain(std::iter::once(feed_key.path())),
         )
         .enqueue(&conn)
         .await?;

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -63,7 +63,7 @@ impl BackgroundJob for DeleteCrateFromStorage {
                 .into_iter()
                 .chain(readme_paths)
                 .chain(std::iter::once(format!("og-images/{name}.png").into()))
-                .chain(std::iter::once(object_store::path::Path::from(&key))),
+                .chain(std::iter::once(key.path())),
         )
         .enqueue(&conn)
         .await?;

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -1,4 +1,4 @@
-use crate::storage::FeedId;
+use crate::storage::StorageKey;
 use crate::worker::Environment;
 use crate::worker::jobs::InvalidateCdns;
 use anyhow::Context;
@@ -28,7 +28,7 @@ impl BackgroundJob for DeleteCrateFromStorage {
 
     async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
         let name = &self.name;
-        let feed_id = FeedId::Crate { name };
+        let key = StorageKey::CrateFeed { name };
 
         let (crate_file_paths, readme_paths, _, _) = try_join!(
             async {
@@ -43,7 +43,7 @@ impl BackgroundJob for DeleteCrateFromStorage {
             },
             async {
                 info!("{name}: Deleting RSS feed from S3…");
-                let result = ctx.storage.delete_feed(&feed_id).await;
+                let result = ctx.storage.delete_feed(&key).await;
                 result.context("Failed to delete RSS feed from S3")
             },
             async {
@@ -63,7 +63,7 @@ impl BackgroundJob for DeleteCrateFromStorage {
                 .into_iter()
                 .chain(readme_paths)
                 .chain(std::iter::once(format!("og-images/{name}.png").into()))
-                .chain(std::iter::once(object_store::path::Path::from(&feed_id))),
+                .chain(std::iter::once(object_store::path::Path::from(&key))),
         )
         .enqueue(&conn)
         .await?;

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -60,9 +60,8 @@ impl BackgroundJob for DumpDb {
 
         info!("Uploading tarball…");
         let tar_key = StorageKey::DbDumpTar;
-        env.storage
-            .upload_db_dump(&tar_key, archives.tar.path())
-            .await?;
+        let tar_file = tokio::fs::File::open(archives.tar.path()).await?;
+        env.storage.upload_stream(&tar_key, tar_file).await?;
         info!("Database dump tarball uploaded");
 
         info!("Invalidating CDN caches…");
@@ -75,9 +74,8 @@ impl BackgroundJob for DumpDb {
 
         info!("Uploading zip file…");
         let zip_key = StorageKey::DbDumpZip;
-        env.storage
-            .upload_db_dump(&zip_key, archives.zip.path())
-            .await?;
+        let zip_file = tokio::fs::File::open(archives.zip.path()).await?;
+        env.storage.upload_stream(&zip_key, zip_file).await?;
         info!("Database dump zip file uploaded");
 
         info!("Invalidating CDN caches…");

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -1,3 +1,4 @@
+use crate::storage::StorageKey;
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
 use crates_io_database::models::CloudFrontDistribution;
@@ -38,9 +39,6 @@ impl BackgroundJob for DumpDb {
     /// Creates CSV dumps of the public information in the database, wraps them in a
     /// tarball and uploads to S3.
     async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
-        const TAR_PATH: &str = "db-dump.tar.gz";
-        const ZIP_PATH: &str = "db-dump.zip";
-
         let db_config = &env.config.db;
         let db_pool_config = db_config.replica.as_ref().unwrap_or(&db_config.primary);
         let database_url = db_pool_config.url.clone();
@@ -61,8 +59,9 @@ impl BackgroundJob for DumpDb {
         .await??;
 
         info!("Uploading tarball…");
+        let tar_key = StorageKey::DbDumpTar;
         env.storage
-            .upload_db_dump(TAR_PATH, archives.tar.path())
+            .upload_db_dump(&tar_key, archives.tar.path())
             .await?;
         info!("Database dump tarball uploaded");
 
@@ -70,18 +69,19 @@ impl BackgroundJob for DumpDb {
         let conn = env.deadpool.get().await?;
         let dist = CloudFrontDistribution::Static;
 
-        if let Err(error) = env.invalidate_cdns(&conn, dist, TAR_PATH).await {
+        if let Err(error) = env.invalidate_cdns(&conn, dist, &tar_key.cdn_path()).await {
             warn!("Failed to invalidate CDN caches: {error}");
         }
 
         info!("Uploading zip file…");
+        let zip_key = StorageKey::DbDumpZip;
         env.storage
-            .upload_db_dump(ZIP_PATH, archives.zip.path())
+            .upload_db_dump(&zip_key, archives.zip.path())
             .await?;
         info!("Database dump zip file uploaded");
 
         info!("Invalidating CDN caches…");
-        if let Err(error) = env.invalidate_cdns(&conn, dist, ZIP_PATH).await {
+        if let Err(error) = env.invalidate_cdns(&conn, dist, &zip_key.cdn_path()).await {
             warn!("Failed to invalidate CDN caches: {error}");
         }
 

--- a/src/worker/jobs/generate_og_image.rs
+++ b/src/worker/jobs/generate_og_image.rs
@@ -1,5 +1,6 @@
 use crate::models::OwnerKind;
 use crate::schema::*;
+use crate::storage::StorageKey;
 use crate::worker::Environment;
 use crate::worker::jobs::ProcessCloudfrontInvalidationQueue;
 use anyhow::Context;
@@ -89,9 +90,8 @@ impl BackgroundJob for GenerateOgImage {
         let image_bytes = option.generate(og_data).await?;
 
         // Upload to storage
-        ctx.storage
-            .upload_og_image(crate_name, image_bytes.into())
-            .await?;
+        let key = StorageKey::for_og_image(crate_name);
+        ctx.storage.upload(&key, image_bytes.into()).await?;
 
         info!("Successfully generated and uploaded OG image for crate {crate_name}");
 
@@ -101,7 +101,7 @@ impl BackgroundJob for GenerateOgImage {
         }
 
         // Invalidate CDN cache for the OG image
-        let og_image_path = format!("og-images/{crate_name}.png");
+        let og_image_path = key.cdn_path();
 
         // Queue CloudFront invalidation for batch processing
         if ctx.cloudfront().is_some() {

--- a/src/worker/jobs/readmes.rs
+++ b/src/worker/jobs/readmes.rs
@@ -1,6 +1,7 @@
 //! Render README files to HTML.
 
 use crate::models::Version;
+use crate::storage::StorageKey;
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
 use crates_io_markdown::text_to_html;
@@ -106,8 +107,8 @@ impl BackgroundJob for RenderAndUploadReadme {
 
             tracing::Span::current().record("krate.name", tracing::field::display(&crate_name));
 
-            let bytes = rendered.into();
-            env.storage.upload_readme(&crate_name, &vers, bytes).await?;
+            let key = StorageKey::for_readme(&crate_name, &vers);
+            env.storage.upload(&key, rendered.into()).await?;
 
             Ok(())
         })

--- a/src/worker/jobs/rss/mod.rs
+++ b/src/worker/jobs/rss/mod.rs
@@ -5,3 +5,11 @@ mod sync_updates_feed;
 pub use sync_crate_feed::SyncCrateFeed;
 pub use sync_crates_feed::SyncCratesFeed;
 pub use sync_updates_feed::SyncUpdatesFeed;
+
+/// Serializes an RSS channel into a pretty-printed XML byte buffer.
+fn serialize_channel(channel: &rss::Channel) -> anyhow::Result<Vec<u8>> {
+    let mut buffer = Vec::new();
+    let mut cursor = std::io::Cursor::new(&mut buffer);
+    channel.pretty_write_to(&mut cursor, b' ', 4)?;
+    Ok(buffer)
+}

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -80,7 +80,8 @@ impl BackgroundJob for SyncCrateFeed {
         let path = key.path();
 
         info!("Uploading feed to storage…");
-        ctx.storage.upload_feed(&key, &channel).await?;
+        let bytes = super::serialize_channel(&channel)?;
+        ctx.storage.upload(&key, bytes.into()).await?;
 
         let dist = CloudFrontDistribution::Static;
         if let Err(error) = ctx.invalidate_cdns(&conn, dist, path.as_ref()).await {

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -80,7 +80,7 @@ impl BackgroundJob for SyncCrateFeed {
         let path = key.path();
 
         info!("Uploading feed to storage…");
-        ctx.storage.upload_feed(&path, &channel).await?;
+        ctx.storage.upload_feed(&key, &channel).await?;
 
         let dist = CloudFrontDistribution::Static;
         if let Err(error) = ctx.invalidate_cdns(&conn, dist, path.as_ref()).await {

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -50,7 +50,7 @@ impl BackgroundJob for SyncCrateFeed {
         let key = StorageKey::CrateFeed { name };
 
         let link = rss::extension::atom::Link {
-            href: ctx.storage.feed_url(&key),
+            href: ctx.storage.location(&key),
             rel: "self".to_string(),
             mime_type: Some("application/rss+xml".to_string()),
             ..Default::default()

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -77,7 +77,7 @@ impl BackgroundJob for SyncCrateFeed {
             ..Default::default()
         };
 
-        let path = object_store::path::Path::from(&key);
+        let path = key.path();
 
         info!("Uploading feed to storage…");
         ctx.storage.upload_feed(&path, &channel).await?;

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -1,5 +1,5 @@
 use crate::schema::{crates, versions};
-use crate::storage::FeedId;
+use crate::storage::StorageKey;
 use crate::worker::Environment;
 use chrono::{Duration, Utc};
 use crates_io_database::models::CloudFrontDistribution;
@@ -47,10 +47,10 @@ impl BackgroundJob for SyncCrateFeed {
 
         let version_updates = load_version_updates(name, &conn).await?;
 
-        let feed_id = FeedId::Crate { name };
+        let key = StorageKey::CrateFeed { name };
 
         let link = rss::extension::atom::Link {
-            href: ctx.storage.feed_url(&feed_id),
+            href: ctx.storage.feed_url(&key),
             rel: "self".to_string(),
             mime_type: Some("application/rss+xml".to_string()),
             ..Default::default()
@@ -77,7 +77,7 @@ impl BackgroundJob for SyncCrateFeed {
             ..Default::default()
         };
 
-        let path = object_store::path::Path::from(&feed_id);
+        let path = object_store::path::Path::from(&key);
 
         info!("Uploading feed to storage…");
         ctx.storage.upload_feed(&path, &channel).await?;

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -1,5 +1,5 @@
 use crate::schema::crates;
-use crate::storage::FeedId;
+use crate::storage::StorageKey;
 use crate::worker::Environment;
 use chrono::{Duration, Utc};
 use crates_io_database::models::CloudFrontDistribution;
@@ -31,7 +31,7 @@ impl BackgroundJob for SyncCratesFeed {
     type Context = Arc<Environment>;
 
     async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
-        let feed_id = FeedId::Crates;
+        let key = StorageKey::CratesFeed;
         let domain = &ctx.config.domain_name;
 
         info!("Loading latest {NUM_ITEMS} crates from the database…");
@@ -39,7 +39,7 @@ impl BackgroundJob for SyncCratesFeed {
         let new_crates = load_new_crates(&conn).await?;
 
         let link = rss::extension::atom::Link {
-            href: ctx.storage.feed_url(&feed_id),
+            href: ctx.storage.feed_url(&key),
             rel: "self".to_string(),
             mime_type: Some("application/rss+xml".to_string()),
             ..Default::default()
@@ -64,7 +64,7 @@ impl BackgroundJob for SyncCratesFeed {
             ..Default::default()
         };
 
-        let path = object_store::path::Path::from(&feed_id);
+        let path = object_store::path::Path::from(&key);
 
         info!("Uploading feed to storage…");
         ctx.storage.upload_feed(&path, &channel).await?;

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -64,7 +64,7 @@ impl BackgroundJob for SyncCratesFeed {
             ..Default::default()
         };
 
-        let path = object_store::path::Path::from(&key);
+        let path = key.path();
 
         info!("Uploading feed to storage…");
         ctx.storage.upload_feed(&path, &channel).await?;

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -39,7 +39,7 @@ impl BackgroundJob for SyncCratesFeed {
         let new_crates = load_new_crates(&conn).await?;
 
         let link = rss::extension::atom::Link {
-            href: ctx.storage.feed_url(&key),
+            href: ctx.storage.location(&key),
             rel: "self".to_string(),
             mime_type: Some("application/rss+xml".to_string()),
             ..Default::default()

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -67,7 +67,8 @@ impl BackgroundJob for SyncCratesFeed {
         let path = key.path();
 
         info!("Uploading feed to storage…");
-        ctx.storage.upload_feed(&key, &channel).await?;
+        let bytes = super::serialize_channel(&channel)?;
+        ctx.storage.upload(&key, bytes.into()).await?;
 
         let dist = CloudFrontDistribution::Static;
         if let Err(error) = ctx.invalidate_cdns(&conn, dist, path.as_ref()).await {

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -67,7 +67,7 @@ impl BackgroundJob for SyncCratesFeed {
         let path = key.path();
 
         info!("Uploading feed to storage…");
-        ctx.storage.upload_feed(&path, &channel).await?;
+        ctx.storage.upload_feed(&key, &channel).await?;
 
         let dist = CloudFrontDistribution::Static;
         if let Err(error) = ctx.invalidate_cdns(&conn, dist, path.as_ref()).await {

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -1,5 +1,5 @@
 use crate::schema::{crates, versions};
-use crate::storage::FeedId;
+use crate::storage::StorageKey;
 use crate::worker::Environment;
 use chrono::{Duration, Utc};
 use crates_io_database::models::CloudFrontDistribution;
@@ -31,7 +31,7 @@ impl BackgroundJob for SyncUpdatesFeed {
     type Context = Arc<Environment>;
 
     async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
-        let feed_id = FeedId::Updates;
+        let key = StorageKey::UpdatesFeed;
         let domain = &ctx.config.domain_name;
 
         info!("Loading latest {NUM_ITEMS} version updates from the database…");
@@ -39,7 +39,7 @@ impl BackgroundJob for SyncUpdatesFeed {
         let version_updates = load_version_updates(&conn).await?;
 
         let link = rss::extension::atom::Link {
-            href: ctx.storage.feed_url(&feed_id),
+            href: ctx.storage.feed_url(&key),
             rel: "self".to_string(),
             mime_type: Some("application/rss+xml".to_string()),
             ..Default::default()
@@ -64,7 +64,7 @@ impl BackgroundJob for SyncUpdatesFeed {
             ..Default::default()
         };
 
-        let path = object_store::path::Path::from(&feed_id);
+        let path = object_store::path::Path::from(&key);
 
         info!("Uploading feed to storage…");
         ctx.storage.upload_feed(&path, &channel).await?;

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -64,7 +64,7 @@ impl BackgroundJob for SyncUpdatesFeed {
             ..Default::default()
         };
 
-        let path = object_store::path::Path::from(&key);
+        let path = key.path();
 
         info!("Uploading feed to storage…");
         ctx.storage.upload_feed(&path, &channel).await?;

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -39,7 +39,7 @@ impl BackgroundJob for SyncUpdatesFeed {
         let version_updates = load_version_updates(&conn).await?;
 
         let link = rss::extension::atom::Link {
-            href: ctx.storage.feed_url(&key),
+            href: ctx.storage.location(&key),
             rel: "self".to_string(),
             mime_type: Some("application/rss+xml".to_string()),
             ..Default::default()

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -67,7 +67,8 @@ impl BackgroundJob for SyncUpdatesFeed {
         let path = key.path();
 
         info!("Uploading feed to storage…");
-        ctx.storage.upload_feed(&key, &channel).await?;
+        let bytes = super::serialize_channel(&channel)?;
+        ctx.storage.upload(&key, bytes.into()).await?;
 
         let dist = CloudFrontDistribution::Static;
         if let Err(error) = ctx.invalidate_cdns(&conn, dist, path.as_ref()).await {

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -67,7 +67,7 @@ impl BackgroundJob for SyncUpdatesFeed {
         let path = key.path();
 
         info!("Uploading feed to storage…");
-        ctx.storage.upload_feed(&path, &channel).await?;
+        ctx.storage.upload_feed(&key, &channel).await?;
 
         let dist = CloudFrontDistribution::Static;
         if let Err(error) = ctx.invalidate_cdns(&conn, dist, path.as_ref()).await {


### PR DESCRIPTION
`Storage` exposed a large per-file-type API: separate `*_location()`, `delete_*()`, and `upload_*()` methods for crate files, zips, zip manifests, readmes, og-images, and feeds, with path construction scattered across free functions and content-type/cache-control metadata duplicated across the upload methods.

This collapses all of that into a single `StorageKey` enum plus a small generic core. `StorageKey` describes every file on the default store (served from `static.crates.io`), including the two database-dump targets, and owns `path()`, `cdn_path()`, `content_type()`, `cache_control()`, and `attributes()`, with `for_*()` constructors per variant.

The per-type methods collapse into generic `location()`, `upload()`, `upload_stream()`, `download_stream()`, and `delete()`, each taking a `&StorageKey`. The prefix deletes (`delete_all_crate_files()`, `delete_all_readmes()`) stay as dedicated methods. The `apply_cdn_prefix()` helper and all the `*_path()` free functions are gone, and the storage layer no longer depends on `rss`.

Each step is its own commit that keeps the build and tests green. The existing path and URL assertions in the storage tests stay green throughout, which proves every refactor preserved behavior.

Two behavior-adjacent changes, both safe:

- `cdn_path()` percent-encodes `+` as `%2B` unconditionally. `+` only ever appears in versions, and the variants without a version never contain one, so this matches the previous per-method `.replace('+', "%2B")`. The old `og_image_location()` skipped that replace, but og-image keys carry no version, so the URL is unchanged.
- The db-dump content-types (`application/gzip`, `application/zip`) now come from the key's `content_type()` and are written as object attributes, instead of from the S3 client's suffix-based `with_content_type_for_suffix()` config. The Content-Type that lands on S3 is identical. The `html`/`json`/`csv` suffix defaults stay, since the version-downloads archive jobs still write through a raw `ObjectStore` handle outside the `StorageKey` API.

The `index_store` / `sync_index()` path stays out of scope, since the index lives in a different backing store.

### Related

- https://github.com/rust-lang/crates.io/pull/14063
