### PR TITLE
Stop updating user.username when a user renames or deletes their github account

### DIFF
--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -125,7 +125,6 @@ impl NewUser<'_> {
             .do_update()
             .set((
                 users::gh_login.eq(excluded(users::gh_login)),
-                users::username.eq(excluded(users::username)),
                 users::name.eq(excluded(users::name)),
                 users::gh_encrypted_token.eq(excluded(users::gh_encrypted_token)),
             ))

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -51,6 +51,8 @@ async fn updating_existing_user_doesnt_change_api_token() -> anyhow::Result<()> 
     let user = assert_ok!(User::find(&conn, api_token.user_id).await);
 
     assert_eq!(user.gh_login, "bar");
+    // updating existing user should not change their username
+    assert_eq!(user.username, "foo");
     let decrypted_token = encryption.decrypt(&user.gh_encrypted_token)?;
     assert_eq!(decrypted_token.expose_secret(), "bar_token");
 

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -82,7 +82,6 @@ impl UpdateTest {
         // For now, we want to update the `User` record too
         let user_after_update = User::find(&conn, user_id).await?;
         assert_eq!(user_after_update.gh_login, expected_username);
-        assert_eq!(user_after_update.username, expected_username);
 
         if job_result.is_err() {
             // The worker leaves failed rows in `background_jobs` so they can

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -82,6 +82,8 @@ impl UpdateTest {
         // For now, we want to update the `User` record too
         let user_after_update = User::find(&conn, user_id).await?;
         assert_eq!(user_after_update.gh_login, expected_username);
+        // The user's username should not be updated
+        assert_eq!(user_after_update.username, existing_gh_user.login);
 
         if job_result.is_err() {
             // The worker leaves failed rows in `background_jobs` so they can

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -167,10 +167,7 @@ impl UpdateUserFromGithub {
                 if oauth_github.login != github_user.login {
                     diesel::update(users::table)
                         .filter(users::id.eq(oauth_github.user_id))
-                        .set((
-                            users::gh_login.eq(&github_user.login),
-                            users::username.eq(&github_user.login),
-                        ))
+                        .set(users::gh_login.eq(&github_user.login))
                         .execute(conn)
                         .await?;
                 }


### PR DESCRIPTION
fixes https://github.com/rust-lang/crates.io/issues/13761

Stop updating a user's username when a user updates or deletes their github account. This update currently happens on background job added in https://github.com/rust-lang/crates.io/pull/13143 and on login.
