### PR TITLE
Limit version numbers to 150 characters

### DIFF
--- a/crates/crates_io_validation/src/lib.rs
+++ b/crates/crates_io_validation/src/lib.rs
@@ -2,6 +2,16 @@
 
 pub const MAX_NAME_LENGTH: usize = 64;
 
+/// Maximum length of a version number.
+///
+/// CloudFront cache tags allow at most 256 characters per tag. The longest tag
+/// we emit is `release:{name}@{version}`, which adds 9 characters of prefix
+/// (`release:` plus `@`) to the crate name and version. With the crate name
+/// capped at [`MAX_NAME_LENGTH`] (64), the version can be at most
+/// `256 - 9 - 64 = 183` characters. We cap it at 150 to leave a bit of
+/// headroom.
+pub const MAX_VERSION_LENGTH: usize = 150;
+
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum InvalidFeature {
     #[error("feature cannot be empty")]

--- a/migrations/2026-06-26-100902-0000_versions_num_max_length/down.sql
+++ b/migrations/2026-06-26-100902-0000_versions_num_max_length/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE versions DROP CONSTRAINT versions_num_max_length;

--- a/migrations/2026-06-26-100902-0000_versions_num_max_length/up.sql
+++ b/migrations/2026-06-26-100902-0000_versions_num_max_length/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE versions
+    ADD CONSTRAINT versions_num_max_length
+    CHECK (char_length(num) <= 150) NOT VALID;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -12,7 +12,8 @@ use chrono::{DateTime, SecondsFormat, Utc};
 use crates_io_cargo_toml::{Dependency, DepsSet, TargetDepsSet};
 use crates_io_tarball::{TarballError, process_tarball};
 use crates_io_validation::{
-    validate_crate_name, validate_dependency_name, validate_feature, validate_feature_name,
+    MAX_VERSION_LENGTH, validate_crate_name, validate_dependency_name, validate_feature,
+    validate_feature_name,
 };
 use crates_io_worker::{BackgroundJob, EnqueueError};
 use diesel::dsl::{exists, now, select};
@@ -126,6 +127,12 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
 
     // Convert the version back to a string to deal with any inconsistencies
     let version_string = semver.to_string();
+
+    if version_string.chars().count() > MAX_VERSION_LENGTH {
+        return Err(bad_request(format_args!(
+            "the version number is too long (max {MAX_VERSION_LENGTH} characters)"
+        )));
+    }
 
     let request_log = req.request_log();
     request_log.add("crate_name", &*metadata.name);

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -1,6 +1,6 @@
 use crate::builders::PublishBuilder;
 use crate::util::{RequestHelper, TestApp};
-use crates_io_validation::MAX_NAME_LENGTH;
+use crates_io_validation::{MAX_NAME_LENGTH, MAX_VERSION_LENGTH};
 use googletest::prelude::*;
 use http::StatusCode;
 use insta::{assert_json_snapshot, assert_snapshot};
@@ -56,6 +56,19 @@ async fn invalid_version() {
     let response = token.publish_crate(body).await;
     assert_snapshot!(response.status(), @"400 Bad Request");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"\"broken\" is an invalid semver version"}]}"#);
+    assert_that!(app.stored_files().await, is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn excessively_long_version() {
+    let (app, _, _, token) = TestApp::full().with_token().await;
+
+    let version = format!("1.0.0-{}", "a".repeat(MAX_VERSION_LENGTH));
+    let crate_to_publish = PublishBuilder::new("foo", &version);
+
+    let response = token.publish_crate(crate_to_publish).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"the version number is too long (max 150 characters)"}]}"#);
     assert_that!(app.stored_files().await, is_empty());
 }
 


### PR DESCRIPTION
Adds a `MAX_VERSION_LENGTH` of 150 characters for version numbers, enforced both at publish time and via a database constraint.

This is a prerequisite for upcoming CDN cache tag work, where versions appear in `release:{name}@{version}` tags. CloudFront caps cache tags at 256 characters per tag, and with the 64-character crate name limit that leaves room for a version of up to 183 characters. 150 sits comfortably below that with headroom above the longest version currently published (147 characters).

The database constraint is added as `NOT VALID` to avoid a blocking table scan, so new and updated rows are enforced immediately while existing rows (all already under the limit) are validated via a separate manual `VALIDATE CONSTRAINT` step after deploy.