### PR TITLE
FileTree: Override tree font with app body font

### DIFF
--- a/svelte/src/lib/components/FileTree.svelte
+++ b/svelte/src/lib/components/FileTree.svelte
@@ -82,6 +82,7 @@
 
   .tree :global(file-tree-container) {
     --trees-bg-override: light-dark(white, #141413);
+    --trees-font-family-override: var(--font-body);
     padding-top: var(--space-xs);
   }
 </style>


### PR DESCRIPTION
The `@pierre/trees` web component defaults its font to `system-ui`. This sets `--trees-font-family-override` so the file tree uses the app's body font instead, matching the surrounding UI.

### Screenshots

Before/After:

<img width="295" height="456" alt="Bildschirmfoto 2026-06-26 um 17 17 07" src="https://github.com/user-attachments/assets/78e54b5f-8029-42b2-9194-d77b1a6a47c5" />
<img width="302" height="428" alt="Bildschirmfoto 2026-06-26 um 17 16 56" src="https://github.com/user-attachments/assets/bc1bca2c-8a26-4cc2-ba32-c024cf283148" />

### Related

- https://rust-lang.zulipchat.com/#narrow/channel/318791-t-crates-io/topic/code.20viewer/near/606737450
