### PR TITLE
Improve `backfill_cache_tags` background job

### DIFF
--- a/src/worker/jobs/backfill_cache_tags.rs
+++ b/src/worker/jobs/backfill_cache_tags.rs
@@ -75,8 +75,11 @@ impl BackgroundJob for BackfillCacheTags {
 
         let mut copied = 0;
         for key in &keys {
+            let path = key.path();
             if copy_with_cache_tags(&client, &bucket, key).await? {
                 copied += 1;
+            } else {
+                warn!(storage.key = %path, "File not found during cache-tags backfill: {path}");
             }
         }
         info!("Backfilled cache-tags for {copied}/{total} objects");

--- a/src/worker/jobs/backfill_cache_tags.rs
+++ b/src/worker/jobs/backfill_cache_tags.rs
@@ -15,6 +15,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Instant;
 use tracing::{info, instrument, warn};
 
 /// Copies every S3 object for a single crate over itself to attach the
@@ -76,8 +77,14 @@ impl BackgroundJob for BackfillCacheTags {
         let mut copied = 0;
         for key in &keys {
             let path = key.path();
+            let start = Instant::now();
             if copy_with_cache_tags(&client, &bucket, key).await? {
                 copied += 1;
+                info!(
+                    duration = start.elapsed().as_nanos(),
+                    storage.key = %path,
+                    "Copied file during cache-tags backfill: {path}",
+                );
             } else {
                 warn!(storage.key = %path, "File not found during cache-tags backfill: {path}");
             }

--- a/src/worker/jobs/backfill_cache_tags.rs
+++ b/src/worker/jobs/backfill_cache_tags.rs
@@ -114,15 +114,11 @@ async fn copy_with_cache_tags(
     let path = key.path();
     let path = path.as_ref();
 
-    // The `x-amz-copy-source` header requires the path to be URL-encoded.
-    // See <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_RequestParameters>.
-    let copy_source = format!("{bucket}/{}", path.replace('+', "%2B"));
-
     let mut request = client
         .copy_object()
         .bucket(bucket)
         .key(path)
-        .copy_source(copy_source)
+        .copy_source(format!("{bucket}/{path}"))
         .metadata_directive(MetadataDirective::Replace);
 
     if let Some(content_type) = key.content_type() {


### PR DESCRIPTION
Testing the backfill in staging showed a couple of small issues, that we will try to address in this PR. First, the handling of `+` characters in versions was apparently not implemented correctly, so we will try a different approach now. Second, the jobs take longer than anticipated, so we add some more logging for the jobs to have some form of progress indicator.