### PR TITLE
jobs/backfill_cache_tags: Add dedicated queue

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -19,23 +19,26 @@ use crates_io::app::create_database_pool;
 use crates_io::cloudfront::CloudFront;
 use crates_io::ssh;
 use crates_io::storage::Storage;
+use crates_io::worker::jobs::BackfillCacheTags;
 use crates_io::worker::{Environment, RunnerExt};
 use crates_io::{Emails, config};
 use crates_io_docs_rs::RealDocsRsClient;
-use crates_io_env_vars::{required_var, var};
+use crates_io_env_vars::{required_var, var, var_parsed};
 use crates_io_fastly::Fastly;
 use crates_io_github::{GitHubClient, RealGitHubClient};
 use crates_io_github_app::{GitHubApp, GitHubAppClient};
 use crates_io_index::RepositoryConfig;
 use crates_io_og_image::OgImageGenerator;
 use crates_io_team_repo::TeamRepoImpl;
-use crates_io_worker::Runner;
+use crates_io_worker::{BackgroundJob, Runner};
 use object_store::prefix::PrefixStore;
 use reqwest::Client;
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
 use url::Url;
+
+const DEFAULT_CACHE_TAGS_WORKERS: usize = 1;
 
 fn main() -> anyhow::Result<()> {
     let _sentry = crates_io::sentry::init();
@@ -129,11 +132,17 @@ fn main() -> anyhow::Result<()> {
         }
     });
 
+    let cache_tags_workers =
+        var_parsed("CACHE_TAGS_WORKERS")?.unwrap_or(DEFAULT_CACHE_TAGS_WORKERS);
+
     let runner = Runner::new(deadpool, environment.clone())
         .configure_default_queue(|queue| queue.num_workers(5))
         .configure_queue("downloads", |queue| queue.num_workers(1))
         .configure_queue("repository", |queue| queue.num_workers(1))
         .configure_queue("cloudfront", |queue| queue.num_workers(1))
+        .configure_queue(BackfillCacheTags::QUEUE, |queue| {
+            queue.num_workers(cache_tags_workers)
+        })
         .register_crates_io_job_types();
 
     runtime.block_on(async {

--- a/src/worker/jobs/backfill_cache_tags.rs
+++ b/src/worker/jobs/backfill_cache_tags.rs
@@ -35,6 +35,7 @@ impl BackfillCacheTags {
 impl BackgroundJob for BackfillCacheTags {
     const JOB_NAME: &'static str = "backfill_cache_tags";
     const DEDUPLICATED: bool = true;
+    const QUEUE: &'static str = "cache-tags-backfill";
 
     type Context = Arc<Environment>;
 
@@ -46,27 +47,31 @@ impl BackgroundJob for BackfillCacheTags {
         }
 
         let name = &self.name;
-        let mut conn = ctx.deadpool.get().await?;
+        let (crate_id, nums) = {
+            let mut conn = ctx.deadpool.get().await?;
 
-        let crate_id = crates::table
-            .filter(crates::name.eq(name))
-            .select(crates::id)
-            .first::<i32>(&mut conn)
-            .await
-            .optional()
-            .context("Failed to look up crate")?;
+            let crate_id = crates::table
+                .filter(crates::name.eq(name))
+                .select(crates::id)
+                .first::<i32>(&mut conn)
+                .await
+                .optional()
+                .context("Failed to look up crate")?;
 
-        let Some(crate_id) = crate_id else {
-            warn!("Crate not found, skipping cache-tags backfill");
-            return Ok(());
+            let Some(crate_id) = crate_id else {
+                warn!("Crate not found, skipping cache-tags backfill");
+                return Ok(());
+            };
+
+            let nums = versions::table
+                .filter(versions::crate_id.eq(crate_id))
+                .select(versions::num)
+                .load::<String>(&mut conn)
+                .await
+                .context("Failed to load crate versions")?;
+
+            (crate_id, nums)
         };
-
-        let nums = versions::table
-            .filter(versions::crate_id.eq(crate_id))
-            .select(versions::num)
-            .load::<String>(&mut conn)
-            .await
-            .context("Failed to load crate versions")?;
 
         let keys = objects_to_backfill(name, &nums);
         let total = keys.len();
@@ -103,6 +108,7 @@ impl BackgroundJob for BackfillCacheTags {
             "Backfilled cache-tags for {copied}/{total} objects",
         );
 
+        let mut conn = ctx.deadpool.get().await?;
         record_completion(&mut conn, crate_id, name).await?;
 
         Ok(())


### PR DESCRIPTION
This allows us to scale the parallelism of these jobs a bit better. They are mostly constrained by the AWS requests, that take about 100ms per `CopyOobject` operation, and scaling this to 50-200 workers should allow us to speed up the backfill a bit.