### PR TITLE
worker: Make database pool size configurable via `DB_WORKER_POOL_SIZE`

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -39,6 +39,7 @@ use std::time::Duration;
 use url::Url;
 
 const DEFAULT_CACHE_TAGS_WORKERS: usize = 1;
+const DEFAULT_POOL_SIZE: usize = 10;
 
 fn main() -> anyhow::Result<()> {
     let _sentry = crates_io::sentry::init();
@@ -52,8 +53,8 @@ fn main() -> anyhow::Result<()> {
 
     let mut config = config::Server::from_environment()?;
 
-    // Override the pool size to 10 for the background worker
-    config.db.primary.pool_size = 10;
+    // Override the pool size for the background worker
+    config.db.primary.pool_size = var_parsed("DB_WORKER_POOL_SIZE")?.unwrap_or(DEFAULT_POOL_SIZE);
 
     // We run some long-running queries in the background worker, so we need to
     // increase the statement timeout a bit…


### PR DESCRIPTION
The background worker hardcoded its primary pool to 10 connections. Running many workers in a single queue (for example via `CACHE_TAGS_WORKERS`) could exceed that, leaving job threads to fail with "Timeout occurred while waiting for a slot to become available" across all queues that share the pool.

This reads the pool size from the new `DB_WORKER_POOL_SIZE` environment variable, defaulting to the previous value of 10. The name is scoped to the worker so it does not clash with the API's `DB_PRIMARY_ASYNC_POOL_SIZE` even though all dynos share the same config vars.