### PR TITLE
tests: Skip git index sync unless explicitly enabled

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -66,6 +66,13 @@ pub struct Server {
 
     pub features: FeaturesConfig,
 
+    /// Whether to enqueue `SyncToGitIndex` jobs to update the
+    /// git-based crate index.
+    ///
+    /// Disabled by default in test environments to avoid unnecessary
+    /// git operations.
+    pub sync_git_index: bool,
+
     /// URL of a git repository to mirror the crate index's snapshot branches
     /// to. When set, the `ArchiveIndexBranch` background job pushes snapshot
     /// branches to this remote; when unset the job is a no-op.
@@ -151,6 +158,7 @@ impl Server {
             disable_token_creation,
             banner_message,
             features,
+            sync_git_index: true,
             index_archive_url: var_parsed("GIT_ARCHIVE_REPO_URL")?,
             postgres_bin_dir: var_parsed("POSTGRES_BIN_DIR")?,
         })

--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -134,12 +134,19 @@ pub async fn delete_crate(
             .execute(conn)
             .await?;
 
-        let git_index_job = jobs::SyncToGitIndex::new(&krate.name);
+        let sync_git_index = async {
+            if app.config.sync_git_index {
+                let git_index_job = jobs::SyncToGitIndex::new(&krate.name);
+                git_index_job.enqueue(&*conn).await?;
+            }
+            Ok(())
+        };
+
         let sparse_index_job = jobs::SyncToSparseIndex::new(&krate.name);
         let delete_from_storage_job = jobs::DeleteCrateFromStorage::new(path.name);
 
         tokio::try_join!(
-            git_index_job.enqueue(&*conn),
+            sync_git_index,
             sparse_index_job.enqueue(&*conn),
             delete_from_storage_job.enqueue(&*conn),
         )?;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -649,7 +649,14 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
             .await
             .map_err(|e| internal(format!("failed to upload crate: {e}")))?;
 
-        let git_index_job = jobs::SyncToGitIndex::new(&krate.name);
+        let sync_git_index = async {
+            if app.config.sync_git_index {
+                let git_index_job = jobs::SyncToGitIndex::new(&krate.name);
+                git_index_job.enqueue(&*conn).await?;
+            }
+            Ok(())
+        };
+
         let sparse_index_job = jobs::SyncToSparseIndex::new(&krate.name);
         let publish_notifications_job = SendPublishNotificationsJob::new(version.id);
         let crate_feed_job = jobs::rss::SyncCrateFeed::new(krate.name.clone());
@@ -665,7 +672,7 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
         };
 
         tokio::try_join!(
-            git_index_job.enqueue(&*conn),
+            sync_git_index,
             sparse_index_job.enqueue(&*conn),
             publish_notifications_job.enqueue(&*conn),
             build_crate_zip,

--- a/src/controllers/version/update.rs
+++ b/src/controllers/version/update.rs
@@ -179,12 +179,19 @@ pub async fn perform_version_yank_update(
         .insert(conn)
         .await?;
 
-    let git_index_job = SyncToGitIndex::new(&krate.name);
+    let sync_git_index = async {
+        if state.config.sync_git_index {
+            let git_index_job = SyncToGitIndex::new(&krate.name);
+            git_index_job.enqueue(&*conn).await?;
+        }
+        Ok(())
+    };
+
     let sparse_index_job = SyncToSparseIndex::new(&krate.name);
     let update_default_version_job = UpdateDefaultVersion::new(krate.id);
 
     tokio::try_join!(
-        git_index_job.enqueue(&*conn),
+        sync_git_index,
         sparse_index_job.enqueue(&*conn),
         update_default_version_job.enqueue(&*conn),
     )?;

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -8,7 +8,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate() {
-    let (app, _, user) = TestApp::full().with_user().await;
+    let (app, _, user) = TestApp::full().with_git_index().with_user().await;
     let mut conn = app.db_conn().await;
 
     let crate_to_publish = PublishBuilder::new("foo_new", "1.0.0");
@@ -90,7 +90,7 @@ async fn new_krate_weird_version() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_twice() {
-    let (app, _, _, token) = TestApp::full().with_token().await;
+    let (app, _, _, token) = TestApp::full().with_git_index().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo_twice", "0.99.0");
     token.publish_crate(crate_to_publish).await.good();
@@ -125,7 +125,7 @@ async fn new_krate_twice() {
 // The primary purpose is to verify that the `default_version` we provide is as expected.
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_twice_alt() {
-    let (app, _, _, token) = TestApp::full().with_token().await;
+    let (app, _, _, token) = TestApp::full().with_git_index().with_token().await;
 
     let crate_to_publish =
         PublishBuilder::new("foo_twice", "2.0.0").description("2.0.0 description");

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -17,7 +17,7 @@ async fn invalid_dependency_name() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_with_renamed_dependency() {
-    let (app, _, user, token) = TestApp::full().with_token().await;
+    let (app, _, user, token) = TestApp::full().with_git_index().with_token().await;
     let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
@@ -141,7 +141,7 @@ async fn empty_dependency_name() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_with_underscore_renamed_dependency() {
-    let (app, _, user, token) = TestApp::full().with_token().await;
+    let (app, _, user, token) = TestApp::full().with_git_index().with_token().await;
     let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
@@ -162,7 +162,7 @@ async fn new_with_underscore_renamed_dependency() {
 async fn new_krate_with_dependency() {
     use crate::routes::crates::versions::dependencies::Deps;
 
-    let (app, anon, user, token) = TestApp::full().with_token().await;
+    let (app, anon, user, token) = TestApp::full().with_git_index().with_token().await;
     let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new_dep can depend on it
@@ -333,7 +333,7 @@ async fn new_krate_dependency_missing() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_sorts_deps() {
-    let (app, _, user, token) = TestApp::full().with_token().await;
+    let (app, _, user, token) = TestApp::full().with_git_index().with_token().await;
     let mut conn = app.db_conn().await;
 
     // Insert crates directly into the database so that two-deps can depend on it

--- a/src/tests/krate/publish/features.rs
+++ b/src/tests/krate/publish/features.rs
@@ -5,7 +5,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn features_version_2() {
-    let (app, _, user, token) = TestApp::full().with_token().await;
+    let (app, _, user, token) = TestApp::full().with_git_index().with_token().await;
     let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that foo_new can depend on it
@@ -27,7 +27,7 @@ async fn features_version_2() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn feature_name_with_dot() {
-    let (app, _, _, token) = TestApp::full().with_token().await;
+    let (app, _, _, token) = TestApp::full().with_git_index().with_token().await;
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("foo.bar", &[]);
     token.publish_crate(crate_to_publish).await.good();
     let crates = app.crates_from_index_head("foo");
@@ -36,7 +36,7 @@ async fn feature_name_with_dot() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn feature_name_start_with_number_and_underscore() {
-    let (app, _, _, token) = TestApp::full().with_token().await;
+    let (app, _, _, token) = TestApp::full().with_git_index().with_token().await;
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0")
         .feature("0foo1.bar", &[])
         .feature("_foo2.bar", &[]);
@@ -47,7 +47,7 @@ async fn feature_name_start_with_number_and_underscore() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn feature_name_with_unicode_chars() {
-    let (app, _, _, token) = TestApp::full().with_token().await;
+    let (app, _, _, token) = TestApp::full().with_git_index().with_token().await;
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("foo.你好世界", &[]);
     token.publish_crate(crate_to_publish).await.good();
     let crates = app.crates_from_index_head("foo");

--- a/src/tests/krate/publish/git.rs
+++ b/src/tests/krate/publish/git.rs
@@ -4,7 +4,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_git_upload_with_conflicts() {
-    let (app, _, _, token) = TestApp::full().with_token().await;
+    let (app, _, _, token) = TestApp::full().with_git_index().with_token().await;
 
     app.upstream_index().create_empty_commit().unwrap();
 

--- a/src/tests/krate/publish/links.rs
+++ b/src/tests/krate/publish/links.rs
@@ -5,7 +5,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_crate_with_links_field() {
-    let (app, anon, _, token) = TestApp::full().with_token().await;
+    let (app, anon, _, token) = TestApp::full().with_git_index().with_token().await;
 
     let manifest = r#"
     [package]

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 #[tokio::test(flavor = "multi_thread")]
 #[allow(unknown_lints, clippy::bool_assert_comparison)] // for claim::assert_some_eq! with bool
 async fn yank_works_as_intended() {
-    let (app, anon, cookie, token) = TestApp::full().with_token().await;
+    let (app, anon, cookie, token) = TestApp::full().with_git_index().with_token().await;
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
@@ -80,6 +80,7 @@ fn check_yanked(app: &TestApp, is_yanked: bool) {
 #[tokio::test(flavor = "multi_thread")]
 async fn yank_ratelimit_hit() {
     let (app, _, _, token) = TestApp::full()
+        .with_git_index()
         .with_rate_limit(LimitedAction::YankUnyank, Duration::from_millis(500), 1)
         .with_token()
         .await;
@@ -117,6 +118,7 @@ async fn yank_ratelimit_hit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn yank_ratelimit_expires() {
     let (app, _, _, token) = TestApp::full()
+        .with_git_index()
         .with_rate_limit(LimitedAction::YankUnyank, Duration::from_millis(500), 1)
         .with_token()
         .await;

--- a/src/tests/routes/crates/delete.rs
+++ b/src/tests/routes/crates/delete.rs
@@ -40,7 +40,7 @@ async fn test_query_params() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_happy_path_new_crate() -> anyhow::Result<()> {
-    let (app, anon, user) = TestApp::full().with_user().await;
+    let (app, anon, user) = TestApp::full().with_git_index().with_user().await;
     let mut conn = app.db_conn().await;
     let upstream = app.upstream_index();
 
@@ -81,7 +81,7 @@ async fn test_happy_path_new_crate() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_happy_path_old_crate() -> anyhow::Result<()> {
-    let (app, anon, user) = TestApp::full().with_user().await;
+    let (app, anon, user) = TestApp::full().with_git_index().with_user().await;
     let mut conn = app.db_conn().await;
     let upstream = app.upstream_index();
 
@@ -120,7 +120,7 @@ async fn test_happy_path_old_crate() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_happy_path_really_old_crate() -> anyhow::Result<()> {
-    let (app, anon, user) = TestApp::full().with_user().await;
+    let (app, anon, user) = TestApp::full().with_git_index().with_user().await;
     let mut conn = app.db_conn().await;
     let upstream = app.upstream_index();
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -130,9 +130,9 @@ impl TestApp {
         }
     }
 
-    /// Initializes a full application, with an index and background worker
+    /// Initializes a full application with a background worker.
     pub fn full() -> TestAppBuilder {
-        Self::init().with_git_index().with_job_runner()
+        Self::init().with_job_runner()
     }
 
     /// Obtain an async database connection from the primary database pool.
@@ -362,7 +362,7 @@ impl TestAppBuilder {
                 .index_location
                 .clone()
                 .or_else(|| self.index.as_ref().map(|i| i.url()))
-                .expect("Index or `index_location` must be configured to build a job runner");
+                .unwrap_or_else(|| Url::parse("file:///nonexistent").unwrap());
 
             let repository_config = RepositoryConfig {
                 index_location,
@@ -452,6 +452,7 @@ impl TestAppBuilder {
 
     pub fn with_git_index(mut self) -> Self {
         self.index = Some(UpstreamIndex::new().unwrap());
+        self.config.sync_git_index = true;
         self
     }
 
@@ -617,6 +618,7 @@ fn simple_config() -> config::Server {
             zip_archives_enabled: true,
             cache_tags_enabled: true,
         },
+        sync_git_index: false,
         index_archive_url: None,
         postgres_bin_dir: None,
     }

--- a/src/tests/worker/archive_index_branch.rs
+++ b/src/tests/worker/archive_index_branch.rs
@@ -26,6 +26,7 @@ async fn archive_index_branch() {
     let archive_url = archive.url();
 
     let (app, _) = TestApp::full()
+        .with_git_index()
         .with_config(|c| c.index_archive_url = Some(archive_url))
         .empty()
         .await;
@@ -45,7 +46,7 @@ async fn archive_index_branch() {
 /// without touching any repositories.
 #[tokio::test(flavor = "multi_thread")]
 async fn archive_index_branch_without_url_configured() {
-    let (app, _) = TestApp::full().empty().await;
+    let (app, _) = TestApp::full().with_git_index().empty().await;
     let conn = app.db_conn().await;
 
     // Seed a branch on origin so the test isn't trivially vacuous: the job
@@ -66,6 +67,7 @@ async fn archive_index_branch_without_index_sync_github_app() {
     let archive_url = archive.url();
 
     let (app, _) = TestApp::full()
+        .with_git_index()
         .with_config(|c| c.index_archive_url = Some(archive_url))
         .with_index_sync_github_app(None)
         .empty()
@@ -93,6 +95,7 @@ async fn archive_index_branch_missing_branch() {
     let archive_url = archive.url();
 
     let (app, _) = TestApp::full()
+        .with_git_index()
         .with_config(|c| c.index_archive_url = Some(archive_url))
         .empty()
         .await;

--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -10,7 +10,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn index_smoke_test() {
-    let (app, _, _, token) = TestApp::full().with_token().await;
+    let (app, _, _, token) = TestApp::full().with_git_index().with_token().await;
     let mut conn = app.db_conn().await;
     let upstream = app.upstream_index();
 
@@ -88,7 +88,7 @@ async fn test_config_changes() {
         "api": "https://crates.io"
     }"#;
 
-    let (app, _, _, token) = TestApp::full().with_token().await;
+    let (app, _, _, token) = TestApp::full().with_git_index().with_token().await;
     let upstream = app.upstream_index();
 
     // Initialize upstream index with a `config.json` file
@@ -120,7 +120,7 @@ async fn test_config_changes() {
 async fn bulk_sync_to_git_index() {
     use crates_io::schema::crates;
 
-    let (app, _, _, token) = TestApp::full().with_token().await;
+    let (app, _, _, token) = TestApp::full().with_git_index().with_token().await;
     let mut conn = app.db_conn().await;
     let upstream = app.upstream_index();
 
@@ -182,7 +182,7 @@ async fn bulk_sync_to_git_index() {
 /// entries already match the DB should not create a new commit.
 #[tokio::test(flavor = "multi_thread")]
 async fn bulk_sync_to_git_index_noop() {
-    let (app, _, _, token) = TestApp::full().with_token().await;
+    let (app, _, _, token) = TestApp::full().with_git_index().with_token().await;
     let conn = app.db_conn().await;
     let upstream = app.upstream_index();
 

--- a/src/tests/worker/normalize_index.rs
+++ b/src/tests/worker/normalize_index.rs
@@ -16,7 +16,7 @@ const UNNORMALIZED_ENTRY: &str = concat!(
 /// single commit on `master`.
 #[tokio::test(flavor = "multi_thread")]
 async fn normalize_index() {
-    let (app, _, _, _) = TestApp::full().with_token().await;
+    let (app, _, _, _) = TestApp::full().with_git_index().with_token().await;
     let conn = app.db_conn().await;
     let upstream = app.upstream_index();
 
@@ -78,7 +78,7 @@ async fn normalize_index() {
 /// `normalization-dry-run` branch, leaving `master` untouched.
 #[tokio::test(flavor = "multi_thread")]
 async fn normalize_index_dry_run() {
-    let (app, _, _, _) = TestApp::full().with_token().await;
+    let (app, _, _, _) = TestApp::full().with_git_index().with_token().await;
     let conn = app.db_conn().await;
     let upstream = app.upstream_index();
 


### PR DESCRIPTION
This adds a `sync_git_index` config flag that controls whether the publish, yank, and delete controllers enqueue `SyncToGitIndex` jobs. It defaults to `true` in production and `false` in the test config.

`TestApp::full()` no longer creates an on-disk git index by default. The tests that assert on git index contents opt in via `with_git_index()`, which flips the flag back on. The remaining `full()` tests skip git repo creation and git sync work entirely.

This cuts the backend integration suite by about 14% at four-core parallelism.
