### PR TITLE
Optimize crypto crates in `dev` profile for faster test connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,16 @@ workspace = true
 insta.opt-level = 3
 similar.opt-level = 3
 
+# This improves the performance of the database connection setup in the
+# test suite by building the crypto crates with optimizations.
+block-buffer.opt-level = 3
+crypto-common.opt-level = 3
+digest.opt-level = 3
+generic-array.opt-level = 3
+hmac.opt-level = 3
+postgres-protocol.opt-level = 3
+sha2.opt-level = 3
+
 [profile.release]
 opt-level = 2
 


### PR DESCRIPTION
Establishing a database connection runs the SCRAM PBKDF2 hash, thousands of HMAC-SHA256 rounds, on every new connection. In unoptimized dev builds the pure-Rust SHA-256 implementation dominates connection setup, a cost the test suite pays on every connection.

Building the hashing crates with `opt-level = 3` cuts the per-connection cost from ~188 ms to ~23 ms on a 4-core CI runner and reduces the integration test suite wall time from 233 s to 161 s. Machines with hardware SHA acceleration (e.g. Apple Silicon) see no difference, so the speedup only appears where it is needed.