### PR TITLE
Explicitly set UTF-8 in the dev database collation and ctype

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       # `semver_ord` stores prerelease identifiers as JSONB strings and
       # relies on byte-wise ordering. Force `C` collation so JSONB string
       # comparison matches the SemVer spec's ASCII sort order.
-      POSTGRES_INITDB_ARGS: '--lc-collate=C --lc-ctype=C'
+      POSTGRES_INITDB_ARGS: '--lc-collate=C.UTF-8 --lc-ctype=C.UTF-8'
       # Trust auth is fine because Postgres is only reachable on the
       # internal Docker network; no port is published to the host.
       POSTGRES_HOST_AUTH_METHOD: trust

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       # `semver_ord` stores prerelease identifiers as JSONB strings and
       # relies on byte-wise ordering. Force `C` collation so JSONB string
       # comparison matches the SemVer spec's ASCII sort order.
-      POSTGRES_INITDB_ARGS: '--lc-collate=C.UTF-8 --lc-ctype=C.UTF-8'
+      POSTGRES_INITDB_ARGS: '--lc-collate=C --lc-ctype=C --encoding=UTF8'
       # Trust auth is fine because Postgres is only reachable on the
       # internal Docker network; no port is published to the host.
       POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
Without this, trying to import a database dump using `import-database-dump.sh` fails due to encoding errors in the tsvector trigger.