### PR TITLE
CI: Disable Postgres durability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,14 @@ jobs:
         shell: bash
 
       - run: sudo systemctl start postgresql.service
+
+      - name: Disable Postgres durability
+        run: |
+          sudo -u postgres psql -c "ALTER SYSTEM SET fsync = off"
+          sudo -u postgres psql -c "ALTER SYSTEM SET synchronous_commit = off"
+          sudo -u postgres psql -c "ALTER SYSTEM SET full_page_writes = off"
+          sudo systemctl restart postgresql.service
+
       - run: sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'postgres'"
       - run: sudo -u postgres createdb --lc-collate=C --lc-ctype=C -T template0 cargo_registry_test
 


### PR DESCRIPTION
The "Backend / Test" job recreates the test database from scratch each run, so `fsync/synchronous_commit/full_page_writes` provide no value. Turning them off removes an fsync per commit and DDL statement. Locally this cut the per-test schema setup from ~460ms to ~245ms, and it speeds up every write the tests perform.