### PR TITLE
devcontainer: Enable `pipefail` in build shell

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/rust:2-bookworm@sha256:9cf2686b6f111f9c1eef20b8103a5f15e96c5a94e2d4d8efeed7af4453872a93
 
+# Enable pipefail so a failure anywhere in a pipeline aborts the build.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Add the official PostgreSQL apt repo so we can install PostgreSQL 16
 # client + libpq. Debian bookworm only ships v15.
 RUN install -d /usr/share/postgresql-common/pgdg \


### PR DESCRIPTION
Set the `RUN` shell to `bash` with `pipefail` so a failing command in a pipeline (such as the `curl | sh` pnpm install) aborts the build instead of being masked by the exit status of the last stage.