### PR TITLE
Replace `asdf` with `mise`

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/heroku/heroku-buildpack-apt#5f0db0f99b0c8d6f893db66695eed43c5df8b480
-https://github.com/Turbo87/heroku-buildpack-crates-io#672169ebbabe6910c0793c4695ab7a4411246b20
+https://github.com/Turbo87/heroku-buildpack-crates-io#b0f8444e7cb92645920d4f4f068b232d36a8a84c

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
-# `.tool-versions` file for asdf version manager
+# `mise.toml` file for the mise version manager (https://mise.jdx.dev)
 #
 # This file specifies the versions of various tools to be used in this project.
 # These versions are also used by our Heroku buildpack setup.
-pnpm 11.9.0
-nodejs 24.18.0
+[tools]
+node = "24.18.0"
+pnpm = "11.9.0"


### PR DESCRIPTION
see https://mise.jdx.dev/

This first changes the buildpack to use `mise` to read the `.tool-versions` file and install the tools (Node.js and pnpm). Then the second commit replaces the `.tool-versions` file with the native `mise.toml`.

In the future this will make it possible to also install/run/use version-pinned tools like `diesel_cli` or `diesel-guard` via `mise` too :)

