### PR TITLE
devcontainer: Install tools via mise

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,18 +17,12 @@ RUN install -d /usr/share/postgresql-common/pgdg \
         git \
     && rm -rf /var/lib/apt/lists/*
 
-# renovate: datasource=crate depName=diesel_cli versioning=semver
-ARG DIESEL_CLI_VERSION=2.3.10
-
-RUN cargo install --locked diesel_cli --version $DIESEL_CLI_VERSION \
-    --no-default-features --features postgres
-
-# Install pnpm under /home/vscode (its $PNPM_HOME) so the named pnpm
-# store volume can be mounted there. Switch back to root afterwards
-# so any downstream Feature install scripts run as expected.
+# Install the mise version manager (https://mise.jdx.dev) for the `vscode` user.
+# The tools themselves are installed by `post-create.sh` via `mise install`.
 USER vscode
+ENV MISE_DATA_DIR=/home/vscode/.local/share/mise
 ENV PNPM_HOME=/home/vscode/.local/share/pnpm
-ENV PATH=$PNPM_HOME:$PATH
-RUN curl -fsSL https://get.pnpm.io/install.sh | env SHELL=/bin/bash sh -
+ENV PATH=/home/vscode/.local/bin:$MISE_DATA_DIR/shims:$PATH
+RUN curl -fsSL https://mise.run | sh
 
 USER root

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -42,12 +42,13 @@ devcontainer exec bash
 
 The `postCreateCommand` runs once after the container is built and:
 
-1. Initializes the local git index in `tmp/index-bare/`
-2. Creates the `cargo_registry_test` database
-3. Runs Diesel migrations against `cargo_registry`
-4. Installs JavaScript dependencies with `pnpm install`
-5. Installs the Playwright Chromium headless shell
-6. Pre-fetches Rust dependencies with `cargo fetch`
+1. Installs the tool versions pinned in `mise.toml` with `mise install`
+2. Initializes the local git index in `tmp/index-bare/`
+3. Creates the `cargo_registry_test` database
+4. Runs Diesel migrations against `cargo_registry`
+5. Installs JavaScript dependencies with `pnpm install`
+6. Installs the Playwright Chromium headless shell
+7. Pre-fetches Rust dependencies with `cargo fetch`
 
 On every subsequent container start, `diesel migration run` is invoked to
 keep the development database schema current.
@@ -89,11 +90,12 @@ documents the callback URL to register with GitHub.
 
 ## Persistent volumes
 
-Four named volumes persist between container rebuilds:
+Five named volumes persist between container rebuilds:
 
 - `/workspaces/crates.io/target` (Cargo build output)
 - `/usr/local/cargo/registry` (downloaded crate sources)
 - `/home/vscode/.local/share/pnpm/store` (pnpm content-addressable store)
+- `/home/vscode/.local/share/mise` (mise-managed tools)
 - `/workspaces/crates.io/local_uploads` (files written by the backend
   when storage isn't configured for S3, e.g. when publishing crates to
   your local instance)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,11 +7,6 @@
   // image (UID 1000, passwordless sudo). Avoids running as root and
   // the file-ownership annoyances that come with bind mounts.
   "remoteUser": "vscode",
-  "features": {
-    "ghcr.io/devcontainers/features/node:2": {
-      "version": "24.18.0"
-    }
-  },
   // Named volumes for state that should survive container rebuilds.
   // The `${devcontainerId}` suffix scopes them per workspace path so
   // different worktrees (or fresh clones) don't share volumes.
@@ -19,6 +14,7 @@
     "source=cratesio-target-${devcontainerId},target=/workspaces/crates.io/target,type=volume",
     "source=cratesio-cargo-registry-${devcontainerId},target=/usr/local/cargo/registry,type=volume",
     "source=cratesio-pnpm-store-${devcontainerId},target=/home/vscode/.local/share/pnpm/store,type=volume",
+    "source=cratesio-mise-${devcontainerId},target=/home/vscode/.local/share/mise,type=volume",
     "source=cratesio-local-uploads-${devcontainerId},target=/workspaces/crates.io/local_uploads,type=volume"
   ],
   // Metadata for the VS Code / Codespaces port-forwarding UI. Actual

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,7 +7,11 @@ sudo chown -R vscode:vscode \
     /workspaces/crates.io/target \
     /workspaces/crates.io/local_uploads \
     /usr/local/cargo/registry \
-    /home/vscode/.local/share/pnpm
+    /home/vscode/.local/share/pnpm \
+    /home/vscode/.local/share/mise
+
+mise trust
+mise install
 
 if [ ! -f .env ]; then
     cp .env.sample .env

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,7 @@
 cargo-insta = "1.48.0"
 "cargo:cargo-deny" = "=0.19.9"
 "cargo:cargo-machete" = "=0.9.2"
+"cargo:diesel_cli" = { version = "2.3.10", features = "postgres", default-features = false }
 "cargo:diesel-guard" = "=0.12.0"
 node = "24.18.0"
 pnpm = "11.10.0"


### PR DESCRIPTION
The Dockerfile now installs `mise` instead of `pnpm` and `diesel_cli`. The `post-create.sh` file then runs `mise install` to provision the tools pinned in the `mise.toml` file (including `pnpm` and `diesel_cli`).

mise also provides `node`, so the `node` devcontainer feature is dropped.

The `cratesio-mise` volume should persist the mise-managed tools across rebuilds.

### Related

- #14153
- #14155