### PR TITLE
api-client: Run type checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
 
       - run: pnpm lint:js
       - run: pnpm prettier:check
+      - run: pnpm --recursive --if-present run typecheck
 
   msw-test:
     name: Frontend / Test (@crates-io/msw)

--- a/packages/crates-io-api-client/client.test.ts
+++ b/packages/crates-io-api-client/client.test.ts
@@ -42,7 +42,7 @@ test('GET /api/v1/crates/{name}', async () => {
   });
 
   expect(response.error).toBeUndefined();
-  expect(response.data.crate.name).toBe('serde');
+  expect(response.data?.crate.name).toBe('serde');
   expect(response.data).toMatchInlineSnapshot(`
     {
       "categories": null,

--- a/packages/crates-io-api-client/package.json
+++ b/packages/crates-io-api-client/package.json
@@ -15,7 +15,8 @@
   "main": "index.ts",
   "scripts": {
     "regenerate": "vitest schema.test.ts --run --update",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "openapi-fetch": "0.17.0"

--- a/packages/crates-io-api-client/tsconfig.json
+++ b/packages/crates-io-api-client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "skipLibCheck": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "esnext",
+    "types": ["node"],
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
We were using TypeScript in the `@crates-io/api-client` package, but we were not actually running any typechecks for the package. This PR fixes it by adding a `typecheck` script to the package and running all `typecheck` scripts in the repository as part of the `frontend-lint` CI job. The first commit also fixes a small type issue that was previously uncaught.