### PR TITLE
msw/keywords: Sort keyword list by name

### DIFF
--- a/packages/crates-io-msw/handlers/keywords/list.js
+++ b/packages/crates-io-msw/handlers/keywords/list.js
@@ -7,7 +7,7 @@ import { pageParams } from '../../utils/handlers.js';
 export default http.get('/api/v1/keywords', ({ request }) => {
   let { skip, take } = pageParams(request);
 
-  let keywords = db.keyword.findMany(undefined, { skip, take, orderBy: { crates_cnt: 'desc' } });
+  let keywords = db.keyword.findMany(undefined, { skip, take, orderBy: { keyword: 'asc' } });
   let total = db.keyword.count();
 
   return HttpResponse.json({ keywords: keywords.map(k => serializeKeyword(k)), meta: { total } });


### PR DESCRIPTION
The list handler sorted by `crates_cnt`, which is not a field on the keyword model, so the sort was a no-op that left records in insertion order. This PR changes it to sort by `keyword` to match the backend default (`keywords::keyword.asc()` in `src/controllers/keyword.rs`).