### PR TITLE
Extract User builder for tests to reduce duplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,6 +2241,7 @@ dependencies = [
  "crates_io_api_types",
  "crates_io_cargo_toml",
  "crates_io_database",
+ "crates_io_encryption",
  "crates_io_tarball",
  "diesel",
  "diesel-async",

--- a/crates/crates_io_test_utils/Cargo.toml
+++ b/crates/crates_io_test_utils/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "=0.4.45"
 crates_io_api_types = { path = "../crates_io_api_types" }
 crates_io_cargo_toml = { path = "../crates_io_cargo_toml" }
 crates_io_database = { path = "../crates_io_database" }
+crates_io_encryption = { path = "../crates_io_encryption" }
 crates_io_tarball = { path = "../crates_io_tarball", features = ["builder"] }
 diesel = "=2.3.10"
 diesel-async = "=0.9.2"

--- a/crates/crates_io_test_utils/src/builders/mod.rs
+++ b/crates/crates_io_test_utils/src/builders/mod.rs
@@ -1,9 +1,11 @@
 mod dependency;
 mod krate;
 mod publish;
+mod user;
 mod version;
 
 pub use self::dependency::DependencyBuilder;
 pub use self::krate::CrateBuilder;
 pub use self::publish::PublishBuilder;
+pub use self::user::UserBuilder;
 pub use self::version::VersionBuilder;

--- a/crates/crates_io_test_utils/src/builders/user.rs
+++ b/crates/crates_io_test_utils/src/builders/user.rs
@@ -4,19 +4,27 @@ use crates_io_database::models::User;
 /// directly into the database.
 ///
 /// If you want to test logic that happens as part of signing up or logging in,
-pub struct UserBuilder {}
+pub struct UserBuilder<'a> {
+    username: &'a str,
+}
 
-impl UserBuilder {
+impl<'a> UserBuilder<'a> {
     /// Create a new instance of the builder. To get a `User`, call `build` (creates an instance in
     /// memory only) or `insert` (creates a record in the database).
     pub fn new() -> Self {
-        Self {}
+        Self {
+            username: "octocat",
+        }
+    }
+
+    pub fn with_username(self, username: &'a str) -> Self {
+        Self { username }
     }
 
     pub fn build(self) -> User {
         User {
             id: 1,
-            gh_login: "octocat".into(),
+            gh_login: self.username.into(),
             name: Some("The Octocat".into()),
             gh_id: 123,
             gh_avatar: None,
@@ -25,13 +33,13 @@ impl UserBuilder {
             account_lock_until: None,
             is_admin: false,
             publish_notifications: true,
-            username: "octocat".into(),
+            username: self.username.into(),
             created_at: None,
         }
     }
 }
 
-impl Default for UserBuilder {
+impl Default for UserBuilder<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/crates_io_test_utils/src/builders/user.rs
+++ b/crates/crates_io_test_utils/src/builders/user.rs
@@ -1,0 +1,38 @@
+use crates_io_database::models::User;
+
+/// A builder to create user instances for the purpose of not using the database or inserting
+/// directly into the database.
+///
+/// If you want to test logic that happens as part of signing up or logging in,
+pub struct UserBuilder {}
+
+impl UserBuilder {
+    /// Create a new instance of the builder. To get a `User`, call `build` (creates an instance in
+    /// memory only) or `insert` (creates a record in the database).
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn build(self) -> User {
+        User {
+            id: 1,
+            gh_login: "octocat".into(),
+            name: Some("The Octocat".into()),
+            gh_id: 123,
+            gh_avatar: None,
+            gh_encrypted_token: vec![],
+            account_lock_reason: None,
+            account_lock_until: None,
+            is_admin: false,
+            publish_notifications: true,
+            username: "octocat".into(),
+            created_at: None,
+        }
+    }
+}
+
+impl Default for UserBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/crates_io_test_utils/src/builders/user.rs
+++ b/crates/crates_io_test_utils/src/builders/user.rs
@@ -1,4 +1,15 @@
-use crates_io_database::models::User;
+use crate::github::next_gh_id;
+
+use crates_io_database::models::{NewUser, User};
+use crates_io_encryption::TokenEncryption;
+
+use std::sync::LazyLock;
+
+static ENCRYPTED_TOKEN: LazyLock<Vec<u8>> = LazyLock::new(|| {
+    TokenEncryption::for_testing()
+        .encrypt("some random token")
+        .unwrap()
+});
 
 /// A builder to create user instances for the purpose of not using the database or inserting
 /// directly into the database.
@@ -36,6 +47,15 @@ impl<'a> UserBuilder<'a> {
             username: self.username.into(),
             created_at: None,
         }
+    }
+
+    pub fn new_user(self) -> NewUser<'a> {
+        NewUser::builder()
+            .gh_id(next_gh_id())
+            .gh_login(self.username)
+            .username(self.username)
+            .gh_encrypted_token(&ENCRYPTED_TOKEN)
+            .build()
     }
 }
 

--- a/src/bin/crates-admin/sync_index.rs
+++ b/src/bin/crates-admin/sync_index.rs
@@ -241,9 +241,8 @@ async fn enqueue_sync_jobs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crates_io_database::models::NewUser;
     use crates_io_test_db::TestDatabase;
-    use crates_io_test_utils::builders::CrateBuilder;
+    use crates_io_test_utils::builders::{CrateBuilder, UserBuilder};
     use insta::assert_json_snapshot;
     use serde::Serialize;
 
@@ -260,16 +259,12 @@ mod tests {
     }
 
     async fn create_user(conn: &AsyncPgConnection) -> i32 {
-        NewUser {
-            gh_id: 1,
-            gh_login: "testuser",
-            username: "testuser",
-            name: None,
-            gh_encrypted_token: b"token",
-        }
-        .insert(conn)
-        .await
-        .unwrap()
+        UserBuilder::new()
+            .with_username("testuser")
+            .new_user()
+            .insert(conn)
+            .await
+            .unwrap()
     }
 
     #[derive(HasQuery, Serialize)]

--- a/src/controllers/trustpub/emails.rs
+++ b/src/controllers/trustpub/emails.rs
@@ -50,23 +50,11 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use claims::assert_ok;
+    use crates_io_test_utils::builders::UserBuilder;
     use insta::assert_snapshot;
 
     fn test_user() -> User {
-        User {
-            id: 1,
-            gh_login: "octocat".into(),
-            name: Some("The Octocat".into()),
-            gh_id: 123,
-            gh_avatar: None,
-            gh_encrypted_token: vec![],
-            account_lock_reason: None,
-            account_lock_until: None,
-            is_admin: false,
-            publish_notifications: true,
-            username: "octocat".into(),
-            created_at: None,
-        }
+        UserBuilder::new().build()
     }
 
     fn test_crate() -> Crate {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,14 +1,11 @@
-use crate::util::{RequestHelper, TestApp};
+use crate::util::{RequestHelper, TestApp, github::next_gh_id};
 use crates_io::models::{NewCategory, NewTeam, NewUser};
 use crates_io::views::{
     EncodableCategory, EncodableCrate, EncodableKeyword, EncodableOwner, EncodableVersion,
     GoodCrate,
 };
 
-use crate::util::github::next_gh_id;
-use crates_io_encryption::TokenEncryption;
 use serde::{Deserialize, Serialize};
-use std::sync::LazyLock;
 
 mod account_lock;
 mod authentication;
@@ -94,18 +91,7 @@ pub struct OwnerResp {
 }
 
 fn new_user(login: &str) -> NewUser<'_> {
-    static ENCRYPTED_TOKEN: LazyLock<Vec<u8>> = LazyLock::new(|| {
-        TokenEncryption::for_testing()
-            .encrypt("some random token")
-            .unwrap()
-    });
-
-    NewUser::builder()
-        .gh_id(next_gh_id())
-        .gh_login(login)
-        .username(login)
-        .gh_encrypted_token(&ENCRYPTED_TOKEN)
-        .build()
+    builders::UserBuilder::new().with_username(login).new_user()
 }
 
 fn new_team(login: &str) -> NewTeam<'_> {

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -166,20 +166,7 @@ impl TestApp {
 
         new_email.insert(&conn).await.unwrap();
 
-        let user = User {
-            id,
-            name: new_user.name.map(str::to_string),
-            gh_id: new_user.gh_id,
-            gh_login: new_user.gh_login.to_string(),
-            gh_avatar: None,
-            gh_encrypted_token: new_user.gh_encrypted_token.to_vec(),
-            account_lock_reason: None,
-            account_lock_until: None,
-            is_admin: false,
-            publish_notifications: true,
-            username: new_user.gh_login.to_string(),
-            created_at: None,
-        };
+        let user = User::find(&conn, id).await.unwrap();
 
         MockCookieUser {
             app: self.clone(),


### PR DESCRIPTION
There are a bunch of places that created users for tests. Rather than do that more, I've extracted a `UserBuilder` to be like the `CrateBuilder` etc and be the one canonical way to create users in tests.

I have left the `new_user` function around for now but implemented it in terms of the `UserBuilder`. The `new_user` function is still only available in the top-level crate, so if you want to create users in tests in some other crate, you should reach for using `UserBuilder` directly. I thought about removing `new_user` to encourage use of `UserBuilder` directly, but I wasn't sure whether that was too much change or not.

This is why I wanted https://github.com/rust-lang/crates.io/pull/14134; now the `crates_io_test_utils` crate can create and use a `TokenEncryption::for_testing()`.