### PR TITLE
Use `regex!` macro instead of `LazyLock<Regex>`

### DIFF
--- a/crates/crates_io_trustpub/src/github/validation.rs
+++ b/crates/crates_io_trustpub/src/github/validation.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use regex::regex;
 
 const MAX_FIELD_LENGTH: usize = 255;
 
@@ -40,14 +40,13 @@ pub enum ValidationError {
 }
 
 pub fn validate_owner(owner: &str) -> Result<(), ValidationError> {
-    static RE_VALID_GITHUB_OWNER: LazyLock<regex::Regex> =
-        LazyLock::new(|| regex::Regex::new(r"^[a-zA-Z0-9][a-zA-Z0-9-]*$").unwrap());
+    let re_valid_github_owner = regex!(r"^[a-zA-Z0-9][a-zA-Z0-9-]*$");
 
     if owner.is_empty() {
         Err(ValidationError::OwnerEmpty)
     } else if owner.len() > MAX_FIELD_LENGTH {
         Err(ValidationError::OwnerTooLong)
-    } else if !RE_VALID_GITHUB_OWNER.is_match(owner) {
+    } else if !re_valid_github_owner.is_match(owner) {
         Err(ValidationError::OwnerInvalid)
     } else {
         Ok(())
@@ -55,14 +54,13 @@ pub fn validate_owner(owner: &str) -> Result<(), ValidationError> {
 }
 
 pub fn validate_repo(repo: &str) -> Result<(), ValidationError> {
-    static RE_VALID_GITHUB_REPO: LazyLock<regex::Regex> =
-        LazyLock::new(|| regex::Regex::new(r"^[a-zA-Z0-9-_.]+$").unwrap());
+    let re_valid_github_repo = regex!(r"^[a-zA-Z0-9-_.]+$");
 
     if repo.is_empty() {
         Err(ValidationError::RepoEmpty)
     } else if repo.len() > MAX_FIELD_LENGTH {
         Err(ValidationError::RepoTooLong)
-    } else if !RE_VALID_GITHUB_REPO.is_match(repo) {
+    } else if !re_valid_github_repo.is_match(repo) {
         Err(ValidationError::RepoInvalid)
     } else {
         Ok(())
@@ -84,8 +82,7 @@ pub fn validate_workflow_filename(filename: &str) -> Result<(), ValidationError>
 }
 
 pub fn validate_environment(env: &str) -> Result<(), ValidationError> {
-    static RE_INVALID_ENVIRONMENT_CHARS: LazyLock<regex::Regex> =
-        LazyLock::new(|| regex::Regex::new(r#"[\x00-\x1F\x7F'"`,;\\]"#).unwrap());
+    let re_invalid_environment_chars = regex!(r#"[\x00-\x1F\x7F'"`,;\\]"#);
 
     if env.is_empty() {
         Err(ValidationError::EnvironmentEmptyString)
@@ -95,7 +92,7 @@ pub fn validate_environment(env: &str) -> Result<(), ValidationError> {
         Err(ValidationError::EnvironmentStartsWithWhitespace)
     } else if env.ends_with(" ") {
         Err(ValidationError::EnvironmentEndsWithWhitespace)
-    } else if RE_INVALID_ENVIRONMENT_CHARS.is_match(env) {
+    } else if re_invalid_environment_chars.is_match(env) {
         Err(ValidationError::EnvironmentInvalidChars)
     } else {
         Ok(())

--- a/crates/crates_io_trustpub/src/github/workflows.rs
+++ b/crates/crates_io_trustpub/src/github/workflows.rs
@@ -1,14 +1,13 @@
-use std::sync::LazyLock;
+use regex::regex;
 
 /// Extracts the workflow filename from a GitHub workflow reference.
 ///
 /// In other words, it turns e.g. `rust-lang/regex/.github/workflows/ci.yml@refs/heads/main`
 /// into `ci.yml`, or `None` if the reference is in an unexpected format.
 pub(crate) fn extract_workflow_filename(workflow_ref: &str) -> Option<&str> {
-    static WORKFLOW_REF_RE: LazyLock<regex::Regex> =
-        LazyLock::new(|| regex::Regex::new(r"([^/]+\.(yml|yaml))(@.+)").unwrap());
+    let workflow_ref_re = regex!(r"([^/]+\.(yml|yaml))(@.+)");
 
-    WORKFLOW_REF_RE
+    workflow_ref_re
         .captures(workflow_ref)
         .and_then(|caps| caps.get(1))
         .map(|m| m.as_str())

--- a/crates/crates_io_trustpub/src/gitlab/validation.rs
+++ b/crates/crates_io_trustpub/src/gitlab/validation.rs
@@ -8,7 +8,7 @@
 //! See <https://docs.gitlab.com/user/reserved_names/#rules-for-usernames-project-and-group-names-and-slugs>
 //! and <https://docs.gitlab.com/ci/yaml/#environment>.
 
-use std::sync::LazyLock;
+use regex::regex;
 
 const MAX_FIELD_LENGTH: usize = 255;
 
@@ -52,9 +52,7 @@ pub enum ValidationError {
 }
 
 pub fn validate_namespace(namespace: &str) -> Result<(), ValidationError> {
-    static RE_VALID_NAMESPACE: LazyLock<regex::Regex> = LazyLock::new(|| {
-        regex::Regex::new(r"^[a-zA-Z0-9](?:[a-zA-Z0-9_.\-/]*[a-zA-Z0-9])?$").unwrap()
-    });
+    let re_valid_namespace = regex!(r"^[a-zA-Z0-9](?:[a-zA-Z0-9_.\-/]*[a-zA-Z0-9])?$");
 
     if namespace.is_empty() {
         Err(ValidationError::NamespaceEmpty)
@@ -62,7 +60,7 @@ pub fn validate_namespace(namespace: &str) -> Result<(), ValidationError> {
         Err(ValidationError::NamespaceTooLong)
     } else if namespace.ends_with(".atom") || namespace.ends_with(".git") {
         Err(ValidationError::NamespaceInvalidSuffix)
-    } else if !RE_VALID_NAMESPACE.is_match(namespace) {
+    } else if !re_valid_namespace.is_match(namespace) {
         Err(ValidationError::NamespaceInvalid)
     } else {
         Ok(())
@@ -70,9 +68,7 @@ pub fn validate_namespace(namespace: &str) -> Result<(), ValidationError> {
 }
 
 pub fn validate_project(project: &str) -> Result<(), ValidationError> {
-    static RE_VALID_PROJECT: LazyLock<regex::Regex> = LazyLock::new(|| {
-        regex::Regex::new(r"^[a-zA-Z0-9](?:[a-zA-Z0-9_.\-]*[a-zA-Z0-9])?$").unwrap()
-    });
+    let re_valid_project = regex!(r"^[a-zA-Z0-9](?:[a-zA-Z0-9_.\-]*[a-zA-Z0-9])?$");
 
     if project.is_empty() {
         Err(ValidationError::ProjectEmpty)
@@ -80,7 +76,7 @@ pub fn validate_project(project: &str) -> Result<(), ValidationError> {
         Err(ValidationError::ProjectTooLong)
     } else if project.ends_with(".atom") || project.ends_with(".git") {
         Err(ValidationError::ProjectInvalidSuffix)
-    } else if !RE_VALID_PROJECT.is_match(project) {
+    } else if !re_valid_project.is_match(project) {
         Err(ValidationError::ProjectInvalid)
     } else {
         Ok(())
@@ -106,14 +102,13 @@ pub fn validate_workflow_filepath(filepath: &str) -> Result<(), ValidationError>
 pub fn validate_environment(env: &str) -> Result<(), ValidationError> {
     // see https://docs.gitlab.com/ci/yaml/#environment
 
-    static RE_VALID_ENVIRONMENT: LazyLock<regex::Regex> =
-        LazyLock::new(|| regex::Regex::new(r"^[a-zA-Z0-9 \-_/${}]+$").unwrap());
+    let re_valid_environment = regex!(r"^[a-zA-Z0-9 \-_/${}]+$");
 
     if env.is_empty() {
         Err(ValidationError::EnvironmentEmptyString)
     } else if env.len() > MAX_FIELD_LENGTH {
         Err(ValidationError::EnvironmentTooLong)
-    } else if !RE_VALID_ENVIRONMENT.is_match(env) {
+    } else if !re_valid_environment.is_match(env) {
         Err(ValidationError::EnvironmentInvalidChars)
     } else {
         Ok(())

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -6,13 +6,9 @@ use crates_io_worker::BackgroundJob;
 use flate2::read::GzDecoder;
 use insta::{assert_debug_snapshot, assert_snapshot};
 use object_store::ObjectStoreExt;
-use regex::Regex;
+use regex::regex;
 use std::io::{Cursor, Read};
-use std::sync::LazyLock;
 use tar::Archive;
-
-static PATH_DATE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^\d{4}-\d{2}-\d{2}-\d{6}").unwrap());
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_dump_db_job() -> anyhow::Result<()> {
@@ -109,10 +105,12 @@ async fn test_dump_db_job() -> anyhow::Result<()> {
 }
 
 fn tar_paths<R: Read>(archive: &mut Archive<R>) -> Vec<String> {
+    let path_date_re = regex!(r"^\d{4}-\d{2}-\d{2}-\d{6}");
+
     archive
         .entries()
         .unwrap()
         .map(|entry| entry.unwrap().path().unwrap().display().to_string())
-        .map(|path| PATH_DATE_RE.replace(&path, "YYYY-MM-DD-HHMMSS").to_string())
+        .map(|path| path_date_re.replace(&path, "YYYY-MM-DD-HHMMSS").to_string())
         .collect()
 }

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -10,8 +10,7 @@ use diesel_async::RunQueryDsl;
 use googletest::prelude::*;
 use http::StatusCode;
 use insta::{assert_debug_snapshot, assert_json_snapshot, assert_snapshot};
-use regex::Regex;
-use std::sync::LazyLock;
+use regex::regex;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn index() -> anyhow::Result<()> {
@@ -1381,12 +1380,9 @@ async fn crates_by_user_id_not_including_deleted_owners() -> anyhow::Result<()> 
     Ok(())
 }
 
-static PAGE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"((?:^page|&page|\?page)=\d+)").unwrap());
-
 // search with both offset-based (prepend with `page=1` query) and seek-based pagination
 async fn search_both<U: RequestHelper>(anon: &U, query: &str) -> [crate::CrateList; 2] {
-    if PAGE_RE.is_match(query) {
+    if regex!(r"((?:^page|&page|\?page)=\d+)").is_match(query) {
         panic!("url already contains page param");
     }
     let (offset, seek) = (

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -29,9 +29,8 @@ use crates_io_worker::Runner;
 use diesel_async::AsyncPgConnection;
 use futures_util::TryStreamExt;
 use oauth2::{ClientId, ClientSecret};
-use regex::Regex;
+use regex::regex;
 use std::collections::HashMap;
-use std::sync::LazyLock;
 use std::{rc::Rc, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 use tokio::task::block_in_place;
@@ -203,21 +202,13 @@ impl TestApp {
     }
 
     pub async fn emails_snapshot(&self) -> String {
-        static EMAIL_HEADER_REGEX: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"(Message-ID|Date): [^\r\n]+\r\n").unwrap());
-
-        static DATE_TIME_REGEX: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z").unwrap());
-
-        static EMAIL_CONFIRM_REGEX: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"/confirm/\w+").unwrap());
-
-        static INVITE_TOKEN_REGEX: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"/accept-invite/\w+").unwrap());
+        let email_header_re = regex!(r"(Message-ID|Date): [^\r\n]+\r\n");
+        let date_time_re = regex!(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z");
+        let email_confirm_re = regex!(r"/confirm/\w+");
+        let invite_token_re = regex!(r"/accept-invite/\w+");
 
         // MIME boundary strings are randomly generated alphanumeric strings
-        static MIME_BOUNDARY_REGEX: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"[A-Za-z0-9]{32,}").unwrap());
+        let mime_boundary_re = regex!(r"[A-Za-z0-9]{32,}");
 
         static SEPARATOR: &str = "\n----------------------------------------\n\n";
 
@@ -230,11 +221,11 @@ impl TestApp {
                 let decoded_email = decode(&email, ParseMode::Robust).unwrap();
                 let email = String::from_utf8_lossy(&decoded_email);
 
-                let email = EMAIL_HEADER_REGEX.replace_all(&email, "");
-                let email = DATE_TIME_REGEX.replace_all(&email, "[0000-00-00T00:00:00Z]");
-                let email = EMAIL_CONFIRM_REGEX.replace_all(&email, "/confirm/[confirm-token]");
-                let email = INVITE_TOKEN_REGEX.replace_all(&email, "/accept-invite/[invite-token]");
-                let email = MIME_BOUNDARY_REGEX.replace_all(&email, "[boundary]");
+                let email = email_header_re.replace_all(&email, "");
+                let email = date_time_re.replace_all(&email, "[0000-00-00T00:00:00Z]");
+                let email = email_confirm_re.replace_all(&email, "/confirm/[confirm-token]");
+                let email = invite_token_re.replace_all(&email, "/accept-invite/[invite-token]");
+                let email = mime_boundary_re.replace_all(&email, "[boundary]");
                 email.to_string()
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
regex 1.13 introduced a `regex!` macro that lazily compiles a regex from a string literal and reuses it automatically, returning a `&'static Regex`.

Replace the `LazyLock<Regex>` + `Regex::new(...).unwrap()` boilerplate with `regex!(...)` at all call sites that use literal patterns. The dynamic `Regex::new` in `block_traffic.rs` is left unchanged since its pattern is built at runtime and is not a string literal.