### PR TITLE
Reject crate/keyword/category requests with invalid names

### DIFF
--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -2,7 +2,7 @@ use super::helpers::pagination::*;
 use crate::app::AppState;
 use crate::models::Category;
 use crate::schema::categories;
-use crate::util::errors::AppResult;
+use crate::util::errors::{AppResult, not_found};
 use crate::views::EncodableCategory;
 use axum::Json;
 use axum::extract::{FromRequestParts, Path, Query};
@@ -93,6 +93,14 @@ pub async fn find_category(
     state: AppState,
     Path(slug): Path<String>,
 ) -> AppResult<Json<GetResponse>> {
+    // Category slugs can never contain null bytes, so we reject such requests
+    // early with a regular "not found" response instead of letting them reach
+    // the database layer, where PostgreSQL rejects the query with a confusing
+    // `invalid byte sequence for encoding "UTF8": 0x00` error.
+    if slug.contains('\0') {
+        return Err(not_found());
+    }
+
     let mut conn = state.db_read().await?;
 
     let cat: Category = Category::by_slug(&slug)

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -2,7 +2,7 @@ use crate::app::AppState;
 use crate::controllers::helpers::pagination::{PaginationOptions, PaginationQueryParams};
 use crate::controllers::helpers::{Paginate, pagination::Paginated};
 use crate::models::Keyword;
-use crate::util::errors::AppResult;
+use crate::util::errors::{AppResult, not_found};
 use crate::views::EncodableKeyword;
 use axum::Json;
 use axum::extract::{FromRequestParts, Path, Query};
@@ -90,6 +90,16 @@ pub async fn find_keyword(
     Path(name): Path<String>,
     state: AppState,
 ) -> AppResult<Json<GetResponse>> {
+    // If the name is not a valid keyword it cannot exist in the database, so we
+    // skip the lookup and return a regular "not found" response. This also
+    // avoids passing invalid input (e.g. names containing null bytes) to the
+    // database layer, where PostgreSQL would reject the query with a confusing
+    // `invalid byte sequence for encoding "UTF8": 0x00` error and cause a 500
+    // response.
+    if !Keyword::valid_name(&name) {
+        return Err(not_found());
+    }
+
     let conn = state.db_read().await?;
     let kw = Keyword::find_by_keyword(&conn, &name).await?;
     let keyword = EncodableKeyword::from(kw);

--- a/src/controllers/krate.rs
+++ b/src/controllers/krate.rs
@@ -1,9 +1,11 @@
 use crate::models::Crate;
-use crate::util::errors::{AppResult, crate_not_found};
+use crate::util::errors::{AppResult, BoxedAppError, crate_not_found, custom};
 use axum::extract::{FromRequestParts, Path};
 use crates_io_database::schema::crates;
+use crates_io_validation::validate_crate_name;
 use diesel::{OptionalExtension, QueryDsl};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use http::request::Parts;
 use serde::Deserialize;
 use utoipa::IntoParams;
 
@@ -18,12 +20,33 @@ pub mod search;
 pub mod update;
 pub mod versions;
 
-#[derive(Deserialize, FromRequestParts, IntoParams)]
+#[derive(Deserialize, IntoParams)]
 #[into_params(parameter_in = Path)]
-#[from_request(via(Path))]
 pub struct CratePath {
     /// Name of the crate
     pub name: String,
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for CratePath {
+    type Rejection = BoxedAppError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let Path(path) = Path::<CratePath>::from_request_parts(parts, state)
+            .await
+            .map_err(|err| custom(err.status(), err.body_text()))?;
+
+        // If the name is not a valid crate name it cannot exist in the
+        // database, so we skip the lookup and return a regular "not found"
+        // response. This also avoids passing invalid input (e.g. names
+        // containing null bytes) to the database layer, where PostgreSQL would
+        // reject the query with a confusing `invalid byte sequence for encoding
+        // "UTF8": 0x00` error and cause a 500 response.
+        if validate_crate_name("crate", &path.name).is_err() {
+            return Err(crate_not_found(&path.name));
+        }
+
+        Ok(path)
+    }
 }
 
 impl CratePath {

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -9,19 +9,20 @@ pub mod yank;
 
 use axum::extract::{FromRequestParts, Path};
 use crates_io_database::fns::canon_crate_name;
+use crates_io_validation::validate_crate_name;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use http::request::Parts;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use utoipa::IntoParams;
 
 use crate::models::{Crate, Version};
 use crate::schema::{crates, versions};
-use crate::util::errors::{AppResult, crate_not_found, version_not_found};
+use crate::util::errors::{AppResult, BoxedAppError, crate_not_found, custom, version_not_found};
 
-#[derive(Deserialize, FromRequestParts, IntoParams)]
+#[derive(Deserialize, IntoParams)]
 #[into_params(parameter_in = Path)]
-#[from_request(via(Path))]
 pub struct CrateVersionPath {
     /// Name of the crate
     pub name: String,
@@ -29,6 +30,29 @@ pub struct CrateVersionPath {
     #[param(example = "1.0.0")]
     #[serde(deserialize_with = "deserialize_version")]
     pub version: String,
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for CrateVersionPath {
+    type Rejection = BoxedAppError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let Path(path) = Path::<CrateVersionPath>::from_request_parts(parts, state)
+            .await
+            .map_err(|err| custom(err.status(), err.body_text()))?;
+
+        // If the name is not a valid crate name it cannot exist in the
+        // database, so we skip the lookup and return a regular "not found"
+        // response. This also avoids passing invalid input (e.g. names
+        // containing null bytes) to the database layer, where PostgreSQL would
+        // reject the query with a confusing `invalid byte sequence for encoding
+        // "UTF8": 0x00` error and cause a 500 response. (The version is already
+        // validated as valid semver during deserialization.)
+        if validate_crate_name("crate", &path.name).is_err() {
+            return Err(crate_not_found(&path.name));
+        }
+
+        Ok(path)
+    }
 }
 
 impl CrateVersionPath {

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -41,6 +41,17 @@ async fn show() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn null_byte_in_slug() {
+    let (_app, anon) = TestApp::init().empty().await;
+
+    // A category slug with a null byte can never exist, so instead of letting
+    // the request fail with a database encoding error it should be treated as a
+    // regular "not found" response.
+    let response = anon.get::<()>("/api/v1/categories/foo%00bar").await;
+    assert_snapshot!(response.status(), @"404 Not Found");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[allow(clippy::cognitive_complexity)]
 async fn update_crate() -> anyhow::Result<()> {
     // Convenience function to get the number of crates in a category

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -117,6 +117,18 @@ async fn test_missing() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_null_byte_in_name() {
+    let (_, anon) = TestApp::init().empty().await;
+
+    // A crate name with a null byte can never exist, so instead of letting the
+    // request fail with a database encoding error it should be treated as a
+    // regular "not found" response.
+    let response = anon.get::<()>("/api/v1/crates/foo%00bar").await;
+    assert_snapshot!(response.status(), @"404 Not Found");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `foo\u0000bar` does not exist"}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn version_size() {
     let (_, _, user) = TestApp::full().with_user().await;
 

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -3,6 +3,7 @@ use crate::util::insta::{self, assert_json_snapshot};
 use crate::util::{RequestHelper, TestApp};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use http::StatusCode;
 use serde_json::Value;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -95,4 +96,15 @@ async fn block_bad_version_urls() {
     assert_eq!(json["version"]["homepage"], Value::Null);
     assert_eq!(json["version"]["documentation"], Value::Null);
     assert_eq!(json["version"]["repository"], Value::Null);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_null_byte_in_crate_name() {
+    let (_, anon) = TestApp::init().empty().await;
+
+    // A crate name with a null byte can never exist, so instead of letting the
+    // request fail with a database encoding error it should be treated as a
+    // regular "not found" response.
+    let response = anon.get::<()>("/api/v1/crates/foo%00bar/1.0.0").await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -45,6 +45,17 @@ async fn uppercase() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn null_byte_in_name() {
+    let (_app, anon) = TestApp::init().empty().await;
+
+    // A keyword with a null byte can never exist, so instead of letting the
+    // request fail with a database encoding error it should be treated as a
+    // regular "not found" response.
+    let response = anon.get::<()>("/api/v1/keywords/foo%00bar").await;
+    assert_snapshot!(response.status(), @"404 Not Found");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn update_crate() -> anyhow::Result<()> {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn().await;


### PR DESCRIPTION
Requests such as `GET /api/v1/crates/foo%00bar` decode to a crate name containing a null byte (`0x00`). The name was passed straight into the database lookup, where PostgreSQL rejects it with `invalid byte sequence for encoding "UTF8": 0x00`. This surfaced as a `500 Internal Server Error` and generated noise in our error reporting.

A crate name can never contain a null byte, so we now validate it in the `CratePath` and `CrateVersionPath` extractors and return a regular `404 Not Found` response before the request ever reaches the database.

The same applies to keywords and categories.