### PR TITLE
tests: Await `render()` and `unmount()`

### DIFF
--- a/svelte/src/lib/components/EmailInput.svelte.test.ts
+++ b/svelte/src/lib/components/EmailInput.svelte.test.ts
@@ -28,7 +28,7 @@ function createUser(overrides: Partial<AuthenticatedUser> = {}): AuthenticatedUs
 
 test('happy path', async ({ worker }) => {
   let user = createUser();
-  render(EmailInputTestWrapper, { user });
+  await render(EmailInputTestWrapper, { user });
 
   worker.use(http.put('/api/v1/users/:user_id', () => HttpResponse.json({ ok: true })));
 
@@ -63,7 +63,7 @@ test('happy path', async ({ worker }) => {
 
 test('happy path with `email: null`', async ({ worker }) => {
   let user = createUser({ email: null, email_verified: false, email_verification_sent: false });
-  render(EmailInputTestWrapper, { user });
+  await render(EmailInputTestWrapper, { user });
 
   worker.use(http.put('/api/v1/users/:user_id', () => HttpResponse.json({ ok: true })));
 
@@ -94,7 +94,7 @@ test('happy path with `email: null`', async ({ worker }) => {
 
 test('cancel button', async () => {
   let user = createUser();
-  render(EmailInputTestWrapper, { user });
+  await render(EmailInputTestWrapper, { user });
 
   await page.getByCSS('[data-test-edit-button]').click();
   await userEvent.fill(page.getByCSS('[data-test-input]'), 'new@email.com');
@@ -108,7 +108,7 @@ test('cancel button', async () => {
 
 test('server error', async ({ worker }) => {
   let user = createUser();
-  render(EmailInputTestWrapper, { user });
+  await render(EmailInputTestWrapper, { user });
 
   worker.use(http.put('/api/v1/users/:user_id', () => HttpResponse.json({}, { status: 500 })));
 
@@ -126,7 +126,7 @@ test('server error', async ({ worker }) => {
 describe('Resend button', () => {
   test('happy path', async ({ worker }) => {
     let user = createUser({ email_verified: false, email_verification_sent: true });
-    render(EmailInputTestWrapper, { user });
+    await render(EmailInputTestWrapper, { user });
 
     worker.use(http.put('/api/v1/users/:user_id/resend', () => HttpResponse.json({ ok: true })));
 
@@ -145,7 +145,7 @@ describe('Resend button', () => {
 
   test('server error', async ({ worker }) => {
     let user = createUser({ email_verified: false, email_verification_sent: true });
-    render(EmailInputTestWrapper, { user });
+    await render(EmailInputTestWrapper, { user });
 
     worker.use(http.put('/api/v1/users/:user_id/resend', () => HttpResponse.json({}, { status: 500 })));
 

--- a/svelte/src/lib/components/NativeReplacementBanner.svelte.test.ts
+++ b/svelte/src/lib/components/NativeReplacementBanner.svelte.test.ts
@@ -15,7 +15,7 @@ const replacement: NativeReplacement = {
 
 describe('NativeReplacementBanner', () => {
   it('renders the description Markdown and a "Learn more" link', async () => {
-    render(NativeReplacementBanner, { replacement });
+    await render(NativeReplacementBanner, { replacement });
 
     let banner = page.getByCSS('[data-test-native-replacement-banner]');
     await expect.element(banner).toBeVisible();

--- a/svelte/src/lib/components/OwnersList.svelte.test.ts
+++ b/svelte/src/lib/components/OwnersList.svelte.test.ts
@@ -36,7 +36,7 @@ describe('OwnersList', () => {
   it('single user', async () => {
     let owners: Owner[] = [createUser(1)];
 
-    render(OwnersList, { owners });
+    await render(OwnersList, { owners });
 
     await expect.element(page.getByCSS('[data-test-owners="detailed"]')).toBeVisible();
     await expect.element(page.getByCSS('ul > li')).toBeVisible();
@@ -56,7 +56,7 @@ describe('OwnersList', () => {
   it('user without `name`', async () => {
     let owners: Owner[] = [createUser(1, { name: null, login: 'anonymous' })];
 
-    render(OwnersList, { owners });
+    await render(OwnersList, { owners });
 
     await expect.element(page.getByCSS('[data-test-owners="detailed"]')).toBeVisible();
     await expect.element(page.getByCSS('ul > li')).toBeVisible();
@@ -76,7 +76,7 @@ describe('OwnersList', () => {
   it('five users', async () => {
     let owners: Owner[] = Array.from({ length: 5 }, (_, i) => createUser(i + 1));
 
-    render(OwnersList, { owners });
+    await render(OwnersList, { owners });
 
     await expect.element(page.getByCSS('[data-test-owners="detailed"]')).toBeVisible();
     expect(page.getByCSS('ul > li').elements()).toHaveLength(5);
@@ -92,7 +92,7 @@ describe('OwnersList', () => {
   it('six users', async () => {
     let owners: Owner[] = Array.from({ length: 6 }, (_, i) => createUser(i + 1));
 
-    render(OwnersList, { owners });
+    await render(OwnersList, { owners });
 
     await expect.element(page.getByCSS('[data-test-owners="basic"]')).toBeVisible();
     expect(page.getByCSS('ul > li').elements()).toHaveLength(6);
@@ -110,7 +110,7 @@ describe('OwnersList', () => {
     let users: Owner[] = [createUser(1), createUser(2), createUser(3)];
     let owners: Owner[] = [...teams, ...users];
 
-    render(OwnersList, { owners });
+    await render(OwnersList, { owners });
 
     await expect.element(page.getByCSS('[data-test-owners="detailed"]')).toBeVisible();
     expect(page.getByCSS('ul > li').elements()).toHaveLength(5);

--- a/svelte/src/lib/components/SearchForm.svelte.test.ts
+++ b/svelte/src/lib/components/SearchForm.svelte.test.ts
@@ -20,7 +20,7 @@ describe('SearchForm', () => {
     // The large input carrying `data-test-search-input` is hidden below 820px,
     // so widen the viewport to make it focusable.
     await page.viewport(1280, 800);
-    render(SearchFormTestWrapper);
+    await render(SearchFormTestWrapper);
     let input = page.getByCSS('[data-test-search-input]').element() as HTMLInputElement;
     expect(document.activeElement).not.toBe(input);
 
@@ -29,8 +29,8 @@ describe('SearchForm', () => {
     expect(document.activeElement).toBe(input);
   });
 
-  it('does not steal focus while typing in an input inside a shadow root', () => {
-    render(SearchFormTestWrapper);
+  it('does not steal focus while typing in an input inside a shadow root', async () => {
+    await render(SearchFormTestWrapper);
     let searchInput = page.getByCSS('[data-test-search-input]').element() as HTMLInputElement;
 
     // An input inside a shadow root: a keydown from it is retargeted to the

--- a/svelte/src/lib/components/Tooltip.svelte.test.ts
+++ b/svelte/src/lib/components/Tooltip.svelte.test.ts
@@ -7,7 +7,7 @@ import TooltipTestWrapper from './TooltipTestWrapper.svelte';
 
 describe('Tooltip', () => {
   it('shows the tooltip on hover', async () => {
-    render(TooltipTestWrapper, { text: 'short', width: '500px' });
+    await render(TooltipTestWrapper, { text: 'short', width: '500px' });
 
     await userEvent.hover(page.getByCSS('[data-test-anchor]'));
 
@@ -16,7 +16,7 @@ describe('Tooltip', () => {
 
   describe('delay', () => {
     it('waits for the configured delay before showing the tooltip', async () => {
-      render(TooltipTestWrapper, { text: 'short', width: '500px', delay: 200 });
+      await render(TooltipTestWrapper, { text: 'short', width: '500px', delay: 200 });
 
       await userEvent.hover(page.getByCSS('[data-test-anchor]'));
       await tick();
@@ -29,7 +29,7 @@ describe('Tooltip', () => {
 
   describe('onlyWhenTruncated', () => {
     it('shows the tooltip when the anchor content is truncated', async () => {
-      render(TooltipTestWrapper, {
+      await render(TooltipTestWrapper, {
         text: 'A very long string that does not fit into the narrow anchor element',
         width: '50px',
         onlyWhenTruncated: true,
@@ -41,7 +41,7 @@ describe('Tooltip', () => {
     });
 
     it('does not show the tooltip when the anchor content fits', async () => {
-      render(TooltipTestWrapper, { text: 'short', width: '500px', onlyWhenTruncated: true });
+      await render(TooltipTestWrapper, { text: 'short', width: '500px', onlyWhenTruncated: true });
 
       await userEvent.hover(page.getByCSS('[data-test-anchor]'));
       await tick();

--- a/svelte/src/lib/components/UnmaintainedBanner.svelte.test.ts
+++ b/svelte/src/lib/components/UnmaintainedBanner.svelte.test.ts
@@ -15,7 +15,7 @@ const unmaintained: Unmaintained = {
 
 describe('UnmaintainedBanner', () => {
   it('renders the explanation and a link to the advisory', async () => {
-    render(UnmaintainedBanner, { unmaintained });
+    await render(UnmaintainedBanner, { unmaintained });
 
     let banner = page.getByCSS('[data-test-unmaintained-banner]');
     await expect.element(banner).toBeVisible();

--- a/svelte/src/lib/components/YankButton.svelte.test.ts
+++ b/svelte/src/lib/components/YankButton.svelte.test.ts
@@ -49,7 +49,7 @@ describe('YankButton', () => {
 
       worker.use(http.delete('/api/v1/crates/:name/:version/yank', () => deferred.promise));
 
-      render(YankButtonTestWrapper, { crateName: 'foo', version, onChanged });
+      await render(YankButtonTestWrapper, { crateName: 'foo', version, onChanged });
 
       await expect.element(page.getByCSS('[data-test-version-yank-button="1.0.0"]')).toHaveTextContent('Yank');
       await expect.element(page.getByCSS('[data-test-version-unyank-button]')).not.toBeInTheDocument();
@@ -71,7 +71,7 @@ describe('YankButton', () => {
 
       worker.use(http.delete('/api/v1/crates/:name/:version/yank', () => HttpResponse.json({}, { status: 500 })));
 
-      render(YankButtonTestWrapper, { crateName: 'foo', version, onChanged });
+      await render(YankButtonTestWrapper, { crateName: 'foo', version, onChanged });
 
       await page.getByCSS('[data-test-version-yank-button="1.0.0"]').click();
 
@@ -89,7 +89,7 @@ describe('YankButton', () => {
 
       worker.use(http.put('/api/v1/crates/:name/:version/unyank', () => deferred.promise));
 
-      render(YankButtonTestWrapper, { crateName: 'foo', version, onChanged });
+      await render(YankButtonTestWrapper, { crateName: 'foo', version, onChanged });
 
       await expect.element(page.getByCSS('[data-test-version-unyank-button="1.0.0"]')).toHaveTextContent('Unyank');
       await expect.element(page.getByCSS('[data-test-version-yank-button]')).not.toBeInTheDocument();
@@ -113,7 +113,7 @@ describe('YankButton', () => {
 
       worker.use(http.put('/api/v1/crates/:name/:version/unyank', () => HttpResponse.json({}, { status: 500 })));
 
-      render(YankButtonTestWrapper, { crateName: 'foo', version, onChanged });
+      await render(YankButtonTestWrapper, { crateName: 'foo', version, onChanged });
 
       await page.getByCSS('[data-test-version-unyank-button="1.0.0"]').click();
 

--- a/svelte/src/lib/components/crate-sidebar/Link.svelte.test.ts
+++ b/svelte/src/lib/components/crate-sidebar/Link.svelte.test.ts
@@ -32,7 +32,7 @@ describe('simplifyUrl', () => {
 
 describe('Link component', () => {
   it('renders title and link', async () => {
-    render(Link, { title: 'Homepage', url: 'https://www.rust-lang.org' });
+    await render(Link, { title: 'Homepage', url: 'https://www.rust-lang.org' });
 
     await expect.element(page.getByCSS('[data-test-title]')).toHaveTextContent('Homepage');
     await expect.element(page.getByCSS('[data-test-icon]')).toHaveAttribute('data-test-icon', 'link');
@@ -41,7 +41,7 @@ describe('Link component', () => {
   });
 
   it('renders GitHub icon for GitHub links', async () => {
-    render(Link, { title: 'Repository', url: 'https://github.com/rust-lang/crates.io' });
+    await render(Link, { title: 'Repository', url: 'https://github.com/rust-lang/crates.io' });
 
     await expect.element(page.getByCSS('[data-test-icon]')).toHaveAttribute('data-test-icon', 'github');
     await expect
@@ -51,7 +51,7 @@ describe('Link component', () => {
   });
 
   it('renders docs.rs icon for docs.rs links', async () => {
-    render(Link, { title: 'Documentation', url: 'https://docs.rs/tracing' });
+    await render(Link, { title: 'Documentation', url: 'https://docs.rs/tracing' });
 
     await expect.element(page.getByCSS('[data-test-icon]')).toHaveAttribute('data-test-icon', 'docs-rs');
     await expect.element(page.getByCSS('[data-test-link]')).toHaveAttribute('href', 'https://docs.rs/tracing');
@@ -59,33 +59,33 @@ describe('Link component', () => {
   });
 
   it('renders GitLab icon for GitLab links', async () => {
-    render(Link, { title: 'Repository', url: 'https://gitlab.com/example/project' });
+    await render(Link, { title: 'Repository', url: 'https://gitlab.com/example/project' });
 
     await expect.element(page.getByCSS('[data-test-icon]')).toHaveAttribute('data-test-icon', 'gitlab');
   });
 
   it('renders Codeberg icon for Codeberg links', async () => {
-    render(Link, { title: 'Repository', url: 'https://codeberg.org/example/project' });
+    await render(Link, { title: 'Repository', url: 'https://codeberg.org/example/project' });
 
     await expect.element(page.getByCSS('[data-test-icon]')).toHaveAttribute('data-test-icon', 'codeberg');
   });
 
   it('does not shorten HTTP links', async () => {
-    render(Link, { title: 'Homepage', url: 'http://www.rust-lang.org' });
+    await render(Link, { title: 'Homepage', url: 'http://www.rust-lang.org' });
 
     await expect.element(page.getByCSS('[data-test-link]')).toHaveAttribute('href', 'http://www.rust-lang.org');
     await expect.element(page.getByCSS('[data-test-link]')).toHaveTextContent('http://www.rust-lang.org');
   });
 
   it('strips trailing slashes', async () => {
-    render(Link, { title: 'Homepage', url: 'https://www.rust-lang.org/' });
+    await render(Link, { title: 'Homepage', url: 'https://www.rust-lang.org/' });
 
     await expect.element(page.getByCSS('[data-test-link]')).toHaveAttribute('href', 'https://www.rust-lang.org/');
     await expect.element(page.getByCSS('[data-test-link]')).toHaveTextContent('rust-lang.org');
   });
 
   it('strips trailing .git from GitHub project URLs', async () => {
-    render(Link, { title: 'Repository', url: 'https://github.com/rust-lang/crates.io.git' });
+    await render(Link, { title: 'Repository', url: 'https://github.com/rust-lang/crates.io.git' });
 
     await expect
       .element(page.getByCSS('[data-test-link]'))
@@ -94,7 +94,7 @@ describe('Link component', () => {
   });
 
   it('does not strip trailing .git from non-GitHub URLs', async () => {
-    render(Link, { title: 'Homepage', url: 'https://foo.git/' });
+    await render(Link, { title: 'Homepage', url: 'https://foo.git/' });
 
     await expect.element(page.getByCSS('[data-test-link]')).toHaveAttribute('href', 'https://foo.git/');
     await expect.element(page.getByCSS('[data-test-link]')).toHaveTextContent('foo.git');

--- a/svelte/src/lib/components/crate-sidebar/PlaygroundButton.svelte.test.ts
+++ b/svelte/src/lib/components/crate-sidebar/PlaygroundButton.svelte.test.ts
@@ -100,7 +100,7 @@ describe('CrateSidebar Playground Button', () => {
     let playgroundCratesPromise = Promise.resolve(PLAYGROUND_CRATES);
     let docsRsStatusPromise = Promise.resolve(null);
 
-    render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise, docsRsStatusPromise });
+    await render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise, docsRsStatusPromise });
 
     // Button should not exist for crates not in the playground list
     expect(page.getByCSS('[data-test-playground-button]').query()).toBeNull();
@@ -113,7 +113,7 @@ describe('CrateSidebar Playground Button', () => {
     let playgroundCratesPromise = Promise.resolve(PLAYGROUND_CRATES);
     let docsRsStatusPromise = Promise.resolve(null);
 
-    render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise, docsRsStatusPromise });
+    await render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise, docsRsStatusPromise });
 
     let expectedHref =
       'https://play.rust-lang.org/?edition=2021&code=use%20aho_corasick%3B%0A%0Afn%20main()%20%7B%0A%20%20%20%20%2F%2F%20try%20using%20the%20%60aho_corasick%60%20crate%20here%0A%7D';
@@ -129,7 +129,7 @@ describe('CrateSidebar Playground Button', () => {
     let deferred = defer<PlaygroundCrate[]>();
     let docsRsStatusPromise = Promise.resolve(null);
 
-    render(CrateSidebarTestWrapper, {
+    await render(CrateSidebarTestWrapper, {
       crate,
       version,
       owners,
@@ -153,7 +153,7 @@ describe('CrateSidebar Playground Button', () => {
     let playgroundCratesPromise = Promise.reject(new Error('Failed to load'));
     let docsRsStatusPromise = Promise.resolve(null);
 
-    render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise, docsRsStatusPromise });
+    await render(CrateSidebarTestWrapper, { crate, version, owners, playgroundCratesPromise, docsRsStatusPromise });
 
     // Button should not exist when the request fails
     expect(page.getByCSS('[data-test-playground-button]').query()).toBeNull();

--- a/svelte/src/lib/components/dependency-list/Row.svelte.test.ts
+++ b/svelte/src/lib/components/dependency-list/Row.svelte.test.ts
@@ -34,7 +34,7 @@ describe('dependency-list/Row', () => {
   it('shows the native-replacement marker for a superseded dependency', async () => {
     let dependency = createDependency({ crate_id: 'lazy_static' });
 
-    render(Row, {
+    await render(Row, {
       dependency,
       descriptionPromise: Promise.resolve(null),
       nativeReplacement: LAZY_STATIC_REPLACEMENT,
@@ -51,7 +51,7 @@ describe('dependency-list/Row', () => {
   it('shows no marker for a dependency without a replacement', async () => {
     let dependency = createDependency({ crate_id: 'serde' });
 
-    render(Row, { dependency, descriptionPromise: Promise.resolve(null) });
+    await render(Row, { dependency, descriptionPromise: Promise.resolve(null) });
 
     await expect.element(page.getByCSS('[data-test-crate-name]')).toHaveTextContent('serde');
     expect(page.getByCSS('[data-test-native-replacement]').elements()).toHaveLength(0);

--- a/svelte/src/lib/components/download-chart/DownloadChart.svelte.test.ts
+++ b/svelte/src/lib/components/download-chart/DownloadChart.svelte.test.ts
@@ -58,7 +58,7 @@ describe('DownloadChart', () => {
   });
 
   it('happy path', async () => {
-    render(TestDownloadChart, { data: exampleData() });
+    await render(TestDownloadChart, { data: exampleData() });
     resolveChart(Chart);
 
     await expect.element(page.getByCSS('[data-test-download-graph]')).toBeVisible();
@@ -68,7 +68,7 @@ describe('DownloadChart', () => {
   });
 
   it('loading spinner', async () => {
-    render(TestDownloadChart, { data: exampleData() });
+    await render(TestDownloadChart, { data: exampleData() });
 
     await expect.element(page.getByCSS('[data-test-download-graph]')).toBeVisible();
     await expect.element(page.getByCSS('[data-test-download-graph] [data-test-spinner]')).toBeVisible();
@@ -85,7 +85,7 @@ describe('DownloadChart', () => {
 
   it('error behavior', async () => {
     let reloadFn = vi.fn();
-    render(TestDownloadChart, { data: exampleData(), onReload: reloadFn });
+    await render(TestDownloadChart, { data: exampleData(), onReload: reloadFn });
     rejectChart(new Error('nope'));
 
     await expect.element(page.getByCSS('[data-test-download-graph]')).toBeVisible();

--- a/svelte/src/lib/components/dropdown/Dropdown.svelte.test.ts
+++ b/svelte/src/lib/components/dropdown/Dropdown.svelte.test.ts
@@ -6,7 +6,7 @@ import TestDropdown from './TestDropdown.svelte';
 
 describe('Dropdown', () => {
   it('toggles content visibility when trigger is clicked', async () => {
-    render(TestDropdown);
+    await render(TestDropdown);
 
     let trigger = page.getByRole('button', { name: 'Open Menu' });
     let content = page.getByText('Menu content');
@@ -22,7 +22,7 @@ describe('Dropdown', () => {
   });
 
   it('closes when clicking outside', async () => {
-    render(TestDropdown);
+    await render(TestDropdown);
 
     let trigger = page.getByRole('button', { name: 'Open Menu' });
     let content = page.getByText('Menu content');
@@ -35,7 +35,7 @@ describe('Dropdown', () => {
   });
 
   it('closes when Escape key is pressed', async () => {
-    render(TestDropdown);
+    await render(TestDropdown);
 
     let trigger = page.getByRole('button', { name: 'Open Menu' });
     let content = page.getByText('Menu content');
@@ -48,7 +48,7 @@ describe('Dropdown', () => {
   });
 
   it('sets correct ARIA attributes on trigger', async () => {
-    render(TestDropdown);
+    await render(TestDropdown);
 
     let trigger = page.getByRole('button', { name: 'Open Menu' });
 
@@ -61,7 +61,7 @@ describe('Dropdown', () => {
   });
 
   it('shows arrow indicator by default, hides when hideArrow is true', async () => {
-    render(TestDropdown);
+    await render(TestDropdown);
 
     let withArrow = page.getByRole('button', { name: 'Open Menu' });
     expect(withArrow.element().querySelector('.arrow')).not.toBeNull();
@@ -73,7 +73,7 @@ describe('Dropdown', () => {
 
 describe('Dropdown.Menu', () => {
   it('renders with correct ARIA roles and attributes', async () => {
-    render(TestDropdown);
+    await render(TestDropdown);
 
     let trigger = page.getByRole('button', { name: 'Menu Dropdown' });
     await trigger.click();

--- a/svelte/src/lib/components/version-list/Row.svelte.test.ts
+++ b/svelte/src/lib/components/version-list/Row.svelte.test.ts
@@ -42,12 +42,12 @@ describe('version-list/Row', () => {
     let firstVersion = createVersion({ num: '0.4.0-alpha.01' });
     let secondVersion = createVersion({ num: '0.3.0-alpha.01' });
 
-    let { unmount } = render(Row, { version: firstVersion, crateName: 'foo' });
+    let { unmount } = await render(Row, { version: firstVersion, crateName: 'foo' });
     await expect.element(page.getByCSS('[data-test-release-track]')).toHaveTextContent('0.4');
     await expect.element(page.getByCSS('[data-test-release-track-link]')).toHaveTextContent('0.4.0-alpha.01');
-    unmount();
+    await unmount();
 
-    render(Row, { version: secondVersion, crateName: 'foo' });
+    await render(Row, { version: secondVersion, crateName: 'foo' });
     await expect.element(page.getByCSS('[data-test-release-track]')).toHaveTextContent('0.3');
     await expect.element(page.getByCSS('[data-test-release-track-link]')).toHaveTextContent('0.3.0-alpha.01');
   });
@@ -56,7 +56,7 @@ describe('version-list/Row', () => {
     let num = '18446744073709551615.18446744073709551615.18446744073709551615';
     let version = createVersion({ num });
 
-    render(Row, { version, crateName: 'foo' });
+    await render(Row, { version, crateName: 'foo' });
     await expect.element(page.getByCSS('[data-test-release-track]')).toHaveTextContent('?');
     await expect.element(page.getByCSS('[data-test-release-track-link]')).toHaveTextContent(num);
   });
@@ -66,15 +66,15 @@ describe('version-list/Row', () => {
     let secondVersion = createVersion({ num: '0.2.0', features: { one: [] } });
     let thirdVersion = createVersion({ num: '0.3.0', features: { one: [], two: [] } });
 
-    let { unmount: unmount1 } = render(Row, { version: firstVersion, crateName: 'foo' });
+    let { unmount: unmount1 } = await render(Row, { version: firstVersion, crateName: 'foo' });
     expect(page.getByCSS('[data-test-feature-list]').query()).toBeNull();
-    unmount1();
+    await unmount1();
 
-    let { unmount: unmount2 } = render(Row, { version: secondVersion, crateName: 'foo' });
+    let { unmount: unmount2 } = await render(Row, { version: secondVersion, crateName: 'foo' });
     await expect.element(page.getByCSS('[data-test-feature-list]')).toHaveTextContent('1 Feature');
-    unmount2();
+    await unmount2();
 
-    render(Row, { version: thirdVersion, crateName: 'foo' });
+    await render(Row, { version: thirdVersion, crateName: 'foo' });
     await expect.element(page.getByCSS('[data-test-feature-list]')).toHaveTextContent('2 Features');
   });
 });


### PR DESCRIPTION
`vitest-browser-svelte` v2 supports awaited lifecycle operations and deprecates synchronous use. This converts every component test call site, including explicit cleanup, so `render()` and `unmount()` trace marks complete before each test continues.

These changes keep the suite compatible with the [v3](https://github.com/rust-lang/crates.io/pull/14212) async-only API without coupling the test migration to the dependency update.