### PR TITLE
Expose `TrustpubData` in OpenAPI schema

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -951,7 +951,6 @@ pub struct EncodableVersion {
     ///
     /// The exact structure of this field depends on the `provider` field
     /// inside it.
-    #[schema(value_type = Option<HashMap<String, serde_json::Value>>)]
     pub trustpub_data: Option<TrustpubData>,
 
     /// Line count statistics for this version.

--- a/crates/crates_io_database/src/models/trustpub/data.rs
+++ b/crates/crates_io_database/src/models/trustpub/data.rs
@@ -6,7 +6,9 @@ use diesel::{AsExpression, FromSqlRow};
 use serde::{Deserialize, Serialize};
 
 /// Data structure containing trusted publisher information extracted from JWT claims
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, FromSqlRow, AsExpression)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, FromSqlRow, AsExpression, utoipa::ToSchema,
+)]
 #[diesel(sql_type = Jsonb)]
 #[serde(tag = "provider")]
 pub enum TrustpubData {

--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -1583,6 +1583,26 @@ export interface components {
              */
             url?: string | null;
         };
+        /** @description Data structure containing trusted publisher information extracted from JWT claims */
+        TrustpubData: {
+            /** @enum {string} */
+            provider: "github";
+            /** @description Repository (e.g. "octo-org/octo-repo") */
+            repository: string;
+            /** @description Workflow run ID */
+            run_id: string;
+            /** @description SHA of the commit */
+            sha: string;
+        } | {
+            /** @description Job ID */
+            job_id: string;
+            /** @description Project path (e.g. "rust-lang/cargo") */
+            project_path: string;
+            /** @enum {string} */
+            provider: "gitlab";
+            /** @description SHA of the commit */
+            sha: string;
+        };
         User: {
             /**
              * @description The user's avatar URL, if set.
@@ -1756,20 +1776,7 @@ export interface components {
              * @example 1.31
              */
             rust_version?: string | null;
-            /**
-             * @description Information about the trusted publisher that published this version, if any.
-             *
-             *     Status: **Unstable**
-             *
-             *     This field is filled if the version was published via trusted publishing
-             *     (e.g., GitHub Actions) rather than a regular API token.
-             *
-             *     The exact structure of this field depends on the `provider` field
-             *     inside it.
-             */
-            trustpub_data?: {
-                [key: string]: unknown;
-            } | null;
+            trustpub_data?: null | components["schemas"]["TrustpubData"];
             /**
              * Format: date-time
              * @description The date and time this version was last updated (i.e. yanked or unyanked).

--- a/packages/crates-io-api-client/schema.test.ts
+++ b/packages/crates-io-api-client/schema.test.ts
@@ -1,10 +1,14 @@
+import type { components } from './schema';
+
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
 
 import openapiTS, { astToString } from 'openapi-typescript';
-import { expect, test } from 'vitest';
+import { expect, expectTypeOf, test } from 'vitest';
 
 const SNAPSHOT_PATH = '../../src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap';
+
+type TrustpubData = NonNullable<components['schemas']['Version']['trustpub_data']>;
 
 const HEADER = `/**
  * This file is auto-generated. Do not edit manually.
@@ -32,4 +36,20 @@ test('schema.d.ts is up to date', async () => {
   let generated = await generateSchema();
   let schemaPath = path.resolve(__dirname, 'schema.d.ts');
   await expect(generated).toMatchFileSnapshot(schemaPath);
+});
+
+test('trusted publishing data preserves provider-specific fields', () => {
+  type GitHubTrustpubData = Extract<TrustpubData, { provider: 'github' }>;
+  type GitLabTrustpubData = Extract<TrustpubData, { provider: 'gitlab' }>;
+
+  expectTypeOf<GitHubTrustpubData>().toMatchObjectType<{
+    repository: string;
+    run_id: string;
+    sha: string;
+  }>();
+  expectTypeOf<GitLabTrustpubData>().toMatchObjectType<{
+    project_path: string;
+    job_id: string;
+    sha: string;
+  }>();
 });

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -953,6 +953,69 @@ expression: response.json()
         ],
         "type": "object"
       },
+      "TrustpubData": {
+        "description": "Data structure containing trusted publisher information extracted from JWT claims",
+        "oneOf": [
+          {
+            "properties": {
+              "provider": {
+                "enum": [
+                  "github"
+                ],
+                "type": "string"
+              },
+              "repository": {
+                "description": "Repository (e.g. \"octo-org/octo-repo\")",
+                "type": "string"
+              },
+              "run_id": {
+                "description": "Workflow run ID",
+                "type": "string"
+              },
+              "sha": {
+                "description": "SHA of the commit",
+                "type": "string"
+              }
+            },
+            "required": [
+              "repository",
+              "run_id",
+              "sha",
+              "provider"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "job_id": {
+                "description": "Job ID",
+                "type": "string"
+              },
+              "project_path": {
+                "description": "Project path (e.g. \"rust-lang/cargo\")",
+                "type": "string"
+              },
+              "provider": {
+                "enum": [
+                  "gitlab"
+                ],
+                "type": "string"
+              },
+              "sha": {
+                "description": "SHA of the commit",
+                "type": "string"
+              }
+            },
+            "required": [
+              "project_path",
+              "job_id",
+              "sha",
+              "provider"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "User": {
         "properties": {
           "avatar": {
@@ -1209,14 +1272,14 @@ expression: response.json()
             ]
           },
           "trustpub_data": {
-            "additionalProperties": {},
-            "description": "Information about the trusted publisher that published this version, if any.\n\nStatus: **Unstable**\n\nThis field is filled if the version was published via trusted publishing\n(e.g., GitHub Actions) rather than a regular API token.\n\nThe exact structure of this field depends on the `provider` field\ninside it.",
-            "propertyNames": {
-              "type": "string"
-            },
-            "type": [
-              "object",
-              "null"
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TrustpubData",
+                "description": "Information about the trusted publisher that published this version, if any.\n\nStatus: **Unstable**\n\nThis field is filled if the version was published via trusted publishing\n(e.g., GitHub Actions) rather than a regular API token.\n\nThe exact structure of this field depends on the `provider` field\ninside it."
+              }
             ]
           },
           "updated_at": {

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -953,6 +953,69 @@ expression: response.json()
         ],
         "type": "object"
       },
+      "TrustpubData": {
+        "description": "Data structure containing trusted publisher information extracted from JWT claims",
+        "oneOf": [
+          {
+            "properties": {
+              "provider": {
+                "enum": [
+                  "github"
+                ],
+                "type": "string"
+              },
+              "repository": {
+                "description": "Repository (e.g. \"octo-org/octo-repo\")",
+                "type": "string"
+              },
+              "run_id": {
+                "description": "Workflow run ID",
+                "type": "string"
+              },
+              "sha": {
+                "description": "SHA of the commit",
+                "type": "string"
+              }
+            },
+            "required": [
+              "repository",
+              "run_id",
+              "sha",
+              "provider"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "job_id": {
+                "description": "Job ID",
+                "type": "string"
+              },
+              "project_path": {
+                "description": "Project path (e.g. \"rust-lang/cargo\")",
+                "type": "string"
+              },
+              "provider": {
+                "enum": [
+                  "gitlab"
+                ],
+                "type": "string"
+              },
+              "sha": {
+                "description": "SHA of the commit",
+                "type": "string"
+              }
+            },
+            "required": [
+              "project_path",
+              "job_id",
+              "sha",
+              "provider"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "User": {
         "properties": {
           "avatar": {
@@ -1209,14 +1272,14 @@ expression: response.json()
             ]
           },
           "trustpub_data": {
-            "additionalProperties": {},
-            "description": "Information about the trusted publisher that published this version, if any.\n\nStatus: **Unstable**\n\nThis field is filled if the version was published via trusted publishing\n(e.g., GitHub Actions) rather than a regular API token.\n\nThe exact structure of this field depends on the `provider` field\ninside it.",
-            "propertyNames": {
-              "type": "string"
-            },
-            "type": [
-              "object",
-              "null"
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TrustpubData",
+                "description": "Information about the trusted publisher that published this version, if any.\n\nStatus: **Unstable**\n\nThis field is filled if the version was published via trusted publishing\n(e.g., GitHub Actions) rather than a regular API token.\n\nThe exact structure of this field depends on the `provider` field\ninside it."
+              }
             ]
           },
           "updated_at": {

--- a/svelte/src/lib/components/version-list/Row.stories.svelte
+++ b/svelte/src/lib/components/version-list/Row.stories.svelte
@@ -79,7 +79,7 @@
   <Row
     version={createVersion({
       published_by: null,
-      trustpub_data: { provider: 'github', repository: 'serde-rs/serde', run_id: '12345678' },
+      trustpub_data: { provider: 'github', repository: 'serde-rs/serde', run_id: '12345678', sha: 'abc123' },
     })}
     crateName="serde"
     isHighestOfReleaseTrack={true}
@@ -89,7 +89,7 @@
   <Row
     version={createVersion({
       published_by: null,
-      trustpub_data: { provider: 'gitlab', project_path: 'serde-rs/serde', job_id: '87654321' },
+      trustpub_data: { provider: 'gitlab', project_path: 'serde-rs/serde', job_id: '87654321', sha: 'abc123' },
     })}
     crateName="serde"
     isHighestOfReleaseTrack={true}

--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -79,7 +79,7 @@
     return { list, more };
   });
 
-  let trustpubProvider = $derived((version.trustpub_data as { provider?: string } | null | undefined)?.provider);
+  let trustpubProvider = $derived(version.trustpub_data?.provider);
 
   let trustpubPublisher = $derived.by(() => {
     if (trustpubProvider === 'github') return 'GitHub';
@@ -88,14 +88,11 @@
   });
 
   let trustpubUrl = $derived.by(() => {
-    let data = version.trustpub_data as
-      | { provider?: string; repository?: string; run_id?: string; project_path?: string; job_id?: string }
-      | null
-      | undefined;
-    if (data?.provider === 'github' && data.repository && data.run_id) {
+    let data = version.trustpub_data;
+    if (data?.provider === 'github') {
       return `https://github.com/${data.repository}/actions/runs/${data.run_id}`;
     }
-    if (data?.provider === 'gitlab' && data.project_path && data.job_id) {
+    if (data?.provider === 'gitlab') {
       return `https://gitlab.com/${data.project_path}/-/jobs/${data.job_id}`;
     }
     return null;


### PR DESCRIPTION
This preserves provider-specific GitHub and GitLab fields in the generated TypeScript client. It lets frontend code narrow on `provider` without casts or optional field checks.