### PR TITLE
tarball: Limit uploaded archive entries

### DIFF
--- a/crates/crates_io_tarball/examples/check_all_crates.rs
+++ b/crates/crates_io_tarball/examples/check_all_crates.rs
@@ -80,6 +80,7 @@ async fn process_path(path: &Path, pb: &ProgressBar) {
 
     let limits = TarballLimits {
         unpack_size: u64::MAX,
+        entries: None,
     };
     let result = process_tarball(&pkg_name, &mut file, limits).await;
     pb.suspend(|| match result {

--- a/crates/crates_io_tarball/examples/check_all_crates.rs
+++ b/crates/crates_io_tarball/examples/check_all_crates.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use clap::Parser;
-use crates_io_tarball::process_tarball;
+use crates_io_tarball::{TarballLimits, process_tarball};
 use futures_util::{StreamExt, stream};
 use indicatif::{ParallelProgressIterator, ProgressBar, ProgressIterator, ProgressStyle};
 use rayon::prelude::*;
@@ -78,7 +78,10 @@ async fn process_path(path: &Path, pb: &ProgressBar) {
     let pkg_name = path_no_ext.file_name().unwrap().to_string_lossy();
     pb.set_message(format!("{pkg_name}"));
 
-    let result = process_tarball(&pkg_name, &mut file, u64::MAX).await;
+    let limits = TarballLimits {
+        unpack_size: u64::MAX,
+    };
+    let result = process_tarball(&pkg_name, &mut file, limits).await;
     pb.suspend(|| match result {
         Ok(result) => debug!(%pkg_name, path = %path.display(), ?result),
         Err(error) => {

--- a/crates/crates_io_tarball/examples/read_file.rs
+++ b/crates/crates_io_tarball/examples/read_file.rs
@@ -33,6 +33,7 @@ async fn main() -> anyhow::Result<()> {
 
     let limits = TarballLimits {
         unpack_size: u64::MAX,
+        entries: None,
     };
     let result = process_tarball(&pkg_name, &mut file, limits)
         .await

--- a/crates/crates_io_tarball/examples/read_file.rs
+++ b/crates/crates_io_tarball/examples/read_file.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, anyhow};
 use clap::Parser;
-use crates_io_tarball::process_tarball;
+use crates_io_tarball::{TarballLimits, process_tarball};
 use std::path::PathBuf;
 use tokio::fs::File;
 use tracing_subscriber::EnvFilter;
@@ -31,7 +31,10 @@ async fn main() -> anyhow::Result<()> {
     let path_no_ext = path.with_extension("");
     let pkg_name = path_no_ext.file_name().unwrap().to_string_lossy();
 
-    let result = process_tarball(&pkg_name, &mut file, u64::MAX)
+    let limits = TarballLimits {
+        unpack_size: u64::MAX,
+    };
+    let result = process_tarball(&pkg_name, &mut file, limits)
         .await
         .context("Failed to process tarball")?;
 

--- a/crates/crates_io_tarball/src/lib.rs
+++ b/crates/crates_io_tarball/src/lib.rs
@@ -32,6 +32,11 @@ const DEFAULT_BUF_SIZE: usize = 128 * 1024;
 pub struct TarballLimits {
     /// Maximum size in bytes of a crate tarball once decompressed.
     pub unpack_size: u64,
+    /// Maximum number of archive entries, including directory entries.
+    ///
+    /// Metadata headers consumed by the tar parser are not counted. `None`
+    /// disables the limit.
+    pub entries: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -52,6 +57,8 @@ pub enum TarballError {
     SizeMismatch,
     #[error("unexpected tar entry type {entry_type:?} found: {path}")]
     UnexpectedEntry { path: String, entry_type: EntryType },
+    #[error("uploaded tarball contains more than {max} entries")]
+    TooManyEntries { max: usize },
     #[error("Cargo.toml manifest is missing")]
     MissingManifest,
     #[error("Cargo.toml manifest is invalid: {0}")]
@@ -87,9 +94,17 @@ pub async fn process_tarball<R: tokio::io::AsyncRead + Unpin>(
     let mut paths = Vec::new();
     let mut manifests = BTreeMap::new();
     let mut entries = archive.entries()?;
+    let mut num_entries = 0;
 
     while let Some(entry) = entries.next().await {
         let mut entry = entry.map_err(TarballError::Malformed)?;
+
+        if let Some(max) = limits.entries {
+            num_entries += 1;
+            if num_entries > max {
+                return Err(TarballError::TooManyEntries { max });
+            }
+        }
 
         // Check that the file size is consistent between the pax and tar
         // headers. We have to do this before anything else because iterating
@@ -257,6 +272,7 @@ mod tests {
     const MANIFEST: &[u8] = b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n";
     const LIMITS: TarballLimits = TarballLimits {
         unpack_size: 512 * 1024 * 1024,
+        entries: None,
     };
 
     fn tarball_with_entry_type(entry_type: tar::EntryType) -> Vec<u8> {
@@ -307,7 +323,7 @@ mod tests {
 
         for (entry_type, entry_type_name) in unexpected_entry_types {
             let tarball = tarball_with_entry_type(entry_type);
-            let error = assert_err!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+            let error = assert_err!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
             assert_eq!(
                 error.to_string(),
                 format!("unexpected tar entry type {entry_type_name} found: foo-0.0.1/bar")
@@ -323,7 +339,7 @@ mod tests {
             .add_file(&long_path, b"")
             .build();
 
-        assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
     }
 
     #[tokio::test]
@@ -374,9 +390,34 @@ mod tests {
 
         let limits = TarballLimits {
             unpack_size: tarball.len() as u64 - 1,
+            entries: None,
         };
         let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, limits).await);
         assert_snapshot!(err, @"uploaded tarball is malformed or too large when decompressed");
+    }
+
+    #[tokio::test]
+    async fn process_tarball_test_entry_limit() {
+        let tarball = TarballBuilder::new()
+            .add_pax_extensions([("comment", b"metadata".as_slice())])
+            .add_dir("foo-0.0.1")
+            .add_file("foo-0.0.1/Cargo.toml", MANIFEST)
+            .add_dir("foo-0.0.1/src")
+            .add_file("foo-0.0.1/src/lib.rs", b"pub fn foo() {}")
+            .build();
+
+        let limits = TarballLimits {
+            entries: Some(4),
+            ..LIMITS
+        };
+        assert_ok!(process_tarball("foo-0.0.1", &*tarball, limits).await);
+
+        let limits = TarballLimits {
+            entries: Some(3),
+            ..LIMITS
+        };
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, limits).await);
+        assert_snapshot!(err, @"uploaded tarball contains more than 3 entries");
     }
 
     #[tokio::test]

--- a/crates/crates_io_tarball/src/lib.rs
+++ b/crates/crates_io_tarball/src/lib.rs
@@ -27,6 +27,13 @@ mod vcs_info;
 
 const DEFAULT_BUF_SIZE: usize = 128 * 1024;
 
+/// Resource limits applied while processing a crate tarball.
+#[derive(Clone, Copy, Debug)]
+pub struct TarballLimits {
+    /// Maximum size in bytes of a crate tarball once decompressed.
+    pub unpack_size: u64,
+}
+
 #[derive(Debug)]
 pub struct TarballInfo {
     pub manifest: Manifest,
@@ -61,7 +68,7 @@ pub enum TarballError {
 pub async fn process_tarball<R: tokio::io::AsyncRead + Unpin>(
     pkg_name: &str,
     tarball: R,
-    max_unpack: u64,
+    limits: TarballLimits,
 ) -> Result<TarballInfo, TarballError> {
     let tarball = BufReader::with_capacity(DEFAULT_BUF_SIZE, tarball);
     // All our data is currently encoded with gzip
@@ -69,7 +76,7 @@ pub async fn process_tarball<R: tokio::io::AsyncRead + Unpin>(
 
     // Don't let gzip decompression go into the weeeds, apply a fixed cap after
     // which point we say the decompressed source is "too large".
-    let decoder = LimitErrorReader::new(decoder, max_unpack);
+    let decoder = LimitErrorReader::new(decoder, limits.unpack_size);
 
     // Use this I/O object now to take a peek inside
     let mut archive = tokio_tar::Archive::new(decoder);
@@ -243,12 +250,14 @@ impl AbstractFilesystem for PathsFileSystem {
 
 #[cfg(test)]
 mod tests {
-    use super::process_tarball;
+    use super::{TarballLimits, process_tarball};
     use crate::TarballBuilder;
     use insta::{assert_debug_snapshot, assert_snapshot};
 
     const MANIFEST: &[u8] = b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n";
-    const MAX_SIZE: u64 = 512 * 1024 * 1024;
+    const LIMITS: TarballLimits = TarballLimits {
+        unpack_size: 512 * 1024 * 1024,
+    };
 
     fn tarball_with_entry_type(entry_type: tar::EntryType) -> Vec<u8> {
         let mut builder = TarballBuilder::new().add_file("foo-0.0.1/Cargo.toml", MANIFEST);
@@ -276,10 +285,10 @@ mod tests {
             .add_dir("foo-0.0.1")
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_debug_snapshot!(tarball_info);
 
-        let err = assert_err!(process_tarball("bar-0.0.1", &*tarball, MAX_SIZE).await);
+        let err = assert_err!(process_tarball("bar-0.0.1", &*tarball, LIMITS).await);
         assert_snapshot!(err, @"invalid path found: foo-0.0.1/Cargo.toml");
     }
 
@@ -331,7 +340,7 @@ mod tests {
         builder.as_mut().append(&header, b"".as_slice()).unwrap();
 
         let tarball = builder.build();
-        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_snapshot!(err, @"invalid path found: foo-0.0.1/../outside");
     }
 
@@ -353,7 +362,7 @@ mod tests {
 
         let tarball = builder.build();
 
-        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_snapshot!(err, @"invalid path found: foo-0.0.1/�");
     }
 
@@ -363,8 +372,10 @@ mod tests {
             .add_file("foo-0.0.1/Cargo.toml", MANIFEST)
             .build();
 
-        let err =
-            assert_err!(process_tarball("foo-0.0.1", &*tarball, tarball.len() as u64 - 1).await);
+        let limits = TarballLimits {
+            unpack_size: tarball.len() as u64 - 1,
+        };
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, limits).await);
         assert_snapshot!(err, @"uploaded tarball is malformed or too large when decompressed");
     }
 
@@ -375,7 +386,7 @@ mod tests {
             .add_file("foo-0.0.1/.cargo_vcs_info.json", br#"{"unknown": "field"}"#)
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_some!(&tarball_info.vcs_info);
         assert_debug_snapshot!(tarball_info);
     }
@@ -388,7 +399,7 @@ mod tests {
             .add_file("foo-0.0.1/.cargo_vcs_info.json", vcs_info)
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_some!(&tarball_info.vcs_info);
         assert_debug_snapshot!(tarball_info);
     }
@@ -407,7 +418,7 @@ mod tests {
             .add_file("foo-0.0.1/Cargo.toml", manifest)
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_debug_snapshot!(tarball_info);
     }
 
@@ -423,7 +434,7 @@ mod tests {
             .add_file("foo-0.0.1/Cargo.toml", manifest)
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_debug_snapshot!(tarball_info);
     }
 
@@ -433,7 +444,7 @@ mod tests {
             .add_file("foo-0.0.1/Cargo.toml", MANIFEST)
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_debug_snapshot!(tarball_info);
     }
 
@@ -449,7 +460,7 @@ mod tests {
             .add_file("foo-0.0.1/Cargo.toml", manifest)
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_debug_snapshot!(tarball_info);
     }
 
@@ -465,7 +476,7 @@ mod tests {
             .add_file("foo-0.0.1/cargo.toml", manifest)
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_debug_snapshot!(tarball_info);
     }
 
@@ -476,7 +487,7 @@ mod tests {
                 .add_file(&format!("foo-0.0.1/{file}"), MANIFEST)
                 .build();
 
-            process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await
+            process_tarball("foo-0.0.1", &*tarball, LIMITS).await
         };
 
         let err = assert_err!(process("CARGO.TOML").await);
@@ -496,7 +507,7 @@ mod tests {
                 })
                 .build();
 
-            process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await
+            process_tarball("foo-0.0.1", &*tarball, LIMITS).await
         };
 
         let err = assert_err!(process(vec!["cargo.toml", "Cargo.toml"]).await);
@@ -521,7 +532,7 @@ mod tests {
             .add_file("foo-0.0.1/Cargo.toml", MANIFEST)
             .build();
 
-        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_snapshot!(err, @"uploaded tarball is malformed or too large when decompressed");
 
         let tarball = TarballBuilder::new()
@@ -529,7 +540,7 @@ mod tests {
             .add_file("foo-0.0.1/Cargo.toml", MANIFEST)
             .build();
 
-        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_snapshot!(err, @"uploaded tarball is malformed or too large when decompressed");
     }
 
@@ -547,7 +558,7 @@ mod tests {
             .add_symlink("smuggled", "/etc/issue")
             .build();
 
-        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_snapshot!(err, @"mismatched pax and tar header sizes");
     }
 
@@ -558,7 +569,7 @@ mod tests {
             .add_file("foo-0.0.1/src/lib.rs", b"pub fn foo() {}")
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_debug_snapshot!(tarball_info);
     }
 
@@ -572,7 +583,7 @@ mod tests {
             .add_file("foo-0.0.1/src/bin/bar.rs", b"fn main() {}")
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_debug_snapshot!(tarball_info);
     }
 
@@ -583,7 +594,7 @@ mod tests {
             .add_file("foo-0.0.1/src/main.rs", b"fn main() {}")
             .build();
 
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
         assert_debug_snapshot!(tarball_info);
     }
 }

--- a/src/config/publish_limits.rs
+++ b/src/config/publish_limits.rs
@@ -1,3 +1,5 @@
+use crates_io_env_vars::var_parsed;
+
 #[derive(Debug)]
 pub struct PublishLimitsConfig {
     /// Maximum size in bytes of an uploaded crate file.
@@ -5,6 +7,12 @@ pub struct PublishLimitsConfig {
 
     /// Maximum size in bytes of a crate file once decompressed.
     pub unpack_size: u64,
+
+    /// Maximum number of entries in an uploaded crate tarball.
+    ///
+    /// Read from the `MAX_TARBALL_ENTRIES` environment variable. An unset
+    /// value disables the limit.
+    pub tarball_entries: Option<usize>,
 
     /// Maximum number of dependencies a crate can have.
     pub dependencies: usize,
@@ -19,6 +27,7 @@ impl Default for PublishLimitsConfig {
         Self {
             upload_size: 10 * 1024 * 1024,  // 10 MB
             unpack_size: 512 * 1024 * 1024, // 512 MB
+            tarball_entries: None,
             dependencies: 500,
             features: 300,
         }
@@ -26,12 +35,21 @@ impl Default for PublishLimitsConfig {
 }
 
 impl PublishLimitsConfig {
+    /// Returns the default publish limits with environment overrides applied.
+    pub fn from_env() -> anyhow::Result<Self> {
+        Ok(Self {
+            tarball_entries: var_parsed("MAX_TARBALL_ENTRIES")?,
+            ..Self::default()
+        })
+    }
+
     /// Returns smaller limits suitable for use in tests.
     #[cfg(any(test, debug_assertions))]
     pub fn for_testing() -> Self {
         Self {
             upload_size: 128 * 1024, // 128 kB should be enough for most testing purposes
             unpack_size: 128 * 1024,
+            tarball_entries: None,
             dependencies: 10,
             features: 10,
         }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -141,7 +141,7 @@ impl Server {
             session_key: cookie::Key::derive_from(required_var("SESSION_KEY")?.as_bytes()),
             github_oauth: GitHubOAuthConfig::from_env()?,
             token_encryption: TokenEncryption::from_environment()?,
-            publish_limits: PublishLimitsConfig::default(),
+            publish_limits: PublishLimitsConfig::from_env()?,
             rate_limits: RateLimitsConfig::from_env()?,
             block: BlockConfig::from_env()?,
             max_allowed_page_offset: var_parsed("WEB_MAX_ALLOWED_PAGE_OFFSET")?.unwrap_or(200),

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -267,6 +267,7 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
     );
     let limits = TarballLimits {
         unpack_size: max_unpack_size,
+        entries: app.config.publish_limits.tarball_entries,
     };
     let tarball_info = process_tarball(&pkg_name, &*tarball_bytes, limits).await?;
 
@@ -1058,6 +1059,9 @@ impl From<TarballError> for BoxedAppError {
             }
             TarballError::MalformedPaxSize | TarballError::SizeMismatch => {
                 bad_request("uploaded tarball is malformed")
+            }
+            TarballError::TooManyEntries { max } => {
+                bad_request(format!("uploaded tarball contains more than {max} entries"))
             }
             TarballError::InvalidPath(path) => bad_request(format!("invalid path found: {path}")),
             error @ TarballError::UnexpectedEntry { .. } => bad_request(error.to_string()),

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -10,7 +10,7 @@ use axum::Json;
 use axum::body::{Body, Bytes};
 use chrono::{DateTime, SecondsFormat, Utc};
 use crates_io_cargo_toml::{Dependency, DepsSet, TargetDepsSet};
-use crates_io_tarball::{TarballError, process_tarball};
+use crates_io_tarball::{TarballError, TarballLimits, process_tarball};
 use crates_io_validation::{
     MAX_VERSION_LENGTH, validate_crate_name, validate_dependency_name, validate_feature,
     validate_feature_name,
@@ -265,7 +265,10 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
         app.config.publish_limits.unpack_size,
         max_upload_size as u64,
     );
-    let tarball_info = process_tarball(&pkg_name, &*tarball_bytes, max_unpack_size).await?;
+    let limits = TarballLimits {
+        unpack_size: max_unpack_size,
+    };
+    let tarball_info = process_tarball(&pkg_name, &*tarball_bytes, limits).await?;
 
     // `unwrap()` is safe here since `process_tarball()` validates that
     // we only accept manifests with a `package` section and without

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -20,6 +20,26 @@ async fn new_krate_wrong_files() {
     assert_that!(app.stored_files().await, is_empty());
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn tarball_entry_limit_applies_to_new_versions() {
+    let (_app, _, _, token) = TestApp::full()
+        .with_config(|config| config.publish_limits.tarball_entries = Some(2))
+        .with_token()
+        .await;
+
+    let version = PublishBuilder::new("foo", "1.0.0").add_file("foo-1.0.0/src/lib.rs", "");
+    let response = token.publish_crate(version).await;
+    assert_snapshot!(response.status(), @"200 OK");
+
+    let version = PublishBuilder::new("foo", "1.1.0")
+        .add_file("foo-1.1.0/src/lib.rs", "")
+        .add_file("foo-1.1.0/README.md", "");
+
+    let response = token.publish_crate(version).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"uploaded tarball contains more than 2 entries"}]}"#);
+}
+
 async fn publish_tarball_with_entry(entry_type: tar::EntryType) -> String {
     let (app, _, _, token) = TestApp::full().with_token().await;
 


### PR DESCRIPTION
Newly uploaded crate versions can contain enough small archive entries to consume disproportionate validation resources despite the existing byte limits. The configurable `MAX_TARBALL_ENTRIES` limit rejects excess entries while remaining disabled when unset and during generic archive processing.

Initial checks have shown that 30k entries appears to be a reasonable limit. It would have rejected only 29 of 2,691,206 historical releases, about 0.0011%. Those 29 releases belong to only three crates: `shrust`, `tsrun`, and `xml-schema`. All three exceeded the limit because they shipped generated documentation or large development test suites.