### PR TITLE
Add feature-flagged cache-tag invalidation

### DIFF
--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -2,9 +2,9 @@ use crate::dialoguer;
 use anyhow::Context;
 use crates_io::models::update_default_version;
 use crates_io::schema::crates;
-use crates_io::storage::{Storage, StorageKey};
+use crates_io::storage::{Storage, StorageKey, release_cache_tag};
 use crates_io::worker::jobs;
-use crates_io::{db, schema::versions};
+use crates_io::{config::FeaturesConfig, db, schema::versions};
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::{AsyncConnection, RunQueryDsl};
@@ -29,6 +29,8 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
+    let features = FeaturesConfig::from_env().context("Failed to load features config")?;
+
     let mut conn = db::oneoff_connection()
         .await
         .context("Failed to establish database connection")?;
@@ -154,10 +156,17 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         }
     }
 
-    if let Err(e) = jobs::InvalidateCdns::new(paths.into_iter())
-        .enqueue(&conn)
-        .await
-    {
+    let job = if features.cache_tag_invalidations_enabled {
+        jobs::InvalidateCdns::cache_tags(
+            opts.versions
+                .iter()
+                .map(|version| release_cache_tag(crate_name, version)),
+        )
+    } else {
+        jobs::InvalidateCdns::paths(paths.into_iter())
+    };
+
+    if let Err(e) = job.enqueue(&conn).await {
         warn!("{crate_name}: Failed to enqueue CDN invalidation background job: {e}");
     }
 

--- a/src/config/fastly.rs
+++ b/src/config/fastly.rs
@@ -8,6 +8,11 @@ pub struct FastlyConfig {
     ///
     /// Read from the `FASTLY_API_TOKEN` environment variable.
     pub api_token: SecretString,
+
+    /// Service ID for `static.crates.io` (or equivalent).
+    ///
+    /// Read from the `FASTLY_SERVICE_ID_STATIC` environment variable.
+    pub service_id_static: Option<String>,
 }
 
 impl FastlyConfig {
@@ -16,9 +21,11 @@ impl FastlyConfig {
         let Some(api_token) = var("FASTLY_API_TOKEN")? else {
             return Ok(None);
         };
+        let service_id_static = var("FASTLY_SERVICE_ID_STATIC")?;
 
         Ok(Some(Self {
             api_token: api_token.into(),
+            service_id_static,
         }))
     }
 }

--- a/src/config/features.rs
+++ b/src/config/features.rs
@@ -16,6 +16,11 @@ pub struct FeaturesConfig {
     ///
     /// Read from the `CACHE_TAGS_ENABLED` environment variable.
     pub cache_tags_enabled: bool,
+
+    /// Invalidate deleted crate objects using CDN cache tags instead of URLs.
+    ///
+    /// Read from the `CACHE_TAG_INVALIDATIONS_ENABLED` environment variable.
+    pub cache_tag_invalidations_enabled: bool,
 }
 
 impl FeaturesConfig {
@@ -23,11 +28,18 @@ impl FeaturesConfig {
         let index_include_pubtime = var_parsed("INDEX_INCLUDE_PUBTIME")?.unwrap_or(false);
         let zip_archives_enabled = var_parsed("ZIP_ARCHIVES_ENABLED")?.unwrap_or(false);
         let cache_tags_enabled = var_parsed("CACHE_TAGS_ENABLED")?.unwrap_or(false);
+        let cache_tag_invalidations_enabled =
+            var_parsed("CACHE_TAG_INVALIDATIONS_ENABLED")?.unwrap_or(false);
+
+        if cache_tag_invalidations_enabled && !cache_tags_enabled {
+            anyhow::bail!("CACHE_TAG_INVALIDATIONS_ENABLED requires CACHE_TAGS_ENABLED");
+        }
 
         Ok(Self {
             index_include_pubtime,
             zip_archives_enabled,
             cache_tags_enabled,
+            cache_tag_invalidations_enabled,
         })
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -27,6 +27,16 @@ const CACHE_CONTROL_INDEX: &str = "public,max-age=600";
 const CACHE_CONTROL_README: &str = "public,max-age=604800";
 const CACHE_CONTROL_OG_IMAGE: &str = "public,max-age=86400";
 
+/// Builds the cache tag shared by every object belonging to a crate.
+pub fn crate_cache_tag(name: &str) -> String {
+    format!("crate:{name}")
+}
+
+/// Builds the cache tag shared by every object belonging to a crate release.
+pub fn release_cache_tag(name: &str, version: &str) -> String {
+    format!("release:{name}@{version}")
+}
+
 #[derive(Debug)]
 pub struct StorageConfig {
     backend: StorageBackend,
@@ -467,11 +477,13 @@ impl<'a> StorageKey<'a> {
             StorageKey::CrateFile { name, version }
             | StorageKey::CrateZip { name, version }
             | StorageKey::CrateZipManifest { name, version }
-            | StorageKey::Readme { name, version } => {
-                Some(format!("crate:{name},release:{name}@{version}"))
-            }
+            | StorageKey::Readme { name, version } => Some(format!(
+                "{},{}",
+                crate_cache_tag(name),
+                release_cache_tag(name, version)
+            )),
             StorageKey::OgImage { name } | StorageKey::CrateFeed { name } => {
-                Some(format!("crate:{name}"))
+                Some(crate_cache_tag(name))
             }
             StorageKey::CratesFeed
             | StorageKey::UpdatesFeed

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -603,6 +603,7 @@ fn simple_config() -> config::Server {
             index_include_pubtime: false,
             zip_archives_enabled: true,
             cache_tags_enabled: true,
+            cache_tag_invalidations_enabled: true,
         },
         fastly: None,
         sync_git_index: false,

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -1,4 +1,4 @@
-use crate::storage::StorageKey;
+use crate::storage::{StorageKey, crate_cache_tag};
 use crate::worker::Environment;
 use crate::worker::jobs::InvalidateCdns;
 use anyhow::Context;
@@ -59,15 +59,18 @@ impl BackgroundJob for DeleteCrateFromStorage {
         info!("{name}: Enqueuing CDN invalidations");
 
         let conn = ctx.deadpool.get().await?;
-        InvalidateCdns::new(
-            crate_file_paths
-                .into_iter()
-                .chain(readme_paths)
-                .chain(std::iter::once(og_image_key.path()))
-                .chain(std::iter::once(feed_key.path())),
-        )
-        .enqueue(&conn)
-        .await?;
+        let job = if ctx.config.features.cache_tag_invalidations_enabled {
+            InvalidateCdns::cache_tags([crate_cache_tag(name)])
+        } else {
+            InvalidateCdns::paths(
+                crate_file_paths
+                    .into_iter()
+                    .chain(readme_paths)
+                    .chain(std::iter::once(og_image_key.path()))
+                    .chain(std::iter::once(feed_key.path())),
+            )
+        };
+        job.enqueue(&conn).await?;
 
         info!("{name}: Successfully enqueued CDN invalidations.");
 

--- a/src/worker/jobs/invalidate_cdns.rs
+++ b/src/worker/jobs/invalidate_cdns.rs
@@ -8,21 +8,51 @@ use serde::{Deserialize, Serialize};
 use crate::worker::Environment;
 use crate::worker::jobs::ProcessCloudfrontInvalidationQueue;
 
-/// A background job that invalidates the given paths on all CDNs in use on crates.io.
+/// A background job that invalidates the given paths or cache tags on all CDNs used by crates.io.
 #[derive(Deserialize, Serialize)]
 pub struct InvalidateCdns {
     paths: Vec<String>,
+
+    #[serde(default)]
+    cache_tags: Vec<String>,
 }
 
 impl InvalidateCdns {
-    pub fn new<I>(paths: I) -> Self
+    pub fn paths<I>(paths: I) -> Self
     where
         I: Iterator,
         I::Item: ToString,
     {
         Self {
             paths: paths.map(|path| path.to_string()).collect(),
+            cache_tags: Vec::new(),
         }
+    }
+
+    pub fn cache_tags<I>(cache_tags: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: ToString,
+    {
+        Self {
+            paths: Vec::new(),
+            cache_tags: cache_tags
+                .into_iter()
+                .map(|cache_tag| cache_tag.to_string())
+                .collect(),
+        }
+    }
+
+    fn cloudfront_items(&self) -> Vec<String> {
+        self.paths
+            .iter()
+            .cloned()
+            .chain(
+                self.cache_tags
+                    .iter()
+                    .map(|cache_tag| format!("#{cache_tag}")),
+            )
+            .collect()
     }
 }
 
@@ -32,13 +62,8 @@ impl BackgroundJob for InvalidateCdns {
     type Context = Arc<Environment>;
 
     async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
-        // Fastly doesn't provide an API to purge multiple paths at once, except through the use of
-        // surrogate keys. We can't use surrogate keys right now because they require a
-        // Fastly-specific header, and not all of our traffic goes through Fastly.
-        //
-        // For now, we won't parallelise: most crate deletions are for new crates with one (or very
-        // few) versions, so the actual number of paths being invalidated is likely to be small, and
-        // this is all happening from either a background job or admin command anyway.
+        // We won't parallelise: most crate deletions are for new crates with one (or very few)
+        // versions, so the number of invalidations is likely to be small.
         if let Some(fastly) = ctx.fastly()
             && let Some(cdn_domain) = &ctx.config.storage.cdn_prefix
         {
@@ -50,14 +75,34 @@ impl BackgroundJob for InvalidateCdns {
             }
         }
 
+        if let Some(fastly) = ctx.fastly()
+            && !self.cache_tags.is_empty()
+        {
+            let config = ctx.config.fastly.as_ref();
+            let config = config.context("Fastly configuration is missing")?;
+            let service_id = config
+                .service_id_static
+                .as_deref()
+                .context("FASTLY_SERVICE_ID_STATIC is not configured")?;
+
+            for cache_tag in &self.cache_tags {
+                fastly
+                    .purge_surrogate_key(service_id, cache_tag)
+                    .await
+                    .with_context(|| {
+                        format!("Failed to invalidate cache tag on Fastly CDN: {cache_tag}")
+                    })?;
+            }
+        }
+
         // Queue CloudFront invalidations for batch processing instead of calling directly
         if ctx.cloudfront().is_some() {
             let conn = ctx.deadpool.get().await?;
+            let items = self.cloudfront_items();
 
             let dist = CloudFrontDistribution::Static;
-            let result =
-                CloudFrontInvalidationQueueItem::queue_paths(&conn, dist, &self.paths).await;
-            result.context("Failed to queue CloudFront invalidation paths")?;
+            let result = CloudFrontInvalidationQueueItem::queue_paths(&conn, dist, &items).await;
+            result.context("Failed to queue CloudFront invalidations")?;
 
             // Schedule the processing job to handle the queued paths
             let result = ProcessCloudfrontInvalidationQueue.enqueue(&conn).await;
@@ -65,5 +110,21 @@ impl BackgroundJob for InvalidateCdns {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cloudfront_items_include_paths_before_cache_tags() {
+        let job: InvalidateCdns = serde_json::from_value(serde_json::json!({
+            "paths": ["/path"],
+            "cache_tags": ["crate:foo"],
+        }))
+        .unwrap();
+
+        assert_eq!(job.cloudfront_items(), ["/path", "#crate:foo"]);
     }
 }


### PR DESCRIPTION
Cache-tag invalidation is selected when CDN invalidation jobs are enqueued through the new `CACHE_TAG_INVALIDATIONS_ENABLED` flag. Crate and version deletions enqueue cache tags when enabled and retain the existing path payloads when disabled.

The `InvalidateCdns` background job provides explicit constructors for path-only and cache-tag-only jobs while continuing to process mixed payloads in path-first order. Fastly purges tags through the service ID (`FASTLY_SERVICE_ID_STATIC`), while CloudFront uses the existing `#` marker for tagged invalidations.

### Related

- https://github.com/rust-lang/crates.io/issues/14219
- https://github.com/rust-lang/crates.io/issues/14245
- #14229 
- #14228
- https://github.com/rust-lang/crates.io/issues/14062