### PR TITLE
OpenAPI: Improve release tracks types

### DIFF
--- a/crates/crates_io_api_types/src/release_tracks.rs
+++ b/crates/crates_io_api_types/src/release_tracks.rs
@@ -64,8 +64,9 @@ impl serde::Serialize for ReleaseTrackName {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, utoipa::ToSchema)]
 pub struct ReleaseTrackDetails {
+    #[schema(value_type = String)]
     pub highest: semver::Version,
 }
 

--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -1536,6 +1536,9 @@ export interface components {
             /** @example [] */
             other: string[];
         };
+        ReleaseTrackDetails: {
+            highest: string;
+        };
         Slug: {
             /**
              * @description A description of the category.
@@ -2859,7 +2862,9 @@ export interface operations {
                              * @description Additional data about the crate's release tracks,
                              *     if `?include=release_tracks` is used.
                              */
-                            release_tracks?: Record<string, never> | null;
+                            release_tracks?: {
+                                [key: string]: components["schemas"]["ReleaseTrackDetails"];
+                            } | null;
                             /**
                              * Format: int64
                              * @description The total number of versions belonging to the crate.

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -11,7 +11,7 @@ use crate::util::RequestUtils;
 use crate::util::errors::{AppResult, BoxedAppError, bad_request};
 use crate::util::string_excl_null::StringExclNull;
 use crate::views::EncodableVersion;
-use crate::views::release_tracks::ReleaseTracks;
+use crate::views::release_tracks::{ReleaseTrackDetails, ReleaseTracks};
 use axum::Json;
 use axum::extract::FromRequestParts;
 use axum_extra::extract::Query;
@@ -334,7 +334,7 @@ struct ResponseMeta {
     /// Additional data about the crate's release tracks,
     /// if `?include=release_tracks` is used.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<Object>)]
+    #[schema(value_type = Option<std::collections::HashMap<String, ReleaseTrackDetails>>)]
     release_tracks: Option<ReleaseTracks>,
 }
 

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -884,6 +884,17 @@ expression: response.json()
         ],
         "type": "object"
       },
+      "ReleaseTrackDetails": {
+        "properties": {
+          "highest": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "highest"
+        ],
+        "type": "object"
+      },
       "Slug": {
         "properties": {
           "description": {
@@ -3107,7 +3118,13 @@ expression: response.json()
                           ]
                         },
                         "release_tracks": {
+                          "additionalProperties": {
+                            "$ref": "#/components/schemas/ReleaseTrackDetails"
+                          },
                           "description": "Additional data about the crate's release tracks,\nif `?include=release_tracks` is used.",
+                          "propertyNames": {
+                            "type": "string"
+                          },
                           "type": [
                             "object",
                             "null"

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -884,6 +884,17 @@ expression: response.json()
         ],
         "type": "object"
       },
+      "ReleaseTrackDetails": {
+        "properties": {
+          "highest": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "highest"
+        ],
+        "type": "object"
+      },
       "Slug": {
         "properties": {
           "description": {
@@ -2770,7 +2781,13 @@ expression: response.json()
                           ]
                         },
                         "release_tracks": {
+                          "additionalProperties": {
+                            "$ref": "#/components/schemas/ReleaseTrackDetails"
+                          },
                           "description": "Additional data about the crate's release tracks,\nif `?include=release_tracks` is used.",
+                          "propertyNames": {
+                            "type": "string"
+                          },
                           "type": [
                             "object",
                             "null"

--- a/svelte/src/routes/crates/[crate_id]/versions/+page.ts
+++ b/svelte/src/routes/crates/[crate_id]/versions/+page.ts
@@ -31,7 +31,7 @@ export async function load({ fetch, params, url, depends }) {
   }
 
   let { versions, meta } = response.data;
-  let releaseTracks: Record<string, { highest: string }> = meta.release_tracks ?? {};
+  let releaseTracks = meta.release_tracks ?? {};
 
   return {
     sort,


### PR DESCRIPTION
The version-list schema now describes each release track with its highest version. The generated client preserves that value instead of reducing release-track entries to `never`.