### PR TITLE
Stop reading from users.gh_encrypted_token

### DIFF
--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -24,8 +24,9 @@ pub struct User {
     pub gh_login: String,
     #[diesel(select_expression = oauth_github::avatar.nullable())]
     pub gh_avatar: Option<String>,
+    #[diesel(select_expression = oauth_github::encrypted_token.nullable())]
     #[serde(skip)]
-    pub gh_encrypted_token: Vec<u8>,
+    pub gh_encrypted_token: Option<Vec<u8>>,
     pub account_lock_reason: Option<String>,
     pub account_lock_until: Option<DateTime<Utc>>,
     pub is_admin: bool,

--- a/crates/crates_io_test_utils/src/builders/user.rs
+++ b/crates/crates_io_test_utils/src/builders/user.rs
@@ -53,7 +53,7 @@ impl<'a> UserBuilder<'a> {
             name: self.display_name.map(ToString::to_string),
             gh_id: 123,
             gh_avatar: None,
-            gh_encrypted_token: vec![],
+            gh_encrypted_token: None,
             account_lock_reason: None,
             account_lock_until: None,
             is_admin: false,
@@ -94,7 +94,7 @@ impl<'a> OauthGithubBuilder<'a> {
         Self {
             user_id: user.id,
             account_id: user.gh_id as i64,
-            encrypted_token: &user.gh_encrypted_token,
+            encrypted_token: &ENCRYPTED_TOKEN,
             login: &user.username,
             avatar: None,
         }

--- a/src/controllers/helpers/authorization.rs
+++ b/src/controllers/helpers/authorization.rs
@@ -28,11 +28,16 @@ impl Rights {
         owners: &[Owner],
         encryption: &TokenEncryption,
     ) -> Result<Self, BoxedAppError> {
-        let token = encryption
-            .decrypt(&user.gh_encrypted_token)
+        // Compute GitHub token once rather than every loop iteration.
+        // If the user doesn't have an associated `oauth_github`, then they can't be associated
+        // with any GitHub teams.
+        let token = user
+            .gh_encrypted_token
+            .as_ref()
+            .map(|gh_encrypted_token| encryption.decrypt(gh_encrypted_token))
+            .transpose()
             .map_err(GitHubError::Other)?;
-
-        let auth = GitHubAuth::bearer(token);
+        let auth = token.map(GitHubAuth::bearer);
 
         let mut best = Self::None;
         for owner in owners {
@@ -43,35 +48,38 @@ impl Rights {
                     }
                 }
                 Owner::Team(ref team) => {
-                    // Phones home to GitHub to ask if this User is a member of the given team.
-                    // Note that we're assuming that the given user is the one interested in
-                    // the answer. If this is not the case, then we could accidentally leak
-                    // private membership information here.
-                    let is_team_member = match gh_client
-                        .team_membership(team.org_id, team.github_id, &user.gh_login, &auth)
-                        .await
-                    {
-                        Ok(membership) => membership.is_some_and(|m| m.is_active()),
-                        Err(GitHubError::Forbidden(_)) => {
-                            let org_name = team
-                                .split_login()
-                                .map(|(_, org, _)| org.to_string())
-                                .unwrap_or_else(|| "unknown".to_string());
+                    if let Some(ref auth) = auth {
+                        // Phones home to GitHub to ask if this User is a member of the given team.
+                        // Note that we're assuming that the given user is the one interested in
+                        // the answer. If this is not the case, then we could accidentally leak
+                        // private membership information here.
+                        let is_team_member = match gh_client
+                            .team_membership(team.org_id, team.github_id, &user.gh_login, auth)
+                            .await
+                        {
+                            Ok(membership) => membership.is_some_and(|m| m.is_active()),
+                            Err(GitHubError::Forbidden(_)) => {
+                                let org_name = team
+                                    .split_login()
+                                    .map(|(_, org, _)| org.to_string())
+                                    .unwrap_or_else(|| "unknown".to_string());
 
-                            return Err(custom(
-                                StatusCode::FORBIDDEN,
-                                format!(
-                                    "GitHub organization '{org_name}' has restricted OAuth access. \
-                                     A '{org_name}' administrator must approve the 'crates.io' \
-                                     application in the organization's 'Third-party access' settings."
-                                ),
-                            ));
+                                return Err(custom(
+                                    StatusCode::FORBIDDEN,
+                                    format!(
+                                        "GitHub organization '{org_name}' has restricted OAuth \
+                                         access. A '{org_name}' administrator must approve the \
+                                         'crates.io' application in the organization's \
+                                         'Third-party access' settings."
+                                    ),
+                                ));
+                            }
+                            Err(e) => return Err(e.into()),
+                        };
+
+                        if is_team_member {
+                            best = Self::Publish;
                         }
-                        Err(e) => return Err(e.into()),
-                    };
-
-                    if is_team_member {
-                        best = Self::Publish;
                     }
                 }
             }

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -438,14 +438,18 @@ pub async fn create_or_update_github_team(
         )));
     }
 
-    let token = encryption
-        .decrypt(&req_user.gh_encrypted_token)
-        .map_err(|err| {
-            custom(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to decrypt GitHub token: {err}"),
-            )
-        })?;
+    let Some(token) = req_user.gh_encrypted_token.as_ref() else {
+        return Err(bad_request(
+            "Cannot add a GitHub team as an owner without a connected GitHub account",
+        ));
+    };
+
+    let token = encryption.decrypt(token).map_err(|err| {
+        custom(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to decrypt GitHub token: {err}"),
+        )
+    })?;
 
     let auth = GitHubAuth::bearer(token);
     let team = gh_client.team_by_name(org_name, team_name, &auth).await

--- a/src/controllers/trustpub/github_configs/create.rs
+++ b/src/controllers/trustpub/github_configs/create.rs
@@ -90,7 +90,11 @@ pub async fn create_trustpub_github_config(
     let owner = &json_config.repository_owner;
 
     let encryption = &state.config.token_encryption;
-    let gh_auth = &auth_user.gh_encrypted_token;
+    let Some(gh_auth) = auth_user.gh_encrypted_token.as_ref() else {
+        return Err(bad_request(
+            "Must have a linked GitHub account to create a Trusted Publishing config",
+        ));
+    };
     let gh_auth = encryption.decrypt(gh_auth).map_err(|err| {
         let login = &auth_user.gh_login;
         warn!("Failed to decrypt GitHub token for user {login}: {err}");

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -51,7 +51,7 @@ async fn updating_existing_user_doesnt_change_api_token() -> anyhow::Result<()> 
     let user = assert_ok!(User::find(&conn, api_token.user_id).await);
 
     assert_eq!(user.gh_login, "bar");
-    let decrypted_token = encryption.decrypt(&user.gh_encrypted_token)?;
+    let decrypted_token = encryption.decrypt(user.gh_encrypted_token.as_ref().unwrap())?;
     assert_eq!(decrypted_token.expose_secret(), "bar_token");
 
     Ok(())
@@ -334,7 +334,7 @@ async fn write_to_users_and_oauth_github() -> anyhow::Result<()> {
     assert_eq!(u.gh_id, gh_id);
     assert_eq!(u.gh_login, gh_login);
     assert_eq!(u.gh_avatar.unwrap(), gh_avatar);
-    let decrypted_token = encryption.decrypt(&u.gh_encrypted_token)?;
+    let decrypted_token = encryption.decrypt(&u.gh_encrypted_token.unwrap())?;
     assert_eq!(decrypted_token.expose_secret(), gh_token);
 
     let oauth_github_records: Vec<OauthGithub> = oauth_github::table.load(&mut conn).await.unwrap();
@@ -368,7 +368,7 @@ async fn write_to_users_and_oauth_github() -> anyhow::Result<()> {
     assert_eq!(u.gh_id, gh_id);
     assert_eq!(u.gh_login, different_gh_login);
     assert_eq!(u.gh_avatar.unwrap(), different_gh_avatar);
-    let decrypted_token = encryption.decrypt(&u.gh_encrypted_token)?;
+    let decrypted_token = encryption.decrypt(&u.gh_encrypted_token.unwrap())?;
     assert_eq!(decrypted_token.expose_secret(), different_gh_token);
 
     let oauth_github_records: Vec<OauthGithub> = oauth_github::table.load(&mut conn).await.unwrap();


### PR DESCRIPTION
Continue writing to it, but always select the value from oauth_github instead.

This is an incremental step towards fully removing the `users.gh_encrypted_token` column. This keeps all writes but moves all reads to `oauth_github.encrypted_token`, so that we can easily revert.

I've opened a PR to show the future commits that I won't submit until there's only one commit left: https://github.com/rust-lang/crates.io/pull/14259