### PR TITLE
Fully remove the `users.gh_encrypted_token` column

### DIFF
--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -177,7 +177,7 @@ pub struct OauthGithub {
     pub account_id: i64,
     /// In the process of being migrated from `users.gh_avatar`.
     pub avatar: Option<String>,
-    /// In the process of being migrated from `users.gh_encrypted_token`.
+    /// The OAuth access token from GitHub for this user, encrypted at rest in our database
     pub encrypted_token: Vec<u8>,
     /// The last time we verified with GitHub what the GitHub username for this user was, and
     /// whether the account was valid.
@@ -198,9 +198,9 @@ pub struct OauthGithub {
     belongs_to(User),
 )]
 pub struct NewOauthGithub<'a> {
-    pub account_id: i64,           // corresponds to users.gh_id
-    pub avatar: Option<&'a str>,   // corresponds to users.gh_avatar
-    pub encrypted_token: &'a [u8], // corresponds to users.gh_encrypted_token
+    pub account_id: i64,         // corresponds to users.gh_id
+    pub avatar: Option<&'a str>, // corresponds to users.gh_avatar
+    pub encrypted_token: &'a [u8],
     #[builder(default = Utc::now())]
     pub last_sync: DateTime<Utc>,
     pub login: &'a str, // corresponds to users.gh_login

--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -1001,8 +1001,6 @@ diesel::table! {
         account_lock_until -> Nullable<Timestamptz>,
         /// The time the user was created.
         created_at -> Nullable<Timestamptz>,
-        /// Encrypted GitHub access token
-        gh_encrypted_token -> Nullable<Bytea>,
         /// The `gh_id` column of the `users` table.
         ///
         /// Its SQL type is `Int4`.

--- a/crates/crates_io_database_dump/src/dump-db.toml
+++ b/crates/crates_io_database_dump/src/dump-db.toml
@@ -273,9 +273,6 @@ account_lock_reason = "private"
 account_lock_until = "private"
 is_admin = "private"
 publish_notifications = "private"
-gh_encrypted_token = "private"
-[users.column_defaults]
-gh_encrypted_token = "''"
 
 [version_downloads]
 dependencies = ["versions"]

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
@@ -27,7 +27,6 @@ BEGIN;
     -- Set defaults for non-nullable columns not included in the dump.
 
     ALTER TABLE "oauth_github" ALTER COLUMN "encrypted_token" SET DEFAULT '';
-    ALTER TABLE "users" ALTER COLUMN "gh_encrypted_token" SET DEFAULT '';
 
     -- Truncate all tables.
 
@@ -80,7 +79,6 @@ BEGIN;
     -- Drop the defaults again.
 
     ALTER TABLE "oauth_github" ALTER COLUMN "encrypted_token" DROP DEFAULT;
-    ALTER TABLE "users" ALTER COLUMN "gh_encrypted_token" DROP DEFAULT;
 
     -- Reenable triggers on each table.
 

--- a/migrations/2026-07-15-182934-0000_drop_users_gh_encrypted_token/down.sql
+++ b/migrations/2026-07-15-182934-0000_drop_users_gh_encrypted_token/down.sql
@@ -1,0 +1,4 @@
+alter table users
+    add column gh_encrypted_token bytea;
+
+comment on column users.gh_encrypted_token is 'Encrypted GitHub access token';

--- a/migrations/2026-07-15-182934-0000_drop_users_gh_encrypted_token/up.sql
+++ b/migrations/2026-07-15-182934-0000_drop_users_gh_encrypted_token/up.sql
@@ -1,0 +1,5 @@
+-- safety-assured:start
+-- The column is no longer read or written. Encrypted GitHub tokens are stored in
+-- `oauth_github.encrypted_token`.
+ALTER TABLE users DROP COLUMN gh_encrypted_token;
+-- safety-assured:end


### PR DESCRIPTION
This drops the `users.gh_encrypted_token` that has been completely migrated to `oauth_github.encrypted_token`.

Extracted PRs that have been deployed already:

- https://github.com/rust-lang/crates.io/pull/14258
- https://github.com/rust-lang/crates.io/pull/14357
- https://github.com/rust-lang/crates.io/pull/14387