### PR TITLE
Replace unnecessary `:global` CSS selectors

### DIFF
--- a/svelte/src/lib/components/CrateList.svelte
+++ b/svelte/src/lib/components/CrateList.svelte
@@ -30,7 +30,7 @@
     padding: 0;
     list-style: none;
 
-    > :global(* + *) {
+    > li + li {
       margin-top: var(--space-s);
     }
   }

--- a/svelte/src/lib/components/CrateRow.svelte
+++ b/svelte/src/lib/components/CrateRow.svelte
@@ -183,7 +183,7 @@
     padding: 0;
     margin: 0;
 
-    > :global(* + *) {
+    > li + li {
       margin-top: var(--space-xs);
     }
   }
@@ -216,7 +216,7 @@
     margin: var(--space-xs) 0 0 0;
     padding: 0;
 
-    > :global(* + *) {
+    > li + li {
       margin-left: var(--space-xs);
     }
   }

--- a/svelte/src/routes/categories/[category_id]/+page.svelte
+++ b/svelte/src/routes/categories/[category_id]/+page.svelte
@@ -125,11 +125,11 @@
     margin-bottom: var(--space-s);
   }
 
-  .subcategories > :global(*) {
+  .subcategories > .subcategory {
     padding: var(--space-s);
   }
 
-  .subcategories > :global(* + *) {
+  .subcategories > .subcategory + .subcategory {
     border-top: 1px solid light-dark(hsla(51, 90%, 42%, 0.25), #424242);
   }
 

--- a/svelte/src/routes/category_slugs/+page.svelte
+++ b/svelte/src/routes/category_slugs/+page.svelte
@@ -35,7 +35,7 @@
     margin: 0 var(--space-s) var(--space-s);
   }
 
-  .list > :global(* + dt) {
+  .list > dd + dt {
     border-top: 1px solid light-dark(hsla(51, 90%, 42%, 0.25), #424242);
   }
 </style>

--- a/svelte/src/routes/crates/[crate_id]/delete/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/delete/+page.svelte
@@ -171,7 +171,7 @@
       margin-top: 0.5em;
     }
 
-    :global(ol ol) {
+    ol ol {
       list-style-type: sub;
       padding-left: 1.5em;
     }
@@ -186,7 +186,7 @@
   }
 
   .confirmation {
-    :global(input) {
+    input {
       margin-right: var(--space-3xs);
     }
   }

--- a/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
@@ -511,12 +511,12 @@
     width: 100%;
     border-spacing: 0;
 
-    :global(tbody) > :global(tr) > :global(td) {
+    tbody > tr > td {
       border-top: 1px solid light-dark(hsla(51, 90%, 42%, 0.25), #232321);
     }
 
-    :global(th),
-    :global(td) {
+    th,
+    td {
       text-align: left;
       padding: var(--space-s) var(--space-m);
     }

--- a/svelte/src/routes/settings/tokens/new/+page.svelte
+++ b/svelte/src/routes/settings/tokens/new/+page.svelte
@@ -440,7 +440,7 @@
       border-color: red;
     }
 
-    > :global(* + *) {
+    > li + li {
       border-top: inherit;
     }
 
@@ -472,7 +472,7 @@
     border: 1px solid var(--gray-border);
     border-radius: var(--space-3xs);
 
-    > :global(* + *) {
+    > li + li {
       border-top: inherit;
     }
   }


### PR DESCRIPTION
Several Svelte components used `:global(...)` for elements rendered directly by the same component. This replaces those selectors with normal scoped CSS across crate lists, category pages, crate deletion and settings, and token creation.
The affected rules continue targeting the same local markup. Selectors that intentionally cross component boundaries remain global.