### PR TITLE
Fix README image distortion by preserving aspect ratio

### DIFF
--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -119,7 +119,6 @@ impl Stack {
 <h3 align="center">
   <a>
     <img width="1000" height="200" alt="Banner with Logo" src="https://static.rerun.io/d0f5443d4803cac65c73fcc064936c09f5e7f208_rerun_banner.png" />
-
   </a>
 </h3>
 `;

--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -115,6 +115,13 @@ impl Stack {
 </li>
 </ol>
 </section>
+
+<h3 align="center">
+  <a>
+    <img width="1000" height="200" alt="Banner with Logo" src="https://static.rerun.io/d0f5443d4803cac65c73fcc064936c09f5e7f208_rerun_banner.png" />
+
+  </a>
+</h3>
 `;
 
 test.describe('Acceptance | README rendering', { tag: '@acceptance' }, () => {

--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -213,11 +213,6 @@
     border-radius: var(--space-3xs);
     box-shadow: var(--shadow);
 
-    /* see: https://github.com/rust-lang/crates.io/issues/14133 */
-    :global(img) {
-      height: auto;
-    }
-
     @media only screen and (max-width: 550px) {
       margin-left: calc(var(--main-layout-padding) * -1);
       margin-right: calc(var(--main-layout-padding) * -1);

--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -213,6 +213,11 @@
     border-radius: var(--space-3xs);
     box-shadow: var(--shadow);
 
+    /* see: https://github.com/rust-lang/crates.io/issues/14133 */
+    :global(img) {
+      height: auto; 
+    }
+
     @media only screen and (max-width: 550px) {
       margin-left: calc(var(--main-layout-padding) * -1);
       margin-right: calc(var(--main-layout-padding) * -1);

--- a/svelte/src/lib/components/CrateVersionPage.svelte
+++ b/svelte/src/lib/components/CrateVersionPage.svelte
@@ -215,7 +215,7 @@
 
     /* see: https://github.com/rust-lang/crates.io/issues/14133 */
     :global(img) {
-      height: auto; 
+      height: auto;
     }
 
     @media only screen and (max-width: 550px) {

--- a/svelte/src/lib/components/TextContent.svelte
+++ b/svelte/src/lib/components/TextContent.svelte
@@ -42,6 +42,8 @@
 
     :global(img) {
       max-width: 100%;
+      /* see: https://github.com/rust-lang/crates.io/issues/14133 */
+      height: auto;
     }
 
     :global(pre) {


### PR DESCRIPTION
Adds `height: auto` to README images to preserve their aspect ratio when constrained by max-width: 100%. This prevents wider-than-container images from being vertically squished and improves README rendering for images with larger dimensions.

Fixes #14133