### PR TITLE
Scope Pierre styling variables to local containers

### DIFF
--- a/svelte/src/lib/components/CodeViewer.svelte
+++ b/svelte/src/lib/components/CodeViewer.svelte
@@ -127,17 +127,15 @@
   }
 
   .code {
+    --diffs-font-family: var(--font-monospace);
+    --diffs-header-font-family: var(--font-body);
+    --diffs-light-bg: white;
+    --diffs-dark-bg: #141413;
+
     flex: 1;
     min-height: 0;
     overflow: auto;
     font-size: calc(0.85 * var(--space-s));
     background-color: light-dark(white, #141413);
-  }
-
-  .code :global(diffs-container) {
-    --diffs-font-family: var(--font-monospace);
-    --diffs-header-font-family: var(--font-body);
-    --diffs-light-bg: white;
-    --diffs-dark-bg: #141413;
   }
 </style>

--- a/svelte/src/lib/components/FileTree.svelte
+++ b/svelte/src/lib/components/FileTree.svelte
@@ -77,12 +77,13 @@
 
 <style>
   .tree {
+    --trees-bg-override: light-dark(white, #141413);
+    --trees-font-family-override: var(--font-body);
+
     height: 100%;
   }
 
   .tree :global(file-tree-container) {
-    --trees-bg-override: light-dark(white, #141413);
-    --trees-font-family-override: var(--font-body);
     padding-top: var(--space-xs);
   }
 </style>


### PR DESCRIPTION
Pierre’s diff viewer and file tree expose CSS custom properties that inherit through their generated custom elements. This moves those properties onto the locally scoped `CodeViewer` and `FileTree` containers, removing unnecessary global selectors while preserving the existing themes.

The file-tree padding still targets `file-tree-container` because that layout belongs to the generated element.

tl;dr one less `:global` in our CSS