### PR TITLE
CI: Pin `mise` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
+          version: 2026.7.7
           install_args: cargo:cargo-deny cargo:cargo-machete
 
       - run: cargo deny check
@@ -104,6 +105,7 @@ jobs:
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
+          version: 2026.7.7
           install_args: cargo:diesel-guard
 
       - run: diesel-guard check migrations/
@@ -140,6 +142,7 @@ jobs:
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
+          version: 2026.7.7
           install_args: cargo-insta
 
       - run: sudo systemctl start postgresql.service
@@ -288,6 +291,7 @@ jobs:
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
+          version: 2026.7.7
           install_args: zizmor
 
       - run: zizmor --format=sarif . > results.sarif


### PR DESCRIPTION
This pins `mise` to 2026.7.7 so CI behavior does not change unexpectedly when upstream publishes a new release. It makes `mise` upgrades explicit and reviewable instead of silently following the latest release.

Renovate will keep the `version` inputs current as new `mise` releases become available.