### PR TITLE
Footer: Remove unused classic theme selector

### DIFF
--- a/svelte/src/lib/components/Footer.svelte
+++ b/svelte/src/lib/components/Footer.svelte
@@ -64,8 +64,7 @@
 </footer>
 
 <style>
-  :root,
-  :global([data-theme='classic']) {
+  :root {
     --footer-bg-color: var(--header-bg-color);
     --footer-header-color: var(--yellow500);
     --footer-header-shadow-color: var(--green900);


### PR DESCRIPTION
The application never sets `data-theme="classic"` anymore, so the selector cannot affect footer variables. This removes the stale global theme hook while leaving the existing root defaults unchanged.