### PR TITLE
dashboard: Remove redundant heading child rule

### DIFF
--- a/svelte/src/routes/dashboard/+page.svelte
+++ b/svelte/src/routes/dashboard/+page.svelte
@@ -165,10 +165,6 @@
       margin: 0;
       --icon-size: 1.25em;
 
-      > :global(*) {
-        flex-shrink: 0;
-      }
-
       :global(.icon) {
         margin-top: -0.125em;
         margin-bottom: -0.125em;


### PR DESCRIPTION
`Icon` already prevents itself from shrinking in flex layouts, so the broad child selector does not affect the current headings. This avoids reaching through the component boundary and constraining unrelated elements added later.