### PR TITLE
Use `gap` instead of global child margins

### DIFF
--- a/svelte/src/lib/components/CrateRow.svelte
+++ b/svelte/src/lib/components/CrateRow.svelte
@@ -161,14 +161,8 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-
-    & > :global(*) {
-      margin-bottom: calc(var(--space-xs) / 2);
-    }
-
-    & > :global(:not(:last-child)) {
-      margin-right: var(--space-2xs);
-    }
+    gap: calc(var(--space-xs) / 2) var(--space-2xs);
+    padding-bottom: calc(var(--space-xs) / 2);
   }
 
   .description {

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
@@ -371,9 +371,9 @@
   }
 
   .links {
-    > :global(* + *) {
-      margin-top: var(--space-m);
-    }
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-m);
   }
 
   .categories {

--- a/svelte/src/lib/components/frontpage/IntroBlurb.svelte
+++ b/svelte/src/lib/components/frontpage/IntroBlurb.svelte
@@ -57,9 +57,6 @@
     flex: 4;
     display: flex;
     flex-direction: column;
-
-    > :global(* + *) {
-      margin-top: var(--space-s);
-    }
+    gap: var(--space-s);
   }
 </style>

--- a/svelte/src/lib/components/side-menu/SideMenu.svelte
+++ b/svelte/src/lib/components/side-menu/SideMenu.svelte
@@ -15,12 +15,11 @@
 
 <style>
   .list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3xs);
     list-style: none;
     margin: 0;
     padding: 0;
-
-    > :global(* + *) {
-      margin-top: var(--space-3xs);
-    }
   }
 </style>


### PR DESCRIPTION
Several Svelte components rendered children with `:global(...)` margin selectors. This replaces those selectors with parent-owned flex `gap` in `CrateRow`, `IntroBlurb`, `SideMenu`, and `CrateSidebar`, removing their dependency on child root elements.

`CrateRow` keeps bottom padding after the final wrapped row, while the three vertical layouts use gap between items.