### PR TITLE
Combine Renovate lock file maintenance updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,18 +35,6 @@
       minimumReleaseAge: '24 hours',
     },
     {
-      matchCategories: ['js'],
-      matchUpdateTypes: ['lockFileMaintenance'],
-      additionalBranchPrefix: 'js-',
-      commitMessageSuffix: '(JS)',
-    },
-    {
-      matchCategories: ['rust'],
-      matchUpdateTypes: ['lockFileMaintenance'],
-      additionalBranchPrefix: 'rust-',
-      commitMessageSuffix: '(Rust)',
-    },
-    {
       matchManagers: ['custom.regex'],
       matchDepNames: ['rust'],
       commitMessageTopic: 'Rust',


### PR DESCRIPTION
The language-specific rules split weekly lock file maintenance into separate JavaScript and Rust pull requests. Removing them lets Renovate combine both lock file updates into a single pull request.