### PR TITLE
svelte: Navigate to index when there is no previous page

### DIFF
--- a/e2e/acceptance/404.spec.ts
+++ b/e2e/acceptance/404.spec.ts
@@ -13,11 +13,15 @@ test.describe('Acceptance | 404', { tag: '@acceptance' }, () => {
   });
 
   test('go back navigates to index when there is no previous page', async ({ page }) => {
-    // Can't use page.goto which adds a history entry
-    await page.evaluate(() => location.replace('/unknown-route'));
+    await page.goto('/unknown-route');
     await expect(page.locator('[data-test-go-back]')).toBeVisible();
     await page.click('[data-test-go-back]');
-    await expect(page).toHaveURL('/');
+    // Svelte doesn't update URL during tests for some reason, so the following assertion only works in actual browsers
+    // await expect(page).toHaveURL('/');
+    // Instead, assert we are no longer on 404 page...
+    await expect(page.locator('[data-test-404-page]')).toBeHidden();
+    // ...but on index page instead
+    await expect(page).toHaveTitle('crates.io: Rust Package Registry');
   });
 
   test('go back navigates to previous page when history exists', async ({ page }) => {

--- a/e2e/acceptance/404.spec.ts
+++ b/e2e/acceptance/404.spec.ts
@@ -13,15 +13,16 @@ test.describe('Acceptance | 404', { tag: '@acceptance' }, () => {
   });
 
   test('go back navigates to index when there is no previous page', async ({ page }) => {
-    await page.goto('/unknown-route');
-    await expect(page.locator('[data-test-go-back]')).toBeVisible();
-    await page.click('[data-test-go-back]');
-    // Svelte doesn't update URL during tests for some reason, so the following assertion only works in actual browsers
-    // await expect(page).toHaveURL('/');
-    // Instead, assert we are no longer on 404 page...
-    await expect(page.locator('[data-test-404-page]')).toBeHidden();
-    // ...but on index page instead
-    await expect(page).toHaveTitle('crates.io: Rust Package Registry');
+    // Pre-warm index page
+    await page.goto('/');
+
+    // Open popup to get a fresh history
+    let [popup] = await Promise.all([page.waitForEvent('popup'), page.evaluate(() => window.open('/unknown-route'))]);
+    await popup.waitForLoadState('domcontentloaded');
+
+    await expect(popup.locator('[data-test-go-back]')).toBeVisible();
+    await popup.click('[data-test-go-back]');
+    await expect(popup).toHaveURL('/');
   });
 
   test('go back navigates to previous page when history exists', async ({ page }) => {

--- a/e2e/acceptance/404.spec.ts
+++ b/e2e/acceptance/404.spec.ts
@@ -13,7 +13,8 @@ test.describe('Acceptance | 404', { tag: '@acceptance' }, () => {
   });
 
   test('go back navigates to index when there is no previous page', async ({ page }) => {
-    await page.goto('/unknown-route');
+    // Can't use page.goto which adds a history entry
+    await page.evaluate(() => location.replace('/unknown-route'));
     await expect(page.locator('[data-test-go-back]')).toBeVisible();
     await page.click('[data-test-go-back]');
     await expect(page).toHaveURL('/');

--- a/e2e/acceptance/404.spec.ts
+++ b/e2e/acceptance/404.spec.ts
@@ -11,4 +11,19 @@ test.describe('Acceptance | 404', { tag: '@acceptance' }, () => {
     await percy.snapshot();
     await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });
   });
+
+  test('go back navigates to index when there is no previous page', async ({ page }) => {
+    await page.goto('/unknown-route');
+    await expect(page.locator('[data-test-go-back]')).toBeVisible();
+    await page.click('[data-test-go-back]');
+    await expect(page).toHaveURL('/');
+  });
+
+  test('go back navigates to previous page when history exists', async ({ page }) => {
+    await page.goto('/policies');
+    await page.goto('/unknown-route');
+    await expect(page.locator('[data-test-go-back]')).toBeVisible();
+    await page.click('[data-test-go-back]');
+    await expect(page).toHaveURL('/policies');
+  });
 });

--- a/svelte/src/routes/+error.svelte
+++ b/svelte/src/routes/+error.svelte
@@ -16,8 +16,7 @@
   }
 
   function goBack() {
-    // window.navigation is only available in modern browsers
-    let canGoBack = window.navigation?.canGoBack ?? history.length > 1;
+    let canGoBack = history.length > 1;
     if (!canGoBack) {
       goto(resolve('/'));
       return;

--- a/svelte/src/routes/+error.svelte
+++ b/svelte/src/routes/+error.svelte
@@ -17,7 +17,7 @@
 
   function goBack() {
     // window.navigation is only available in modern browsers
-    const canGoBack = window.navigation?.canGoBack ?? history.length > 1;
+    let canGoBack = window.navigation?.canGoBack ?? history.length > 1;
     if (!canGoBack) {
       goto(resolve('/'));
       return;

--- a/svelte/src/routes/+error.svelte
+++ b/svelte/src/routes/+error.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import { goto } from '$app/navigation';
 
   import Ferris from '$lib/components/Ferris.svelte';
   import { getSession } from '$lib/utils/session.svelte';
@@ -14,6 +15,10 @@
   }
 
   function goBack() {
+    if (history.length <= 1) {
+      goto('/');
+      return;
+    }
     history.back();
   }
 

--- a/svelte/src/routes/+error.svelte
+++ b/svelte/src/routes/+error.svelte
@@ -16,7 +16,9 @@
   }
 
   function goBack() {
-    if (history.length <= 1) {
+    // window.navigation is only available in modern browsers
+    const canGoBack = window.navigation?.canGoBack ?? history.length > 1;
+    if (!canGoBack) {
       goto(resolve('/'));
       return;
     }

--- a/svelte/src/routes/+error.svelte
+++ b/svelte/src/routes/+error.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { page } from '$app/state';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
+  import { page } from '$app/state';
 
   import Ferris from '$lib/components/Ferris.svelte';
   import { getSession } from '$lib/utils/session.svelte';

--- a/svelte/src/routes/+error.svelte
+++ b/svelte/src/routes/+error.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
 
   import Ferris from '$lib/components/Ferris.svelte';
   import { getSession } from '$lib/utils/session.svelte';
@@ -16,7 +17,7 @@
 
   function goBack() {
     if (history.length <= 1) {
-      goto('/');
+      goto(resolve('/'));
       return;
     }
     history.back();


### PR DESCRIPTION
Title. Currently the "Go Back" button does nothing when e.g. navigating directly to a not found page like https://crates.io/404. One could always use the top left header link but this is mo intuitive.