### PR TITLE
msw: Own API client integration test

### DIFF
--- a/.github/changed-files.yml
+++ b/.github/changed-files.yml
@@ -38,14 +38,14 @@ frontend_lint:
 
 msw_test:
   - .github/workflows/**
+  - packages/crates-io-api-client/**
   - packages/crates-io-msw/**
   - pnpm-lock.yaml
 
 api_client_test:
   - .github/workflows/**
-  - packages/crates-io-msw/**
   - packages/crates-io-api-client/**
-  - src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+  - src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
   - pnpm-lock.yaml
 
 e2e_test:

--- a/packages/crates-io-api-client/package.json
+++ b/packages/crates-io-api-client/package.json
@@ -22,7 +22,6 @@
     "openapi-fetch": "0.17.0"
   },
   "devDependencies": {
-    "@crates-io/msw": "workspace:*",
     "msw": "2.15.0",
     "openapi-typescript": "7.13.0",
     "vitest": "4.1.10"

--- a/packages/crates-io-msw/api-client.test.ts
+++ b/packages/crates-io-msw/api-client.test.ts
@@ -1,18 +1,9 @@
-import { db, handlers } from '@crates-io/msw';
-import { setupServer } from 'msw/node';
-import { afterAll, afterEach, beforeAll, expect, test } from 'vitest';
+import { createClient } from '@crates-io/api-client';
+import { expect, test } from 'vitest';
 
-import { createClient } from './index.js';
+import { db } from './index.js';
 
 const baseUrl = 'https://crates.io/';
-globalThis.location = { href: baseUrl } as Location;
-
-const server = setupServer(...handlers);
-
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterEach(() => db.reset());
-afterAll(() => server.close());
 
 test('GET /api/v1/site_metadata', async () => {
   let client = createClient({ baseUrl });

--- a/packages/crates-io-msw/package.json
+++ b/packages/crates-io-msw/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@crates-io/api-client": "workspace:*",
     "@msw/data": "1.1.7",
     "msw": "2.15.0",
     "semver": "7.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,9 +94,6 @@ importers:
         specifier: 0.17.0
         version: 0.17.0
     devDependencies:
-      '@crates-io/msw':
-        specifier: workspace:*
-        version: link:../crates-io-msw
       msw:
         specifier: 2.15.0
         version: 2.15.0(@types/node@24.13.3)(typescript@6.0.3)
@@ -121,6 +118,9 @@ importers:
 
   packages/crates-io-msw:
     dependencies:
+      '@crates-io/api-client':
+        specifier: workspace:*
+        version: link:../crates-io-api-client
       '@msw/data':
         specifier: 1.1.7
         version: 1.1.7


### PR DESCRIPTION
The integration test exercises the generated API client against the MSW handlers. MSW owns the test and depends on the client directly, which will let serializers reuse API response types in the future without creating a package cycle.