### PR TITLE
Extract Datadog metrics client into workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,6 +1767,7 @@ dependencies = [
  "crates_io_crate_zip",
  "crates_io_database",
  "crates_io_database_dump",
+ "crates_io_datadog",
  "crates_io_docs_rs",
  "crates_io_encryption",
  "crates_io_env_vars",
@@ -1967,6 +1968,17 @@ dependencies = [
  "toml 1.1.3+spec-1.1.0",
  "tracing",
  "zip",
+]
+
+[[package]]
+name = "crates_io_datadog"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bon",
+ "reqwest",
+ "secrecy",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,9 +1976,13 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bon",
+ "claims",
+ "insta",
+ "mockito",
  "reqwest",
  "secrecy",
  "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ crates_io_api_types = { path = "crates/crates_io_api_types" }
 crates_io_cargo_toml = { path = "crates/crates_io_cargo_toml" }
 crates_io_cdn_logs = { path = "crates/crates_io_cdn_logs" }
 crates_io_crate_zip = { path = "crates/crates_io_crate_zip" }
+crates_io_datadog = { path = "crates/crates_io_datadog" }
 crates_io_database = { path = "crates/crates_io_database" }
 crates_io_database_dump = { path = "crates/crates_io_database_dump" }
 crates_io_docs_rs = { path = "crates/crates_io_docs_rs" }

--- a/crates/crates_io_datadog/Cargo.toml
+++ b/crates/crates_io_datadog/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "crates_io_datadog"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "=1.0.104"
+bon = "=3.9.3"
+reqwest = { version = "=0.13.4", features = ["json"] }
+secrecy = "=0.10.3"
+serde = { version = "=1.0.229", features = ["derive"] }

--- a/crates/crates_io_datadog/Cargo.toml
+++ b/crates/crates_io_datadog/Cargo.toml
@@ -13,3 +13,9 @@ bon = "=3.9.3"
 reqwest = { version = "=0.13.4", features = ["json"] }
 secrecy = "=0.10.3"
 serde = { version = "=1.0.229", features = ["derive"] }
+
+[dev-dependencies]
+claims = "=0.8.0"
+insta = "=1.48.0"
+mockito = "=1.7.2"
+tokio = { version = "=1.53.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/crates_io_datadog/README.md
+++ b/crates/crates_io_datadog/README.md
@@ -1,0 +1,8 @@
+# `crates_io_datadog`
+
+This package implements functionality for submitting metrics to the
+[Datadog metrics API](https://docs.datadoghq.com/api/latest/metrics/).
+
+`DatadogClient::builder()` requires a `reqwest::Client` and API key, and
+defaults to the `datadoghq.com` site. The client owns authentication, payload
+serialization, request timeouts, and response validation.

--- a/crates/crates_io_datadog/src/lib.rs
+++ b/crates/crates_io_datadog/src/lib.rs
@@ -1,0 +1,108 @@
+#![doc = include_str!("../README.md")]
+
+use anyhow::Context;
+use bon::Builder;
+use reqwest::Client;
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Serialize, Serializer};
+use std::time::Duration;
+
+const DEFAULT_SITE: &str = "datadoghq.com";
+
+/// Per-request timeout for a single submission.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// A client for submitting data to the Datadog API.
+#[derive(Builder, Debug)]
+pub struct DatadogClient {
+    http_client: Client,
+    api_key: SecretString,
+    #[builder(default = DEFAULT_SITE.to_string())]
+    site: String,
+}
+
+impl DatadogClient {
+    /// Submits a batch of metric series to Datadog.
+    pub async fn submit_metrics(&self, series: &[Series]) -> anyhow::Result<()> {
+        let url = format!("https://api.{}/api/v2/series", self.site);
+        let body = MetricsBody { series };
+
+        let response = self
+            .http_client
+            .post(url)
+            .header("DD-API-KEY", self.api_key.expose_secret())
+            .timeout(REQUEST_TIMEOUT)
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to send request to Datadog")?;
+
+        response
+            .error_for_status()
+            .context("Datadog returned an error response")?;
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+struct MetricsBody<'a> {
+    series: &'a [Series],
+}
+
+/// A metric series submitted to Datadog.
+#[derive(Builder, Debug, PartialEq, Serialize)]
+pub struct Series {
+    #[builder(into)]
+    metric: String,
+    #[serde(rename = "type")]
+    kind: MetricType,
+    points: Vec<Point>,
+    resources: Vec<Resource>,
+    tags: Vec<String>,
+}
+
+/// The type of a Datadog metric series.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MetricType {
+    /// A count representing the total number of event occurrences in one time
+    /// interval.
+    Count,
+    /// A rate representing the normalized number of event occurrences per
+    /// second.
+    Rate,
+    /// A gauge representing a value at a specific point in time.
+    Gauge,
+}
+
+impl Serialize for MetricType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = match self {
+            Self::Count => 1,
+            Self::Rate => 2,
+            Self::Gauge => 3,
+        };
+
+        serializer.serialize_u8(value)
+    }
+}
+
+/// A timestamped value in a Datadog metric series.
+#[derive(Builder, Debug, PartialEq, Serialize)]
+pub struct Point {
+    timestamp: i64,
+    value: f64,
+}
+
+/// A resource associated with a Datadog metric series.
+#[derive(Builder, Clone, Debug, PartialEq, Serialize)]
+pub struct Resource {
+    #[builder(into)]
+    #[serde(rename = "type")]
+    kind: String,
+    #[builder(into)]
+    name: String,
+}

--- a/crates/crates_io_datadog/src/lib.rs
+++ b/crates/crates_io_datadog/src/lib.rs
@@ -17,14 +17,27 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 pub struct DatadogClient {
     http_client: Client,
     api_key: SecretString,
-    #[builder(default = DEFAULT_SITE.to_string())]
-    site: String,
+    #[builder(default = format!("https://api.{DEFAULT_SITE}"))]
+    base_url: String,
+}
+
+impl<S: datadog_client_builder::State> DatadogClientBuilder<S> {
+    /// Uses the API endpoint for the given Datadog site.
+    pub fn site(
+        self,
+        site: impl AsRef<str>,
+    ) -> DatadogClientBuilder<datadog_client_builder::SetBaseUrl<S>>
+    where
+        S::BaseUrl: datadog_client_builder::IsUnset,
+    {
+        self.base_url(format!("https://api.{}", site.as_ref()))
+    }
 }
 
 impl DatadogClient {
     /// Submits a batch of metric series to Datadog.
     pub async fn submit_metrics(&self, series: &[Series]) -> anyhow::Result<()> {
-        let url = format!("https://api.{}/api/v2/series", self.site);
+        let url = self.api_url("/api/v2/series");
         let body = MetricsBody { series };
 
         let response = self
@@ -42,6 +55,11 @@ impl DatadogClient {
             .context("Datadog returned an error response")?;
 
         Ok(())
+    }
+
+    /// Builds a URL for a Datadog API endpoint.
+    fn api_url(&self, path: &str) -> String {
+        format!("{}{path}", self.base_url)
     }
 }
 
@@ -105,4 +123,39 @@ pub struct Resource {
     kind: String,
     #[builder(into)]
     name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_API_KEY: &str = "test-api-key";
+
+    #[test]
+    fn uses_site_for_default_base_url() {
+        let client = DatadogClient::builder()
+            .http_client(Client::new())
+            .api_key(TEST_API_KEY.to_string().into())
+            .site("datadoghq.eu")
+            .build();
+
+        assert_eq!(
+            client.api_url("/api/v2/series"),
+            "https://api.datadoghq.eu/api/v2/series"
+        );
+    }
+
+    #[test]
+    fn uses_explicit_base_url() {
+        let client = DatadogClient::builder()
+            .http_client(Client::new())
+            .api_key(TEST_API_KEY.to_string().into())
+            .base_url("http://localhost".to_string())
+            .build();
+
+        assert_eq!(
+            client.api_url("/api/v2/series"),
+            "http://localhost/api/v2/series"
+        );
+    }
 }

--- a/crates/crates_io_datadog/src/lib.rs
+++ b/crates/crates_io_datadog/src/lib.rs
@@ -128,8 +128,47 @@ pub struct Resource {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use claims::{assert_err, assert_ok, assert_some, assert_some_eq};
+    use insta::assert_snapshot;
+    use mockito::{Matcher, Server, ServerOpts};
 
     const TEST_API_KEY: &str = "test-api-key";
+
+    async fn mock_server() -> Server {
+        Server::new_with_opts_async(ServerOpts {
+            assert_on_drop: true,
+            ..Default::default()
+        })
+        .await
+    }
+
+    fn client_with_server(server: &Server) -> DatadogClient {
+        DatadogClient::builder()
+            .http_client(Client::new())
+            .api_key(TEST_API_KEY.to_string().into())
+            .base_url(server.url())
+            .build()
+    }
+
+    fn metric_series() -> Series {
+        let point = Point::builder()
+            .timestamp(1_753_000_000)
+            .value(42.0)
+            .build();
+
+        let resource = Resource::builder().kind("host").name("crates.io").build();
+
+        Series::builder()
+            .metric("crates_io.background_jobs")
+            .kind(MetricType::Gauge)
+            .points(vec![point])
+            .resources(vec![resource])
+            .tags(vec![
+                "env:test".to_string(),
+                "service:crates_io".to_string(),
+            ])
+            .build()
+    }
 
     #[test]
     fn uses_site_for_default_base_url() {
@@ -157,5 +196,56 @@ mod tests {
             client.api_url("/api/v2/series"),
             "http://localhost/api/v2/series"
         );
+    }
+
+    #[tokio::test]
+    async fn submits_metric_series() {
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock("POST", "/api/v2/series")
+            .match_header("dd-api-key", TEST_API_KEY)
+            .match_body(Matcher::JsonString(
+                r#"{
+                    "series": [{
+                        "metric": "crates_io.background_jobs",
+                        "type": 3,
+                        "points": [{
+                            "timestamp": 1753000000,
+                            "value": 42.0
+                        }],
+                        "resources": [{
+                            "type": "host",
+                            "name": "crates.io"
+                        }],
+                        "tags": ["env:test", "service:crates_io"]
+                    }]
+                }"#
+                .to_string(),
+            ))
+            .with_status(202)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        assert_ok!(client.submit_metrics(&[metric_series()]).await);
+    }
+
+    #[tokio::test]
+    async fn reports_rejected_metric_submissions() {
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock("POST", "/api/v2/series")
+            .with_status(403)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_server(&server);
+        let error = assert_err!(client.submit_metrics(&[metric_series()]).await);
+        assert_snapshot!(error, @"Datadog returned an error response");
+
+        let http_error = assert_some!(error.downcast_ref::<reqwest::Error>());
+        assert_some_eq!(http_error.status(), reqwest::StatusCode::FORBIDDEN);
     }
 }

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -83,6 +83,7 @@ fn main() -> anyhow::Result<()> {
 
     let user_agent = crates_io_version::user_agent();
     let http_client = Client::builder().user_agent(user_agent).build()?;
+    let datadog = config.datadog.client(http_client.clone());
 
     let cloudfront = CloudFront::from_environment();
     let storage = Arc::new(Storage::from_config(&config.storage));
@@ -101,7 +102,7 @@ fn main() -> anyhow::Result<()> {
 
     let docs_rs = RealDocsRsClient::from_environment().map(|cl| Box::new(cl) as _);
 
-    let github: Arc<dyn GitHubClient> = Arc::new(RealGitHubClient::new(http_client.clone()));
+    let github: Arc<dyn GitHubClient> = Arc::new(RealGitHubClient::new(http_client));
     let index_sync_github_app = build_index_sync_github_app(config.index_archive_url.as_ref())?;
     let sync_github_app = build_sync_github_app()?;
 
@@ -153,7 +154,7 @@ fn main() -> anyhow::Result<()> {
         crates_io::metrics::datadog::spawn(
             &environment.config,
             environment.deadpool.clone(),
-            http_client,
+            datadog,
         );
 
         info!("Runner booted, running jobs");

--- a/src/config/datadog.rs
+++ b/src/config/datadog.rs
@@ -1,4 +1,6 @@
+use crates_io_datadog::DatadogClient;
 use crates_io_env_vars::var;
+use reqwest::Client;
 use secrecy::SecretString;
 
 const DEFAULT_SITE: &str = "datadoghq.com";
@@ -26,6 +28,19 @@ impl Default for DatadogConfig {
 }
 
 impl DatadogConfig {
+    /// Creates a Datadog client when an API key is configured.
+    pub fn client(&self, http_client: Client) -> Option<DatadogClient> {
+        let api_key = self.api_key.clone()?;
+
+        let client = DatadogClient::builder()
+            .http_client(http_client)
+            .api_key(api_key)
+            .site(self.site.clone())
+            .build();
+
+        Some(client)
+    }
+
     pub fn from_env() -> anyhow::Result<Self> {
         let api_key = var("DD_API_KEY")?.map(SecretString::from);
         let site = var("DD_SITE")?.unwrap_or_else(|| DEFAULT_SITE.into());

--- a/src/metrics/datadog.rs
+++ b/src/metrics/datadog.rs
@@ -10,20 +10,15 @@
 use crate::config::Server;
 use crate::metrics::ServiceMetrics;
 use anyhow::{Context, anyhow};
+use crates_io_datadog::{DatadogClient, MetricType as DatadogMetricType, Point, Resource, Series};
 use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::deadpool::Pool;
 use prometheus::proto::{MetricFamily, MetricType};
-use reqwest::Client;
-use secrecy::{ExposeSecret, SecretString};
-use serde::Serialize;
 use std::time::Duration;
 use tracing::{info, warn};
 
 /// Interval between metric submissions.
 const SUBMIT_INTERVAL: Duration = Duration::from_secs(5);
-
-/// Per-request timeout for a single submission.
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Spawns a background task that periodically submits the service metrics to
 /// Datadog.
@@ -32,23 +27,18 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 /// `background_worker` dyno; scaling the worker horizontally would make every
 /// instance submit the same series (identical host and tags per environment),
 /// causing last-write-wins collisions.
-pub fn spawn(config: &Server, deadpool: Pool<AsyncPgConnection>, http_client: Client) {
-    let Some(api_key) = config.datadog.api_key.clone() else {
+pub fn spawn(config: &Server, deadpool: Pool<AsyncPgConnection>, datadog: Option<DatadogClient>) {
+    let Some(datadog) = datadog else {
         info!("Datadog API key not configured, skipping Datadog metrics submission");
         return;
     };
-
-    let url = format!("https://api.{}/api/v2/series", config.datadog.site);
 
     let domain = config.domain_name.clone();
     let env = match domain.as_str() {
         "staging.crates.io" => "staging",
         _ => "prod",
     };
-    let resources = vec![Resource {
-        kind: "host".into(),
-        name: domain,
-    }];
+    let resources = vec![Resource::builder().kind("host").name(domain).build()];
 
     let mut common_tags = vec![format!("env:{env}"), "service:crates_io".into()];
     if let Ok(Some(commit)) = crates_io_version::commit() {
@@ -68,9 +58,7 @@ pub fn spawn(config: &Server, deadpool: Pool<AsyncPgConnection>, http_client: Cl
             let result = submit(
                 &deadpool,
                 &service_metrics,
-                &http_client,
-                &url,
-                &api_key,
+                &datadog,
                 &resources,
                 &common_tags,
             )
@@ -89,9 +77,7 @@ pub fn spawn(config: &Server, deadpool: Pool<AsyncPgConnection>, http_client: Cl
 async fn submit(
     deadpool: &Pool<AsyncPgConnection>,
     service_metrics: &ServiceMetrics,
-    http_client: &Client,
-    url: &str,
-    api_key: &SecretString,
+    datadog: &DatadogClient,
     resources: &[Resource],
     common_tags: &[String],
 ) -> anyhow::Result<()> {
@@ -108,50 +94,10 @@ async fn submit(
 
     let timestamp = chrono::Utc::now().timestamp();
     let series = families_to_series(&families, timestamp, resources, common_tags);
-    let body = Body { series };
 
-    let response = http_client
-        .post(url)
-        .header("DD-API-KEY", api_key.expose_secret())
-        .timeout(REQUEST_TIMEOUT)
-        .json(&body)
-        .send()
-        .await
-        .context("Failed to send request to Datadog")?;
-
-    response
-        .error_for_status()
-        .context("Datadog returned an error response")?;
+    datadog.submit_metrics(&series).await?;
 
     Ok(())
-}
-
-#[derive(Serialize, Debug, PartialEq)]
-struct Body {
-    series: Vec<Series>,
-}
-
-#[derive(Serialize, Debug, PartialEq)]
-struct Series {
-    metric: String,
-    #[serde(rename = "type")]
-    kind: u32,
-    points: Vec<Point>,
-    resources: Vec<Resource>,
-    tags: Vec<String>,
-}
-
-#[derive(Serialize, Debug, PartialEq)]
-struct Point {
-    timestamp: i64,
-    value: f64,
-}
-
-#[derive(Serialize, Debug, PartialEq, Clone)]
-struct Resource {
-    #[serde(rename = "type")]
-    kind: String,
-    name: String,
 }
 
 /// Builds one Datadog [`Series`] per metric in the gathered families.
@@ -180,8 +126,8 @@ fn families_to_series(
 
         for proto in family.get_metric() {
             let (kind, value) = match family.get_field_type() {
-                MetricType::GAUGE => (3, proto.get_gauge().get_value()),
-                MetricType::COUNTER => (1, proto.get_counter().get_value()),
+                MetricType::GAUGE => (DatadogMetricType::Gauge, proto.get_gauge().get_value()),
+                MetricType::COUNTER => (DatadogMetricType::Count, proto.get_counter().get_value()),
                 other => {
                     warn!("unsupported metric type: {other:?}");
                     continue;
@@ -196,13 +142,15 @@ fn families_to_series(
 
             tags.extend_from_slice(common_tags);
 
-            series.push(Series {
-                metric: metric.clone(),
-                kind,
-                points: vec![Point { timestamp, value }],
-                resources: resources.to_vec(),
-                tags,
-            });
+            let point = Point::builder().timestamp(timestamp).value(value).build();
+            let series_item = Series::builder()
+                .metric(metric.clone())
+                .kind(kind)
+                .points(vec![point])
+                .resources(resources.to_vec())
+                .tags(tags)
+                .build();
+            series.push(series_item);
         }
     }
 
@@ -216,10 +164,7 @@ mod tests {
     use prometheus::{Histogram, HistogramOpts, IntCounter, IntGaugeVec, Opts, Registry};
 
     fn host() -> Resource {
-        Resource {
-            kind: "host".into(),
-            name: "crates.io".into(),
-        }
+        Resource::builder().kind("host").name("crates.io").build()
     }
 
     #[test]


### PR DESCRIPTION
This extracts the Datadog API wire types and submission logic into a new `crates_io_datadog` workspace crate. `DatadogClient` now owns authentication, payload serialization, request timeouts, response validation, and endpoint selection, while the main application remains responsible for gathering Prometheus metrics, constructing series, and scheduling submissions.

The background worker constructs the client only when credentials are configured, preserving the existing optional submission behavior. Site-based endpoints retain the current default, while an explicit base URL supports alternative endpoints and HTTP-level tests covering request serialization, authentication, accepted submissions, and error responses.