### PR TITLE
datadog: Submit `monitor` results as service checks

### DIFF
--- a/crates/crates_io_datadog/README.md
+++ b/crates/crates_io_datadog/README.md
@@ -1,7 +1,8 @@
 # `crates_io_datadog`
 
-This package implements functionality for submitting metrics to the
-[Datadog metrics API](https://docs.datadoghq.com/api/latest/metrics/).
+This package implements functionality for submitting data to the
+[Datadog metrics API](https://docs.datadoghq.com/api/latest/metrics/) and
+[service checks API](https://docs.datadoghq.com/api/latest/service-checks/).
 
 `DatadogClient::builder()` requires a `reqwest::Client` and API key, and
 defaults to the `datadoghq.com` site. The client owns authentication, payload

--- a/crates/crates_io_datadog/src/lib.rs
+++ b/crates/crates_io_datadog/src/lib.rs
@@ -37,8 +37,21 @@ impl<S: datadog_client_builder::State> DatadogClientBuilder<S> {
 impl DatadogClient {
     /// Submits a batch of metric series to Datadog.
     pub async fn submit_metrics(&self, series: &[Series]) -> anyhow::Result<()> {
-        let url = self.api_url("/api/v2/series");
         let body = MetricsBody { series };
+
+        self.submit("/api/v2/series", &body).await
+    }
+
+    /// Submits a batch of service checks to Datadog.
+    pub async fn submit_service_checks(&self, checks: &[ServiceCheck]) -> anyhow::Result<()> {
+        self.submit("/api/v1/check_run", checks).await
+    }
+
+    async fn submit<T>(&self, path: &str, body: &T) -> anyhow::Result<()>
+    where
+        T: Serialize + ?Sized,
+    {
+        let url = self.api_url(path);
 
         let response = self
             .http_client
@@ -66,6 +79,48 @@ impl DatadogClient {
 #[derive(Serialize)]
 struct MetricsBody<'a> {
     series: &'a [Series],
+}
+
+/// A service check submitted to Datadog.
+#[derive(Builder, Debug, PartialEq, Serialize)]
+pub struct ServiceCheck {
+    #[builder(into)]
+    check: String,
+    #[builder(into)]
+    host_name: String,
+    status: ServiceCheckStatus,
+    #[builder(into)]
+    message: String,
+    tags: Vec<String>,
+}
+
+/// The status of a Datadog service check.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ServiceCheckStatus {
+    /// The service is operating normally.
+    Ok,
+    /// The service may require attention.
+    Warning,
+    /// The service is not operating normally.
+    Critical,
+    /// The service status could not be determined.
+    Unknown,
+}
+
+impl Serialize for ServiceCheckStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = match self {
+            Self::Ok => 0,
+            Self::Warning => 1,
+            Self::Critical => 2,
+            Self::Unknown => 3,
+        };
+
+        serializer.serialize_u8(value)
+    }
 }
 
 /// A metric series submitted to Datadog.
@@ -170,6 +225,19 @@ mod tests {
             .build()
     }
 
+    fn service_check(check: &str, status: ServiceCheckStatus, message: &str) -> ServiceCheck {
+        ServiceCheck::builder()
+            .check(check)
+            .host_name("crates.io")
+            .status(status)
+            .message(message)
+            .tags(vec![
+                "env:test".to_string(),
+                "service:crates_io".to_string(),
+            ])
+            .build()
+    }
+
     #[test]
     fn uses_site_for_default_base_url() {
         let client = DatadogClient::builder()
@@ -243,6 +311,75 @@ mod tests {
 
         let client = client_with_server(&server);
         let error = assert_err!(client.submit_metrics(&[metric_series()]).await);
+        assert_snapshot!(error, @"Datadog returned an error response");
+
+        let http_error = assert_some!(error.downcast_ref::<reqwest::Error>());
+        assert_some_eq!(http_error.status(), reqwest::StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn submits_service_checks() {
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock("POST", "/api/v1/check_run")
+            .match_header("dd-api-key", TEST_API_KEY)
+            .match_body(Matcher::JsonString(
+                r#"[
+                    {
+                        "check": "crates_io.background_jobs.healthy",
+                        "host_name": "crates.io",
+                        "status": 0,
+                        "message": "No stalled background jobs",
+                        "tags": ["env:test", "service:crates_io"]
+                    },
+                    {
+                        "check": "crates_io.spam_attack.detected",
+                        "host_name": "crates.io",
+                        "status": 2,
+                        "message": "Spam crate published",
+                        "tags": ["env:test", "service:crates_io"]
+                    }
+                ]"#
+                .to_string(),
+            ))
+            .with_status(202)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let checks = [
+            service_check(
+                "crates_io.background_jobs.healthy",
+                ServiceCheckStatus::Ok,
+                "No stalled background jobs",
+            ),
+            service_check(
+                "crates_io.spam_attack.detected",
+                ServiceCheckStatus::Critical,
+                "Spam crate published",
+            ),
+        ];
+        let client = client_with_server(&server);
+        assert_ok!(client.submit_service_checks(&checks).await);
+    }
+
+    #[tokio::test]
+    async fn reports_rejected_service_check_submissions() {
+        let mut server = mock_server().await;
+        let _mock = server
+            .mock("POST", "/api/v1/check_run")
+            .with_status(403)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let check = service_check(
+            "crates_io.background_jobs.healthy",
+            ServiceCheckStatus::Critical,
+            "Stalled background jobs",
+        );
+        let client = client_with_server(&server);
+        let error = assert_err!(client.submit_service_checks(&[check]).await);
         assert_snapshot!(error, @"Datadog returned an error response");
 
         let http_error = assert_some!(error.downcast_ref::<reqwest::Error>());

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -1,13 +1,16 @@
-//! Checks for any invariants we expect to be true, and pages whoever is on call
-//! if they are not.
+//! Checks application invariants, pages whoever is on call when they fail, and
+//! optionally submits the results to Datadog as service checks.
 //!
 //! Usage:
 //!     cargo run --bin monitor
 
 use anyhow::Result;
+use crates_io::config::DatadogConfig;
+use crates_io::datadog::common_tags;
 use crates_io::worker::jobs;
 use crates_io::{db, schema::*};
 use crates_io_database::fns::canon_crate_name;
+use crates_io_datadog::{DatadogClient, ServiceCheck, ServiceCheckStatus};
 use crates_io_env_vars::{required_var, var, var_parsed};
 use crates_io_pagerduty as pagerduty;
 use crates_io_pagerduty::PagerdutyClient;
@@ -15,6 +18,7 @@ use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel::sql_types::Timestamptz;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use reqwest::Client;
 
 /// Identifies an invariant evaluated by the monitor.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -44,18 +48,46 @@ async fn main() -> Result<()> {
     let service_key = required_var("PAGERDUTY_INTEGRATION_KEY")?.into();
     let pagerduty = PagerdutyClient::new(service_key);
 
+    let datadog_service_checks_enabled = var_parsed("DD_SERVICE_CHECKS_ENABLED")?.unwrap_or(false);
+    let datadog_client = if datadog_service_checks_enabled {
+        let http_client = Client::builder()
+            .user_agent(crates_io_version::user_agent())
+            .build()?;
+        let client = DatadogConfig::from_env()?.client(http_client);
+
+        if client.is_none() {
+            eprintln!("Failed to configure Datadog service checks: `DD_API_KEY` is not configured");
+        }
+
+        client
+    } else {
+        None
+    };
+
     let conn = &mut db::oneoff_connection().await?;
 
-    let result = check_failing_background_jobs(conn).await?;
-    report_to_pagerduty(&pagerduty, &result).await?;
+    let results = [
+        check_failing_background_jobs(conn).await?,
+        check_stalled_update_downloads(conn).await?,
+        check_spam_attack(conn).await?,
+    ];
 
-    let result = check_stalled_update_downloads(conn).await?;
-    report_to_pagerduty(&pagerduty, &result).await?;
+    let datadog_reporting = async {
+        if let Some(datadog) = datadog_client {
+            let domain_name = dotenvy::var("DOMAIN_NAME").unwrap_or_else(|_| "crates.io".into());
+            let datadog_tags = common_tags(&domain_name);
+            if let Err(error) =
+                report_to_datadog(&datadog, &results, &domain_name, &datadog_tags).await
+            {
+                eprintln!("Failed to submit Datadog service checks: {error:#}");
+            }
+        }
+    };
 
-    let result = check_spam_attack(conn).await?;
-    report_to_pagerduty(&pagerduty, &result).await?;
+    let pagerduty_reporting = report_to_pagerduty(&pagerduty, &results);
+    let (_, pagerduty_result) = tokio::join!(datadog_reporting, pagerduty_reporting);
 
-    Ok(())
+    pagerduty_result
 }
 
 /// Checks for old background jobs that are not currently running.
@@ -201,15 +233,55 @@ fn pagerduty_event(result: &CheckResult) -> pagerduty::Event {
     }
 }
 
-/// Reports a monitor result to PagerDuty.
-async fn report_to_pagerduty(pagerduty: &PagerdutyClient, result: &CheckResult) -> Result<()> {
-    match result.status {
-        CheckStatus::Healthy => println!("{}", result.message),
-        CheckStatus::Unhealthy => println!("Paging on-call: {}", result.message),
+/// Converts a provider-independent result into a Datadog service check.
+fn datadog_service_check(result: &CheckResult, host_name: &str, tags: &[String]) -> ServiceCheck {
+    let check = match result.id {
+        CheckId::BackgroundJobs => "crates_io.background_jobs.healthy",
+        CheckId::UpdateDownloads => "crates_io.update_downloads.healthy",
+        CheckId::SpamAttack => "crates_io.spam_attack.detected",
+    };
+    let status = match result.status {
+        CheckStatus::Healthy => ServiceCheckStatus::Ok,
+        CheckStatus::Unhealthy => ServiceCheckStatus::Critical,
+    };
+
+    ServiceCheck::builder()
+        .check(check)
+        .host_name(host_name)
+        .status(status)
+        .message(result.message.clone())
+        .tags(tags.to_vec())
+        .build()
+}
+
+/// Reports monitor results to Datadog.
+async fn report_to_datadog(
+    datadog: &DatadogClient,
+    results: &[CheckResult],
+    host_name: &str,
+    tags: &[String],
+) -> Result<()> {
+    let checks = results
+        .iter()
+        .map(|result| datadog_service_check(result, host_name, tags))
+        .collect::<Vec<_>>();
+
+    datadog.submit_service_checks(&checks).await
+}
+
+/// Reports monitor results to PagerDuty.
+async fn report_to_pagerduty(pagerduty: &PagerdutyClient, results: &[CheckResult]) -> Result<()> {
+    for result in results {
+        match result.status {
+            CheckStatus::Healthy => println!("{}", result.message),
+            CheckStatus::Unhealthy => println!("Paging on-call: {}", result.message),
+        }
+
+        let event = pagerduty_event(result);
+        pagerduty.send(&event).await?;
     }
 
-    let event = pagerduty_event(result);
-    pagerduty.send(&event).await
+    Ok(())
 }
 
 #[cfg(test)]
@@ -217,9 +289,8 @@ mod tests {
     use super::*;
     use insta::assert_json_snapshot;
 
-    #[test]
-    fn maps_results_to_pagerduty_events() {
-        let results = [
+    fn check_results() -> [CheckResult; 6] {
+        [
             CheckResult {
                 id: CheckId::BackgroundJobs,
                 status: CheckStatus::Unhealthy,
@@ -250,7 +321,12 @@ mod tests {
                 status: CheckStatus::Healthy,
                 message: "no spam attack detected".into(),
             },
-        ];
+        ]
+    }
+
+    #[test]
+    fn maps_results_to_pagerduty_events() {
+        let results = check_results();
         let events: Vec<_> = results.iter().map(pagerduty_event).collect();
 
         assert_json_snapshot!(events, @r#"
@@ -284,6 +360,80 @@ mod tests {
             "event_type": "resolve",
             "incident_key": "spam_attack",
             "description": "no spam attack detected"
+          }
+        ]
+        "#);
+    }
+
+    #[test]
+    fn maps_results_to_datadog_service_checks() {
+        let tags = ["env:test".to_string(), "service:crates_io".to_string()];
+        let checks: Vec<_> = check_results()
+            .iter()
+            .map(|result| datadog_service_check(result, "crates.io", &tags))
+            .collect();
+
+        assert_json_snapshot!(checks, @r#"
+        [
+          {
+            "check": "crates_io.background_jobs.healthy",
+            "host_name": "crates.io",
+            "status": 2,
+            "message": "background jobs unhealthy",
+            "tags": [
+              "env:test",
+              "service:crates_io"
+            ]
+          },
+          {
+            "check": "crates_io.background_jobs.healthy",
+            "host_name": "crates.io",
+            "status": 0,
+            "message": "background jobs healthy",
+            "tags": [
+              "env:test",
+              "service:crates_io"
+            ]
+          },
+          {
+            "check": "crates_io.update_downloads.healthy",
+            "host_name": "crates.io",
+            "status": 2,
+            "message": "update downloads unhealthy",
+            "tags": [
+              "env:test",
+              "service:crates_io"
+            ]
+          },
+          {
+            "check": "crates_io.update_downloads.healthy",
+            "host_name": "crates.io",
+            "status": 0,
+            "message": "update downloads healthy",
+            "tags": [
+              "env:test",
+              "service:crates_io"
+            ]
+          },
+          {
+            "check": "crates_io.spam_attack.detected",
+            "host_name": "crates.io",
+            "status": 2,
+            "message": "spam attack detected",
+            "tags": [
+              "env:test",
+              "service:crates_io"
+            ]
+          },
+          {
+            "check": "crates_io.spam_attack.detected",
+            "host_name": "crates.io",
+            "status": 0,
+            "message": "no spam attack detected",
+            "tags": [
+              "env:test",
+              "service:crates_io"
+            ]
           }
         ]
         "#);

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -16,16 +16,45 @@ use diesel::prelude::*;
 use diesel::sql_types::Timestamptz;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
+/// Identifies an invariant evaluated by the monitor.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CheckId {
+    BackgroundJobs,
+    UpdateDownloads,
+    SpamAttack,
+}
+
+/// The outcome of evaluating a monitor invariant.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CheckStatus {
+    Healthy,
+    Unhealthy,
+}
+
+/// A provider-independent monitor result.
+#[derive(Debug, Eq, PartialEq)]
+struct CheckResult {
+    id: CheckId,
+    status: CheckStatus,
+    message: String,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let service_key = required_var("PAGERDUTY_INTEGRATION_KEY")?.into();
-    let client = PagerdutyClient::new(service_key);
+    let pagerduty = PagerdutyClient::new(service_key);
 
     let conn = &mut db::oneoff_connection().await?;
 
-    check_failing_background_jobs(conn, &client).await?;
-    check_stalled_update_downloads(conn, &client).await?;
-    check_spam_attack(conn, &client).await?;
+    let result = check_failing_background_jobs(conn).await?;
+    report_to_pagerduty(&pagerduty, &result).await?;
+
+    let result = check_stalled_update_downloads(conn).await?;
+    report_to_pagerduty(&pagerduty, &result).await?;
+
+    let result = check_spam_attack(conn).await?;
+    report_to_pagerduty(&pagerduty, &result).await?;
+
     Ok(())
 }
 
@@ -37,14 +66,9 @@ async fn main() -> Result<()> {
 ///
 /// Within the default 15 minute time, a job should have already had several
 /// failed retry attempts.
-async fn check_failing_background_jobs(
-    conn: &mut AsyncPgConnection,
-    pagerduty: &PagerdutyClient,
-) -> Result<()> {
+async fn check_failing_background_jobs(conn: &mut AsyncPgConnection) -> Result<CheckResult> {
     use diesel::dsl::*;
     use diesel::sql_types::Integer;
-
-    const EVENT_KEY: &str = "background_jobs";
 
     println!("Checking for failed background jobs");
 
@@ -64,33 +88,28 @@ async fn check_failing_background_jobs(
 
     let stalled_job_count = stalled_jobs.len();
 
-    let event = if stalled_job_count > 0 {
-        pagerduty::Event::Trigger {
-            incident_key: Some(EVENT_KEY.into()),
-            description: format!(
+    let result = if stalled_job_count > 0 {
+        CheckResult {
+            id: CheckId::BackgroundJobs,
+            status: CheckStatus::Unhealthy,
+            message: format!(
                 "{stalled_job_count} jobs have been in the queue for more than {max_job_time} minutes"
             ),
         }
     } else {
-        pagerduty::Event::Resolve {
-            incident_key: EVENT_KEY.into(),
-            description: Some("No stalled background jobs".into()),
+        CheckResult {
+            id: CheckId::BackgroundJobs,
+            status: CheckStatus::Healthy,
+            message: "No stalled background jobs".into(),
         }
     };
 
-    log_and_trigger_event(pagerduty, event).await?;
-
-    Ok(())
+    Ok(result)
 }
 
 /// Checks for an `update_downloads` job that has run longer than expected
-async fn check_stalled_update_downloads(
-    mut conn: &AsyncPgConnection,
-    pagerduty: &PagerdutyClient,
-) -> Result<()> {
+async fn check_stalled_update_downloads(conn: &mut AsyncPgConnection) -> Result<CheckResult> {
     use chrono::{DateTime, Utc};
-
-    const EVENT_KEY: &str = "update_downloads_stalled";
 
     println!("Checking for stalled background jobs");
 
@@ -100,41 +119,30 @@ async fn check_stalled_update_downloads(
     let start_time: Result<DateTime<Utc>, _> = background_jobs::table
         .filter(background_jobs::job_type.eq(jobs::UpdateDownloads::JOB_NAME))
         .select(background_jobs::created_at)
-        .first(&mut conn)
+        .first(conn)
         .await;
 
     if let Ok(start_time) = start_time {
         let minutes = Utc::now().signed_duration_since(start_time).num_minutes();
 
         if minutes > max_job_time {
-            return log_and_trigger_event(
-                pagerduty,
-                pagerduty::Event::Trigger {
-                    incident_key: Some(EVENT_KEY.into()),
-                    description: format!("update_downloads job running for {minutes} minutes"),
-                },
-            )
-            .await;
+            return Ok(CheckResult {
+                id: CheckId::UpdateDownloads,
+                status: CheckStatus::Unhealthy,
+                message: format!("update_downloads job running for {minutes} minutes"),
+            });
         }
     };
 
-    log_and_trigger_event(
-        pagerduty,
-        pagerduty::Event::Resolve {
-            incident_key: EVENT_KEY.into(),
-            description: Some("No stalled update_downloads job".into()),
-        },
-    )
-    .await
+    Ok(CheckResult {
+        id: CheckId::UpdateDownloads,
+        status: CheckStatus::Healthy,
+        message: "No stalled update_downloads job".into(),
+    })
 }
 
 /// Checks for known spam patterns
-async fn check_spam_attack(
-    mut conn: &AsyncPgConnection,
-    pagerduty: &PagerdutyClient,
-) -> Result<()> {
-    const EVENT_KEY: &str = "spam_attack";
-
+async fn check_spam_attack(conn: &mut AsyncPgConnection) -> Result<CheckResult> {
     println!("Checking for crates indicating someone is spamming us");
 
     let bad_crate_names = var("SPAM_CRATE_NAMES")?;
@@ -148,7 +156,7 @@ async fn check_spam_attack(
     let bad_crate: Option<String> = crates::table
         .filter(canon_crate_name(crates::name).eq_any(bad_crate_names))
         .select(crates::name)
-        .first(&mut conn)
+        .first(conn)
         .await
         .optional()?;
 
@@ -156,32 +164,128 @@ async fn check_spam_attack(
         event_description = Some(format!("Crate named {bad_crate} published"));
     }
 
-    let event = if let Some(event_description) = event_description {
-        pagerduty::Event::Trigger {
-            incident_key: Some(EVENT_KEY.into()),
-            description: format!("{event_description}, possible spam attack underway"),
+    let result = if let Some(event_description) = event_description {
+        CheckResult {
+            id: CheckId::SpamAttack,
+            status: CheckStatus::Unhealthy,
+            message: format!("{event_description}, possible spam attack underway"),
         }
     } else {
-        pagerduty::Event::Resolve {
-            incident_key: EVENT_KEY.into(),
-            description: Some("No spam crates detected".into()),
+        CheckResult {
+            id: CheckId::SpamAttack,
+            status: CheckStatus::Healthy,
+            message: "No spam crates detected".into(),
         }
     };
 
-    log_and_trigger_event(pagerduty, event).await?;
-    Ok(())
+    Ok(result)
 }
 
-async fn log_and_trigger_event(pagerduty: &PagerdutyClient, event: pagerduty::Event) -> Result<()> {
-    match event {
-        pagerduty::Event::Trigger {
-            ref description, ..
-        } => println!("Paging on-call: {description}"),
-        pagerduty::Event::Resolve {
-            description: Some(ref description),
-            ..
-        } => println!("{description}"),
-        _ => {} // noop
+/// Converts a provider-independent result into a PagerDuty event.
+fn pagerduty_event(result: &CheckResult) -> pagerduty::Event {
+    let incident_key = match result.id {
+        CheckId::BackgroundJobs => "background_jobs",
+        CheckId::UpdateDownloads => "update_downloads_stalled",
+        CheckId::SpamAttack => "spam_attack",
+    };
+
+    match result.status {
+        CheckStatus::Healthy => pagerduty::Event::Resolve {
+            incident_key: incident_key.into(),
+            description: Some(result.message.clone()),
+        },
+        CheckStatus::Unhealthy => pagerduty::Event::Trigger {
+            incident_key: Some(incident_key.into()),
+            description: result.message.clone(),
+        },
     }
+}
+
+/// Reports a monitor result to PagerDuty.
+async fn report_to_pagerduty(pagerduty: &PagerdutyClient, result: &CheckResult) -> Result<()> {
+    match result.status {
+        CheckStatus::Healthy => println!("{}", result.message),
+        CheckStatus::Unhealthy => println!("Paging on-call: {}", result.message),
+    }
+
+    let event = pagerduty_event(result);
     pagerduty.send(&event).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_json_snapshot;
+
+    #[test]
+    fn maps_results_to_pagerduty_events() {
+        let results = [
+            CheckResult {
+                id: CheckId::BackgroundJobs,
+                status: CheckStatus::Unhealthy,
+                message: "background jobs unhealthy".into(),
+            },
+            CheckResult {
+                id: CheckId::BackgroundJobs,
+                status: CheckStatus::Healthy,
+                message: "background jobs healthy".into(),
+            },
+            CheckResult {
+                id: CheckId::UpdateDownloads,
+                status: CheckStatus::Unhealthy,
+                message: "update downloads unhealthy".into(),
+            },
+            CheckResult {
+                id: CheckId::UpdateDownloads,
+                status: CheckStatus::Healthy,
+                message: "update downloads healthy".into(),
+            },
+            CheckResult {
+                id: CheckId::SpamAttack,
+                status: CheckStatus::Unhealthy,
+                message: "spam attack detected".into(),
+            },
+            CheckResult {
+                id: CheckId::SpamAttack,
+                status: CheckStatus::Healthy,
+                message: "no spam attack detected".into(),
+            },
+        ];
+        let events: Vec<_> = results.iter().map(pagerduty_event).collect();
+
+        assert_json_snapshot!(events, @r#"
+        [
+          {
+            "event_type": "trigger",
+            "incident_key": "background_jobs",
+            "description": "background jobs unhealthy"
+          },
+          {
+            "event_type": "resolve",
+            "incident_key": "background_jobs",
+            "description": "background jobs healthy"
+          },
+          {
+            "event_type": "trigger",
+            "incident_key": "update_downloads_stalled",
+            "description": "update downloads unhealthy"
+          },
+          {
+            "event_type": "resolve",
+            "incident_key": "update_downloads_stalled",
+            "description": "update downloads healthy"
+          },
+          {
+            "event_type": "trigger",
+            "incident_key": "spam_attack",
+            "description": "spam attack detected"
+          },
+          {
+            "event_type": "resolve",
+            "incident_key": "spam_attack",
+            "description": "no spam attack detected"
+          }
+        ]
+        "#);
+    }
 }

--- a/src/config/datadog.rs
+++ b/src/config/datadog.rs
@@ -6,13 +6,13 @@ use secrecy::SecretString;
 const DEFAULT_SITE: &str = "datadoghq.com";
 
 pub struct DatadogConfig {
-    /// Datadog API key used to submit service metrics. If missing, the
-    /// background worker does not push metrics to Datadog.
+    /// Datadog API key used to submit data. If missing, Datadog submissions
+    /// are disabled.
     ///
     /// Read from the `DD_API_KEY` environment variable.
     pub api_key: Option<SecretString>,
 
-    /// Datadog site to submit metrics to. Defaults to `datadoghq.com`.
+    /// Datadog site to submit data to. Defaults to `datadoghq.com`.
     ///
     /// Read from the `DD_SITE` environment variable.
     pub site: String,

--- a/src/datadog.rs
+++ b/src/datadog.rs
@@ -1,0 +1,33 @@
+/// Builds the tags shared by Datadog submissions from this application.
+pub fn common_tags(domain_name: &str) -> Vec<String> {
+    let environment = match domain_name {
+        "staging.crates.io" => "staging",
+        _ => "prod",
+    };
+
+    vec![format!("env:{environment}"), "service:crates_io".into()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_common_tags() {
+        let staging = common_tags("staging.crates.io");
+        insta::assert_json_snapshot!(staging, @r#"
+        [
+          "env:staging",
+          "service:crates_io"
+        ]
+        "#);
+
+        let production = common_tags("crates.io");
+        insta::assert_json_snapshot!(production, @r#"
+        [
+          "env:prod",
+          "service:crates_io"
+        ]
+        "#);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod certs;
 pub mod cloudfront;
 pub mod config;
 pub mod controllers;
+pub mod datadog;
 pub mod db;
 pub mod email;
 pub mod headers;

--- a/src/metrics/datadog.rs
+++ b/src/metrics/datadog.rs
@@ -8,6 +8,7 @@
 //! [api]: https://docs.datadoghq.com/api/latest/metrics/
 
 use crate::config::Server;
+use crate::datadog::common_tags;
 use crate::metrics::ServiceMetrics;
 use anyhow::{Context, anyhow};
 use crates_io_datadog::{DatadogClient, MetricType as DatadogMetricType, Point, Resource, Series};
@@ -33,17 +34,12 @@ pub fn spawn(config: &Server, deadpool: Pool<AsyncPgConnection>, datadog: Option
         return;
     };
 
-    let domain = config.domain_name.clone();
-    let env = match domain.as_str() {
-        "staging.crates.io" => "staging",
-        _ => "prod",
-    };
-    let resources = vec![Resource::builder().kind("host").name(domain).build()];
-
-    let mut common_tags = vec![format!("env:{env}"), "service:crates_io".into()];
+    let domain_name = config.domain_name.clone();
+    let mut common_tags = common_tags(&domain_name);
     if let Ok(Some(commit)) = crates_io_version::commit() {
         common_tags.push(format!("version:{commit}"));
     }
+    let resources = vec![Resource::builder().kind("host").name(domain_name).build()];
 
     let service_metrics = match ServiceMetrics::new() {
         Ok(metrics) => metrics,


### PR DESCRIPTION
This adds typed, batched service-check submissions to `crates_io_datadog`, with HTTP test coverage for authentication, endpoint selection, serialization, accepted responses, and rejected responses.

The `monitor` binary now evaluates its invariants into provider-independent results, preserving the existing PagerDuty incident keys while translating the same results into Datadog service checks.

Datadog reporting is disabled by default behind the temporary `DD_SERVICE_CHECKS_ENABLED` rollout flag. Service checks use stable `env` and `service` tags so healthy results resolve the same check context across deployments. The `version` tag is specifically not included for this reason.