### PR TITLE
Footer: Use color tokens directly

### DIFF
--- a/svelte/src/lib/components/Footer.svelte
+++ b/svelte/src/lib/components/Footer.svelte
@@ -64,19 +64,10 @@
 </footer>
 
 <style>
-  :root {
-    --footer-bg-color: var(--header-bg-color);
-    --footer-header-color: var(--yellow500);
-    --footer-header-shadow-color: var(--green900);
-    --footer-link-color: #fff;
-    --footer-link-hover-color: var(--yellow500);
-    --footer-link-hover-shadow-color: var(--green900);
-  }
-
   .footer {
     display: grid;
     justify-items: center;
-    background: var(--footer-bg-color);
+    background: var(--header-bg-color);
   }
 
   .content {
@@ -98,8 +89,8 @@
       margin: 0 0 var(--space-s);
       font-size: 20px;
       font-weight: 500;
-      color: var(--footer-header-color);
-      text-shadow: 1px 1px 1px var(--footer-header-shadow-color);
+      color: var(--yellow500);
+      text-shadow: 1px 1px 1px var(--green900);
     }
 
     & ul {
@@ -128,13 +119,13 @@
       transition: var(--transition-medium);
 
       &:hover {
-        color: var(--footer-link-hover-color);
-        text-shadow: 1px 1px 1px var(--footer-link-hover-shadow-color);
+        color: var(--yellow500);
+        text-shadow: 1px 1px 1px var(--green900);
         /* apply color fade only on mouse-out */
         transition: var(--transition-instant);
 
         & :global(.icon) {
-          filter: drop-shadow(1px 1px 1px var(--footer-link-hover-shadow-color));
+          filter: drop-shadow(1px 1px 1px var(--green900));
         }
       }
     }


### PR DESCRIPTION
The footer variables only alias existing global color tokens, are read exclusively within `Footer.svelte`, and have no external overrides. Defining them on `:root` publishes component-specific state globally without providing a useful customization API.

This replaces those aliases with the underlying tokens and removes the unused `--footer-link-color` declaration. The rendered light and dark colors remain unchanged.