### PR TITLE
session: Return `{"ok":true}` from `DELETE /api/private/session`

### DIFF
--- a/packages/crates-io-api-client/schema.d.ts
+++ b/packages/crates-io-api-client/schema.d.ts
@@ -1921,7 +1921,12 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        ok: boolean;
+                    };
+                };
             };
         };
     };

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -1,4 +1,5 @@
 use crate::app::AppState;
+use crate::controllers::helpers::OkResponse;
 use crate::email::EmailMessage;
 use crate::email::Emails;
 use crate::middleware::log_request::RequestLogExt;
@@ -308,11 +309,11 @@ async fn find_user_by_gh_id(mut conn: &AsyncPgConnection, gh_id: i32) -> QueryRe
     security(("cookie" = [])),
     tag = "session",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response")),
+    responses((status = 200, description = "Successful Response", body = inline(OkResponse))),
 )]
-pub async fn end_session(session: SessionExtension) -> Json<bool> {
+pub async fn end_session(session: SessionExtension) -> OkResponse {
     session.remove("user_id");
-    Json(true)
+    OkResponse::new()
 }
 
 #[cfg(test)]

--- a/src/tests/routes/session/end.rs
+++ b/src/tests/routes/session/end.rs
@@ -1,0 +1,12 @@
+use crate::util::{RequestHelper, TestApp};
+use insta::assert_snapshot;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn returns_ok_response() {
+    let (_, _, user) = TestApp::init().with_user().await;
+
+    let response = user.delete::<()>("/api/private/session").await;
+
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_snapshot!(response.text(), @r#"{"ok":true}"#);
+}

--- a/src/tests/routes/session/mod.rs
+++ b/src/tests/routes/session/mod.rs
@@ -1,2 +1,3 @@
 mod authorize;
 mod begin;
+mod end;

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1538,6 +1538,22 @@ expression: response.json()
         "operationId": "end_session",
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "example": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
             "description": "Successful Response"
           }
         },


### PR DESCRIPTION
The logout endpoint has returned a bare `true` JSON value since it was introduced in 2014. Mutation endpoints later standardized on `{"ok":true}`, but logout kept its original response while the MSW handler adopted the object shape.

This changes the backend and OpenAPI contract to match the established response shape and existing mock. Since this is a private endpoint that is only used by our frontend (which ignores the response body anyway), I don't think this should be considered a breaking change.