### PR TITLE
CI: Serialize Cargo tool installation in `mise`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.7.7
-          install_args: cargo:cargo-deny cargo:cargo-machete
+          install_args: --jobs=1 cargo:cargo-deny cargo:cargo-machete
 
       - run: cargo deny check
       - run: cargo machete


### PR DESCRIPTION
This prevents parallel Cargo invocations from racing while rustup installs the pinned Rust toolchain.