### PR TITLE
controllers: Qualify request and response type names

### DIFF
--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -2055,6 +2055,7 @@ export interface operations {
                     "application/json": {
                         /** @description The list of categories. */
                         categories: components["schemas"]["Category"][];
+                        /** @description Pagination metadata for a category list response. */
                         meta: {
                             /**
                              * Format: int64

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -3906,6 +3906,7 @@ export interface operations {
                 content: {
                     "application/json": {
                         gitlab_configs: components["schemas"]["GitLabConfig"][];
+                        /** @description Pagination metadata for a GitLab configuration list response. */
                         meta: {
                             /**
                              * @description Query string to the next page of results, if any.

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -2242,6 +2242,7 @@ export interface operations {
                 content: {
                     "application/json": {
                         crates: components["schemas"]["Crate"][];
+                        /** @description Pagination metadata for a crate list response. */
                         meta: {
                             /**
                              * @description Query string to the next page of results, if any.

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -3786,6 +3786,7 @@ export interface operations {
                 content: {
                     "application/json": {
                         github_configs: components["schemas"]["GitHubConfig"][];
+                        /** @description Pagination metadata for a GitHub configuration list response. */
                         meta: {
                             /**
                              * @description Query string to the next page of results, if any.

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -3256,6 +3256,7 @@ export interface operations {
                     "application/json": {
                         /** @description The list of keywords. */
                         keywords: components["schemas"]["Keyword"][];
+                        /** @description Pagination metadata for a keyword list response. */
                         meta: {
                             /**
                              * Format: int64

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -77,8 +77,9 @@ pub async fn list_categories(
     Ok(Json(CategoryListResponse { categories, meta }))
 }
 
+/// Response returned when getting category metadata.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct GetResponse {
+pub struct CategoryGetResponse {
     pub category: EncodableCategory,
 }
 
@@ -90,12 +91,12 @@ pub struct GetResponse {
         ("category" = String, Path, description = "Name of the category"),
     ),
     tag = "categories",
-    responses((status = 200, description = "Successful Response", body = inline(GetResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(CategoryGetResponse))),
 )]
 pub async fn find_category(
     state: AppState,
     Path(slug): Path<String>,
-) -> AppResult<Json<GetResponse>> {
+) -> AppResult<Json<CategoryGetResponse>> {
     // Category slugs can never contain null bytes, so we reject such requests
     // early with a regular "not found" response instead of letting them reach
     // the database layer, where PostgreSQL rejects the query with a confusing
@@ -120,7 +121,7 @@ pub async fn find_category(
     category.subcategories = Some(subcats);
     category.parent_categories = Some(parents);
 
-    Ok(Json(GetResponse { category }))
+    Ok(Json(CategoryGetResponse { category }))
 }
 
 #[derive(Debug, Serialize, Queryable, utoipa::ToSchema)]

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -11,10 +11,11 @@ use diesel_async::RunQueryDsl;
 use http::request::Parts;
 use serde::{Deserialize, Serialize};
 
+/// Query parameters for listing categories.
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
 #[from_request(via(Query))]
 #[into_params(parameter_in = Query)]
-pub struct ListQueryParams {
+pub struct CategoryListQueryParams {
     /// The sort order of the categories.
     ///
     /// Valid values: `alpha`, and `crates`.
@@ -23,17 +24,19 @@ pub struct ListQueryParams {
     sort: Option<String>,
 }
 
+/// Response returned when listing categories.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListResponse {
+pub struct CategoryListResponse {
     /// The list of categories.
     pub categories: Vec<EncodableCategory>,
 
     #[schema(inline)]
-    pub meta: ListMeta,
+    pub meta: CategoryListMeta,
 }
 
+/// Pagination metadata for a category list response.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListMeta {
+pub struct CategoryListMeta {
     /// The total number of categories.
     #[schema(example = 123)]
     pub total: i64,
@@ -43,15 +46,15 @@ pub struct ListMeta {
 #[utoipa::path(
     get,
     path = "/api/v1/categories",
-    params(ListQueryParams, PaginationQueryParams),
+    params(CategoryListQueryParams, PaginationQueryParams),
     tag = "categories",
-    responses((status = 200, description = "Successful Response", body = inline(ListResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(CategoryListResponse))),
 )]
 pub async fn list_categories(
     app: AppState,
-    params: ListQueryParams,
+    params: CategoryListQueryParams,
     req: Parts,
-) -> AppResult<Json<ListResponse>> {
+) -> AppResult<Json<CategoryListResponse>> {
     // FIXME: There are 69 categories, 47 top level. This isn't going to
     // grow by an OoM. We need a limit for /summary, but we don't need
     // to paginate this.
@@ -70,8 +73,8 @@ pub async fn list_categories(
 
     let categories = categories.into_iter().map(Category::into).collect();
 
-    let meta = ListMeta { total };
-    Ok(Json(ListResponse { categories, meta }))
+    let meta = CategoryListMeta { total };
+    Ok(Json(CategoryListResponse { categories, meta }))
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -89,10 +89,11 @@ pub async fn list_crate_owner_invitations_for_user(
     ))
 }
 
+/// Query parameters for listing crate owner invitations.
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
 #[from_request(via(Query))]
 #[into_params(parameter_in = Query)]
-pub struct ListQueryParams {
+pub struct CrateOwnerInvitationListQueryParams {
     /// Filter crate owner invitations by crate name.
     ///
     /// Only crate owners can query pending invitations for their crate.
@@ -108,7 +109,7 @@ pub struct ListQueryParams {
 #[utoipa::path(
     get,
     path = "/api/private/crate_owner_invitations",
-    params(ListQueryParams, PaginationQueryParams),
+    params(CrateOwnerInvitationListQueryParams, PaginationQueryParams),
     security(("cookie" = [])),
     tag = "owners",
     extensions(("x-internal" = json!(true))),
@@ -116,7 +117,7 @@ pub struct ListQueryParams {
 )]
 pub async fn list_crate_owner_invitations(
     app: AppState,
-    params: ListQueryParams,
+    params: CrateOwnerInvitationListQueryParams,
     req: Parts,
 ) -> AppResult<(TypedHeader<CacheControl>, Json<PrivateListResponse>)> {
     let mut conn = app.db_read().await?;
@@ -132,10 +133,10 @@ enum ListFilter {
     InviteeId(i32),
 }
 
-impl TryFrom<ListQueryParams> for ListFilter {
+impl TryFrom<CrateOwnerInvitationListQueryParams> for ListFilter {
     type Error = BoxedAppError;
 
-    fn try_from(params: ListQueryParams) -> Result<Self, Self::Error> {
+    fn try_from(params: CrateOwnerInvitationListQueryParams) -> Result<Self, Self::Error> {
         let filter = if let Some(crate_name) = params.crate_name {
             ListFilter::CrateName(crate_name.clone())
         } else if let Some(id) = params.invitee_id {

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -74,8 +74,9 @@ pub async fn list_keywords(
     Ok(Json(KeywordListResponse { keywords, meta }))
 }
 
+/// Response returned when getting keyword metadata.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct GetResponse {
+pub struct KeywordGetResponse {
     pub keyword: EncodableKeyword,
 }
 
@@ -87,12 +88,12 @@ pub struct GetResponse {
         ("keyword" = String, Path, description = "The keyword to find"),
     ),
     tag = "keywords",
-    responses((status = 200, description = "Successful Response", body = inline(GetResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(KeywordGetResponse))),
 )]
 pub async fn find_keyword(
     Path(name): Path<String>,
     state: AppState,
-) -> AppResult<Json<GetResponse>> {
+) -> AppResult<Json<KeywordGetResponse>> {
     // If the name is not a valid keyword it cannot exist in the database, so we
     // skip the lookup and return a regular "not found" response. This also
     // avoids passing invalid input (e.g. names containing null bytes) to the
@@ -106,5 +107,5 @@ pub async fn find_keyword(
     let conn = state.db_read().await?;
     let kw = Keyword::find_by_keyword(&conn, &name).await?;
     let keyword = EncodableKeyword::from(kw);
-    Ok(Json(GetResponse { keyword }))
+    Ok(Json(KeywordGetResponse { keyword }))
 }

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -10,10 +10,11 @@ use diesel::prelude::*;
 use http::request::Parts;
 use serde::{Deserialize, Serialize};
 
+/// Query parameters for listing keywords.
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
 #[from_request(via(Query))]
 #[into_params(parameter_in = Query)]
-pub struct ListQueryParams {
+pub struct KeywordListQueryParams {
     /// The sort order of the keywords.
     ///
     /// Valid values: `alpha`, and `crates`.
@@ -22,17 +23,19 @@ pub struct ListQueryParams {
     sort: Option<String>,
 }
 
+/// Response returned when listing keywords.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListResponse {
+pub struct KeywordListResponse {
     /// The list of keywords.
     pub keywords: Vec<EncodableKeyword>,
 
     #[schema(inline)]
-    pub meta: ListMeta,
+    pub meta: KeywordListMeta,
 }
 
+/// Pagination metadata for a keyword list response.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListMeta {
+pub struct KeywordListMeta {
     /// The total number of keywords.
     #[schema(example = 123)]
     pub total: i64,
@@ -42,15 +45,15 @@ pub struct ListMeta {
 #[utoipa::path(
     get,
     path = "/api/v1/keywords",
-    params(ListQueryParams, PaginationQueryParams),
+    params(KeywordListQueryParams, PaginationQueryParams),
     tag = "keywords",
-    responses((status = 200, description = "Successful Response", body = inline(ListResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(KeywordListResponse))),
 )]
 pub async fn list_keywords(
     state: AppState,
-    params: ListQueryParams,
+    params: KeywordListQueryParams,
     req: Parts,
-) -> AppResult<Json<ListResponse>> {
+) -> AppResult<Json<KeywordListResponse>> {
     use crate::schema::keywords;
 
     let mut query = Keyword::query().into_boxed();
@@ -67,8 +70,8 @@ pub async fn list_keywords(
     let total = data.total();
     let keywords = data.into_iter().map(Keyword::into).collect();
 
-    let meta = ListMeta { total };
-    Ok(Json(ListResponse { keywords, meta }))
+    let meta = KeywordListMeta { total };
+    Ok(Json(KeywordListResponse { keywords, meta }))
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -39,8 +39,9 @@ pub struct FindQueryParams {
     include: Option<String>,
 }
 
+/// Response returned when getting crate metadata.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct GetResponse {
+pub struct CrateGetResponse {
     /// The crate metadata.
     #[serde(rename = "crate")]
     krate: EncodableCrate,
@@ -66,12 +67,12 @@ pub struct GetResponse {
     get,
     path = "/api/v1/crates/new",
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(GetResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(CrateGetResponse))),
 )]
 pub async fn find_new_crate(
     app: AppState,
     params: FindQueryParams,
-) -> AppResult<Json<GetResponse>> {
+) -> AppResult<Json<CrateGetResponse>> {
     let name = "new".to_string();
     find_crate(app, CratePath { name }, params).await
 }
@@ -82,13 +83,13 @@ pub async fn find_new_crate(
     path = "/api/v1/crates/{name}",
     params(CratePath, FindQueryParams),
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(GetResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(CrateGetResponse))),
 )]
 pub async fn find_crate(
     app: AppState,
     path: CratePath,
     params: FindQueryParams,
-) -> AppResult<Json<GetResponse>> {
+) -> AppResult<Json<CrateGetResponse>> {
     let mut conn = app.db_read().await?;
 
     let include = params
@@ -206,7 +207,7 @@ pub async fn find_crate(
             .collect::<Vec<EncodableCategory>>()
     });
 
-    Ok(Json(GetResponse {
+    Ok(Json(CrateGetResponse {
         krate: encodable_crate,
         versions: encodable_versions,
         keywords: encodable_keywords,

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -36,16 +36,18 @@ use crates_io_database::fns::{array_agg, canon_crate_name, lower};
 /// query (see [`FilterParams::relevance_candidate_ids`]).
 const RELEVANCE_CANDIDATE_LIMIT: i64 = 1000;
 
+/// Response returned when listing crates.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListResponse {
+pub struct CrateListResponse {
     crates: Vec<EncodableCrate>,
 
     #[schema(inline)]
-    meta: ListMeta,
+    meta: CrateListMeta,
 }
 
+/// Pagination metadata for a crate list response.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListMeta {
+pub struct CrateListMeta {
     /// The total number of crates that match the query.
     #[schema(example = 123)]
     total: i64,
@@ -71,20 +73,20 @@ pub struct ListMeta {
 #[utoipa::path(
     get,
     path = "/api/v1/crates",
-    params(ListQueryParams, PaginationQueryParams),
+    params(CrateListQueryParams, PaginationQueryParams),
     security(
         (),
         ("api_token" = []),
         ("cookie" = []),
     ),
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(ListResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(CrateListResponse))),
 )]
 pub async fn list_crates(
     app: AppState,
-    params: ListQueryParams,
+    params: CrateListQueryParams,
     req: Parts,
-) -> AppResult<(Option<TypedHeader<CacheControl>>, Json<ListResponse>)> {
+) -> AppResult<(Option<TypedHeader<CacheControl>>, Json<CrateListResponse>)> {
     // Notes:
     // The different use cases this function covers is handled through passing
     // in parameters in the GET request.
@@ -307,9 +309,9 @@ pub async fn list_crates(
 
     Ok((
         cache_control,
-        Json(ListResponse {
+        Json(CrateListResponse {
             crates,
-            meta: ListMeta {
+            meta: CrateListMeta {
                 total,
                 next_page,
                 prev_page,
@@ -318,10 +320,11 @@ pub async fn list_crates(
     ))
 }
 
+/// Query parameters for listing and filtering crates.
 #[derive(Debug, Deserialize, FromRequestParts, IntoParams)]
 #[from_request(via(Query))]
 #[into_params(parameter_in = Query)]
-pub struct ListQueryParams {
+pub struct CrateListQueryParams {
     /// The sort order of the crates.
     ///
     /// Valid values: `alphabetical`, `relevance`, `downloads`,
@@ -384,7 +387,7 @@ pub struct ListQueryParams {
     ids: Vec<StringExclNull>,
 }
 
-impl ListQueryParams {
+impl CrateListQueryParams {
     pub fn include_yanked(&self) -> bool {
         let include_yanked = self.include_yanked.as_ref();
         include_yanked.map(|s| s == "yes").unwrap_or(true)
@@ -394,14 +397,14 @@ impl ListQueryParams {
 #[derive(Deref)]
 struct FilterParams {
     #[deref]
-    search_params: ListQueryParams,
+    search_params: CrateListQueryParams,
     letter: Option<char>,
     auth_user_id: Option<i32>,
 }
 
 impl FilterParams {
     async fn from(
-        search_params: ListQueryParams,
+        search_params: CrateListQueryParams,
         parts: &Parts,
         conn: &mut AsyncPgConnection,
     ) -> AppResult<Self> {

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -25,10 +25,11 @@ use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+/// Query parameters for listing versions of a crate.
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
 #[from_request(via(Query))]
 #[into_params(parameter_in = Query)]
-pub struct ListQueryParams {
+pub struct VersionListQueryParams {
     /// Additional data to include in the response.
     ///
     /// Valid values: `release_tracks`.
@@ -51,7 +52,7 @@ pub struct ListQueryParams {
     nums: Vec<StringExclNull>,
 }
 
-impl ListQueryParams {
+impl VersionListQueryParams {
     fn include(&self) -> AppResult<ShowIncludeMode> {
         let include = self
             .include
@@ -63,8 +64,9 @@ impl ListQueryParams {
     }
 }
 
+/// Response returned when listing versions of a crate.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListResponse {
+pub struct VersionListResponse {
     versions: Vec<EncodableVersion>,
 
     #[schema(inline)]
@@ -75,17 +77,17 @@ pub struct ListResponse {
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/versions",
-    params(CratePath, ListQueryParams, PaginationQueryParams),
+    params(CratePath, VersionListQueryParams, PaginationQueryParams),
     tag = "versions",
-    responses((status = 200, description = "Successful Response", body = inline(ListResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(VersionListResponse))),
 )]
 pub async fn list_versions(
     state: AppState,
     path: CratePath,
-    params: ListQueryParams,
+    params: VersionListQueryParams,
     pagination: PaginationQueryParams,
     req: Parts,
-) -> AppResult<Json<ListResponse>> {
+) -> AppResult<Json<VersionListResponse>> {
     let conn = state.db_read().await?;
 
     let crate_id = path.load_crate_id(&conn).await?;
@@ -116,7 +118,7 @@ pub async fn list_versions(
         .map(|((v, pb), aas)| EncodableVersion::from(v, &path.name, pb, aas))
         .collect::<Vec<_>>();
 
-    Ok(Json(ListResponse {
+    Ok(Json(VersionListResponse {
         versions,
         meta: versions_and_publishers.meta,
     }))
@@ -130,7 +132,7 @@ pub async fn list_versions(
 async fn list(
     crate_id: i32,
     options: Option<&PaginationOptions>,
-    params: &ListQueryParams,
+    params: &VersionListQueryParams,
     req: &Parts,
     mut conn: &AsyncPgConnection,
 ) -> AppResult<PaginatedVersionsAndPublishers> {

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -8,8 +8,9 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use serde::Serialize;
 
+/// Response returned when getting a team by login.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct GetResponse {
+pub struct TeamGetResponse {
     team: EncodableTeam,
 }
 
@@ -21,9 +22,12 @@ pub struct GetResponse {
         ("team" = String, Path, description = "Name of the team", example = "github:rust-lang:crates-io"),
     ),
     tag = "teams",
-    responses((status = 200, description = "Successful Response", body = inline(GetResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(TeamGetResponse))),
 )]
-pub async fn find_team(state: AppState, Path(name): Path<String>) -> AppResult<Json<GetResponse>> {
+pub async fn find_team(
+    state: AppState,
+    Path(name): Path<String>,
+) -> AppResult<Json<TeamGetResponse>> {
     use crate::schema::teams::dsl::login;
 
     let mut conn = state.db_read().await?;
@@ -32,5 +36,5 @@ pub async fn find_team(state: AppState, Path(name): Path<String>) -> AppResult<J
         .first(&mut conn)
         .await?;
     let team = EncodableTeam::from(team);
-    Ok(Json(GetResponse { team }))
+    Ok(Json(TeamGetResponse { team }))
 }

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -50,8 +50,9 @@ impl GetParams {
     }
 }
 
+/// Response returned when listing API tokens for the authenticated user.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListResponse {
+pub struct ApiTokenListResponse {
     pub api_tokens: Vec<ApiToken>,
 }
 
@@ -63,7 +64,7 @@ pub struct ListResponse {
     security(("cookie" = [])),
     tag = "api_tokens",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(ListResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(ApiTokenListResponse))),
 )]
 pub async fn list_api_tokens(
     app: AppState,

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -232,8 +232,9 @@ pub async fn create_api_token(
     Ok(Json(CreateResponse { api_token }))
 }
 
+/// Response returned when getting an API token by ID.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct GetResponse {
+pub struct ApiTokenGetResponse {
     pub api_token: ApiToken,
 }
 
@@ -249,13 +250,13 @@ pub struct GetResponse {
         ("cookie" = []),
     ),
     tag = "api_tokens",
-    responses((status = 200, description = "Successful Response", body = inline(GetResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(ApiTokenGetResponse))),
 )]
 pub async fn find_api_token(
     app: AppState,
     Path(id): Path<i32>,
     req: Parts,
-) -> AppResult<(TypedHeader<CacheControl>, Json<GetResponse>)> {
+) -> AppResult<(TypedHeader<CacheControl>, Json<ApiTokenGetResponse>)> {
     let mut conn = app.db_write().await?;
     let auth = AuthCheck::default().check(&req, &mut conn).await?;
     let user = auth.user();
@@ -265,7 +266,7 @@ pub async fn find_api_token(
         .first(&mut conn)
         .await?;
 
-    Ok((no_store(), Json(GetResponse { api_token })))
+    Ok((no_store(), Json(ApiTokenGetResponse { api_token })))
 }
 
 /// Revoke API token.

--- a/src/controllers/trustpub/github_configs/json.rs
+++ b/src/controllers/trustpub/github_configs/json.rs
@@ -16,16 +16,18 @@ pub struct CreateResponse {
     pub github_config: GitHubConfig,
 }
 
+/// Response returned when listing GitHub trusted publishing configurations.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListResponse {
+pub struct GitHubConfigListResponse {
     pub github_configs: Vec<GitHubConfig>,
 
     #[schema(inline)]
-    pub meta: ListResponseMeta,
+    pub meta: GitHubConfigListMeta,
 }
 
+/// Pagination metadata for a GitHub configuration list response.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListResponseMeta {
+pub struct GitHubConfigListMeta {
     /// The total number of GitHub configs belonging to the crate.
     #[schema(example = 42)]
     pub total: i64,

--- a/src/controllers/trustpub/github_configs/list.rs
+++ b/src/controllers/trustpub/github_configs/list.rs
@@ -4,7 +4,9 @@ use crate::controllers::helpers::pagination::{
     Page, PaginationOptions, PaginationQueryParams, encode_seek,
 };
 use crate::controllers::krate::load_crate;
-use crate::controllers::trustpub::github_configs::json::{self, ListResponse, ListResponseMeta};
+use crate::controllers::trustpub::github_configs::json::{
+    self, GitHubConfigListMeta, GitHubConfigListResponse,
+};
 use crate::util::RequestUtils;
 use crate::util::errors::{AppResult, bad_request, forbidden};
 use crate::util::no_store;
@@ -23,10 +25,11 @@ use http::request::Parts;
 use indexmap::IndexMap;
 use serde::Deserialize;
 
+/// Query parameters for listing GitHub trusted publishing configurations.
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
 #[from_request(via(Query))]
 #[into_params(parameter_in = Query)]
-pub struct ListQueryParams {
+pub struct GitHubConfigListQueryParams {
     /// Name of the crate to list Trusted Publishing configurations for.
     #[serde(rename = "crate")]
     pub krate: Option<String>,
@@ -39,16 +42,16 @@ pub struct ListQueryParams {
 #[utoipa::path(
     get,
     path = "/api/v1/trusted_publishing/github_configs",
-    params(ListQueryParams, PaginationQueryParams),
+    params(GitHubConfigListQueryParams, PaginationQueryParams),
     security(("cookie" = []), ("api_token" = [])),
     tag = "trusted_publishing",
-    responses((status = 200, description = "Successful Response", body = inline(ListResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(GitHubConfigListResponse))),
 )]
 pub async fn list_trustpub_github_configs(
     state: AppState,
-    params: ListQueryParams,
+    params: GitHubConfigListQueryParams,
     parts: Parts,
-) -> AppResult<(TypedHeader<CacheControl>, Json<ListResponse>)> {
+) -> AppResult<(TypedHeader<CacheControl>, Json<GitHubConfigListResponse>)> {
     let configs = match (&params.krate, params.user_id) {
         (Some(krate), None) => list_by_crate(state, krate, parts).await,
         (None, Some(user_id)) => list_by_user(state, user_id, parts).await,
@@ -67,7 +70,7 @@ async fn list_by_crate(
     state: AppState,
     krate_name: &str,
     parts: Parts,
-) -> AppResult<Json<ListResponse>> {
+) -> AppResult<Json<GitHubConfigListResponse>> {
     let mut conn = state.db_read().await?;
 
     let auth = AuthCheck::default()
@@ -101,7 +104,7 @@ async fn list_by_user(
     state: AppState,
     user_id: i32,
     parts: Parts,
-) -> AppResult<Json<ListResponse>> {
+) -> AppResult<Json<GitHubConfigListResponse>> {
     let mut conn = state.db_read().await?;
 
     let auth = AuthCheck::default()
@@ -151,7 +154,7 @@ async fn paginated_response(
     conn: &mut diesel_async::AsyncPgConnection,
     crate_ids: &[i32],
     parts: &Parts,
-) -> AppResult<Json<ListResponse>> {
+) -> AppResult<Json<GitHubConfigListResponse>> {
     let pagination = PaginationOptions::builder()
         .enable_seek(true)
         .enable_pages(false)
@@ -161,9 +164,9 @@ async fn paginated_response(
 
     let github_configs = configs.into_iter().map(to_json_config).collect();
 
-    Ok(Json(ListResponse {
+    Ok(Json(GitHubConfigListResponse {
         github_configs,
-        meta: ListResponseMeta { total, next_page },
+        meta: GitHubConfigListMeta { total, next_page },
     }))
 }
 

--- a/src/controllers/trustpub/gitlab_configs/json.rs
+++ b/src/controllers/trustpub/gitlab_configs/json.rs
@@ -16,16 +16,18 @@ pub struct CreateResponse {
     pub gitlab_config: GitLabConfig,
 }
 
+/// Response returned when listing GitLab trusted publishing configurations.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListResponse {
+pub struct GitLabConfigListResponse {
     pub gitlab_configs: Vec<GitLabConfig>,
 
     #[schema(inline)]
-    pub meta: ListResponseMeta,
+    pub meta: GitLabConfigListMeta,
 }
 
+/// Pagination metadata for a GitLab configuration list response.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct ListResponseMeta {
+pub struct GitLabConfigListMeta {
     /// The total number of GitLab configs belonging to the crate.
     #[schema(example = 42)]
     pub total: i64,

--- a/src/controllers/trustpub/gitlab_configs/list.rs
+++ b/src/controllers/trustpub/gitlab_configs/list.rs
@@ -4,7 +4,9 @@ use crate::controllers::helpers::pagination::{
     Page, PaginationOptions, PaginationQueryParams, encode_seek,
 };
 use crate::controllers::krate::load_crate;
-use crate::controllers::trustpub::gitlab_configs::json::{self, ListResponse, ListResponseMeta};
+use crate::controllers::trustpub::gitlab_configs::json::{
+    self, GitLabConfigListMeta, GitLabConfigListResponse,
+};
 use crate::util::RequestUtils;
 use crate::util::errors::{AppResult, bad_request, forbidden};
 use crate::util::no_store;
@@ -23,10 +25,11 @@ use http::request::Parts;
 use indexmap::IndexMap;
 use serde::Deserialize;
 
+/// Query parameters for listing GitLab trusted publishing configurations.
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
 #[from_request(via(Query))]
 #[into_params(parameter_in = Query)]
-pub struct ListQueryParams {
+pub struct GitLabConfigListQueryParams {
     /// Name of the crate to list Trusted Publishing configurations for.
     #[serde(rename = "crate")]
     pub krate: Option<String>,
@@ -39,16 +42,16 @@ pub struct ListQueryParams {
 #[utoipa::path(
     get,
     path = "/api/v1/trusted_publishing/gitlab_configs",
-    params(ListQueryParams, PaginationQueryParams),
+    params(GitLabConfigListQueryParams, PaginationQueryParams),
     security(("cookie" = []), ("api_token" = [])),
     tag = "trusted_publishing",
-    responses((status = 200, description = "Successful Response", body = inline(ListResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(GitLabConfigListResponse))),
 )]
 pub async fn list_trustpub_gitlab_configs(
     state: AppState,
-    params: ListQueryParams,
+    params: GitLabConfigListQueryParams,
     parts: Parts,
-) -> AppResult<(TypedHeader<CacheControl>, Json<ListResponse>)> {
+) -> AppResult<(TypedHeader<CacheControl>, Json<GitLabConfigListResponse>)> {
     let configs = match (&params.krate, params.user_id) {
         (Some(krate), None) => list_by_crate(state, krate, parts).await,
         (None, Some(user_id)) => list_by_user(state, user_id, parts).await,
@@ -67,7 +70,7 @@ async fn list_by_crate(
     state: AppState,
     krate_name: &str,
     parts: Parts,
-) -> AppResult<Json<ListResponse>> {
+) -> AppResult<Json<GitLabConfigListResponse>> {
     let mut conn = state.db_read().await?;
 
     let auth = AuthCheck::default()
@@ -101,7 +104,7 @@ async fn list_by_user(
     state: AppState,
     user_id: i32,
     parts: Parts,
-) -> AppResult<Json<ListResponse>> {
+) -> AppResult<Json<GitLabConfigListResponse>> {
     let mut conn = state.db_read().await?;
 
     let auth = AuthCheck::default()
@@ -151,7 +154,7 @@ async fn paginated_response(
     conn: &mut diesel_async::AsyncPgConnection,
     crate_ids: &[i32],
     parts: &Parts,
-) -> AppResult<Json<ListResponse>> {
+) -> AppResult<Json<GitLabConfigListResponse>> {
     let pagination = PaginationOptions::builder()
         .enable_seek(true)
         .enable_pages(false)
@@ -161,9 +164,9 @@ async fn paginated_response(
 
     let gitlab_configs = configs.into_iter().map(to_json_config).collect();
 
-    Ok(Json(ListResponse {
+    Ok(Json(GitLabConfigListResponse {
         gitlab_configs,
-        meta: ListResponseMeta { total, next_page },
+        meta: GitLabConfigListMeta { total, next_page },
     }))
 }
 

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -11,8 +11,9 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use serde::Serialize;
 
+/// Response returned when getting a user by login.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct GetResponse {
+pub struct UserGetResponse {
     pub user: EncodablePublicUser,
 }
 
@@ -24,12 +25,12 @@ pub struct GetResponse {
         ("user" = String, Path, description = "Login name of the user"),
     ),
     tag = "users",
-    responses((status = 200, description = "Successful Response", body = inline(GetResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(UserGetResponse))),
 )]
 pub async fn find_user(
     state: AppState,
     Path(user_name): Path<String>,
-) -> AppResult<Json<GetResponse>> {
+) -> AppResult<Json<UserGetResponse>> {
     let mut conn = state.db_read_prefer_primary().await?;
 
     use crate::schema::users::dsl::{gh_login, id};
@@ -41,7 +42,7 @@ pub async fn find_user(
         .first(&mut conn)
         .await?;
 
-    Ok(Json(GetResponse { user: user.into() }))
+    Ok(Json(UserGetResponse { user: user.into() }))
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -13,8 +13,9 @@ use serde::Serialize;
 
 use super::CrateVersionPath;
 
+/// Response returned when getting crate version metadata.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct GetResponse {
+pub struct VersionGetResponse {
     pub version: EncodableVersion,
 }
 
@@ -24,9 +25,12 @@ pub struct GetResponse {
     path = "/api/v1/crates/{name}/{version}",
     params(CrateVersionPath),
     tag = "versions",
-    responses((status = 200, description = "Successful Response", body = inline(GetResponse))),
+    responses((status = 200, description = "Successful Response", body = inline(VersionGetResponse))),
 )]
-pub async fn find_version(state: AppState, path: CrateVersionPath) -> AppResult<Json<GetResponse>> {
+pub async fn find_version(
+    state: AppState,
+    path: CrateVersionPath,
+) -> AppResult<Json<VersionGetResponse>> {
     let conn = state.db_read().await?;
     let (version, krate) = path.load_version_and_crate(&conn).await?;
     let (actions, published_by) = tokio::try_join!(
@@ -35,5 +39,5 @@ pub async fn find_version(state: AppState, path: CrateVersionPath) -> AppResult<
     )?;
 
     let version = EncodableVersion::from(version, &krate.name, published_by, actions);
-    Ok(Json(GetResponse { version }))
+    Ok(Json(VersionGetResponse { version }))
 }

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -3216,6 +3216,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting crate version metadata.",
                   "properties": {
                     "version": {
                       "$ref": "#/components/schemas/Version"

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -3784,6 +3784,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing keywords.",
                   "properties": {
                     "keywords": {
                       "description": "The list of keywords.",
@@ -3793,6 +3794,7 @@ expression: response.json()
                       "type": "array"
                     },
                     "meta": {
+                      "description": "Pagination metadata for a keyword list response.",
                       "properties": {
                         "total": {
                           "description": "The total number of keywords.",

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -4958,6 +4958,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing GitLab trusted publishing configurations.",
                   "properties": {
                     "gitlab_configs": {
                       "items": {
@@ -4966,6 +4967,7 @@ expression: response.json()
                       "type": "array"
                     },
                     "meta": {
+                      "description": "Pagination metadata for a GitLab configuration list response.",
                       "properties": {
                         "next_page": {
                           "description": "Query string to the next page of results, if any.",

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1741,6 +1741,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing categories.",
                   "properties": {
                     "categories": {
                       "description": "The list of categories.",
@@ -1750,6 +1751,7 @@ expression: response.json()
                       "type": "array"
                     },
                     "meta": {
+                      "description": "Pagination metadata for a category list response.",
                       "properties": {
                         "total": {
                           "description": "The total number of categories.",

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -4370,6 +4370,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting an API token by ID.",
                   "properties": {
                     "api_token": {
                       "$ref": "#/components/schemas/ApiToken"

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -5304,6 +5304,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting a user by login.",
                   "properties": {
                     "user": {
                       "$ref": "#/components/schemas/User"

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -3845,6 +3845,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting keyword metadata.",
                   "properties": {
                     "keyword": {
                       "$ref": "#/components/schemas/Keyword"

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -2052,6 +2052,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing crates.",
                   "properties": {
                     "crates": {
                       "items": {
@@ -2060,6 +2061,7 @@ expression: response.json()
                       "type": "array"
                     },
                     "meta": {
+                      "description": "Pagination metadata for a crate list response.",
                       "properties": {
                         "next_page": {
                           "description": "Query string to the next page of results, if any.",

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -4615,6 +4615,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting a team by login.",
                   "properties": {
                     "team": {
                       "$ref": "#/components/schemas/Team"

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -3129,6 +3129,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing versions of a crate.",
                   "properties": {
                     "meta": {
                       "properties": {

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -2127,6 +2127,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting crate metadata.",
                   "properties": {
                     "categories": {
                       "description": "The categories of the crate.",
@@ -2290,6 +2291,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting crate metadata.",
                   "properties": {
                     "categories": {
                       "description": "The categories of the crate.",

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1802,6 +1802,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting category metadata.",
                   "properties": {
                     "category": {
                       "$ref": "#/components/schemas/Category"

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -4196,6 +4196,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing API tokens for the authenticated user.",
                   "properties": {
                     "api_tokens": {
                       "items": {

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -4723,6 +4723,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing GitHub trusted publishing configurations.",
                   "properties": {
                     "github_configs": {
                       "items": {
@@ -4731,6 +4732,7 @@ expression: response.json()
                       "type": "array"
                     },
                     "meta": {
+                      "description": "Pagination metadata for a GitHub configuration list response.",
                       "properties": {
                         "next_page": {
                           "description": "Query string to the next page of results, if any.",

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -4033,6 +4033,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing GitHub trusted publishing configurations.",
                   "properties": {
                     "github_configs": {
                       "items": {
@@ -4041,6 +4042,7 @@ expression: response.json()
                       "type": "array"
                     },
                     "meta": {
+                      "description": "Pagination metadata for a GitHub configuration list response.",
                       "properties": {
                         "next_page": {
                           "description": "Query string to the next page of results, if any.",

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -1532,6 +1532,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting category metadata.",
                   "properties": {
                     "category": {
                       "$ref": "#/components/schemas/Category"

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -4614,6 +4614,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting a user by login.",
                   "properties": {
                     "user": {
                       "$ref": "#/components/schemas/User"

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -3452,6 +3452,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting keyword metadata.",
                   "properties": {
                     "keyword": {
                       "$ref": "#/components/schemas/Keyword"

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -3925,6 +3925,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting a team by login.",
                   "properties": {
                     "team": {
                       "$ref": "#/components/schemas/Team"

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -1782,6 +1782,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing crates.",
                   "properties": {
                     "crates": {
                       "items": {
@@ -1790,6 +1791,7 @@ expression: response.json()
                       "type": "array"
                     },
                     "meta": {
+                      "description": "Pagination metadata for a crate list response.",
                       "properties": {
                         "next_page": {
                           "description": "Query string to the next page of results, if any.",

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -3731,6 +3731,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting an API token by ID.",
                   "properties": {
                     "api_token": {
                       "$ref": "#/components/schemas/ApiToken"

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -1471,6 +1471,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing categories.",
                   "properties": {
                     "categories": {
                       "description": "The list of categories.",
@@ -1480,6 +1481,7 @@ expression: response.json()
                       "type": "array"
                     },
                     "meta": {
+                      "description": "Pagination metadata for a category list response.",
                       "properties": {
                         "total": {
                           "description": "The total number of categories.",

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -1857,6 +1857,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting crate metadata.",
                   "properties": {
                     "categories": {
                       "description": "The categories of the crate.",
@@ -1983,6 +1984,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting crate metadata.",
                   "properties": {
                     "categories": {
                       "description": "The categories of the crate.",

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -4268,6 +4268,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing GitLab trusted publishing configurations.",
                   "properties": {
                     "gitlab_configs": {
                       "items": {
@@ -4276,6 +4277,7 @@ expression: response.json()
                       "type": "array"
                     },
                     "meta": {
+                      "description": "Pagination metadata for a GitLab configuration list response.",
                       "properties": {
                         "next_page": {
                           "description": "Query string to the next page of results, if any.",

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -2863,6 +2863,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when getting crate version metadata.",
                   "properties": {
                     "version": {
                       "$ref": "#/components/schemas/Version"

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -3391,6 +3391,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing keywords.",
                   "properties": {
                     "keywords": {
                       "description": "The list of keywords.",
@@ -3400,6 +3401,7 @@ expression: response.json()
                       "type": "array"
                     },
                     "meta": {
+                      "description": "Pagination metadata for a keyword list response.",
                       "properties": {
                         "total": {
                           "description": "The total number of keywords.",

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -2776,6 +2776,7 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
+                  "description": "Response returned when listing versions of a crate.",
                   "properties": {
                     "meta": {
                       "properties": {


### PR DESCRIPTION
Generic controller types such as `ListResponse`, `GetResponse`, and `ListQueryParams` were difficult to distinguish in search results. This renames them to domain- and endpoint-specific names, including `CrateListResponse`, `UserGetResponse`, and `VersionListQueryParams`, and adds brief documentation to the exported structs.

The change is limited to Rust type names and references. API payloads, routes, and behavior remain unchanged.