### PR TITLE
msw: Include missing `created_at` in keyword responses

### DIFF
--- a/packages/crates-io-msw/handlers/crates/get.test.ts
+++ b/packages/crates-io-msw/handlers/crates/get.test.ts
@@ -375,6 +375,7 @@ test('includes related keywords', async function () {
     [
       {
         "crates_cnt": 1,
+        "created_at": "2010-06-16T21:30:45Z",
         "id": "no-std",
         "keyword": "no-std",
       },

--- a/packages/crates-io-msw/handlers/keywords/get.test.ts
+++ b/packages/crates-io-msw/handlers/keywords/get.test.ts
@@ -25,6 +25,7 @@ test('returns a keyword object for known keywords', async function () {
     {
       "keyword": {
         "crates_cnt": 0,
+        "created_at": "2010-06-16T21:30:45Z",
         "id": "cli",
         "keyword": "cli",
       },
@@ -44,6 +45,7 @@ test('calculates `crates_cnt` correctly', async function () {
     {
       "keyword": {
         "crates_cnt": 7,
+        "created_at": "2010-06-16T21:30:45Z",
         "id": "test-cli-keyword",
         "keyword": "test-cli-keyword",
       },

--- a/packages/crates-io-msw/handlers/keywords/list.test.ts
+++ b/packages/crates-io-msw/handlers/keywords/list.test.ts
@@ -26,16 +26,19 @@ test('returns a paginated keywords list', async function () {
       "keywords": [
         {
           "crates_cnt": 0,
+          "created_at": "2010-06-16T21:30:45Z",
           "id": "api",
           "keyword": "api",
         },
         {
           "crates_cnt": 0,
+          "created_at": "2010-06-16T21:30:45Z",
           "id": "keyword-2",
           "keyword": "keyword-2",
         },
         {
           "crates_cnt": 0,
+          "created_at": "2010-06-16T21:30:45Z",
           "id": "keyword-3",
           "keyword": "keyword-3",
         },

--- a/packages/crates-io-msw/handlers/summary.test.ts
+++ b/packages/crates-io-msw/handlers/summary.test.ts
@@ -189,6 +189,7 @@ test('returns the data for the front page', async function () {
   expect(responsePayload.popular_keywords[0]).toMatchInlineSnapshot(`
     {
       "crates_cnt": 0,
+      "created_at": "2010-06-16T21:30:45Z",
       "id": "keyword-1",
       "keyword": "keyword-1",
     }

--- a/packages/crates-io-msw/models/crate.test.ts
+++ b/packages/crates-io-msw/models/crate.test.ts
@@ -58,10 +58,12 @@ test('attributes can be set', async ({ expect }) => {
       "id": 1,
       "keywords": [
         {
+          "created_at": "2010-06-16T21:30:45Z",
           "id": "keyword-1",
           "keyword": "keyword-1",
         },
         {
+          "created_at": "2010-06-16T21:30:45Z",
           "id": "keyword-2",
           "keyword": "keyword-2",
         },

--- a/packages/crates-io-msw/models/keyword.test.ts
+++ b/packages/crates-io-msw/models/keyword.test.ts
@@ -6,6 +6,7 @@ test('default are applied', async ({ expect }) => {
   let keyword = await db.keyword.create({});
   expect(keyword).toMatchInlineSnapshot(`
     {
+      "created_at": "2010-06-16T21:30:45Z",
       "id": "keyword-1",
       "keyword": "keyword-1",
     }
@@ -16,6 +17,7 @@ test('name can be set', async ({ expect }) => {
   let keyword = await db.keyword.create({ keyword: 'gamedev' });
   expect(keyword).toMatchInlineSnapshot(`
     {
+      "created_at": "2010-06-16T21:30:45Z",
       "id": "gamedev",
       "keyword": "gamedev",
     }

--- a/packages/crates-io-msw/models/keyword.ts
+++ b/packages/crates-io-msw/models/keyword.ts
@@ -7,6 +7,7 @@ const schema = v.pipe(
   v.object({
     id: v.optional(v.string()),
     keyword: v.optional(v.string()),
+    created_at: v.optional(v.string(), '2010-06-16T21:30:45Z'),
   }),
   v.transform(function (input) {
     let counter = counters.increment('keyword');


### PR DESCRIPTION
This aligns the keyword responses with what the real Rust backend replies.