### PR TITLE
msw: Include missing fields in version responses

### DIFF
--- a/packages/crates-io-msw/handlers/crates/downloads.test.ts
+++ b/packages/crates-io-msw/handlers/crates/downloads.test.ts
@@ -99,6 +99,8 @@ test('includes related versions', async function () {
       ],
       "versions": [
         {
+          "audit_actions": [],
+          "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
           "crate": "rand",
           "crate_size": 162963,
           "created_at": "2010-06-16T21:30:45Z",
@@ -124,6 +126,7 @@ test('includes related versions', async function () {
             "total_comment_lines": 90,
           },
           "links": {
+            "authors": "/api/v1/crates/rand/1.0.0/authors",
             "dependencies": "/api/v1/crates/rand/1.0.0/dependencies",
             "version_downloads": "/api/v1/crates/rand/1.0.0/downloads",
           },
@@ -137,6 +140,8 @@ test('includes related versions', async function () {
           "yanked": false,
         },
         {
+          "audit_actions": [],
+          "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
           "crate": "rand",
           "crate_size": 325926,
           "created_at": "2010-06-16T21:30:45Z",
@@ -167,6 +172,7 @@ test('includes related versions', async function () {
             "total_comment_lines": 216,
           },
           "links": {
+            "authors": "/api/v1/crates/rand/1.0.1/authors",
             "dependencies": "/api/v1/crates/rand/1.0.1/dependencies",
             "version_downloads": "/api/v1/crates/rand/1.0.1/downloads",
           },

--- a/packages/crates-io-msw/handlers/crates/get.test.ts
+++ b/packages/crates-io-msw/handlers/crates/get.test.ts
@@ -61,6 +61,8 @@ test('returns a crate object for known crates', async function () {
       "keywords": [],
       "versions": [
         {
+          "audit_actions": [],
+          "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
           "crate": "rand",
           "crate_size": 162963,
           "created_at": "2010-06-16T21:30:45Z",
@@ -86,6 +88,7 @@ test('returns a crate object for known crates', async function () {
             "total_comment_lines": 90,
           },
           "links": {
+            "authors": "/api/v1/crates/rand/1.0.0-beta.1/authors",
             "dependencies": "/api/v1/crates/rand/1.0.0-beta.1/dependencies",
             "version_downloads": "/api/v1/crates/rand/1.0.0-beta.1/downloads",
           },
@@ -148,6 +151,8 @@ test('works for non-canonical names', async function () {
       "keywords": [],
       "versions": [
         {
+          "audit_actions": [],
+          "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
           "crate": "foo-bar",
           "crate_size": 162963,
           "created_at": "2010-06-16T21:30:45Z",
@@ -173,6 +178,7 @@ test('works for non-canonical names', async function () {
             "total_comment_lines": 90,
           },
           "links": {
+            "authors": "/api/v1/crates/foo-bar/1.0.0-beta.1/authors",
             "dependencies": "/api/v1/crates/foo-bar/1.0.0-beta.1/dependencies",
             "version_downloads": "/api/v1/crates/foo-bar/1.0.0-beta.1/downloads",
           },
@@ -210,6 +216,8 @@ test('includes related versions', async function () {
   expect(responsePayload.versions).toMatchInlineSnapshot(`
     [
       {
+        "audit_actions": [],
+        "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
         "crate": "rand",
         "crate_size": 488889,
         "created_at": "2010-06-16T21:30:45Z",
@@ -230,6 +238,7 @@ test('includes related versions', async function () {
           "total_comment_lines": 64,
         },
         "links": {
+          "authors": "/api/v1/crates/rand/1.2.0/authors",
           "dependencies": "/api/v1/crates/rand/1.2.0/dependencies",
           "version_downloads": "/api/v1/crates/rand/1.2.0/downloads",
         },
@@ -243,6 +252,8 @@ test('includes related versions', async function () {
         "yanked": false,
       },
       {
+        "audit_actions": [],
+        "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
         "crate": "rand",
         "crate_size": 325926,
         "created_at": "2010-06-16T21:30:45Z",
@@ -273,6 +284,7 @@ test('includes related versions', async function () {
           "total_comment_lines": 216,
         },
         "links": {
+          "authors": "/api/v1/crates/rand/1.1.0/authors",
           "dependencies": "/api/v1/crates/rand/1.1.0/dependencies",
           "version_downloads": "/api/v1/crates/rand/1.1.0/downloads",
         },
@@ -286,6 +298,8 @@ test('includes related versions', async function () {
         "yanked": false,
       },
       {
+        "audit_actions": [],
+        "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
         "crate": "rand",
         "crate_size": 162963,
         "created_at": "2010-06-16T21:30:45Z",
@@ -311,6 +325,7 @@ test('includes related versions', async function () {
           "total_comment_lines": 90,
         },
         "links": {
+          "authors": "/api/v1/crates/rand/1.0.0/authors",
           "dependencies": "/api/v1/crates/rand/1.0.0/dependencies",
           "version_downloads": "/api/v1/crates/rand/1.0.0/downloads",
         },

--- a/packages/crates-io-msw/handlers/crates/reverse-dependencies.test.ts
+++ b/packages/crates-io-msw/handlers/crates/reverse-dependencies.test.ts
@@ -82,6 +82,8 @@ test('returns a paginated list of crate versions depending to the specified crat
       },
       "versions": [
         {
+          "audit_actions": [],
+          "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
           "crate": "baz",
           "crate_size": 325926,
           "created_at": "2010-06-16T21:30:45Z",
@@ -112,6 +114,7 @@ test('returns a paginated list of crate versions depending to the specified crat
             "total_comment_lines": 216,
           },
           "links": {
+            "authors": "/api/v1/crates/baz/1.0.1/authors",
             "dependencies": "/api/v1/crates/baz/1.0.1/dependencies",
             "version_downloads": "/api/v1/crates/baz/1.0.1/downloads",
           },
@@ -125,6 +128,8 @@ test('returns a paginated list of crate versions depending to the specified crat
           "yanked": false,
         },
         {
+          "audit_actions": [],
+          "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
           "crate": "bar",
           "crate_size": 162963,
           "created_at": "2010-06-16T21:30:45Z",
@@ -150,6 +155,7 @@ test('returns a paginated list of crate versions depending to the specified crat
             "total_comment_lines": 90,
           },
           "links": {
+            "authors": "/api/v1/crates/bar/1.0.0/authors",
             "dependencies": "/api/v1/crates/bar/1.0.0/dependencies",
             "version_downloads": "/api/v1/crates/bar/1.0.0/downloads",
           },

--- a/packages/crates-io-msw/handlers/versions/follow-updates.test.ts
+++ b/packages/crates-io-msw/handlers/versions/follow-updates.test.ts
@@ -35,6 +35,8 @@ test('returns latest versions of followed crates', async function () {
       },
       "versions": [
         {
+          "audit_actions": [],
+          "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
           "crate": "foo",
           "crate_size": 162963,
           "created_at": "2010-06-16T21:30:45Z",
@@ -60,6 +62,7 @@ test('returns latest versions of followed crates', async function () {
             "total_comment_lines": 90,
           },
           "links": {
+            "authors": "/api/v1/crates/foo/1.2.3/authors",
             "dependencies": "/api/v1/crates/foo/1.2.3/dependencies",
             "version_downloads": "/api/v1/crates/foo/1.2.3/downloads",
           },

--- a/packages/crates-io-msw/handlers/versions/get.test.ts
+++ b/packages/crates-io-msw/handlers/versions/get.test.ts
@@ -41,6 +41,8 @@ test('returns a version object for known version', async function () {
   expect(await response.json()).toMatchInlineSnapshot(`
     {
       "version": {
+        "audit_actions": [],
+        "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
         "crate": "rand",
         "crate_size": 162963,
         "created_at": "2010-06-16T21:30:45Z",
@@ -66,6 +68,7 @@ test('returns a version object for known version', async function () {
           "total_comment_lines": 90,
         },
         "links": {
+          "authors": "/api/v1/crates/rand/1.0.0-beta.1/authors",
           "dependencies": "/api/v1/crates/rand/1.0.0-beta.1/dependencies",
           "version_downloads": "/api/v1/crates/rand/1.0.0-beta.1/downloads",
         },

--- a/packages/crates-io-msw/handlers/versions/list.test.ts
+++ b/packages/crates-io-msw/handlers/versions/list.test.ts
@@ -49,6 +49,8 @@ test('returns all versions belonging to the specified crate', async function () 
       },
       "versions": [
         {
+          "audit_actions": [],
+          "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
           "crate": "rand",
           "crate_size": 488889,
           "created_at": "2010-06-16T21:30:45Z",
@@ -69,6 +71,7 @@ test('returns all versions belonging to the specified crate', async function () 
             "total_comment_lines": 64,
           },
           "links": {
+            "authors": "/api/v1/crates/rand/1.2.0/authors",
             "dependencies": "/api/v1/crates/rand/1.2.0/dependencies",
             "version_downloads": "/api/v1/crates/rand/1.2.0/downloads",
           },
@@ -82,6 +85,8 @@ test('returns all versions belonging to the specified crate', async function () 
           "yanked": false,
         },
         {
+          "audit_actions": [],
+          "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
           "crate": "rand",
           "crate_size": 325926,
           "created_at": "2010-06-16T21:30:45Z",
@@ -112,6 +117,7 @@ test('returns all versions belonging to the specified crate', async function () 
             "total_comment_lines": 216,
           },
           "links": {
+            "authors": "/api/v1/crates/rand/1.1.0/authors",
             "dependencies": "/api/v1/crates/rand/1.1.0/dependencies",
             "version_downloads": "/api/v1/crates/rand/1.1.0/downloads",
           },
@@ -131,6 +137,8 @@ test('returns all versions belonging to the specified crate', async function () 
           "yanked": false,
         },
         {
+          "audit_actions": [],
+          "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
           "crate": "rand",
           "crate_size": 162963,
           "created_at": "2010-06-16T21:30:45Z",
@@ -156,6 +164,7 @@ test('returns all versions belonging to the specified crate', async function () 
             "total_comment_lines": 90,
           },
           "links": {
+            "authors": "/api/v1/crates/rand/1.0.0/authors",
             "dependencies": "/api/v1/crates/rand/1.0.0/dependencies",
             "version_downloads": "/api/v1/crates/rand/1.0.0/downloads",
           },

--- a/packages/crates-io-msw/handlers/versions/patch.test.ts
+++ b/packages/crates-io-msw/handlers/versions/patch.test.ts
@@ -79,6 +79,8 @@ test('yanks the version', async function () {
   expect(await response.json()).toMatchInlineSnapshot(`
     {
       "version": {
+        "audit_actions": [],
+        "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
         "crate": "foo",
         "crate_size": 162963,
         "created_at": "2010-06-16T21:30:45Z",
@@ -104,6 +106,7 @@ test('yanks the version', async function () {
           "total_comment_lines": 90,
         },
         "links": {
+          "authors": "/api/v1/crates/foo/1.0.0/authors",
           "dependencies": "/api/v1/crates/foo/1.0.0/dependencies",
           "version_downloads": "/api/v1/crates/foo/1.0.0/downloads",
         },
@@ -128,6 +131,8 @@ test('yanks the version', async function () {
   expect(await response.json()).toMatchInlineSnapshot(`
     {
       "version": {
+        "audit_actions": [],
+        "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
         "crate": "foo",
         "crate_size": 162963,
         "created_at": "2010-06-16T21:30:45Z",
@@ -153,6 +158,7 @@ test('yanks the version', async function () {
           "total_comment_lines": 90,
         },
         "links": {
+          "authors": "/api/v1/crates/foo/1.0.0/authors",
           "dependencies": "/api/v1/crates/foo/1.0.0/dependencies",
           "version_downloads": "/api/v1/crates/foo/1.0.0/downloads",
         },

--- a/packages/crates-io-msw/models/dependency.test.ts
+++ b/packages/crates-io-msw/models/dependency.test.ts
@@ -49,6 +49,8 @@ test('happy path', async ({ expect }) => {
       "req": "^2.1.3",
       "target": null,
       "version": {
+        "audit_actions": [],
+        "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
         "crate": {
           "_extra_downloads": [],
           "badges": [],

--- a/packages/crates-io-msw/models/version-download.test.ts
+++ b/packages/crates-io-msw/models/version-download.test.ts
@@ -19,6 +19,8 @@ test('happy path', async ({ expect }) => {
       "downloads": 7035,
       "id": 1,
       "version": {
+        "audit_actions": [],
+        "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
         "crate": {
           "_extra_downloads": [],
           "badges": [],

--- a/packages/crates-io-msw/models/version.test.ts
+++ b/packages/crates-io-msw/models/version.test.ts
@@ -14,6 +14,8 @@ test('happy path', async ({ expect }) => {
   let version = await db.version.create({ crate });
   expect(version).toMatchInlineSnapshot(`
     {
+      "audit_actions": [],
+      "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": {
         "_extra_downloads": [],
         "badges": [],

--- a/packages/crates-io-msw/models/version.ts
+++ b/packages/crates-io-msw/models/version.ts
@@ -16,6 +16,17 @@ const schema = v.pipe(
     updated_at: v.optional(v.string(), '2017-02-24T12:34:56Z'),
     yanked: v.optional(v.boolean(), false),
     yank_message: v.optional(v.nullable(v.string()), null),
+    audit_actions: v.optional(
+      v.array(
+        v.object({
+          action: v.string(),
+          time: v.string(),
+          user: v.any(),
+        }),
+      ),
+      [],
+    ),
+    checksum: v.optional(v.string(), '0000000000000000000000000000000000000000000000000000000000000000'),
     license: v.optional(v.string()),
     downloads: v.optional(v.number()),
     features: v.optional(v.record(v.string(), v.any()), {}),

--- a/packages/crates-io-msw/serializers/version.ts
+++ b/packages/crates-io-msw/serializers/version.ts
@@ -11,6 +11,7 @@ export function serializeVersion(version: Version) {
   serialized.readme_path = `/api/v1/crates/${version.crate.name}/${version.num}/readme`;
 
   serialized.links = {
+    authors: `/api/v1/crates/${version.crate.name}/${version.num}/authors`,
     dependencies: `/api/v1/crates/${version.crate.name}/${version.num}/dependencies`,
     version_downloads: `/api/v1/crates/${version.crate.name}/${version.num}/downloads`,
   };


### PR DESCRIPTION
This aligns the version responses with what the real Rust backend replies.

### Related

- #14321