### PR TITLE
msw: Hide `revoked` field for API token responses

### DIFF
--- a/packages/crates-io-msw/handlers/api-tokens/create.test.ts
+++ b/packages/crates-io-msw/handlers/api-tokens/create.test.ts
@@ -32,7 +32,6 @@ test('creates a new API token', async function () {
         "id": 1,
         "last_used_at": null,
         "name": "foooo",
-        "revoked": false,
         "token": "6270739405881613",
       },
     }
@@ -71,7 +70,6 @@ test('creates a new API token with scopes', async function () {
         "id": 1,
         "last_used_at": null,
         "name": "foooo",
-        "revoked": false,
         "token": "6270739405881613",
       },
     }
@@ -104,7 +102,6 @@ test('creates a new API token with expiry date', async function () {
         "id": 1,
         "last_used_at": null,
         "name": "foooo",
-        "revoked": false,
         "token": "6270739405881613",
       },
     }

--- a/packages/crates-io-msw/serializers/api-token.ts
+++ b/packages/crates-io-msw/serializers/api-token.ts
@@ -16,9 +16,9 @@ export function serializeApiToken(token: ApiToken, { forCreate = false } = {}) {
   }
 
   delete serialized.user;
+  delete serialized.revoked;
 
   if (!forCreate) {
-    delete serialized.revoked;
     delete serialized.token;
   }
 


### PR DESCRIPTION
This aligns the API token responses with what the real Rust backend replies.