### PR TITLE
msw: Type successful responses with OpenAPI contracts

### DIFF
--- a/packages/crates-io-msw/handlers/api-tokens/create.ts
+++ b/packages/crates-io-msw/handlers/api-tokens/create.ts
@@ -1,4 +1,5 @@
 import type { components } from '@crates-io/api-client';
+import type { SuccessBody } from '../../utils/api-types.js';
 
 import { http, HttpResponse } from 'msw';
 
@@ -32,7 +33,7 @@ export default http.put('/api/v1/me/tokens', async ({ request }) => {
     createdAt: new Date().toISOString(),
   });
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'create_api_token'>>({
     api_token: serializeApiToken(token, { forCreate: true }),
   });
 });

--- a/packages/crates-io-msw/handlers/api-tokens/delete.ts
+++ b/packages/crates-io-msw/handlers/api-tokens/delete.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -12,5 +14,5 @@ export default http.delete<{ tokenId: string }>('/api/v1/me/tokens/:tokenId', as
   let { tokenId } = params;
   db.apiToken.delete(q => q.where(token => token.id === parseInt(tokenId) && token.user.id === user.id));
 
-  return HttpResponse.json({});
+  return HttpResponse.json<SuccessBody<'revoke_api_token'>>({});
 });

--- a/packages/crates-io-msw/handlers/api-tokens/get.ts
+++ b/packages/crates-io-msw/handlers/api-tokens/get.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -15,7 +17,7 @@ export default http.get<{ tokenId: string }>('/api/v1/me/tokens/:tokenId', async
   let token = db.apiToken.findFirst(q => q.where(token => token.id === parseInt(tokenId) && token.user.id === user.id));
   if (!token) return notFound();
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'find_api_token'>>({
     api_token: serializeApiToken(token),
   });
 });

--- a/packages/crates-io-msw/handlers/api-tokens/list.ts
+++ b/packages/crates-io-msw/handlers/api-tokens/list.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -21,7 +23,7 @@ export default http.get('/api/v1/me/tokens', async ({ request }) => {
     .findMany(q => q.where(token => token.user.id === user.id), { orderBy: { id: 'desc' } })
     .filter(token => !token.expiredAt || new Date(token.expiredAt) > expiredAfter);
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'list_api_tokens'>>({
     api_tokens: apiTokens.map(token => serializeApiToken(token)),
   });
 });

--- a/packages/crates-io-msw/handlers/categories/get.ts
+++ b/packages/crates-io-msw/handlers/categories/get.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -11,5 +13,5 @@ export default http.get<{ category_id: string }>('/api/v1/categories/:category_i
     return notFound();
   }
 
-  return HttpResponse.json({ category: serializeCategory(category) });
+  return HttpResponse.json<SuccessBody<'find_category'>>({ category: serializeCategory(category) });
 });

--- a/packages/crates-io-msw/handlers/categories/list-slugs.ts
+++ b/packages/crates-io-msw/handlers/categories/list-slugs.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -6,5 +8,7 @@ import { serializeCategorySlug } from '../../serializers/category.js';
 export default http.get('/api/v1/category_slugs', () => {
   let allCategories = db.category.findMany(undefined, { orderBy: { category: 'asc' } });
 
-  return HttpResponse.json({ category_slugs: allCategories.map(c => serializeCategorySlug(c)) });
+  return HttpResponse.json<SuccessBody<'list_category_slugs'>>({
+    category_slugs: allCategories.map(c => serializeCategorySlug(c)),
+  });
 });

--- a/packages/crates-io-msw/handlers/categories/list.ts
+++ b/packages/crates-io-msw/handlers/categories/list.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -10,5 +12,8 @@ export default http.get('/api/v1/categories', ({ request }) => {
   let categories = db.category.findMany(undefined, { skip, take, orderBy: { category: 'asc' } });
   let total = db.category.count();
 
-  return HttpResponse.json({ categories: categories.map(c => serializeCategory(c)), meta: { total } });
+  return HttpResponse.json<SuccessBody<'list_categories'>>({
+    categories: categories.map(c => serializeCategory(c)),
+    meta: { total },
+  });
 });

--- a/packages/crates-io-msw/handlers/crates/add-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/add-owners.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -50,5 +52,5 @@ export default http.put<{ name: string }>('/api/v1/crates/:name/owners', async (
     await db.crateOwnerInvitation.create({ crate, inviter: user, invitee });
   }
 
-  return HttpResponse.json({ ok: true, msg: msgs.join(',') });
+  return HttpResponse.json<SuccessBody<'add_owners'>>({ ok: true, msg: msgs.join(',') });
 });

--- a/packages/crates-io-msw/handlers/crates/downloads.ts
+++ b/packages/crates-io-msw/handlers/crates/downloads.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -9,11 +11,7 @@ export default http.get<{ name: string }>('/api/v1/crates/:name/downloads', asyn
   if (!crate) return notFound();
 
   let downloads = db.versionDownload.findMany(q => q.where(download => download.version.crate.id === crate.id));
-  let resp: {
-    version_downloads: Array<{ date: string; downloads: number; version: number }>;
-    meta: { extra_downloads: unknown };
-    versions?: Array<ReturnType<typeof serializeVersion>>;
-  } = {
+  let resp: SuccessBody<'get_crate_downloads'> = {
     version_downloads: downloads.map(download => ({
       date: download.date,
       downloads: download.downloads,
@@ -29,5 +27,5 @@ export default http.get<{ name: string }>('/api/v1/crates/:name/downloads', asyn
     let versions = [...new Set(downloads.map(it => it.version))];
     resp.versions = versions.map(it => serializeVersion(it));
   }
-  return HttpResponse.json(resp);
+  return HttpResponse.json<SuccessBody<'get_crate_downloads'>>(resp);
 });

--- a/packages/crates-io-msw/handlers/crates/follow.ts
+++ b/packages/crates-io-msw/handlers/crates/follow.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -21,5 +23,5 @@ export default http.put<{ name: string }>('/api/v1/crates/:name/follow', async (
     },
   });
 
-  return HttpResponse.json({ ok: true });
+  return HttpResponse.json<SuccessBody<'follow_crate'>>({ ok: true });
 });

--- a/packages/crates-io-msw/handlers/crates/following.ts
+++ b/packages/crates-io-msw/handlers/crates/following.ts
@@ -1,4 +1,5 @@
 import type { Crate } from '../../models/index.js';
+import type { SuccessBody } from '../../utils/api-types.js';
 
 import { http, HttpResponse } from 'msw';
 
@@ -19,5 +20,5 @@ export default http.get<{ name: string }>('/api/v1/crates/:name/following', asyn
 
   let following = (user.followedCrates as Crate[]).some(followedCrate => followedCrate.id === crate.id);
 
-  return HttpResponse.json({ following });
+  return HttpResponse.json<SuccessBody<'get_following_crate'>>({ following });
 });

--- a/packages/crates-io-msw/handlers/crates/get.ts
+++ b/packages/crates-io-msw/handlers/crates/get.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -42,7 +44,7 @@ export default http.get<{ name: string }>('/api/v1/crates/:name', async ({ reque
     serializedVersions = [serializeVersion(defaultVersion!)];
   }
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'find_crate'>>({
     crate: serializedCrate,
     categories: includeCategories ? crate.categories.map(c => serializeCategory(c)) : null,
     keywords: includeKeywords ? crate.keywords.map(k => serializeKeyword(k)) : null,

--- a/packages/crates-io-msw/handlers/crates/list-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/list-owners.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -34,5 +36,5 @@ export default http.get<{ name: string }>('/api/v1/crates/:name/owners', async (
       })),
   ];
 
-  return HttpResponse.json({ users });
+  return HttpResponse.json<SuccessBody<'list_owners'>>({ users });
 });

--- a/packages/crates-io-msw/handlers/crates/list.ts
+++ b/packages/crates-io-msw/handlers/crates/list.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -78,7 +80,7 @@ export default http.get('/api/v1/crates', async ({ request }) => {
     .slice(start, end)
     .map(c => ({ ...serializeCrate(c), exact_match: c.name.toLowerCase() === q }));
 
-  return HttpResponse.json({ crates: serialized, meta: { total } });
+  return HttpResponse.json<SuccessBody<'list_crates'>>({ crates: serialized, meta: { total } });
 });
 
 export function compare(a: string, b: string) {

--- a/packages/crates-io-msw/handlers/crates/patch.ts
+++ b/packages/crates-io-msw/handlers/crates/patch.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -27,5 +29,5 @@ export default http.patch<{ name: string }>('/api/v1/crates/:name', async ({ req
     });
   }
 
-  return HttpResponse.json({ crate: serializeCrate(crate!) });
+  return HttpResponse.json<SuccessBody<'update_crate'>>({ crate: serializeCrate(crate!) });
 });

--- a/packages/crates-io-msw/handlers/crates/remove-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/remove-owners.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -27,5 +29,5 @@ export default http.delete<{ name: string }>('/api/v1/crates/:name/owners', asyn
     db.crateOwnership.delete(q => q.where({ id: ownership.id }));
   }
 
-  return HttpResponse.json({ ok: true, msg: 'owners successfully removed' });
+  return HttpResponse.json<SuccessBody<'remove_owners'>>({ ok: true, msg: 'owners successfully removed' });
 });

--- a/packages/crates-io-msw/handlers/crates/reverse-dependencies.ts
+++ b/packages/crates-io-msw/handlers/crates/reverse-dependencies.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -20,7 +22,7 @@ export default http.get<{ name: string }>('/api/v1/crates/:name/reverse_dependen
 
   let versions = dependencies.map(d => d.version);
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'list_reverse_dependencies'>>({
     dependencies: dependencies.map(d => serializeDependency(d)),
     versions: versions.map(v => serializeVersion(v)),
     meta: { total },

--- a/packages/crates-io-msw/handlers/crates/team-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/team-owners.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -12,7 +14,7 @@ export default http.get<{ name: string }>('/api/v1/crates/:name/owner_team', asy
 
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.crate.id === crate.id));
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'get_team_owners'>>({
     teams: ownerships.filter(o => o.team).map(o => ({ ...serializeTeam(o.team), kind: 'team' })),
   });
 });

--- a/packages/crates-io-msw/handlers/crates/unfollow.ts
+++ b/packages/crates-io-msw/handlers/crates/unfollow.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -21,5 +23,5 @@ export default http.delete<{ name: string }>('/api/v1/crates/:name/follow', asyn
     },
   });
 
-  return HttpResponse.json({ ok: true });
+  return HttpResponse.json<SuccessBody<'unfollow_crate'>>({ ok: true });
 });

--- a/packages/crates-io-msw/handlers/crates/user-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/user-owners.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -12,7 +14,7 @@ export default http.get<{ name: string }>('/api/v1/crates/:name/owner_user', asy
 
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.crate.id === crate.id));
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'get_user_owners'>>({
     users: ownerships.filter(o => o.user).map(o => ({ ...serializeUser(o.user), kind: 'user' })),
   });
 });

--- a/packages/crates-io-msw/handlers/invites/legacy-list.ts
+++ b/packages/crates-io-msw/handlers/invites/legacy-list.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -17,7 +19,7 @@ export default http.get('/api/v1/me/crate_owner_invitations', () => {
   let invitees = invites.map(invite => invite.invitee);
   let users = [...new Set([...inviters, ...invitees])].toSorted((a, b) => a.id - b.id);
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'list_crate_owner_invitations_for_user'>>({
     crate_owner_invitations: invites.map(invite => serializeLegacyInvite(invite)),
     users: users.map(user => serializeUser(user)),
   });

--- a/packages/crates-io-msw/handlers/invites/list.ts
+++ b/packages/crates-io-msw/handlers/invites/list.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -47,7 +49,7 @@ export default http.get('/api/private/crate_owner_invitations', ({ request }) =>
   let invitees = invites.map(invite => invite.invitee);
   let users = [...new Set([...inviters, ...invitees])].toSorted((a, b) => a.id - b.id);
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'list_crate_owner_invitations'>>({
     invitations: invites.map(invite => serializeInvite(invite)),
     users: users.map(user => serializeUser(user)),
     meta: { next_page: nextPage },

--- a/packages/crates-io-msw/handlers/invites/redeem-by-crate-id.ts
+++ b/packages/crates-io-msw/handlers/invites/redeem-by-crate-id.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -24,5 +26,7 @@ export default http.put('/api/v1/me/crate_owner_invitations/:crate_id', async ({
 
   db.crateOwnerInvitation.delete(q => q.where({ id: invite.id }));
 
-  return HttpResponse.json({ crate_owner_invitation: { crate_id: invite.crate.id, accepted } });
+  return HttpResponse.json<SuccessBody<'handle_crate_owner_invitation'>>({
+    crate_owner_invitation: { crate_id: invite.crate.id, accepted },
+  });
 });

--- a/packages/crates-io-msw/handlers/invites/redeem-by-token.ts
+++ b/packages/crates-io-msw/handlers/invites/redeem-by-token.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -12,5 +14,7 @@ export default http.put<{ token: string }>('/api/v1/me/crate_owner_invitations/a
   await db.crateOwnership.create({ crate: invite.crate, user: invite.invitee });
   db.crateOwnerInvitation.delete(q => q.where({ id: invite.id }));
 
-  return HttpResponse.json({ crate_owner_invitation: { crate_id: invite.crate.id, accepted: true } });
+  return HttpResponse.json<SuccessBody<'accept_crate_owner_invitation_with_token'>>({
+    crate_owner_invitation: { crate_id: invite.crate.id, accepted: true },
+  });
 });

--- a/packages/crates-io-msw/handlers/keywords/get.ts
+++ b/packages/crates-io-msw/handlers/keywords/get.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -11,5 +13,5 @@ export default http.get<{ keyword_id: string }>('/api/v1/keywords/:keyword_id', 
     return notFound();
   }
 
-  return HttpResponse.json({ keyword: serializeKeyword(keyword) });
+  return HttpResponse.json<SuccessBody<'find_keyword'>>({ keyword: serializeKeyword(keyword) });
 });

--- a/packages/crates-io-msw/handlers/keywords/list.ts
+++ b/packages/crates-io-msw/handlers/keywords/list.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -10,5 +12,8 @@ export default http.get('/api/v1/keywords', ({ request }) => {
   let keywords = db.keyword.findMany(undefined, { skip, take, orderBy: { keyword: 'asc' } });
   let total = db.keyword.count();
 
-  return HttpResponse.json({ keywords: keywords.map(k => serializeKeyword(k)), meta: { total } });
+  return HttpResponse.json<SuccessBody<'list_keywords'>>({
+    keywords: keywords.map(k => serializeKeyword(k)),
+    meta: { total },
+  });
 });

--- a/packages/crates-io-msw/handlers/metadata.ts
+++ b/packages/crates-io-msw/handlers/metadata.ts
@@ -1,10 +1,12 @@
+import type { SuccessBody } from '../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 const EXAMPLE_SHA1 = '5048d31943118c6d67359bd207d307c854e82f45';
 
 export default [
   http.get('/api/v1/site_metadata', () => {
-    return HttpResponse.json({
+    return HttpResponse.json<SuccessBody<'get_site_metadata'>>({
       commit: EXAMPLE_SHA1,
       deployed_sha: EXAMPLE_SHA1,
       read_only: false,

--- a/packages/crates-io-msw/handlers/summary.ts
+++ b/packages/crates-io-msw/handlers/summary.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../index.js';
@@ -21,7 +23,7 @@ export default [
     let popularCategories = db.category.findMany(undefined, { take: 10 });
     let popularKeywords = db.keyword.findMany(undefined, { take: 10 });
 
-    return HttpResponse.json({
+    return HttpResponse.json<SuccessBody<'get_summary'>>({
       just_updated: just_updated.map(c => serializeCrate(c)),
       most_downloaded: most_downloaded.map(c => serializeCrate(c)),
       new_crates: new_crates.map(c => serializeCrate(c)),

--- a/packages/crates-io-msw/handlers/teams/get.ts
+++ b/packages/crates-io-msw/handlers/teams/get.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -11,5 +13,5 @@ export default http.get<{ team_id: string }>('/api/v1/teams/:team_id', ({ params
     return notFound();
   }
 
-  return HttpResponse.json({ team: serializeTeam(team) });
+  return HttpResponse.json<SuccessBody<'find_team'>>({ team: serializeTeam(team) });
 });

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/create.ts
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/create.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../../index.js';
@@ -59,7 +61,7 @@ export default http.post('/api/v1/trusted_publishing/github_configs', async ({ r
     created_at: new Date().toISOString(),
   });
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'create_trustpub_github_config'>>({
     github_config: serializeGitHubConfig(config),
   });
 });

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/list.ts
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/list.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../../index.js';
@@ -31,7 +33,7 @@ export default http.get('/api/v1/trusted_publishing/github_configs', ({ request 
 
   let configs = db.trustpubGithubConfig.findMany(q => q.where(config => config.crate.id === crate.id));
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'list_trustpub_github_configs'>>({
     github_configs: configs.map(config => serializeGitHubConfig(config)),
     meta: { total: configs.length, next_page: null },
   });

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/create.ts
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/create.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../../index.js';
@@ -60,7 +62,7 @@ export default http.post('/api/v1/trusted_publishing/gitlab_configs', async ({ r
     created_at: new Date().toISOString(),
   });
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'create_trustpub_gitlab_config'>>({
     gitlab_config: serializeGitLabConfig(config),
   });
 });

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.ts
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../../index.js';
@@ -31,7 +33,7 @@ export default http.get('/api/v1/trusted_publishing/gitlab_configs', ({ request 
 
   let configs = db.trustpubGitlabConfig.findMany(q => q.where(config => config.crate.id === crate.id));
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'list_trustpub_gitlab_configs'>>({
     gitlab_configs: configs.map(config => serializeGitLabConfig(config)),
     meta: { total: configs.length, next_page: null },
   });

--- a/packages/crates-io-msw/handlers/users/confirm-email.ts
+++ b/packages/crates-io-msw/handlers/users/confirm-email.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -17,5 +19,5 @@ export default http.put<{ token: string }>('/api/v1/confirm/:token', async ({ pa
     },
   });
 
-  return HttpResponse.json({ ok: true });
+  return HttpResponse.json<SuccessBody<'confirm_user_email'>>({ ok: true });
 });

--- a/packages/crates-io-msw/handlers/users/get.ts
+++ b/packages/crates-io-msw/handlers/users/get.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -11,5 +13,5 @@ export default http.get<{ user_id: string }>('/api/v1/users/:user_id', ({ params
     return notFound();
   }
 
-  return HttpResponse.json({ user: serializeUser(user) });
+  return HttpResponse.json<SuccessBody<'find_user'>>({ user: serializeUser(user) });
 });

--- a/packages/crates-io-msw/handlers/users/me.ts
+++ b/packages/crates-io-msw/handlers/users/me.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -12,7 +14,7 @@ export default http.get('/api/v1/me', () => {
 
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.user?.id === user.id));
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'get_authenticated_user'>>({
     user: serializeUser(user, { removePrivateData: false }),
     owned_crates: ownerships.map(ownership => ({
       id: ownership.crate.id,

--- a/packages/crates-io-msw/handlers/users/resend.ts
+++ b/packages/crates-io-msw/handlers/users/resend.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { getSession } from '../../utils/session.js';
@@ -14,5 +16,5 @@ export default http.put<{ user_id: string }>('/api/v1/users/:user_id/resend', ({
 
   // let's pretend that we're sending an email here... :D
 
-  return HttpResponse.json({ ok: true });
+  return HttpResponse.json<SuccessBody<'resend_email_verification'>>({ ok: true });
 });

--- a/packages/crates-io-msw/handlers/users/stats.ts
+++ b/packages/crates-io-msw/handlers/users/stats.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -11,5 +13,5 @@ export default http.get<{ user_id: string }>('/api/v1/users/:user_id/stats', ({ 
   let ownerships = db.crateOwnership.findMany(q => q.where(o => o.user?.id === userId));
   let total_downloads = ownerships.reduce((sum, o) => sum + o.crate.downloads, 0);
 
-  return HttpResponse.json({ total_downloads });
+  return HttpResponse.json<SuccessBody<'get_user_stats'>>({ total_downloads });
 });

--- a/packages/crates-io-msw/handlers/users/update.ts
+++ b/packages/crates-io-msw/handlers/users/update.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -43,5 +45,5 @@ export default http.put<{ user_id: string }>('/api/v1/users/:user_id', async ({ 
     });
   }
 
-  return HttpResponse.json({ ok: true });
+  return HttpResponse.json<SuccessBody<'update_user'>>({ ok: true });
 });

--- a/packages/crates-io-msw/handlers/versions/dependencies.ts
+++ b/packages/crates-io-msw/handlers/versions/dependencies.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -20,7 +22,7 @@ export default http.get<{ name: string; version: string }>(
 
     let dependencies = db.dependency.findMany(q => q.where(dep => dep.version.id === version.id));
 
-    return HttpResponse.json({
+    return HttpResponse.json<SuccessBody<'get_version_dependencies'>>({
       dependencies: dependencies.map(d => serializeDependency(d)),
     });
   },

--- a/packages/crates-io-msw/handlers/versions/downloads.ts
+++ b/packages/crates-io-msw/handlers/versions/downloads.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -19,7 +21,7 @@ export default http.get<{ name: string; version: string }>(
 
     let downloads = db.versionDownload.findMany(q => q.where(download => download.version.id === version.id));
 
-    return HttpResponse.json({
+    return HttpResponse.json<SuccessBody<'get_version_downloads'>>({
       version_downloads: downloads.map(download => ({
         date: download.date,
         downloads: download.downloads,

--- a/packages/crates-io-msw/handlers/versions/follow-updates.ts
+++ b/packages/crates-io-msw/handlers/versions/follow-updates.ts
@@ -1,4 +1,5 @@
 import type { Crate } from '../../models/index.js';
+import type { SuccessBody } from '../../utils/api-types.js';
 
 import { http, HttpResponse } from 'msw';
 
@@ -23,7 +24,7 @@ export default http.get('/api/v1/me/updates', ({ request }) => {
   let totalCount = allVersions.length;
   let totalPages = Math.ceil(totalCount / perPage);
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'get_authenticated_user_updates'>>({
     versions: versions.map(v => serializeVersion(v)),
     meta: { more: page < totalPages },
   });

--- a/packages/crates-io-msw/handlers/versions/get.ts
+++ b/packages/crates-io-msw/handlers/versions/get.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -16,7 +18,7 @@ export default http.get<{ name: string; version: string }>('/api/v1/crates/:name
     return HttpResponse.json({ errors: [{ detail: errorMessage }] }, { status: 404 });
   }
 
-  return HttpResponse.json({
+  return HttpResponse.json<SuccessBody<'find_version'>>({
     version: serializeVersion(version),
   });
 });

--- a/packages/crates-io-msw/handlers/versions/list.ts
+++ b/packages/crates-io-msw/handlers/versions/list.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 import compareSemver from 'semver/functions/compare-loose.js';
 
@@ -62,5 +64,5 @@ export default http.get<{ name: string }>('/api/v1/crates/:name/versions', async
   }
 
   let serializedVersions = versions.map(v => serializeVersion(v));
-  return HttpResponse.json({ versions: serializedVersions, meta });
+  return HttpResponse.json<SuccessBody<'list_versions'>>({ versions: serializedVersions, meta });
 });

--- a/packages/crates-io-msw/handlers/versions/patch.ts
+++ b/packages/crates-io-msw/handlers/versions/patch.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -34,6 +36,6 @@ export default http.patch<{ name: string; version: string }>(
       },
     });
 
-    return HttpResponse.json({ version: serializeVersion(version!) });
+    return HttpResponse.json<SuccessBody<'update_version'>>({ version: serializeVersion(version!) });
   },
 );

--- a/packages/crates-io-msw/handlers/versions/unyank.ts
+++ b/packages/crates-io-msw/handlers/versions/unyank.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -27,6 +29,6 @@ export default http.put<{ name: string; version: string }>(
       },
     });
 
-    return HttpResponse.json({ ok: true });
+    return HttpResponse.json<SuccessBody<'unyank_version'>>({ ok: true });
   },
 );

--- a/packages/crates-io-msw/handlers/versions/yank.ts
+++ b/packages/crates-io-msw/handlers/versions/yank.ts
@@ -1,3 +1,5 @@
+import type { SuccessBody } from '../../utils/api-types.js';
+
 import { http, HttpResponse } from 'msw';
 
 import { db } from '../../index.js';
@@ -26,6 +28,6 @@ export default http.delete<{ name: string; version: string }>(
       },
     });
 
-    return HttpResponse.json({ ok: true });
+    return HttpResponse.json<SuccessBody<'yank_version'>>({ ok: true });
   },
 );

--- a/packages/crates-io-msw/utils/api-types.test.ts
+++ b/packages/crates-io-msw/utils/api-types.test.ts
@@ -1,0 +1,25 @@
+import type { operations } from '@crates-io/api-client';
+import type { SuccessBody } from './api-types.js';
+
+import { expectTypeOf, test } from 'vitest';
+
+test('extracts successful JSON response bodies', () => {
+  type FindCrateBody = operations['find_crate']['responses'][200]['content']['application/json'];
+  type ListCategoriesBody = operations['list_categories']['responses'][200]['content']['application/json'];
+
+  expectTypeOf<SuccessBody<'find_crate'>>().toEqualTypeOf<FindCrateBody>();
+  expectTypeOf<SuccessBody<'find_crate', 200>>().toEqualTypeOf<FindCrateBody>();
+  expectTypeOf<SuccessBody<'list_categories'>>().toEqualTypeOf<ListCategoriesBody>();
+});
+
+test('excludes successful responses without JSON content', () => {
+  expectTypeOf<SuccessBody<'delete_crate'>>().toBeNever();
+});
+
+test('rejects unknown operations and response statuses', () => {
+  // @ts-expect-error `missing_operation` is not part of the generated API schema
+  expectTypeOf<SuccessBody<'missing_operation'>>();
+
+  // @ts-expect-error `find_crate` only documents a `200` response
+  expectTypeOf<SuccessBody<'find_crate', 201>>();
+});

--- a/packages/crates-io-msw/utils/api-types.ts
+++ b/packages/crates-io-msw/utils/api-types.ts
@@ -1,0 +1,28 @@
+import type { operations } from '@crates-io/api-client';
+
+type Operation = keyof operations;
+type Responses<Op extends Operation> = operations[Op]['responses'];
+
+type JsonBody<Response> = Response extends { content: { 'application/json': infer Body } } ? Body : never;
+
+type JsonSuccessStatus<Op extends Operation> = {
+  [Status in keyof Responses<Op>]: `${Extract<Status, string | number>}` extends `2${string}`
+    ? JsonBody<Responses<Op>[Status]> extends never
+      ? never
+      : Status
+    : never;
+}[keyof Responses<Op>];
+
+type IsUnion<Type, Copy = Type> = Type extends Copy ? ([Copy] extends [Type] ? false : true) : never;
+
+type OnlyStatus<Status> = [Status] extends [never] ? never : IsUnion<Status> extends false ? Status : never;
+
+/**
+ * The JSON body returned by a successful OpenAPI operation.
+ *
+ * `Status` can be omitted when the operation has exactly one successful JSON response.
+ */
+export type SuccessBody<
+  Op extends Operation,
+  Status extends JsonSuccessStatus<Op> = OnlyStatus<JsonSuccessStatus<Op>>,
+> = Status extends keyof Responses<Op> ? JsonBody<Responses<Op>[Status]> : never;


### PR DESCRIPTION
This PR bind successful JSON responses from the MSW handlers to their generated OpenAPI operation types.

This makes schema drift visible where mock responses are authored without changing runtime behavior or vice-versa.
