### PR TITLE
drop unused username index

### DIFF
--- a/migrations/2026-07-25-142459-0000_create/down.sql
+++ b/migrations/2026-07-25-142459-0000_create/down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS index_users_username on users(canon_username(username))

--- a/migrations/2026-07-25-142459-0000_create/metadata.toml
+++ b/migrations/2026-07-25-142459-0000_create/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction=false

--- a/migrations/2026-07-25-142459-0000_create/up.sql
+++ b/migrations/2026-07-25-142459-0000_create/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS index_users_username;


### PR DESCRIPTION
depends on https://github.com/rust-lang/crates.io/pull/14349 being merged.

drops redundant username index now that we have a unique index on the same column