### PR TITLE
jobs/invalidate_cdns: Percent-encode `+` in invalidation paths

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -27,6 +27,17 @@ const CACHE_CONTROL_INDEX: &str = "public,max-age=600";
 const CACHE_CONTROL_README: &str = "public,max-age=604800";
 const CACHE_CONTROL_OG_IMAGE: &str = "public,max-age=86400";
 
+/// Renders a storage path for use with an external HTTP system, percent-encoding
+/// `+` as `%2B`.
+///
+/// A literal `+` in a URL path is ambiguous (see #4891), so the CDNs cache and
+/// serve objects under the `%2B` form. Any path handed to a CDN — whether in a
+/// redirect URL or a cache invalidation — has to use the same form to refer to
+/// the same object.
+pub fn encode_cdn_path(path: &str) -> String {
+    path.replace('+', "%2B")
+}
+
 /// Builds the cache tag shared by every object belonging to a crate.
 pub fn crate_cache_tag(name: &str) -> String {
     format!("crate:{name}")
@@ -428,7 +439,7 @@ impl<'a> StorageKey<'a> {
     /// [`Self::path()`] rendered for a public URL, with `+` percent-encoded as
     /// `%2B`.
     pub fn cdn_path(&self) -> String {
-        self.path().as_ref().replace('+', "%2B")
+        encode_cdn_path(self.path().as_ref())
     }
 
     /// The content-type the file should be stored with, or `None` to rely on

--- a/src/worker/jobs/invalidate_cdns.rs
+++ b/src/worker/jobs/invalidate_cdns.rs
@@ -5,6 +5,7 @@ use crates_io_database::models::{CloudFrontDistribution, CloudFrontInvalidationQ
 use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
 
+use crate::storage::encode_cdn_path;
 use crate::worker::Environment;
 use crate::worker::jobs::ProcessCloudfrontInvalidationQueue;
 
@@ -24,7 +25,12 @@ impl InvalidateCdns {
         I::Item: ToString,
     {
         Self {
-            paths: paths.map(|path| path.to_string()).collect(),
+            // `object_store::Path` does not percent-encode `+`, but the CDNs cache objects
+            // under `%2B` (see `encode_cdn_path()`). Without this the purge request targets a
+            // path that was never cached, so it succeeds while invalidating nothing.
+            paths: paths
+                .map(|path| encode_cdn_path(&path.to_string()))
+                .collect(),
             cache_tags: Vec::new(),
         }
     }
@@ -126,5 +132,34 @@ mod tests {
         .unwrap();
 
         assert_eq!(job.cloudfront_items(), ["/path", "#crate:foo"]);
+    }
+
+    #[test]
+    fn paths_percent_encode_plus() {
+        let paths = [
+            object_store::path::Path::from("crates/foo/foo-1.0.0+foo.crate"),
+            object_store::path::Path::from("readmes/foo/foo-1.0.0+foo.html"),
+        ];
+
+        // `object_store::Path` renders `+` literally, which is what made the paths diverge
+        // from the `%2B` form the CDNs cache under.
+        assert!(paths[0].to_string().contains('+'));
+
+        let job = InvalidateCdns::paths(paths.into_iter());
+
+        assert_eq!(
+            job.paths,
+            [
+                "crates/foo/foo-1.0.0%2Bfoo.crate",
+                "readmes/foo/foo-1.0.0%2Bfoo.html",
+            ]
+        );
+    }
+
+    #[test]
+    fn cache_tags_are_not_path_encoded() {
+        let job = InvalidateCdns::cache_tags(["crate:foo+bar"]);
+
+        assert_eq!(job.cache_tags, ["crate:foo+bar"]);
     }
 }


### PR DESCRIPTION
Fixes #14062.

`InvalidateCdns::paths()` receives `object_store::Path` values and renders them with `to_string()`. `object_store` omits `+` from its `INVALID` set, so the literal byte survives.

Everywhere else a path is handed to an external HTTP system it goes through `StorageKey::cdn_path()`, which encodes `+` as `%2B`, and both CDNs rewrite literal `+` to `%2B` at the viewer stage. Cached objects for build-metadata versions (e.g. `crates/foo/foo-1.0.0+foo.crate`) are therefore keyed under `%2B`.

CDN invalidation was the exception. The purge request targeted a path that was never cached, so it succeeded while invalidating nothing. This affects both consumers — Fastly via `purge_both_domains()` and the CloudFront invalidation queue.

Crate files are stored with `CACHE_CONTROL_IMMUTABLE` (`max-age=31536000`), so for a build-metadata version the practical consequence is that the `.crate` file stays served from the CDN for up to a year after the version was deleted, rather than until the next short TTL window.

## Changes

- Extract the `+` to `%2B` normalization out of `StorageKey::cdn_path()` into `storage::encode_cdn_path()`, so the two places that need this rendering share one implementation.
- Apply it in `InvalidateCdns::paths()`, which is the single point both callers (`DeleteCrateFromStorage` and the `delete-version` admin command) funnel through.

Cache tags are surrogate keys rather than paths, so they are deliberately left unencoded; there is a test asserting that.

## Testing

Two new unit tests in `invalidate_cdns`. `paths_percent_encode_plus` also asserts the underlying `object_store::Path` behaviour, so it documents the cause rather than just the symptom.

Verified the test actually pins the bug by reverting the fix and re-running:

```
assertion `left == right` failed
  left:  ["crates/foo/foo-1.0.0+foo.crate",   "readmes/foo/foo-1.0.0+foo.html"]
  right: ["crates/foo/foo-1.0.0%2Bfoo.crate", "readmes/foo/foo-1.0.0%2Bfoo.html"]
```

The 17 existing `storage::` tests pass unchanged, including `storage::tests::locations`, which covers `cdn_path()` and confirms the extraction is behaviour-neutral. `cargo clippy --lib --all-features` and `cargo fmt --check` are clean.

## AI tool disclosure

Per `docs/AI-TOOLS.md`: Claude was used to help trace the encoding divergence through `storage.rs`, `invalidate_cdns.rs` and `crates_io_fastly`, and to draft the tests and this description. I reviewed the change and ran the tests, including the negative control above.