### PR TITLE
Make `users.gh_encrypted_token` optional

### DIFF
--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -1002,7 +1002,7 @@ diesel::table! {
         /// The time the user was created.
         created_at -> Nullable<Timestamptz>,
         /// Encrypted GitHub access token
-        gh_encrypted_token -> Bytea,
+        gh_encrypted_token -> Nullable<Bytea>,
         /// The `gh_id` column of the `users` table.
         ///
         /// Its SQL type is `Int4`.

--- a/migrations/2026-07-15-181652-0000_make_users_gh_encrypted_token_optional/down.sql
+++ b/migrations/2026-07-15-181652-0000_make_users_gh_encrypted_token_optional/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ALTER COLUMN gh_encrypted_token SET NOT NULL;

--- a/migrations/2026-07-15-181652-0000_make_users_gh_encrypted_token_optional/up.sql
+++ b/migrations/2026-07-15-181652-0000_make_users_gh_encrypted_token_optional/up.sql
@@ -1,0 +1,7 @@
+-- safety-assured:start
+-- This column is not being read anywhere anymore. All reads are now using
+-- `oauth_github.encrypted_token` (an associated GitHub account is optional and all code paths have
+-- been updated to reflect that). This change means we can stop writing this column but not yet
+-- drop it.
+ALTER TABLE users ALTER COLUMN gh_encrypted_token DROP NOT NULL;
+-- safety-assured:end


### PR DESCRIPTION
But still continue writing it. A conservative baby step towards https://github.com/rust-lang/crates.io/pull/14259.