### PR TITLE
api: Extract `PublicUser` database model

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -8,8 +8,8 @@ pub use self::krate_publish::{EncodableCrateDependency, PublishMetadata};
 
 use chrono::{DateTime, Utc};
 use crates_io_database::models::{
-    ApiToken, Category, Crate, Dependency, DependencyKind, Keyword, Owner, ReverseDependency, Team,
-    TopVersions, TrustpubData, User, Version, VersionDownload, VersionOwnerAction,
+    ApiToken, Category, Crate, Dependency, DependencyKind, Keyword, PublicUser, ReverseDependency,
+    Team, TopVersions, TrustpubData, User, Version, VersionDownload, VersionOwnerAction,
 };
 use serde::{Deserialize, Serialize};
 
@@ -552,7 +552,7 @@ pub struct EncodableOwner {
 }
 
 impl EncodableOwner {
-    pub fn from_user(user: User) -> Self {
+    pub fn from_user(user: PublicUser) -> Self {
         Self {
             id: user.id,
             url: Some(format!("https://github.com/{}", user.gh_login)),
@@ -571,15 +571,6 @@ impl EncodableOwner {
             avatar: team.avatar,
             name: team.name,
             kind: String::from("team"),
-        }
-    }
-}
-
-impl From<Owner> for EncodableOwner {
-    fn from(owner: Owner) -> Self {
-        match owner {
-            Owner::User(user) => Self::from_user(user),
-            Owner::Team(team) => Self::from_team(team),
         }
     }
 }
@@ -785,10 +776,10 @@ pub struct EncodablePublicUser {
     pub created_at: Option<DateTime<Utc>>,
 }
 
-/// Converts a `User` model into an `EncodablePublicUser` for JSON serialization.
-impl From<User> for EncodablePublicUser {
-    fn from(user: User) -> Self {
-        let User {
+/// Converts a `PublicUser` model into an `EncodablePublicUser` for JSON serialization.
+impl From<PublicUser> for EncodablePublicUser {
+    fn from(user: PublicUser) -> Self {
+        let PublicUser {
             id,
             name,
             gh_login,
@@ -958,8 +949,8 @@ impl EncodableVersion {
     pub fn from(
         version: Version,
         crate_name: &str,
-        published_by: Option<User>,
-        audit_actions: Vec<(VersionOwnerAction, User)>,
+        published_by: Option<PublicUser>,
+        audit_actions: Vec<(VersionOwnerAction, PublicUser)>,
     ) -> Self {
         let Version {
             id,
@@ -1024,7 +1015,7 @@ impl EncodableVersion {
             repository,
             trustpub_data,
             linecounts,
-            published_by: published_by.map(User::into),
+            published_by: published_by.map(PublicUser::into),
             audit_actions: audit_actions
                 .into_iter()
                 .map(|(audit_action, user)| EncodableAuditAction {

--- a/crates/crates_io_database/src/models/action.rs
+++ b/crates/crates_io_database/src/models/action.rs
@@ -1,4 +1,4 @@
-use crate::models::{ApiToken, User, Version};
+use crate::models::{ApiToken, PublicUser, User, Version};
 use crate::pg_enum;
 use crate::schema::*;
 use bon::Builder;
@@ -57,13 +57,13 @@ impl VersionOwnerAction {
     pub async fn by_version(
         mut conn: &AsyncPgConnection,
         version: &Version,
-    ) -> QueryResult<Vec<(Self, User)>> {
+    ) -> QueryResult<Vec<(Self, PublicUser)>> {
         use version_owner_actions::dsl::version_id;
 
         version_owner_actions::table
             .filter(version_id.eq(version.id))
             .inner_join(users::table.left_join(oauth_github::table))
-            .select((VersionOwnerAction::as_select(), User::as_select()))
+            .select((VersionOwnerAction::as_select(), PublicUser::as_select()))
             .order(version_owner_actions::dsl::id)
             .load(&mut conn)
             .await
@@ -72,10 +72,10 @@ impl VersionOwnerAction {
     pub async fn for_versions(
         mut conn: &AsyncPgConnection,
         versions: &[&Version],
-    ) -> QueryResult<Vec<Vec<(Self, User)>>> {
+    ) -> QueryResult<Vec<Vec<(Self, PublicUser)>>> {
         Ok(Self::belonging_to(versions)
             .inner_join(users::table.left_join(oauth_github::table))
-            .select((VersionOwnerAction::as_select(), User::as_select()))
+            .select((VersionOwnerAction::as_select(), PublicUser::as_select()))
             .order(version_owner_actions::dsl::id)
             .load(&mut conn)
             .await?

--- a/crates/crates_io_database/src/models/mod.rs
+++ b/crates/crates_io_database/src/models/mod.rs
@@ -18,7 +18,7 @@ pub use self::owner::{CrateOwner, Owner, OwnerKind};
 pub use self::team::{NewTeam, Team};
 pub use self::token::ApiToken;
 pub use self::trustpub::TrustpubData;
-pub use self::user::{NewOauthGithub, NewUser, OauthGithub, User};
+pub use self::user::{NewOauthGithub, NewUser, OauthGithub, PublicUser, User};
 pub use self::version::{NewVersion, TopVersions, Version};
 
 pub mod helpers;

--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -11,6 +11,33 @@ use crate::fns::lower;
 use crate::models::{Crate, CrateOwner, Email, OwnerKind};
 use crate::schema::{crate_owners, emails, oauth_github, users};
 
+/// Public data for a crates.io user.
+#[derive(Clone, Debug, HasQuery, Serialize)]
+#[diesel(
+    table_name = users,
+    base_query = users::table.left_join(oauth_github::table),
+)]
+pub struct PublicUser {
+    pub id: i32,
+    pub name: Option<String>,
+    pub gh_login: String,
+    #[diesel(select_expression = oauth_github::avatar.nullable())]
+    pub gh_avatar: Option<String>,
+    pub username: String,
+    pub created_at: Option<DateTime<Utc>>,
+}
+
+impl PublicUser {
+    pub async fn owning(krate: &Crate, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Self>> {
+        CrateOwner::by_owner_kind(OwnerKind::User)
+            .inner_join(users::table.left_join(oauth_github::table))
+            .select(PublicUser::as_select())
+            .filter(crate_owners::crate_id.eq(krate.id))
+            .load(&mut conn)
+            .await
+    }
+}
+
 /// The model representing a row in the `users` database table.
 #[derive(Clone, Debug, HasQuery, Identifiable, Serialize)]
 #[diesel(

--- a/crates/crates_io_database/src/models/version.rs
+++ b/crates/crates_io_database/src/models/version.rs
@@ -7,7 +7,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::Deserialize;
 
-use crate::models::{Crate, TrustpubData, User};
+use crate::models::{Crate, PublicUser, TrustpubData};
 use crate::schema::{readme_renderings, users, versions};
 
 #[derive(Clone, Identifiable, Associations, Debug, HasQuery)]
@@ -64,9 +64,12 @@ impl Version {
 
     /// Gets the User who ran `cargo publish` for this version, if recorded.
     /// Not for use when you have a group of versions you need the publishers for.
-    pub async fn published_by(&self, mut conn: &AsyncPgConnection) -> QueryResult<Option<User>> {
+    pub async fn published_by(
+        &self,
+        mut conn: &AsyncPgConnection,
+    ) -> QueryResult<Option<PublicUser>> {
         match self.published_by {
-            Some(pb) => User::query()
+            Some(pb) => PublicUser::query()
                 .filter(users::id.eq(pb))
                 .first(&mut conn)
                 .await

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -4,7 +4,7 @@ use crate::auth::Authentication;
 use crate::controllers::helpers::authorization::Rights;
 use crate::controllers::helpers::pagination::{Page, PaginationOptions, PaginationQueryParams};
 use crate::models::crate_owner_invitation::AcceptError;
-use crate::models::{Crate, CrateOwnerInvitation, User};
+use crate::models::{Crate, CrateOwnerInvitation, PublicUser};
 use crate::schema::{crate_owner_invitations, crates, users};
 use crate::util::RequestUtils;
 use crate::util::errors::{AppResult, BoxedAppError, bad_request, custom, forbidden, internal};
@@ -166,8 +166,6 @@ async fn prepare_list(
     let config = &state.config;
 
     let mut crate_names = HashMap::new();
-    let mut users = IndexMap::new();
-    users.insert(user.id, user.clone());
 
     let sql_filter: Box<dyn BoxableExpression<crate_owner_invitations::table, Pg, SqlType = Bool>> =
         match filter {
@@ -271,10 +269,11 @@ async fn prepare_list(
             std::iter::once(invite.invited_user_id)
                 .chain(std::iter::once(invite.invited_by_user_id))
         })
-        .filter(|id| !users.contains_key(id))
         .collect::<Vec<_>>();
+
+    let mut users = IndexMap::new();
     if !missing_users.is_empty() {
-        let new_users: Vec<User> = User::query()
+        let new_users: Vec<PublicUser> = PublicUser::query()
             .filter(users::id.eq_any(missing_users))
             .load(&mut conn)
             .await?;

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -6,15 +6,14 @@
 use crate::app::AppState;
 use crate::controllers::krate::CratePath;
 use crate::models::download::Version;
-use crate::models::{User, Version as FullVersion, VersionDownload, VersionOwnerAction};
-use crate::schema::{version_downloads, version_owner_actions, versions};
+use crate::models::{PublicUser, Version as FullVersion, VersionDownload, VersionOwnerAction};
+use crate::schema::{oauth_github, users, version_downloads, version_owner_actions, versions};
 use crate::util::errors::{AppResult, BoxedAppError, bad_request};
 use crate::views::{EncodableVersion, EncodableVersionDownload};
 use axum::Json;
 use axum::extract::FromRequestParts;
 use axum_extra::extract::Query;
 use crates_io_database::fns::to_char;
-use crates_io_database::schema::{oauth_github, users};
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use futures_util::FutureExt;
@@ -160,7 +159,7 @@ pub async fn get_crate_downloads(
     }))
 }
 
-type VersionsAndPublishers = (FullVersion, Option<User>);
+type VersionsAndPublishers = (FullVersion, Option<PublicUser>);
 
 async fn load_versions_and_publishers(
     mut conn: &AsyncPgConnection,
@@ -181,13 +180,13 @@ async fn load_actions(
     mut conn: &AsyncPgConnection,
     versions: &[Version],
     includes: bool,
-) -> QueryResult<Vec<(VersionOwnerAction, User)>> {
+) -> QueryResult<Vec<(VersionOwnerAction, PublicUser)>> {
     if !includes {
         return Ok(vec![]);
     }
     VersionOwnerAction::belonging_to(versions)
         .inner_join(users::table.left_join(oauth_github::table))
-        .select((VersionOwnerAction::as_select(), User::as_select()))
+        .select((VersionOwnerAction::as_select(), PublicUser::as_select()))
         .order(version_owner_actions::id)
         .load(&mut conn)
         .await

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -7,7 +7,7 @@
 use crate::app::AppState;
 use crate::controllers::krate::CratePath;
 use crate::models::{
-    Category, Crate, CrateCategory, CrateKeyword, Keyword, TopVersions, User, Version,
+    Category, Crate, CrateCategory, CrateKeyword, Keyword, PublicUser, TopVersions, Version,
     VersionOwnerAction,
 };
 use crate::schema::*;
@@ -215,7 +215,7 @@ pub async fn find_crate(
     }))
 }
 
-type VersionsAndPublishers = (Version, Option<User>);
+type VersionsAndPublishers = (Version, Option<PublicUser>);
 
 async fn load_versions_and_publishers(
     conn: &AsyncPgConnection,
@@ -309,7 +309,7 @@ async fn _load_versions_and_publishers(
 ) -> AppResult<Option<Vec<VersionsAndPublishers>>> {
     let mut query = Version::belonging_to(krate)
         .left_outer_join(users::table.left_join(oauth_github::table))
-        .select(<(Version, Option<User>)>::as_select())
+        .select(<(Version, Option<PublicUser>)>::as_select())
         .order_by(versions::id.desc())
         .into_boxed();
 

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -3,7 +3,7 @@
 use crate::controllers::helpers::authorization::Rights;
 use crate::controllers::krate::CratePath;
 use crate::models::krate::OwnerRemoveError;
-use crate::models::{Crate, Owner, Team, User};
+use crate::models::{Crate, Owner, PublicUser, Team, User};
 use crate::models::{
     CrateOwner, NewCrateOwnerInvitation, NewCrateOwnerInvitationOutcome, NewTeam,
     krate::NewOwnerInvite, token::EndpointScope,
@@ -44,16 +44,18 @@ pub async fn list_owners(state: AppState, path: CratePath) -> AppResult<Json<Use
 
     let krate = path.load_crate(&conn).await?;
 
-    let mut owners = krate.owners(&conn).await?;
-    owners.sort_by_key(|owner| match owner {
-        Owner::User(user) => (0, user.id),
-        Owner::Team(team) => (1, team.id),
-    });
+    let (mut users, mut teams) = tokio::try_join!(
+        PublicUser::owning(&krate, &conn),
+        Team::owning(&krate, &conn),
+    )?;
+    users.sort_by_key(|user| user.id);
+    teams.sort_by_key(|team| team.id);
 
-    let users = owners
+    let users = users
         .into_iter()
-        .map(Owner::into)
-        .collect::<Vec<EncodableOwner>>();
+        .map(EncodableOwner::from_user)
+        .chain(teams.into_iter().map(EncodableOwner::from_team))
+        .collect::<Vec<_>>();
 
     Ok(Json(UsersResponse { users }))
 }
@@ -99,7 +101,7 @@ pub async fn get_user_owners(state: AppState, path: CratePath) -> AppResult<Json
 
     let krate = path.load_crate(&conn).await?;
 
-    let mut users = User::owning(&krate, &conn).await?;
+    let mut users = PublicUser::owning(&krate, &conn).await?;
     users.sort_by_key(|user| user.id);
 
     let users = users

--- a/src/controllers/krate/rev_deps.rs
+++ b/src/controllers/krate/rev_deps.rs
@@ -1,7 +1,7 @@
 use crate::app::AppState;
 use crate::controllers::helpers::pagination::{PaginationOptions, PaginationQueryParams};
 use crate::controllers::krate::CratePath;
-use crate::models::{CrateName, ReverseDependency, User, Version, VersionOwnerAction};
+use crate::models::{CrateName, PublicUser, ReverseDependency, Version, VersionOwnerAction};
 use crate::util::errors::AppResult;
 use crate::views::{EncodableDependency, EncodableVersion};
 use axum::Json;
@@ -64,11 +64,11 @@ pub async fn list_reverse_dependencies(
 
     let version_ids: Vec<i32> = rev_deps.iter().map(|dep| dep.version_id).collect();
 
-    let versions_and_publishers: Vec<(Version, CrateName, Option<User>)> = versions::table
+    let versions_and_publishers: Vec<(Version, CrateName, Option<PublicUser>)> = versions::table
         .filter(versions::id.eq_any(version_ids))
         .inner_join(crates::table)
         .left_outer_join(users::table.left_join(oauth_github::table))
-        .select(<(Version, CrateName, Option<User>)>::as_select())
+        .select(<(Version, CrateName, Option<PublicUser>)>::as_select())
         .order(versions::id)
         .load(&mut conn)
         .await?;

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -5,7 +5,7 @@ use crate::controllers::helpers::pagination::{
     Page, PaginationOptions, PaginationQueryParams, encode_seek,
 };
 use crate::controllers::krate::CratePath;
-use crate::models::{User, Version, VersionOwnerAction};
+use crate::models::{PublicUser, Version, VersionOwnerAction};
 use crate::schema::{oauth_github, users, versions};
 use crate::util::RequestUtils;
 use crate::util::errors::{AppResult, BoxedAppError, bad_request};
@@ -147,7 +147,7 @@ async fn list(
         let mut query = versions::table
             .filter(versions::crate_id.eq(crate_id))
             .left_outer_join(users::table.left_join(oauth_github::table))
-            .select(<(Version, Option<User>)>::as_select())
+            .select(<(Version, Option<PublicUser>)>::as_select())
             .into_boxed();
 
         if !params.nums.is_empty() {
@@ -194,7 +194,7 @@ async fn list(
         query = query.order((versions::semver_ord_v2.desc(), versions::id.desc()));
     }
 
-    let data: Vec<(Version, Option<User>)> = query.load(&mut conn).await?;
+    let data: Vec<(Version, Option<PublicUser>)> = query.load(&mut conn).await?;
     let mut next_page = None;
     if let Some(options) = options {
         next_page = next_seek_params(&data, options, |last| seek.to_payload(last))?
@@ -259,7 +259,7 @@ async fn list(
 
 mod seek {
     use crate::controllers::helpers::pagination::seek;
-    use crate::models::{User, Version};
+    use crate::models::{PublicUser, Version};
     use chrono::Utc;
     use chrono::serde::ts_microseconds;
 
@@ -281,7 +281,7 @@ mod seek {
     );
 
     impl Seek {
-        pub(crate) fn to_payload(&self, record: &(Version, Option<User>)) -> SeekPayload {
+        pub(crate) fn to_payload(&self, record: &(Version, Option<PublicUser>)) -> SeekPayload {
             let (Version { id, created_at, .. }, _) = *record;
             match *self {
                 Seek::Semver => SeekPayload::Semver(Semver {
@@ -319,7 +319,7 @@ where
 }
 
 struct PaginatedVersionsAndPublishers {
-    data: Vec<(Version, Option<User>)>,
+    data: Vec<(Version, Option<PublicUser>)>,
     meta: ResponseMeta,
 }
 

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -3,7 +3,7 @@ use crate::auth::AuthCheck;
 use crate::controllers::helpers::Paginate;
 use crate::controllers::helpers::pagination::{Paginated, PaginationOptions};
 use crate::models::krate::CrateName;
-use crate::models::{CrateOwner, Follow, OwnerKind, User, Version, VersionOwnerAction};
+use crate::models::{CrateOwner, Follow, OwnerKind, PublicUser, User, Version, VersionOwnerAction};
 use crate::schema::{crate_owners, crates, emails, follows, oauth_github, users, versions};
 use crate::util::errors::AppResult;
 use crate::util::no_store;
@@ -122,10 +122,10 @@ pub async fn get_authenticated_user_updates(
         .left_outer_join(users::table.left_join(oauth_github::table))
         .filter(crates::id.eq_any(followed_crates))
         .order(versions::created_at.desc())
-        .select(<(Version, CrateName, Option<User>)>::as_select())
+        .select(<(Version, CrateName, Option<PublicUser>)>::as_select())
         .pages_pagination(PaginationOptions::builder().gather(&req)?);
 
-    let data: Paginated<(Version, CrateName, Option<User>)> = query.load(&mut conn).await?;
+    let data: Paginated<(Version, CrateName, Option<PublicUser>)> = query.load(&mut conn).await?;
 
     let more = data.next_page_params().is_some();
     let versions = data.iter().map(|(v, ..)| v).collect::<Vec<_>>();

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -1,5 +1,5 @@
 use crate::app::AppState;
-use crate::models::{CrateOwner, OwnerKind, User};
+use crate::models::{CrateOwner, OwnerKind, PublicUser};
 use crate::schema::{crate_downloads, crate_owners, crates};
 use crate::util::errors::AppResult;
 use crate::views::EncodablePublicUser;
@@ -36,7 +36,7 @@ pub async fn find_user(
     use crate::schema::users::dsl::{gh_login, id};
 
     let name = lower(&user_name);
-    let user: User = User::query()
+    let user: PublicUser = PublicUser::query()
         .filter(lower(gh_login).eq(name))
         .order(id.desc())
         .first(&mut conn)


### PR DESCRIPTION
This introduces a `PublicUser` database model for data used by public user and owner responses. It updates the affected queries and serializers to use the narrower type while preserving existing JSON and OAuth join behavior.

The dedicated projection keeps private user fields out of public response paths and makes the data requirements of public API responses explicit. It will also make it easier in the future to introduce the planned [`github_username_matches`](https://github.com/rust-lang/crates.io/issues/14380) field.

/cc @carols10cents 