### PR TITLE
Stop writing `users.gh_encrypted_token`

### DIFF
--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -97,7 +97,6 @@ pub struct NewUser<'a> {
     pub gh_login: &'a str,
     pub username: &'a str,
     pub name: Option<&'a str>,
-    pub gh_encrypted_token: &'a [u8],
 }
 
 impl NewUser<'_> {
@@ -133,7 +132,6 @@ impl NewUser<'_> {
                 users::gh_login.eq(excluded(users::gh_login)),
                 users::username.eq(excluded(users::username)),
                 users::name.eq(excluded(users::name)),
-                users::gh_encrypted_token.eq(excluded(users::gh_encrypted_token)),
             ))
             .returning(users::id)
             .get_result(&mut conn)

--- a/crates/crates_io_database/tests/reserved_usernames.rs
+++ b/crates/crates_io_database/tests/reserved_usernames.rs
@@ -26,7 +26,6 @@ async fn insert_user(conn: &AsyncPgConnection, username: &str) -> QueryResult<i3
         .gh_id(NEXT_GH_ID.fetch_add(1, Ordering::SeqCst))
         .gh_login(username)
         .username(username)
-        .gh_encrypted_token(&[])
         .build()
         .insert(conn)
         .await

--- a/crates/crates_io_test_utils/src/builders/user.rs
+++ b/crates/crates_io_test_utils/src/builders/user.rs
@@ -69,7 +69,6 @@ impl<'a> UserBuilder<'a> {
             .gh_login(self.username)
             .username(self.username)
             .maybe_name(self.display_name)
-            .gh_encrypted_token(&ENCRYPTED_TOKEN)
             .build()
     }
 }

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -217,7 +217,6 @@ async fn update_user(
             users::username.eq(&gh_user.login),
             // These fields are soon to be deprecated.
             users::gh_login.eq(&gh_user.login),
-            users::gh_encrypted_token.eq(encrypted_token),
         ))
         .execute(conn)
         .await?;
@@ -243,7 +242,6 @@ async fn create_user(
         .gh_login(&gh_user.login)
         .username(&gh_user.login)
         .maybe_name(gh_user.name.as_deref())
-        .gh_encrypted_token(encrypted_token)
         .build();
 
     let user_id = new_user.insert(conn).await?;

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -795,7 +795,6 @@ async fn inactive_users_dont_get_invitations() {
         .gh_id(-1)
         .gh_login(invited_gh_login)
         .username(invited_gh_login)
-        .gh_encrypted_token(&[])
         .build()
         .insert(&conn)
         .await

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -76,7 +76,6 @@ async fn user_without_github_account() {
         .gh_login("foobar")
         .username("foobar")
         .name("I deleted my github account")
-        .gh_encrypted_token(&[])
         .build();
     new_user.insert(&conn).await.unwrap();
     // This user doesn't have a linked record in `oauth_github`

--- a/src/tests/worker/sync_admins.rs
+++ b/src/tests/worker/sync_admins.rs
@@ -94,7 +94,6 @@ async fn create_user(
             users::gh_login.eq(name),
             users::username.eq(name),
             users::gh_id.eq(account_id as i32),
-            users::gh_encrypted_token.eq(&[]),
             users::is_admin.eq(is_admin),
         ))
         .returning(users::id)


### PR DESCRIPTION
This value is no longer being read anywhere, so now we can stop writing it.

The value is also being written to the `oauth_github.encrypted_token` field; if we need to revert this, we can backfill any missed values in `users.gh_encrypted_token` using `oauth_github.encrypted_token`.

Part of https://github.com/rust-lang/crates.io/pull/14259.