### PR TITLE
Add backend support for explicit signup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4578,6 +4578,7 @@ dependencies = [
  "nom",
  "percent-encoding",
  "quoted_printable",
+ "serde",
  "socket2 0.6.5",
  "tokio",
  "tokio-native-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ hyper = { version = "=1.11.0", features = ["client", "http1"] }
 indexmap = { version = "=2.14.0", features = ["serde"] }
 indicatif = "=0.18.6"
 json-subscriber = "=0.3.0"
-lettre = { version = "=0.11.23", default-features = false, features = ["file-transport", "smtp-transport", "hostname", "builder", "tokio1", "tokio1-native-tls"] }
+lettre = { version = "=0.11.23", default-features = false, features = ["file-transport", "smtp-transport", "hostname", "builder", "serde", "tokio1", "tokio1-native-tls"] }
 minijinja = { version = "=2.23.0", features = ["loader"] }
 mockall = "=0.15.0"
 moka = { version = "=0.12.15", default-features = false, features = ["future"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ hyper = { version = "=1.11.0", features = ["client", "http1"] }
 indexmap = { version = "=2.14.0", features = ["serde"] }
 indicatif = "=0.18.6"
 json-subscriber = "=0.3.0"
-lettre = { version = "=0.11.23", default-features = false, features = ["file-transport", "smtp-transport", "hostname", "builder", "tokio1", "tokio1-native-tls"] }
+lettre = { version = "=0.11.23", default-features = false, features = ["file-transport", "smtp-transport", "hostname", "builder", "serde", "tokio1", "tokio1-native-tls"] }
 minijinja = { version = "=2.22.0", features = ["loader"] }
 mockall = "=0.15.0"
 moka = { version = "=0.12.15", default-features = false, features = ["future"] }

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -418,7 +418,7 @@ impl From<reqwest::Error> for GitHubError {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct GitHubUser {
     pub avatar_url: Option<String>,
     pub email: Option<String>,

--- a/e2e/acceptance/login.spec.ts
+++ b/e2e/acceptance/login.spec.ts
@@ -1,9 +1,8 @@
-import type { SuccessBody } from '@crates-io/msw/utils/api-types';
 import type { Page } from '@playwright/test';
 
 import { expect, test } from '@/e2e/helper';
 import { serializeUser } from '@crates-io/msw/serializers/user';
-import { http, HttpResponse } from 'msw';
+import { http } from '@crates-io/msw/utils/openapi-http';
 
 const MOCK_CODE = '901dd10e07c7e9fa1cd5';
 const MOCK_STATE = 'fYcUY3FMdUUz00FC7vLT7A';
@@ -37,14 +36,15 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
     let user = await msw.db.user.create({ name: 'John Doe' });
 
     msw.worker.use(
-      http.post('/api/private/session/authorize', async ({ request }) => {
+      http.post('/api/private/session/authorize', async ({ request, response }) => {
         let body = await request.json();
         expect(Object.keys(body)).toEqual(['code', 'state']);
         expect(body.code).toBe(MOCK_CODE);
         expect(body.state).toBe(MOCK_STATE);
 
         await msw.db.mswSession.create({ user });
-        return HttpResponse.json<SuccessBody<'authorize_session'>>({
+        return response(200).json({
+          status: 'signed_in',
           user: serializeUser(user, { removePrivateData: false }),
           owned_crates: [],
         });
@@ -56,12 +56,27 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-user-menu] [data-test-toggle]')).toHaveText('John Doe');
   });
 
+  test('shows an error when signup is required', async ({ page, msw }) => {
+    await setupGitHubOAuthRoutes(page);
+
+    msw.worker.use(
+      http.post('/api/private/session/authorize', ({ response }) => response(200).json({ status: 'signup_required' })),
+    );
+
+    await page.goto('/');
+    await page.click('[data-test-login-button]');
+    await expect(page.locator('[data-test-notification-message="error"]')).toHaveText(
+      'Signup is currently not possible.',
+    );
+    expect(await page.evaluate(() => localStorage.getItem('isLoggedIn'))).toBeNull();
+  });
+
   test('failed login', async ({ page, msw }) => {
     await setupGitHubOAuthRoutes(page);
 
     msw.worker.use(
-      http.post('/api/private/session/authorize', () =>
-        HttpResponse.json({ errors: [{ detail: 'Forbidden' }] }, { status: 403 }),
+      http.post('/api/private/session/authorize', ({ response }) =>
+        response.untyped(Response.json({ errors: [{ detail: 'Forbidden' }] }, { status: 403 })),
       ),
     );
 
@@ -76,14 +91,15 @@ test.describe('Acceptance | Login', { tag: '@acceptance' }, () => {
     let user = await msw.db.user.create({ name: 'John Doe' });
 
     msw.worker.use(
-      http.post('/api/private/session/authorize', async ({ request }) => {
+      http.post('/api/private/session/authorize', async ({ request, response }) => {
         let body = await request.json();
         expect(Object.keys(body)).toEqual(['code', 'state']);
         expect(body.code).toBe(MOCK_CODE);
         expect(body.state).toBe(MOCK_STATE);
 
         await msw.db.mswSession.create({ user });
-        return HttpResponse.json<SuccessBody<'authorize_session'>>({
+        return response(200).json({
+          status: 'signed_in',
           user: serializeUser(user, { removePrivateData: false }),
           owned_crates: [],
         });

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -88,6 +88,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/private/session/signup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Load the GitHub account details for a pending signup.
+         * @description The encrypted GitHub token remains in the signed session cookie and is never returned to the
+         *     frontend. Missing, malformed, and expired signup state require restarting GitHub
+         *     authentication.
+         */
+        get: operations["get_pending_signup"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/categories": {
         parameters: {
             query?: never;
@@ -1548,6 +1570,13 @@ export interface components {
         ReleaseTrackDetails: {
             highest: string;
         };
+        /** @description Public GitHub account details displayed while a user completes signup. */
+        SignupDetails: {
+            /** @description The email address suggested by GitHub, if one is available. */
+            email?: string | null;
+            /** @description The GitHub account login. */
+            login: string;
+        };
         Slug: {
             /**
              * @description A description of the category.
@@ -2077,6 +2106,46 @@ export interface operations {
                         state: string;
                         /** @example https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg */
                         url: string;
+                    };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    get_pending_signup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        signup: components["schemas"]["SignupDetails"];
                     };
                 };
             };

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -52,8 +52,9 @@ export interface paths {
          * Complete authentication flow.
          * @description This route is called from the GitHub API OAuth flow after the user accepted or rejected
          *     the data access permissions. It will check the `state` parameter and then call the GitHub API
-         *     to exchange the temporary `code` for an API token. The response indicates whether the
-         *     corresponding user was signed in or needs to complete signup.
+         *     to exchange the temporary `code` for an API token. Existing crates.io users are signed in.
+         *     New users must complete signup when explicit signup is enabled and are created immediately
+         *     otherwise.
          *
          *     see <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>
          */

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -52,8 +52,8 @@ export interface paths {
          * Complete authentication flow.
          * @description This route is called from the GitHub API OAuth flow after the user accepted or rejected
          *     the data access permissions. It will check the `state` parameter and then call the GitHub API
-         *     to exchange the temporary `code` for an API token. The API token is returned together with
-         *     the corresponding user information.
+         *     to exchange the temporary `code` for an API token. The response indicates whether the
+         *     corresponding user was signed in or needs to complete signup.
          *
          *     see <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>
          */
@@ -2008,7 +2008,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
+                    "application/json": ({
                         /** @description The crates that the authenticated user owns. */
                         owned_crates: {
                             /** @deprecated */
@@ -2027,6 +2027,12 @@ export interface operations {
                         }[];
                         /** @description The authenticated user. */
                         user: components["schemas"]["AuthenticatedUser"];
+                    } & {
+                        /** @enum {string} */
+                        status: "signed_in";
+                    }) | {
+                        /** @enum {string} */
+                        status: "signup_required";
                     };
                 };
             };
@@ -5308,6 +5314,12 @@ type ReadonlyArray<T> = [
 ] extends [
     unknown[]
 ] ? Readonly<Exclude<T, undefined>> : Readonly<Exclude<T, undefined>[]>;
+export const pathsApiPrivateSessionAuthorizePostResponses200ContentApplicationJsonOneOf0StatusValues: ReadonlyArray<Extract<FlattenedDeepRequired<paths>["/api/private/session/authorize"]["post"]["responses"]["200"]["content"]["application/json"], {
+    status: unknown;
+}>["status"]> = ["signed_in"];
+export const pathsApiPrivateSessionAuthorizePostResponses200ContentApplicationJsonOneOf1StatusValues: ReadonlyArray<Extract<FlattenedDeepRequired<paths>["/api/private/session/authorize"]["post"]["responses"]["200"]["content"]["application/json"], {
+    status: unknown;
+}>["status"]> = ["signup_required"];
 export const endpointScopeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["EndpointScope"]> = ["publish-new", "publish-update", "trusted-publishing", "yank", "change-owners"];
 export const trustpubDataOneOf0ProviderValues: ReadonlyArray<Extract<FlattenedDeepRequired<components>["schemas"]["TrustpubData"], {
     provider: unknown;

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -104,7 +104,8 @@ export interface paths {
         get: operations["get_pending_signup"];
         put?: never;
         post?: never;
-        delete?: never;
+        /** Cancel a pending signup. */
+        delete: operations["delete_pending_signup"];
         options?: never;
         head?: never;
         patch?: never;
@@ -2146,6 +2147,47 @@ export interface operations {
                 content: {
                     "application/json": {
                         signup: components["schemas"]["SignupDetails"];
+                    };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    delete_pending_signup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        ok: boolean;
                     };
                 };
             };

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -103,7 +103,8 @@ export interface paths {
          */
         get: operations["get_pending_signup"];
         put?: never;
-        post?: never;
+        /** Complete a pending signup. */
+        post: operations["complete_pending_signup"];
         /** Cancel a pending signup. */
         delete: operations["delete_pending_signup"];
         options?: never;
@@ -2147,6 +2148,77 @@ export interface operations {
                 content: {
                     "application/json": {
                         signup: components["schemas"]["SignupDetails"];
+                    };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    complete_pending_signup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description User-controlled signup details. */
+                    signup: {
+                        /**
+                         * Format: email
+                         * @description The email address to associate with the new account.
+                         * @example new-user@example.com
+                         */
+                        email: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description The crates that the authenticated user owns. */
+                        owned_crates: {
+                            /** @deprecated */
+                            email_notifications: boolean;
+                            /**
+                             * Format: int32
+                             * @description The opaque identifier of the crate.
+                             * @example 123
+                             */
+                            id: number;
+                            /**
+                             * @description The name of the crate.
+                             * @example serde
+                             */
+                            name: string;
+                        }[];
+                        /** @description The authenticated user. */
+                        user: components["schemas"]["AuthenticatedUser"];
                     };
                 };
             };

--- a/packages/crates-io-msw/handlers/sessions.ts
+++ b/packages/crates-io-msw/handlers/sessions.ts
@@ -1,5 +1,6 @@
+import completePendingSignup from './sessions/complete-pending-signup.js';
 import deletePendingSignup from './sessions/delete-pending-signup.js';
 import deleteSession from './sessions/delete.js';
 import getPendingSignup from './sessions/get-pending-signup.js';
 
-export default [deletePendingSignup, deleteSession, getPendingSignup];
+export default [completePendingSignup, deletePendingSignup, deleteSession, getPendingSignup];

--- a/packages/crates-io-msw/handlers/sessions.ts
+++ b/packages/crates-io-msw/handlers/sessions.ts
@@ -1,4 +1,5 @@
+import deletePendingSignup from './sessions/delete-pending-signup.js';
 import deleteSession from './sessions/delete.js';
 import getPendingSignup from './sessions/get-pending-signup.js';
 
-export default [deleteSession, getPendingSignup];
+export default [deletePendingSignup, deleteSession, getPendingSignup];

--- a/packages/crates-io-msw/handlers/sessions.ts
+++ b/packages/crates-io-msw/handlers/sessions.ts
@@ -1,3 +1,4 @@
 import deleteSession from './sessions/delete.js';
+import getPendingSignup from './sessions/get-pending-signup.js';
 
-export default [deleteSession];
+export default [deleteSession, getPendingSignup];

--- a/packages/crates-io-msw/handlers/sessions/complete-pending-signup.test.ts
+++ b/packages/crates-io-msw/handlers/sessions/complete-pending-signup.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from 'vitest';
+
+import { db } from '../../index.js';
+
+test('creates a user and session from the pending signup', async function () {
+  await db.pendingSignup.create({ login: 'ghost', email: 'ghost@example.com' });
+
+  let response = await fetch('/api/private/session/signup', {
+    method: 'POST',
+    body: JSON.stringify({ signup: { email: 'new-user@example.com' } }),
+  });
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "owned_crates": [],
+      "user": {
+        "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+        "email": "new-user@example.com",
+        "email_verification_sent": true,
+        "email_verified": false,
+        "id": 1,
+        "is_admin": false,
+        "login": "ghost",
+        "name": "User 1",
+        "publish_notifications": true,
+        "url": "https://github.com/ghost",
+      },
+    }
+  `);
+
+  expect(db.pendingSignup.findFirst()).toBeFalsy();
+  expect(db.mswSession.findFirst()?.user.login).toBe('ghost');
+});
+
+test('returns an error without a pending signup', async function () {
+  let response = await fetch('/api/private/session/signup', {
+    method: 'POST',
+    body: JSON.stringify({ signup: { email: 'new-user@example.com' } }),
+  });
+
+  expect(response.status).toBe(400);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Your signup session is missing or has expired. Please authenticate with GitHub again.",
+        },
+      ],
+    }
+  `);
+});
+
+test('preserves the pending signup when the email is empty', async function () {
+  await db.pendingSignup.create({ login: 'ghost' });
+
+  let response = await fetch('/api/private/session/signup', {
+    method: 'POST',
+    body: JSON.stringify({ signup: { email: '' } }),
+  });
+
+  expect(response.status).toBe(422);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Please enter an email address.",
+        },
+      ],
+    }
+  `);
+
+  expect(db.pendingSignup.findFirst()?.login).toBe('ghost');
+  expect(db.mswSession.findFirst()).toBeFalsy();
+});
+
+test('preserves the pending signup when the email is invalid', async function () {
+  await db.pendingSignup.create({ login: 'ghost' });
+
+  let response = await fetch('/api/private/session/signup', {
+    method: 'POST',
+    body: JSON.stringify({ signup: { email: 'not-an-email' } }),
+  });
+
+  expect(response.status).toBe(422);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Please enter a valid email address.",
+        },
+      ],
+    }
+  `);
+
+  expect(db.pendingSignup.findFirst()?.login).toBe('ghost');
+  expect(db.mswSession.findFirst()).toBeFalsy();
+});

--- a/packages/crates-io-msw/handlers/sessions/complete-pending-signup.ts
+++ b/packages/crates-io-msw/handlers/sessions/complete-pending-signup.ts
@@ -1,0 +1,41 @@
+import * as v from 'valibot';
+
+import { db } from '../../index.js';
+import { serializeUser } from '../../serializers/user.js';
+import { http } from '../../utils/openapi-http.js';
+
+const EMAIL_SCHEMA = v.pipe(v.string(), v.email());
+
+export default http.post('/api/private/session/signup', async ({ request, response }) => {
+  let pendingSignup = db.pendingSignup.findFirst();
+  if (!pendingSignup) {
+    let detail = 'Your signup session is missing or has expired. Please authenticate with GitHub again.';
+    return response('4XX').json({ errors: [{ detail }] }, { status: 400 });
+  }
+
+  let body = await request.json();
+  let email = body.signup?.email;
+  if (!email) {
+    let detail = 'Please enter an email address.';
+    return response('4XX').json({ errors: [{ detail }] }, { status: 422 });
+  }
+  if (!v.safeParse(EMAIL_SCHEMA, email).success) {
+    let detail = 'Please enter a valid email address.';
+    return response('4XX').json({ errors: [{ detail }] }, { status: 422 });
+  }
+
+  let user = await db.user.create({
+    login: pendingSignup.login,
+    email,
+    emailVerified: false,
+    emailVerificationToken: 'pending-signup',
+  });
+  await db.mswSession.deleteMany(q => q.where(() => true));
+  await db.mswSession.create({ user });
+  await db.pendingSignup.deleteMany(q => q.where(() => true));
+
+  return response(200).json({
+    user: serializeUser(user, { removePrivateData: false }),
+    owned_crates: [],
+  });
+});

--- a/packages/crates-io-msw/handlers/sessions/delete-pending-signup.test.ts
+++ b/packages/crates-io-msw/handlers/sessions/delete-pending-signup.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest';
+
+import { db } from '../../index.js';
+
+test('clears the pending signup', async function () {
+  await db.pendingSignup.create({ login: 'ghost' });
+
+  let response = await fetch('/api/private/session/signup', { method: 'DELETE' });
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
+
+  expect(db.pendingSignup.findFirst()).toBeFalsy();
+});
+
+test('returns 200 without a pending signup', async function () {
+  let response = await fetch('/api/private/session/signup', { method: 'DELETE' });
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "ok": true,
+    }
+  `);
+
+  expect(db.pendingSignup.findFirst()).toBeFalsy();
+});

--- a/packages/crates-io-msw/handlers/sessions/delete-pending-signup.ts
+++ b/packages/crates-io-msw/handlers/sessions/delete-pending-signup.ts
@@ -1,0 +1,7 @@
+import { db } from '../../index.js';
+import { http } from '../../utils/openapi-http.js';
+
+export default http.delete('/api/private/session/signup', ({ response }) => {
+  db.pendingSignup.deleteMany(q => q.where(() => true));
+  return response(200).json({ ok: true });
+});

--- a/packages/crates-io-msw/handlers/sessions/get-pending-signup.test.ts
+++ b/packages/crates-io-msw/handlers/sessions/get-pending-signup.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'vitest';
+
+import { db } from '../../index.js';
+
+test('returns the first pending signup', async function () {
+  await db.pendingSignup.create({ login: 'first', email: null });
+  await db.pendingSignup.create({ login: 'second', email: 'second@crates.io' });
+
+  let response = await fetch('/api/private/session/signup');
+
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "signup": {
+        "email": null,
+        "login": "first",
+      },
+    }
+  `);
+});
+
+test('returns an error without a pending signup', async function () {
+  let response = await fetch('/api/private/session/signup');
+
+  expect(response.status).toBe(400);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "errors": [
+        {
+          "detail": "Your signup session is missing or has expired. Please authenticate with GitHub again.",
+        },
+      ],
+    }
+  `);
+});

--- a/packages/crates-io-msw/handlers/sessions/get-pending-signup.ts
+++ b/packages/crates-io-msw/handlers/sessions/get-pending-signup.ts
@@ -1,0 +1,14 @@
+import { db } from '../../index.js';
+import { serializePendingSignup } from '../../serializers/pending-signup.js';
+import { http } from '../../utils/openapi-http.js';
+
+export default http.get('/api/private/session/signup', ({ response }) => {
+  let pendingSignup = db.pendingSignup.findFirst();
+  if (!pendingSignup) {
+    let detail = 'Your signup session is missing or has expired. Please authenticate with GitHub again.';
+    return response('4XX').json({ errors: [{ detail }] }, { status: 400 });
+  }
+
+  let signup = serializePendingSignup(pendingSignup);
+  return response(200).json({ signup });
+});

--- a/packages/crates-io-msw/models/index.ts
+++ b/packages/crates-io-msw/models/index.ts
@@ -9,6 +9,7 @@ import crates from './crate.js';
 import dependencies from './dependency.js';
 import keywords from './keyword.js';
 import mswSessions from './msw-session.js';
+import pendingSignups from './pending-signup.js';
 import teams from './team.js';
 import trustpubGithubConfigs from './trustpub/github-config.js';
 import trustpubGitlabConfigs from './trustpub/gitlab-config.js';
@@ -77,6 +78,7 @@ export const db = {
   dependency: dependencies,
   keyword: keywords,
   mswSession: mswSessions,
+  pendingSignup: pendingSignups,
   team: teams,
   trustpubGithubConfig: trustpubGithubConfigs,
   trustpubGitlabConfig: trustpubGitlabConfigs,
@@ -109,6 +111,7 @@ export type CrateOwnership = ReturnType<typeof crateOwnerships.all>[number];
 export type Dependency = ReturnType<typeof dependencies.all>[number];
 export type Keyword = ReturnType<typeof keywords.all>[number];
 export type MswSession = ReturnType<typeof mswSessions.all>[number];
+export type PendingSignup = ReturnType<typeof pendingSignups.all>[number];
 export type Team = ReturnType<typeof teams.all>[number];
 export type TrustpubGithubConfig = ReturnType<typeof trustpubGithubConfigs.all>[number];
 export type TrustpubGitlabConfig = ReturnType<typeof trustpubGitlabConfigs.all>[number];

--- a/packages/crates-io-msw/models/pending-signup.test.ts
+++ b/packages/crates-io-msw/models/pending-signup.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'vitest';
+
+import { db } from '../index.js';
+
+test('throws if `login` is not set', async ({ expect }) => {
+  // @ts-expect-error: missing required field
+  await expect(() => db.pendingSignup.create({})).rejects.toThrowErrorMatchingInlineSnapshot(
+    `[Error: Failed to create a new record with initial values: does not match the schema. Please see the schema validation errors above.]`,
+  );
+});
+
+test('happy path', async ({ expect }) => {
+  let pendingSignup = await db.pendingSignup.create({ login: 'ghost' });
+
+  expect(pendingSignup).toMatchInlineSnapshot(`
+    {
+      "email": null,
+      "id": 1,
+      "login": "ghost",
+    }
+  `);
+});

--- a/packages/crates-io-msw/models/pending-signup.ts
+++ b/packages/crates-io-msw/models/pending-signup.ts
@@ -1,0 +1,26 @@
+import { Collection } from '@msw/data';
+import * as v from 'valibot';
+
+import * as counters from '../utils/counters.js';
+
+/**
+ * MSW-only pending signup state used because request handlers cannot access
+ * the signed session cookie used by the real API.
+ */
+const schema = v.pipe(
+  v.object({
+    id: v.optional(v.number()),
+
+    login: v.string(),
+    email: v.optional(v.nullable(v.string()), null),
+  }),
+  v.transform(function (input) {
+    let counter = counters.increment('pendingSignup');
+    let id = input.id ?? counter;
+    return { ...input, id };
+  }),
+);
+
+const collection = new Collection({ schema });
+
+export default collection;

--- a/packages/crates-io-msw/serializers/pending-signup.ts
+++ b/packages/crates-io-msw/serializers/pending-signup.ts
@@ -1,0 +1,12 @@
+import type { components } from '@crates-io/api-client';
+import type { PendingSignup } from '../models/index.js';
+
+type ApiSignupDetails = components['schemas']['SignupDetails'];
+
+/** Serializes MSW pending-signup state for the API response. */
+export function serializePendingSignup(pendingSignup: PendingSignup): ApiSignupDetails {
+  return {
+    login: pendingSignup.login,
+    email: pendingSignup.email,
+  };
+}

--- a/src/config/features.rs
+++ b/src/config/features.rs
@@ -2,6 +2,11 @@ use crates_io_env_vars::var_parsed;
 
 #[derive(Debug, Default)]
 pub struct FeaturesConfig {
+    /// Require new GitHub users to complete the explicit signup flow.
+    ///
+    /// Read from the `EXPLICIT_SIGNUP_ENABLED` environment variable.
+    pub explicit_signup_enabled: bool,
+
     /// Include publication timestamps in index entries (ISO8601 format).
     ///
     /// Read from the `INDEX_INCLUDE_PUBTIME` environment variable.
@@ -25,6 +30,7 @@ pub struct FeaturesConfig {
 
 impl FeaturesConfig {
     pub fn from_env() -> anyhow::Result<Self> {
+        let explicit_signup_enabled = var_parsed("EXPLICIT_SIGNUP_ENABLED")?.unwrap_or(false);
         let index_include_pubtime = var_parsed("INDEX_INCLUDE_PUBTIME")?.unwrap_or(false);
         let zip_archives_enabled = var_parsed("ZIP_ARCHIVES_ENABLED")?.unwrap_or(false);
         let cache_tags_enabled = var_parsed("CACHE_TAGS_ENABLED")?.unwrap_or(false);
@@ -36,6 +42,7 @@ impl FeaturesConfig {
         }
 
         Ok(Self {
+            explicit_signup_enabled,
             index_include_pubtime,
             zip_archives_enabled,
             cache_tags_enabled,

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -10,7 +10,7 @@ use crate::util::errors::{AppResult, bad_request, server_error};
 use crate::util::oauth::ReqwestClient;
 use crate::views::EncodableMe;
 use axum::Json;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use crates_io_github::{GitHubAuth, GitHubUser};
 use crates_io_session::SessionExtension;
 use diesel::prelude::*;
@@ -21,6 +21,8 @@ use oauth2::{AuthorizationCode, CsrfToken, Scope, TokenResponse};
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use tracing::{error, warn};
+
+const PENDING_SIGNUP_KEY: &str = "pending_signup";
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct BeginResponse {
@@ -51,6 +53,8 @@ pub struct BeginResponse {
     ),
 )]
 pub async fn begin_session(app: AppState, session: SessionExtension) -> Json<BeginResponse> {
+    session.remove(PENDING_SIGNUP_KEY);
+
     let (url, state) = app
         .github_oauth
         .authorize_url(oauth2::CsrfToken::new_random)
@@ -84,12 +88,35 @@ pub enum AuthorizeResponse {
     SignupRequired,
 }
 
+/// GitHub account details retained while a user completes signup.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PendingSignup {
+    /// GitHub-controlled account details captured during OAuth authorization.
+    pub github_user: GitHubUser,
+    /// Encrypted GitHub access token used when the account is created.
+    pub encrypted_token: Vec<u8>,
+    /// Creation time used to determine when this pending signup expires.
+    pub created_at: DateTime<Utc>,
+}
+
+impl PendingSignup {
+    /// Creates pending signup state with the current time.
+    fn new(github_user: GitHubUser, encrypted_token: Vec<u8>) -> Self {
+        Self {
+            github_user,
+            encrypted_token,
+            created_at: Utc::now(),
+        }
+    }
+}
+
 /// Complete authentication flow.
 ///
 /// This route is called from the GitHub API OAuth flow after the user accepted or rejected
 /// the data access permissions. It will check the `state` parameter and then call the GitHub API
-/// to exchange the temporary `code` for an API token. The response indicates whether the
-/// corresponding user was signed in or needs to complete signup.
+/// to exchange the temporary `code` for an API token. Existing crates.io users are signed in.
+/// New users must complete signup when explicit signup is enabled and are created immediately
+/// otherwise.
 ///
 /// see <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>
 #[utoipa::path(
@@ -148,56 +175,96 @@ pub async fn authorize_session(
     let ghuser = app.github.current_user(&auth).await?;
 
     let mut conn = app.db_write().await?;
-    let user_id = save_user_to_database(&ghuser, &encrypted_token, &app.emails, &mut conn).await?;
+    let user_id = save_user_to_database(
+        app.config.features.explicit_signup_enabled,
+        &ghuser,
+        &encrypted_token,
+        &app.emails,
+        &mut conn,
+    )
+    .await?;
 
-    // Log in by setting a cookie and the middleware authentication
-    session.insert("user_id".to_string(), user_id.to_string());
+    match user_id {
+        Some(user_id) => {
+            session.remove(PENDING_SIGNUP_KEY);
+            session.insert("user_id".to_string(), user_id.to_string());
 
-    let Json(user) = super::user::me::authenticated_user(&mut conn, user_id).await?;
-    Ok(Json(AuthorizeResponse::SignedIn(user)))
+            let Json(user) = super::user::me::authenticated_user(&mut conn, user_id).await?;
+            Ok(Json(AuthorizeResponse::SignedIn(user)))
+        }
+        None => {
+            let pending_signup = PendingSignup::new(ghuser, encrypted_token);
+            let pending_signup = serde_json::to_string(&pending_signup)?;
+            session.remove("user_id");
+            session.insert(PENDING_SIGNUP_KEY.to_string(), pending_signup);
+            Ok(Json(AuthorizeResponse::SignupRequired))
+        }
+    }
 }
 
+/// Updates a GitHub-linked user or creates one when explicit signup is disabled.
+///
+/// Returns `None` when explicit signup is enabled and no existing user was found.
 pub async fn save_user_to_database(
+    explicit_signup_enabled: bool,
     gh_user: &GitHubUser,
     encrypted_token: &[u8],
     emails: &Emails,
     conn: &mut AsyncPgConnection,
-) -> QueryResult<i32> {
+) -> QueryResult<Option<i32>> {
     // There should not be one transaction around both the `create_or_update_user` call and the
     // `find_user_by_gh_id` call. If they're in one transaction and we're in read only mode, the
     // entire transaction will be poisoned and the `find_user_by_gh_id` will fail too, thus
     // negating the purpose of the fallback. There _is_ a transaction around the body of
     // `create_or_update_user`.
-    match create_or_update_user(gh_user, encrypted_token, emails, conn).await {
-        Ok(id) => Ok(id),
+    match create_or_update_user(
+        explicit_signup_enabled,
+        gh_user,
+        encrypted_token,
+        emails,
+        conn,
+    )
+    .await
+    {
+        Ok(user_id) => Ok(user_id),
         Err(error) if is_read_only_error(&error) => {
-            // If we're in read only mode, we can't update their details or create new users.
-            // just look for an existing user
-            find_user_by_gh_id(conn, gh_user.id).await?.ok_or(error)
+            // In read-only mode, we can't update users or create new ones.
+            // Look up the GitHub account to distinguish an existing user from a new signup.
+            match find_user_by_gh_id(conn, gh_user.id).await? {
+                Some(user_id) => Ok(Some(user_id)),
+                None if explicit_signup_enabled => Ok(None),
+                None => Err(error),
+            }
         }
         Err(error) => Err(error),
     }
 }
 
-/// Updates an existing user or inserts a new user into the database within a transaction.
+/// Updates an existing user or optionally inserts a new user within a transaction.
+///
+/// Returns `None` when explicit signup is enabled and no existing user was found.
 async fn create_or_update_user(
+    explicit_signup_enabled: bool,
     gh_user: &GitHubUser,
     encrypted_token: &[u8],
     emails: &Emails,
     conn: &mut AsyncPgConnection,
-) -> QueryResult<i32> {
+) -> QueryResult<Option<i32>> {
     conn.transaction(async |conn| {
         let update_result = update_user(gh_user, encrypted_token, conn).await;
 
         match update_result {
-            Ok(user_id) => Ok(user_id),
+            Ok(user_id) => Ok(Some(user_id)),
+            Err(diesel::result::Error::NotFound) if explicit_signup_enabled => Ok(None),
             Err(diesel::result::Error::NotFound) => {
                 // If the update fails because the `oauth_github` record doesn't exist, this
                 // currently means the `user` record doesn't exist either and we need to create
                 // both. This assumption holds because crates.io and GitHub accounts currently have
                 // a one-to-one relationship; this will need to be changed if/when we allow
                 // crates.io users to link more than one GitHub account to their crates.io account.
-                create_user(gh_user, encrypted_token, emails, conn).await
+                create_user(gh_user, encrypted_token, emails, conn)
+                    .await
+                    .map(Some)
             }
             Err(error) => Err(error),
         }
@@ -334,6 +401,7 @@ async fn find_user_by_gh_id(mut conn: &AsyncPgConnection, gh_id: i32) -> QueryRe
 )]
 pub async fn end_session(session: SessionExtension) -> OkResponse {
     session.remove("user_id");
+    session.remove(PENDING_SIGNUP_KEY);
     OkResponse::new()
 }
 
@@ -341,8 +409,114 @@ pub async fn end_session(session: SessionExtension) -> OkResponse {
 mod tests {
     use super::*;
     use crate::views::{EncodablePrivateUser, OwnedCrate};
+    use claims::{assert_none, assert_ok, assert_some, assert_some_eq};
     use crates_io_test_db::TestDatabase;
+    use diesel_async::RunQueryDsl;
     use insta::assert_json_snapshot;
+
+    fn github_user() -> GitHubUser {
+        GitHubUser {
+            avatar_url: Some("https://avatars.example.com/42".into()),
+            email: Some("ghost@example.com".into()),
+            id: 42,
+            login: "ghost".into(),
+            name: Some("Ghost".into()),
+        }
+    }
+
+    async fn count_users(conn: &mut AsyncPgConnection) -> i64 {
+        users::table.count().get_result(conn).await.unwrap()
+    }
+
+    async fn count_oauth_github(conn: &mut AsyncPgConnection) -> i64 {
+        oauth_github::table.count().get_result(conn).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn explicit_signup_does_not_create_new_user() {
+        let emails = Emails::new_in_memory();
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+
+        let user_id = assert_ok!(
+            save_user_to_database(true, &github_user(), &[1, 2, 3], &emails, &mut conn).await
+        );
+
+        assert_none!(user_id);
+        assert_eq!(count_users(&mut conn).await, 0);
+        assert_eq!(count_oauth_github(&mut conn).await, 0);
+    }
+
+    #[tokio::test]
+    async fn explicit_signup_signs_in_existing_user() {
+        let emails = Emails::new_in_memory();
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+        let user = github_user();
+        let user_id = assert_some!(assert_ok!(
+            save_user_to_database(false, &user, &[1], &emails, &mut conn).await
+        ));
+
+        let actual_user_id =
+            assert_ok!(save_user_to_database(true, &user, &[2], &emails, &mut conn).await);
+
+        assert_some_eq!(actual_user_id, user_id);
+        assert_eq!(count_users(&mut conn).await, 1);
+    }
+
+    #[tokio::test]
+    async fn legacy_signup_creates_and_signs_in_new_user() {
+        let emails = Emails::new_in_memory();
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+
+        let user_id = assert_ok!(
+            save_user_to_database(false, &github_user(), &[1, 2, 3], &emails, &mut conn).await
+        );
+
+        assert_some!(user_id);
+        assert_eq!(count_users(&mut conn).await, 1);
+        assert_eq!(count_oauth_github(&mut conn).await, 1);
+    }
+
+    #[tokio::test]
+    async fn explicit_signup_detects_new_user_during_read_only_mode() {
+        let emails = Emails::new_in_memory();
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+        assert_ok!(
+            diesel::sql_query("SET default_transaction_read_only = 't'")
+                .execute(&mut conn)
+                .await
+        );
+
+        let user_id = assert_ok!(
+            save_user_to_database(true, &github_user(), &[1, 2, 3], &emails, &mut conn).await
+        );
+
+        assert_none!(user_id);
+    }
+
+    #[tokio::test]
+    async fn explicit_signup_signs_in_existing_user_during_read_only_mode() {
+        let emails = Emails::new_in_memory();
+        let test_db = TestDatabase::new();
+        let mut conn = test_db.async_connect().await;
+        let user = github_user();
+        let user_id = assert_some!(assert_ok!(
+            save_user_to_database(false, &user, &[1], &emails, &mut conn).await
+        ));
+        assert_ok!(
+            diesel::sql_query("SET default_transaction_read_only = 't'")
+                .execute(&mut conn)
+                .await
+        );
+
+        let actual_user_id =
+            assert_ok!(save_user_to_database(true, &user, &[2], &emails, &mut conn).await);
+
+        assert_some_eq!(actual_user_id, user_id);
+    }
 
     #[test]
     fn authorize_response_serializes_signed_in() {
@@ -418,7 +592,7 @@ mod tests {
             avatar_url: None,
         };
 
-        let result = save_user_to_database(&gh_user, &[], &emails, &mut conn).await;
+        let result = save_user_to_database(false, &gh_user, &[], &emails, &mut conn).await;
 
         assert!(
             result.is_ok(),

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -194,6 +194,23 @@ pub async fn get_pending_signup(
     Ok((no_store(), json))
 }
 
+/// Cancel a pending signup.
+#[utoipa::path(
+    delete,
+    path = "/api/private/session/signup",
+    tag = "session",
+    extensions(("x-internal" = json!(true))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(OkResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
+)]
+pub async fn delete_pending_signup(session: SessionExtension) -> OkResponse {
+    session.remove(PENDING_SIGNUP_KEY);
+    OkResponse::new()
+}
+
 /// Complete authentication flow.
 ///
 /// This route is called from the GitHub API OAuth flow after the user accepted or rejected

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -6,7 +6,7 @@ use crate::middleware::log_request::RequestLogExt;
 use crate::models::{NewEmail, NewOauthGithub, NewUser, OauthGithub};
 use crate::schema::{oauth_github, users};
 use crate::util::diesel::is_read_only_error;
-use crate::util::errors::{AppResult, bad_request, not_found, server_error};
+use crate::util::errors::{AppResult, BoxedAppError, bad_request, not_found, server_error};
 use crate::util::no_store;
 use crate::util::oauth::ReqwestClient;
 use crate::views::EncodableMe;
@@ -18,6 +18,7 @@ use crates_io_session::SessionExtension;
 use diesel::prelude::*;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use http::request::Parts;
+use lettre::Address;
 use minijinja::context;
 use oauth2::{AuthorizationCode, CsrfToken, Scope, TokenResponse};
 use secrecy::ExposeSecret;
@@ -136,6 +137,22 @@ pub struct SignupResponse {
     signup: SignupDetails,
 }
 
+/// Request to complete a pending signup.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct CompletePendingSignupRequest {
+    /// User-controlled signup details.
+    #[schema(inline)]
+    signup: CompletePendingSignupData,
+}
+
+/// User-controlled details for a pending signup.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct CompletePendingSignupData {
+    /// The email address to associate with the new account.
+    #[schema(value_type = String, format = Email, example = "new-user@example.com")]
+    email: Address,
+}
+
 /// Loads valid pending-signup state from the signed session cookie.
 fn load_pending_signup(session: &SessionExtension) -> AppResult<PendingSignup> {
     let Some(value) = session.get(PENDING_SIGNUP_KEY) else {
@@ -192,6 +209,55 @@ pub async fn get_pending_signup(
     });
 
     Ok((no_store(), json))
+}
+
+/// Complete a pending signup.
+#[utoipa::path(
+    post,
+    path = "/api/private/session/signup",
+    request_body = inline(CompletePendingSignupRequest),
+    tag = "session",
+    extensions(("x-internal" = json!(true))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(EncodableMe)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
+)]
+pub async fn complete_pending_signup(
+    app: AppState,
+    session: SessionExtension,
+    Json(body): Json<CompletePendingSignupRequest>,
+) -> AppResult<Json<EncodableMe>> {
+    if !app.config.features.explicit_signup_enabled {
+        return Err(not_found());
+    }
+    if session.get("user_id").is_some() {
+        return Err(bad_request("You are already signed in."));
+    }
+
+    let pending_signup = load_pending_signup(&session)?;
+    let mut github_user = pending_signup.github_user;
+    github_user.email = Some(body.signup.email.to_string());
+
+    let mut conn = app.db_write().await?;
+    let (user_id, user) = conn
+        .transaction(async |conn| {
+            let user_id = create_user(
+                &github_user,
+                &pending_signup.encrypted_token,
+                &app.emails,
+                conn,
+            )
+            .await?;
+            let user = super::user::me::authenticated_user(conn, user_id).await?;
+            Ok::<_, BoxedAppError>((user_id, user))
+        })
+        .await?;
+
+    session.remove(PENDING_SIGNUP_KEY);
+    session.insert("user_id".to_string(), user_id.to_string());
+    Ok(user)
 }
 
 /// Cancel a pending signup.
@@ -416,8 +482,8 @@ async fn update_user(
 /// This method also inserts the email address into the `emails` table
 /// and sends a confirmation email to the user.
 ///
-/// Should be called in a transaction, as `create_or_update_user` does, so both the `users` and
-/// `emails` records are inserted or neither are.
+/// Should be called in a transaction so the `users`, `oauth_github`, and `emails` records are
+/// inserted together.
 async fn create_user(
     gh_user: &GitHubUser,
     encrypted_token: &[u8],

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -74,12 +74,22 @@ pub struct AuthorizeBody {
     state: CsrfToken,
 }
 
+/// The result of completing the GitHub OAuth flow.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum AuthorizeResponse {
+    /// The GitHub OAuth flow signed in a crates.io user.
+    SignedIn(#[schema(inline)] EncodableMe),
+    /// The GitHub account needs a crates.io account.
+    SignupRequired,
+}
+
 /// Complete authentication flow.
 ///
 /// This route is called from the GitHub API OAuth flow after the user accepted or rejected
 /// the data access permissions. It will check the `state` parameter and then call the GitHub API
-/// to exchange the temporary `code` for an API token. The API token is returned together with
-/// the corresponding user information.
+/// to exchange the temporary `code` for an API token. The response indicates whether the
+/// corresponding user was signed in or needs to complete signup.
 ///
 /// see <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>
 #[utoipa::path(
@@ -89,7 +99,7 @@ pub struct AuthorizeBody {
     request_body = inline(AuthorizeBody),
     extensions(("x-internal" = json!(true))),
     responses(
-        (status = 200, description = "Successful Response", body = inline(EncodableMe)),
+        (status = 200, description = "Successful Response", body = inline(AuthorizeResponse)),
         (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
         (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
     ),
@@ -99,7 +109,7 @@ pub async fn authorize_session(
     session: SessionExtension,
     req: Parts,
     Json(body): Json<AuthorizeBody>,
-) -> AppResult<Json<EncodableMe>> {
+) -> AppResult<Json<AuthorizeResponse>> {
     // Make sure that the state we just got matches the session state that we
     // should have issued earlier.
     let session_state = session.remove("github_oauth_state").map(CsrfToken::new);
@@ -143,7 +153,8 @@ pub async fn authorize_session(
     // Log in by setting a cookie and the middleware authentication
     session.insert("user_id".to_string(), user_id.to_string());
 
-    super::user::me::authenticated_user(&mut conn, user_id).await
+    let Json(user) = super::user::me::authenticated_user(&mut conn, user_id).await?;
+    Ok(Json(AuthorizeResponse::SignedIn(user)))
 }
 
 pub async fn save_user_to_database(
@@ -329,7 +340,68 @@ pub async fn end_session(session: SessionExtension) -> OkResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::views::{EncodablePrivateUser, OwnedCrate};
     use crates_io_test_db::TestDatabase;
+    use insta::assert_json_snapshot;
+
+    #[test]
+    fn authorize_response_serializes_signed_in() {
+        let response = AuthorizeResponse::SignedIn(EncodableMe {
+            user: EncodablePrivateUser {
+                id: 42,
+                login: "ghost".into(),
+                email_verified: true,
+                email_verification_sent: true,
+                name: Some("Kate Morgan".into()),
+                email: Some("kate@morgan.dev".into()),
+                avatar: Some("https://avatars2.githubusercontent.com/u/1234567?v=4".into()),
+                url: Some("https://github.com/ghost".into()),
+                is_admin: false,
+                publish_notifications: true,
+                created_at: None,
+            },
+            owned_crates: vec![OwnedCrate {
+                id: 123,
+                name: "serde".into(),
+                email_notifications: true,
+            }],
+        });
+
+        assert_json_snapshot!(response, @r#"
+        {
+          "status": "signed_in",
+          "user": {
+            "id": 42,
+            "login": "ghost",
+            "email_verified": true,
+            "email_verification_sent": true,
+            "name": "Kate Morgan",
+            "email": "kate@morgan.dev",
+            "avatar": "https://avatars2.githubusercontent.com/u/1234567?v=4",
+            "url": "https://github.com/ghost",
+            "is_admin": false,
+            "publish_notifications": true,
+            "created_at": null
+          },
+          "owned_crates": [
+            {
+              "id": 123,
+              "name": "serde",
+              "email_notifications": true
+            }
+          ]
+        }
+        "#);
+    }
+
+    #[test]
+    fn authorize_response_serializes_signup_required() {
+        assert_json_snapshot!(AuthorizeResponse::SignupRequired, @r#"
+        {
+          "status": "signup_required"
+        }
+        "#);
+    }
 
     #[tokio::test]
     async fn gh_user_with_invalid_email_doesnt_fail() {

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -6,10 +6,12 @@ use crate::middleware::log_request::RequestLogExt;
 use crate::models::{NewEmail, NewOauthGithub, NewUser, OauthGithub};
 use crate::schema::{oauth_github, users};
 use crate::util::diesel::is_read_only_error;
-use crate::util::errors::{AppResult, bad_request, server_error};
+use crate::util::errors::{AppResult, bad_request, not_found, server_error};
+use crate::util::no_store;
 use crate::util::oauth::ReqwestClient;
 use crate::views::EncodableMe;
 use axum::Json;
+use axum::response::IntoResponse;
 use chrono::{DateTime, Utc};
 use crates_io_github::{GitHubAuth, GitHubUser};
 use crates_io_session::SessionExtension;
@@ -22,7 +24,11 @@ use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use tracing::{error, warn};
 
-const PENDING_SIGNUP_KEY: &str = "pending_signup";
+/// Session key containing serialized pending-signup state.
+pub const PENDING_SIGNUP_KEY: &str = "pending_signup";
+const PENDING_SIGNUP_LIFETIME: chrono::TimeDelta = chrono::TimeDelta::minutes(30);
+const PENDING_SIGNUP_ERROR: &str =
+    "Your signup session is missing or has expired. Please authenticate with GitHub again.";
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct BeginResponse {
@@ -108,6 +114,84 @@ impl PendingSignup {
             created_at: Utc::now(),
         }
     }
+
+    /// Returns whether this pending signup has reached its absolute expiry.
+    fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        now.signed_duration_since(self.created_at) >= PENDING_SIGNUP_LIFETIME
+    }
+}
+
+/// Public GitHub account details displayed while a user completes signup.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct SignupDetails {
+    /// The GitHub account login.
+    login: String,
+    /// The email address suggested by GitHub, if one is available.
+    email: Option<String>,
+}
+
+/// Response containing details for a pending signup.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct SignupResponse {
+    signup: SignupDetails,
+}
+
+/// Loads valid pending-signup state from the signed session cookie.
+fn load_pending_signup(session: &SessionExtension) -> AppResult<PendingSignup> {
+    let Some(value) = session.get(PENDING_SIGNUP_KEY) else {
+        return Err(bad_request(PENDING_SIGNUP_ERROR));
+    };
+
+    let pending_signup: PendingSignup = serde_json::from_str(&value).map_err(|_| {
+        session.remove(PENDING_SIGNUP_KEY);
+        bad_request(PENDING_SIGNUP_ERROR)
+    })?;
+
+    if pending_signup.is_expired(Utc::now()) {
+        session.remove(PENDING_SIGNUP_KEY);
+        return Err(bad_request(PENDING_SIGNUP_ERROR));
+    }
+
+    Ok(pending_signup)
+}
+
+/// Load the GitHub account details for a pending signup.
+///
+/// The encrypted GitHub token remains in the signed session cookie and is never returned to the
+/// frontend. Missing, malformed, and expired signup state require restarting GitHub
+/// authentication.
+#[utoipa::path(
+    get,
+    path = "/api/private/session/signup",
+    tag = "session",
+    extensions(("x-internal" = json!(true))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(SignupResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
+)]
+pub async fn get_pending_signup(
+    app: AppState,
+    session: SessionExtension,
+) -> AppResult<impl IntoResponse> {
+    if !app.config.features.explicit_signup_enabled {
+        return Err(not_found());
+    }
+    if session.get("user_id").is_some() {
+        return Err(bad_request("You are already signed in."));
+    }
+
+    let pending_signup = load_pending_signup(&session)?;
+
+    let json = Json(SignupResponse {
+        signup: SignupDetails {
+            login: pending_signup.github_user.login,
+            email: pending_signup.github_user.email,
+        },
+    });
+
+    Ok((no_store(), json))
 }
 
 /// Complete authentication flow.
@@ -422,6 +506,30 @@ mod tests {
             login: "ghost".into(),
             name: Some("Ghost".into()),
         }
+    }
+
+    #[test]
+    fn pending_signup_expires_after_thirty_minutes() {
+        let now = Utc::now();
+        let pending_signup = PendingSignup {
+            github_user: github_user(),
+            encrypted_token: vec![1, 2, 3],
+            created_at: now - chrono::TimeDelta::minutes(30),
+        };
+
+        assert!(pending_signup.is_expired(now));
+    }
+
+    #[test]
+    fn pending_signup_is_valid_before_thirty_minutes() {
+        let now = Utc::now();
+        let pending_signup = PendingSignup {
+            github_user: github_user(),
+            encrypted_token: vec![1, 2, 3],
+            created_at: now - chrono::TimeDelta::minutes(29),
+        };
+
+        assert!(!pending_signup.is_expired(now));
     }
 
     async fn count_users(conn: &mut AsyncPgConnection) -> i64 {

--- a/src/router.rs
+++ b/src/router.rs
@@ -89,7 +89,10 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         // Session management
         .routes(routes!(session::begin_session))
         .routes(routes!(session::authorize_session))
-        .routes(routes!(session::get_pending_signup))
+        .routes(routes!(
+            session::get_pending_signup,
+            session::delete_pending_signup
+        ))
         .routes(routes!(session::end_session))
         // OIDC / Trusted Publishing
         .routes(routes!(

--- a/src/router.rs
+++ b/src/router.rs
@@ -89,6 +89,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         // Session management
         .routes(routes!(session::begin_session))
         .routes(routes!(session::authorize_session))
+        .routes(routes!(session::get_pending_signup))
         .routes(routes!(session::end_session))
         // OIDC / Trusted Publishing
         .routes(routes!(

--- a/src/router.rs
+++ b/src/router.rs
@@ -91,6 +91,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         .routes(routes!(session::authorize_session))
         .routes(routes!(
             session::get_pending_signup,
+            session::complete_pending_signup,
             session::delete_pending_signup
         ))
         .routes(routes!(session::end_session))

--- a/src/tests/routes/session/mod.rs
+++ b/src/tests/routes/session/mod.rs
@@ -1,3 +1,4 @@
 mod authorize;
 mod begin;
 mod end;
+mod signup;

--- a/src/tests/routes/session/signup.rs
+++ b/src/tests/routes/session/signup.rs
@@ -127,3 +127,43 @@ async fn get_rejects_and_clears_expired_signup() {
     assert_snapshot!(response.status(), @"400 Bad Request");
     assert!(response.headers().get(header::SET_COOKIE).is_none());
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_clears_pending_signup_and_leaves_user_logged_out() {
+    let (app, anon) = TestApp::init().empty().await;
+    let cookie = pending_signup_header(&app, Utc::now());
+    let mut request = anon.request_builder(Method::DELETE, "/api/private/session/signup");
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_snapshot!(response.json(), @r#"{"ok":true}"#);
+
+    let set_cookie = response.headers().get(header::SET_COOKIE).unwrap();
+    let cookie = set_cookie.to_str().unwrap();
+    let cookie = cookie.split(';').next().unwrap();
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+
+    let mut request = anon.request_builder(Method::GET, "/api/v1/me");
+    request.header(header::COOKIE, cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"403 Forbidden");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_without_pending_signup_returns_ok_when_explicit_signup_is_disabled() {
+    let (_, anon) = TestApp::init()
+        .with_config(|config| config.features.explicit_signup_enabled = false)
+        .empty()
+        .await;
+
+    let request = anon.request_builder(Method::DELETE, "/api/private/session/signup");
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_snapshot!(response.json(), @r#"{"ok":true}"#);
+}

--- a/src/tests/routes/session/signup.rs
+++ b/src/tests/routes/session/signup.rs
@@ -2,10 +2,13 @@ use crate::util::{MockRequestExt, RequestHelper, TestApp};
 use chrono::{Duration, Utc};
 use cookie::{Cookie, CookieJar, Key};
 use crates_io::controllers::session::{PENDING_SIGNUP_KEY, PendingSignup};
+use crates_io::schema::{emails, oauth_github, users};
 use crates_io_github::GitHubUser;
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use http::{Method, header};
-use insta::assert_snapshot;
-use serde_json::Value;
+use insta::{assert_json_snapshot, assert_snapshot};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 
 /// Encodes arbitrary session values as a signed cookie for an integration test request.
@@ -37,6 +40,21 @@ fn pending_signup_header(app: &TestApp, created_at: chrono::DateTime<Utc>) -> St
     let pending_signup = serde_json::to_string(&pending_signup(created_at)).unwrap();
     let values = HashMap::from([(PENDING_SIGNUP_KEY.into(), pending_signup)]);
     encode_session_header(app.as_inner().session_key(), values)
+}
+
+/// Counts user records created during a signup test.
+async fn user_count(conn: &mut AsyncPgConnection) -> i64 {
+    users::table.count().get_result(conn).await.unwrap()
+}
+
+/// Counts GitHub account records created during a signup test.
+async fn github_account_count(conn: &mut AsyncPgConnection) -> i64 {
+    oauth_github::table.count().get_result(conn).await.unwrap()
+}
+
+/// Counts email records created during a signup test.
+async fn email_count(conn: &mut AsyncPgConnection) -> i64 {
+    emails::table.count().get_result(conn).await.unwrap()
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -166,4 +184,217 @@ async fn delete_without_pending_signup_returns_ok_when_explicit_signup_is_disabl
     let response = anon.run::<Value>(request).await;
     assert_snapshot!(response.status(), @"200 OK");
     assert_snapshot!(response.json(), @r#"{"ok":true}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_returns_not_found_when_explicit_signup_is_disabled() {
+    let (app, anon) = TestApp::init()
+        .with_config(|config| config.features.explicit_signup_enabled = false)
+        .empty()
+        .await;
+    let cookie = pending_signup_header(&app, Utc::now());
+    let body = json!({ "signup": { "email": "new-user@example.com" } });
+    let mut request = anon
+        .request_builder(Method::POST, "/api/private/session/signup")
+        .with_body(body.to_string().into());
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"404 Not Found");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Not Found"}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_rejects_signed_in_user() {
+    let (_, _, user) = TestApp::init().with_user().await;
+    let body = json!({ "signup": { "email": "new-user@example.com" } });
+    let request = user
+        .request_builder(Method::POST, "/api/private/session/signup")
+        .with_body(body.to_string().into());
+
+    let response = user.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"You are already signed in."}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_creates_user_and_signs_in() {
+    let (app, anon) = TestApp::init().empty().await;
+    let cookie = pending_signup_header(&app, Utc::now());
+    let body = json!({ "signup": { "email": "new-user@example.com" } });
+    let mut request = anon
+        .request_builder(Method::POST, "/api/private/session/signup")
+        .with_body(body.to_string().into());
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"200 OK");
+    let signup_response = response.json();
+    assert_json_snapshot!(signup_response, { ".user.created_at" => "[datetime]" }, @r#"
+    {
+      "owned_crates": [],
+      "user": {
+        "avatar": "https://avatars.example.com/42",
+        "created_at": "[datetime]",
+        "email": "new-user@example.com",
+        "email_verification_sent": true,
+        "email_verified": false,
+        "id": 1,
+        "is_admin": false,
+        "login": "ghost",
+        "name": "Ghost",
+        "publish_notifications": true,
+        "url": "https://github.com/ghost"
+      }
+    }
+    "#);
+
+    let mut conn = app.db_conn().await;
+    assert_eq!(user_count(&mut conn).await, 1);
+    assert_eq!(github_account_count(&mut conn).await, 1);
+    assert_eq!(email_count(&mut conn).await, 1);
+
+    let github = oauth_github::table
+        .select((
+            oauth_github::account_id,
+            oauth_github::login,
+            oauth_github::encrypted_token,
+        ))
+        .first::<(i64, String, Vec<u8>)>(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(github, (42, "ghost".into(), vec![1, 2, 3]));
+
+    let email = emails::table
+        .select(emails::email)
+        .first::<String>(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(email, "new-user@example.com");
+    assert_eq!(app.emails().await.len(), 1);
+
+    let set_cookie = response.headers().get(header::SET_COOKIE).unwrap();
+    let cookie = set_cookie.to_str().unwrap();
+    let cookie = cookie.split(';').next().unwrap();
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+
+    let mut request = anon.request_builder(Method::GET, "/api/v1/me");
+    request.header(header::COOKIE, cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_eq!(response.json(), signup_response);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_requires_email() {
+    let (app, anon) = TestApp::init().empty().await;
+    let cookie = pending_signup_header(&app, Utc::now());
+    let mut request = anon
+        .request_builder(Method::POST, "/api/private/session/signup")
+        .with_body(r#"{"signup":{}}"#.into());
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"422 Unprocessable Entity");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: signup: missing field `email` at line 1 column 12"}]}"#);
+
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"200 OK");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_rejects_empty_email_and_preserves_pending_signup() {
+    let (app, anon) = TestApp::init().empty().await;
+    let cookie = pending_signup_header(&app, Utc::now());
+    let body = json!({ "signup": { "email": "" } });
+    let mut request = anon
+        .request_builder(Method::POST, "/api/private/session/signup")
+        .with_body(body.to_string().into());
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"422 Unprocessable Entity");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: signup.email: Missing domain or user at line 1 column 21"}]}"#);
+    assert!(response.headers().get(header::SET_COOKIE).is_none());
+
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"200 OK");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_rejects_invalid_email_and_preserves_pending_signup() {
+    let (app, anon) = TestApp::init().empty().await;
+    let cookie = pending_signup_header(&app, Utc::now());
+    let body = json!({ "signup": { "email": "not-an-email" } });
+    let mut request = anon
+        .request_builder(Method::POST, "/api/private/session/signup")
+        .with_body(body.to_string().into());
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"422 Unprocessable Entity");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: signup.email: Missing domain or user at line 1 column 33"}]}"#);
+    assert!(response.headers().get(header::SET_COOKIE).is_none());
+
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"200 OK");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_rejects_and_clears_expired_signup() {
+    let (app, anon) = TestApp::init().empty().await;
+    let created_at = Utc::now() - Duration::minutes(31);
+    let cookie = pending_signup_header(&app, created_at);
+    let body = json!({ "signup": { "email": "new-user@example.com" } });
+    let mut request = anon
+        .request_builder(Method::POST, "/api/private/session/signup")
+        .with_body(body.to_string().into());
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Your signup session is missing or has expired. Please authenticate with GitHub again."}]}"#);
+    assert!(response.headers().get(header::SET_COOKIE).is_some());
+
+    let mut conn = app.db_conn().await;
+    assert_eq!(user_count(&mut conn).await, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_read_only_failure_preserves_pending_signup() {
+    let (app, anon) = TestApp::init()
+        .with_config(|config| config.db.primary.read_only_mode = true)
+        .empty()
+        .await;
+    let cookie = pending_signup_header(&app, Utc::now());
+    let body = json!({ "signup": { "email": "new-user@example.com" } });
+    let mut request = anon
+        .request_builder(Method::POST, "/api/private/session/signup")
+        .with_body(body.to_string().into());
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"503 Service Unavailable");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"crates.io is currently in read-only mode. Please check https://status.crates.io/ for details and try again later."}]}"#);
+    assert!(response.headers().get(header::SET_COOKIE).is_none());
+
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"200 OK");
 }

--- a/src/tests/routes/session/signup.rs
+++ b/src/tests/routes/session/signup.rs
@@ -1,0 +1,129 @@
+use crate::util::{MockRequestExt, RequestHelper, TestApp};
+use chrono::{Duration, Utc};
+use cookie::{Cookie, CookieJar, Key};
+use crates_io::controllers::session::{PENDING_SIGNUP_KEY, PendingSignup};
+use crates_io_github::GitHubUser;
+use http::{Method, header};
+use insta::assert_snapshot;
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Encodes arbitrary session values as a signed cookie for an integration test request.
+fn encode_session_header(session_key: &Key, values: HashMap<String, String>) -> String {
+    let encoded = crates_io_session::encode(&values);
+    let cookie = Cookie::build((crates_io_session::COOKIE_NAME, encoded));
+    let mut jar = CookieJar::new();
+    jar.signed_mut(session_key).add(cookie);
+    jar.get(crates_io_session::COOKIE_NAME).unwrap().to_string()
+}
+
+/// Builds pending-signup state with a configurable creation time.
+fn pending_signup(created_at: chrono::DateTime<Utc>) -> PendingSignup {
+    PendingSignup {
+        github_user: GitHubUser {
+            avatar_url: Some("https://avatars.example.com/42".into()),
+            email: Some("ghost@example.com".into()),
+            id: 42,
+            login: "ghost".into(),
+            name: Some("Ghost".into()),
+        },
+        encrypted_token: vec![1, 2, 3],
+        created_at,
+    }
+}
+
+/// Encodes pending-signup state as a signed session cookie.
+fn pending_signup_header(app: &TestApp, created_at: chrono::DateTime<Utc>) -> String {
+    let pending_signup = serde_json::to_string(&pending_signup(created_at)).unwrap();
+    let values = HashMap::from([(PENDING_SIGNUP_KEY.into(), pending_signup)]);
+    encode_session_header(app.as_inner().session_key(), values)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_returns_safe_signup_details() {
+    let (app, anon) = TestApp::init().empty().await;
+    let cookie = pending_signup_header(&app, Utc::now());
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_snapshot!(response.json(), @r#"{"signup":{"email":"ghost@example.com","login":"ghost"}}"#);
+    response.assert_cache_control("no-store");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_returns_not_found_when_explicit_signup_is_disabled() {
+    let (_, anon) = TestApp::init()
+        .with_config(|config| config.features.explicit_signup_enabled = false)
+        .empty()
+        .await;
+
+    let response = anon.get::<Value>("/api/private/session/signup").await;
+    assert_snapshot!(response.status(), @"404 Not Found");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Not Found"}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_rejects_signed_in_user() {
+    let (_, _, user) = TestApp::init().with_user().await;
+
+    let response = user.get::<Value>("/api/private/session/signup").await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"You are already signed in."}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_rejects_missing_signup() {
+    let (_, anon) = TestApp::init().empty().await;
+
+    let response = anon.get::<Value>("/api/private/session/signup").await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Your signup session is missing or has expired. Please authenticate with GitHub again."}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_rejects_and_clears_malformed_signup() {
+    let (app, anon) = TestApp::init().empty().await;
+    let values = HashMap::from([(PENDING_SIGNUP_KEY.into(), "not-json".into())]);
+    let cookie = encode_session_header(app.as_inner().session_key(), values);
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Your signup session is missing or has expired. Please authenticate with GitHub again."}]}"#);
+
+    let set_cookie = response.headers().get(header::SET_COOKIE).unwrap();
+    let cookie = set_cookie.to_str().unwrap();
+    let cookie = cookie.split(';').next().unwrap();
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert!(response.headers().get(header::SET_COOKIE).is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_rejects_and_clears_expired_signup() {
+    let (app, anon) = TestApp::init().empty().await;
+    let created_at = Utc::now() - Duration::minutes(31);
+    let cookie = pending_signup_header(&app, created_at);
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, &cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.json(), @r#"{"errors":[{"detail":"Your signup session is missing or has expired. Please authenticate with GitHub again."}]}"#);
+
+    let set_cookie = response.headers().get(header::SET_COOKIE).unwrap();
+    let cookie = set_cookie.to_str().unwrap();
+    let cookie = cookie.split(';').next().unwrap();
+    let mut request = anon.request_builder(Method::GET, "/api/private/session/signup");
+    request.header(header::COOKIE, cookie);
+
+    let response = anon.run::<Value>(request).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert!(response.headers().get(header::SET_COOKIE).is_none());
+}

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1879,6 +1879,54 @@ expression: response.json()
       }
     },
     "/api/private/session/signup": {
+      "delete": {
+        "operationId": "delete_pending_signup",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "ok": {
+                      "example": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
+          }
+        },
+        "summary": "Cancel a pending signup.",
+        "tags": [
+          "session"
+        ]
+      },
       "get": {
         "description": "The encrypted GitHub token remains in the signed session cookie and is never returned to the\nfrontend. Missing, malformed, and expired signup state require restarting GitHub\nauthentication.",
         "operationId": "get_pending_signup",

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1653,7 +1653,7 @@ expression: response.json()
     },
     "/api/private/session/authorize": {
       "post": {
-        "description": "This route is called from the GitHub API OAuth flow after the user accepted or rejected\nthe data access permissions. It will check the `state` parameter and then call the GitHub API\nto exchange the temporary `code` for an API token. The response indicates whether the\ncorresponding user was signed in or needs to complete signup.\n\nsee <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>",
+        "description": "This route is called from the GitHub API OAuth flow after the user accepted or rejected\nthe data access permissions. It will check the `state` parameter and then call the GitHub API\nto exchange the temporary `code` for an API token. Existing crates.io users are signed in.\nNew users must complete signup when explicit signup is enabled and are created immediately\notherwise.\n\nsee <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>",
         "operationId": "authorize_session",
         "requestBody": {
           "content": {

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1653,7 +1653,7 @@ expression: response.json()
     },
     "/api/private/session/authorize": {
       "post": {
-        "description": "This route is called from the GitHub API OAuth flow after the user accepted or rejected\nthe data access permissions. It will check the `state` parameter and then call the GitHub API\nto exchange the temporary `code` for an API token. The API token is returned together with\nthe corresponding user information.\n\nsee <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>",
+        "description": "This route is called from the GitHub API OAuth flow after the user accepted or rejected\nthe data access permissions. It will check the `state` parameter and then call the GitHub API\nto exchange the temporary `code` for an API token. The response indicates whether the\ncorresponding user was signed in or needs to complete signup.\n\nsee <https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site>",
         "operationId": "authorize_session",
         "requestBody": {
           "content": {
@@ -1686,46 +1686,90 @@ expression: response.json()
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "owned_crates": {
-                      "description": "The crates that the authenticated user owns.",
-                      "items": {
-                        "properties": {
-                          "email_notifications": {
-                            "deprecated": true,
-                            "type": "boolean"
-                          },
-                          "id": {
-                            "description": "The opaque identifier of the crate.",
-                            "example": 123,
-                            "format": "int32",
-                            "type": "integer"
-                          },
-                          "name": {
-                            "description": "The name of the crate.",
-                            "example": "serde",
-                            "type": "string"
-                          }
+                  "description": "The result of completing the GitHub OAuth flow.",
+                  "oneOf": [
+                    {
+                      "allOf": [
+                        {
+                          "description": "The GitHub OAuth flow signed in a crates.io user.",
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "owned_crates": {
+                                  "description": "The crates that the authenticated user owns.",
+                                  "items": {
+                                    "properties": {
+                                      "email_notifications": {
+                                        "deprecated": true,
+                                        "type": "boolean"
+                                      },
+                                      "id": {
+                                        "description": "The opaque identifier of the crate.",
+                                        "example": 123,
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "name": {
+                                        "description": "The name of the crate.",
+                                        "example": "serde",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "id",
+                                      "name",
+                                      "email_notifications"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "user": {
+                                  "$ref": "#/components/schemas/AuthenticatedUser",
+                                  "description": "The authenticated user."
+                                }
+                              },
+                              "required": [
+                                "user",
+                                "owned_crates"
+                              ],
+                              "type": "object"
+                            }
+                          ]
                         },
-                        "required": [
-                          "id",
-                          "name",
-                          "email_notifications"
-                        ],
-                        "type": "object"
-                      },
-                      "type": "array"
+                        {
+                          "properties": {
+                            "status": {
+                              "enum": [
+                                "signed_in"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "status"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "The GitHub OAuth flow signed in a crates.io user."
                     },
-                    "user": {
-                      "$ref": "#/components/schemas/AuthenticatedUser",
-                      "description": "The authenticated user."
+                    {
+                      "description": "The GitHub account needs a crates.io account.",
+                      "properties": {
+                        "status": {
+                          "enum": [
+                            "signup_required"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "status"
+                      ],
+                      "type": "object"
                     }
-                  },
-                  "required": [
-                    "user",
-                    "owned_crates"
-                  ],
-                  "type": "object"
+                  ]
                 }
               }
             },

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1975,6 +1975,120 @@ expression: response.json()
         "tags": [
           "session"
         ]
+      },
+      "post": {
+        "operationId": "complete_pending_signup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Request to complete a pending signup.",
+                "properties": {
+                  "signup": {
+                    "description": "User-controlled signup details.",
+                    "oneOf": [
+                      {
+                        "description": "User-controlled details for a pending signup.",
+                        "properties": {
+                          "email": {
+                            "description": "The email address to associate with the new account.",
+                            "example": "new-user@example.com",
+                            "format": "email",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "email"
+                        ],
+                        "type": "object"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "signup"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "owned_crates": {
+                      "description": "The crates that the authenticated user owns.",
+                      "items": {
+                        "properties": {
+                          "email_notifications": {
+                            "deprecated": true,
+                            "type": "boolean"
+                          },
+                          "id": {
+                            "description": "The opaque identifier of the crate.",
+                            "example": 123,
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "The name of the crate.",
+                            "example": "serde",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email_notifications"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/AuthenticatedUser",
+                      "description": "The authenticated user."
+                    }
+                  },
+                  "required": [
+                    "user",
+                    "owned_crates"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
+          }
+        },
+        "summary": "Complete a pending signup.",
+        "tags": [
+          "session"
+        ]
       }
     },
     "/api/v1/categories": {

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -921,6 +921,26 @@ expression: response.json()
         ],
         "type": "object"
       },
+      "SignupDetails": {
+        "description": "Public GitHub account details displayed while a user completes signup.",
+        "properties": {
+          "email": {
+            "description": "The email address suggested by GitHub, if one is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "login": {
+            "description": "The GitHub account login.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "login"
+        ],
+        "type": "object"
+      },
       "Slug": {
         "properties": {
           "description": {
@@ -1853,6 +1873,57 @@ expression: response.json()
           }
         },
         "summary": "Begin authentication flow.",
+        "tags": [
+          "session"
+        ]
+      }
+    },
+    "/api/private/session/signup": {
+      "get": {
+        "description": "The encrypted GitHub token remains in the signed session cookie and is never returned to the\nfrontend. Missing, malformed, and expired signup state require restarting GitHub\nauthentication.",
+        "operationId": "get_pending_signup",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Response containing details for a pending signup.",
+                  "properties": {
+                    "signup": {
+                      "$ref": "#/components/schemas/SignupDetails"
+                    }
+                  },
+                  "required": [
+                    "signup"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
+          }
+        },
+        "summary": "Load the GitHub account details for a pending signup.",
         "tags": [
           "session"
         ]

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -921,6 +921,26 @@ expression: response.json()
         ],
         "type": "object"
       },
+      "SignupDetails": {
+        "description": "Public GitHub account details displayed while a user completes signup.",
+        "properties": {
+          "email": {
+            "description": "The email address suggested by GitHub, if one is available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "login": {
+            "description": "The GitHub account login.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "login"
+        ],
+        "type": "object"
+      },
       "Slug": {
         "properties": {
           "description": {

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -43,7 +43,9 @@ async fn updating_existing_user_doesnt_change_api_token() -> anyhow::Result<()> 
         avatar_url: None,
     };
     let encrypted_token = encryption.encrypt("bar_token")?;
-    assert_ok!(session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await);
+    assert_ok!(
+        session::save_user_to_database(false, &gh_user, &encrypted_token, emails, &mut conn).await
+    );
 
     // Use the original API token to find the now updated user
     let hashed_token = assert_ok!(HashedToken::parse(token));
@@ -85,7 +87,9 @@ async fn github_without_email_does_not_overwrite_email() -> anyhow::Result<()> {
         avatar_url: None,
     };
 
-    let user_id = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(false, &gh_user, &[], emails, &mut conn)
+        .await?
+        .unwrap();
     let u = User::find(&conn, user_id).await?;
 
     let user_without_github_email = MockCookieUser::new(&app, u);
@@ -109,7 +113,9 @@ async fn github_without_email_does_not_overwrite_email() -> anyhow::Result<()> {
         avatar_url: None,
     };
 
-    let user_id = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(false, &gh_user, &[], emails, &mut conn)
+        .await?
+        .unwrap();
     let u = User::find(&conn, user_id).await?;
 
     let again_user_without_github_email = MockCookieUser::new(&app, u);
@@ -151,7 +157,9 @@ async fn github_with_email_does_not_overwrite_email() -> anyhow::Result<()> {
         avatar_url: None,
     };
 
-    let user_id = session::save_user_to_database(&gh_user, &[], &emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(false, &gh_user, &[], &emails, &mut conn)
+        .await?
+        .unwrap();
     let u = User::find(&conn, user_id).await?;
 
     let user_with_different_email_in_github = MockCookieUser::new(&app, u);
@@ -208,7 +216,9 @@ async fn test_confirm_user_email() -> anyhow::Result<()> {
         avatar_url: None,
     };
 
-    let user_id = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(false, &gh_user, &[], emails, &mut conn)
+        .await?
+        .unwrap();
     let u = User::find(&conn, user_id).await?;
 
     let user = MockCookieUser::new(&app, u);
@@ -254,7 +264,9 @@ async fn test_existing_user_email() -> anyhow::Result<()> {
         avatar_url: None,
     };
 
-    let user_id = session::save_user_to_database(&gh_user, &[], emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(false, &gh_user, &[], emails, &mut conn)
+        .await?
+        .unwrap();
     let u = User::find(&conn, user_id).await?;
 
     update(Email::belonging_to(&u))
@@ -294,7 +306,9 @@ async fn also_write_to_users_username() -> anyhow::Result<()> {
         avatar_url: None,
     };
     let encrypted_token = encryption.encrypt("some random token")?;
-    let uid = session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await?;
+    let uid = session::save_user_to_database(false, &gh_user, &encrypted_token, emails, &mut conn)
+        .await?
+        .unwrap();
     let u = User::find(&conn, uid).await?;
 
     assert_eq!(u.username, "arbitrary_username");
@@ -327,7 +341,9 @@ async fn write_to_users_and_oauth_github() -> anyhow::Result<()> {
         avatar_url: Some(gh_avatar.clone()),
     };
     let encrypted_token = encryption.encrypt(gh_token)?;
-    let uid = session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await?;
+    let uid = session::save_user_to_database(false, &gh_user, &encrypted_token, emails, &mut conn)
+        .await?
+        .unwrap();
     let u = User::find(&conn, uid).await?;
     assert_eq!(u.username, gh_login);
     assert_eq!(u.name.unwrap(), gh_display_name);
@@ -361,7 +377,9 @@ async fn write_to_users_and_oauth_github() -> anyhow::Result<()> {
         avatar_url: Some(different_gh_avatar.clone()),
     };
     let encrypted_token = encryption.encrypt(different_gh_token)?;
-    let uid = session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await?;
+    let uid = session::save_user_to_database(false, &gh_user, &encrypted_token, emails, &mut conn)
+        .await?
+        .unwrap();
     let u = User::find(&conn, uid).await?;
     assert_eq!(u.username, different_gh_login);
     assert_eq!(u.name.unwrap(), different_gh_display_name);
@@ -393,7 +411,9 @@ async fn write_to_users_and_oauth_github() -> anyhow::Result<()> {
     };
     let another_gh_token = "a different random token";
     let encrypted_token = encryption.encrypt(another_gh_token)?;
-    let uid = session::save_user_to_database(&gh_user, &encrypted_token, emails, &mut conn).await?;
+    let uid = session::save_user_to_database(false, &gh_user, &encrypted_token, emails, &mut conn)
+        .await?
+        .unwrap();
     let u = User::find(&conn, uid).await?;
 
     assert_eq!(u.gh_login, gh_login);
@@ -431,7 +451,9 @@ async fn existing_user_can_log_in_during_read_only_mode() -> anyhow::Result<()> 
     };
 
     // Create the user and its `oauth_github` record while the database is writable.
-    let user_id = session::save_user_to_database(&gh_user, b"token", emails, &mut conn).await?;
+    let user_id = session::save_user_to_database(false, &gh_user, b"token", emails, &mut conn)
+        .await?
+        .unwrap();
 
     // Switch the connection into read-only mode, mirroring how the app configures
     // read-only connections in `ConnectionConfig::apply()`.
@@ -441,9 +463,9 @@ async fn existing_user_can_log_in_during_read_only_mode() -> anyhow::Result<()> 
 
     // Logging in again as an existing user must still succeed by falling back to a lookup, even
     // though the write attempts fail in read-only mode.
-    let result = session::save_user_to_database(&gh_user, b"token", emails, &mut conn).await;
+    let result = session::save_user_to_database(false, &gh_user, b"token", emails, &mut conn).await;
 
-    assert_ok_eq!(result, user_id);
+    assert_ok_eq!(result, Some(user_id));
 
     Ok(())
 }
@@ -469,7 +491,7 @@ async fn new_user_cannot_log_in_during_read_only_mode() -> anyhow::Result<()> {
         .await?;
 
     // Logging in as a new user can't work in read-only mode.
-    let result = session::save_user_to_database(&gh_user, b"token", emails, &mut conn).await;
+    let result = session::save_user_to_database(false, &gh_user, b"token", emails, &mut conn).await;
 
     let error = assert_err!(result);
     assert_snapshot!(error, @"cannot execute UPDATE in a read-only transaction");

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -600,6 +600,7 @@ fn simple_config() -> config::Server {
         disable_token_creation: None,
         banner_message: None,
         features: FeaturesConfig {
+            explicit_signup_enabled: true,
             index_include_pubtime: false,
             zip_archives_enabled: true,
             cache_tags_enabled: true,

--- a/src/tests/worker/update_user_from_github.rs
+++ b/src/tests/worker/update_user_from_github.rs
@@ -51,9 +51,15 @@ impl UpdateTest {
         let emails = &app.as_inner().emails;
         let mut conn = app.db_conn().await;
 
-        let user_id =
-            session::save_user_to_database(&existing_gh_user, &ENCRYPTED_TOKEN, emails, &mut conn)
-                .await?;
+        let user_id = session::save_user_to_database(
+            false,
+            &existing_gh_user,
+            &ENCRYPTED_TOKEN,
+            emails,
+            &mut conn,
+        )
+        .await?
+        .unwrap();
 
         let oauth_github_before_update = oauth_github::table
             .filter(oauth_github::user_id.eq(user_id))

--- a/svelte/src/lib/utils/session.svelte.ts
+++ b/svelte/src/lib/utils/session.svelte.ts
@@ -205,6 +205,12 @@ export class SessionState {
       return;
     }
 
+    if (data.status === 'signup_required') {
+      this.#notifications?.error('Signup is currently not possible.');
+      this.state = 'logged-out';
+      return;
+    }
+
     localStorage.setItem(LOGIN_KEY, '1');
 
     let user = await loadUser(this.#client);


### PR DESCRIPTION
This introduces an `explicit_signup_enabled` feature flag and tagged authorization outcomes so existing GitHub-linked users continue to sign in while new users enter a bounded pending-signup session. Until the signup page lands and if the feature flag is enabled, the frontend reports that signup is temporarily unavailable without marking the user as logged in.

Best reviewed commit-by-commit :)

/cc @carols10cents 

### Related

- #13907