### PR TITLE
controllers/version: Document update request body

### DIFF
--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -1834,6 +1834,10 @@ export interface components {
              */
             version_downloads: string;
         };
+        VersionUpdate: {
+            yank_message?: string | null;
+            yanked?: boolean | null;
+        };
     };
     responses: never;
     parameters: never;
@@ -2930,7 +2934,13 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": {
+                    version: components["schemas"]["VersionUpdate"];
+                };
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/src/controllers/version/update.rs
+++ b/src/controllers/version/update.rs
@@ -18,12 +18,12 @@ use http::request::Parts;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct VersionUpdate {
     yanked: Option<bool>,
     yank_message: Option<String>,
 }
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct VersionUpdateRequest {
     version: VersionUpdate,
 }
@@ -40,6 +40,7 @@ pub struct UpdateResponse {
     patch,
     path = "/api/v1/crates/{name}/{version}",
     params(CrateVersionPath),
+    request_body = inline(VersionUpdateRequest),
     security(
         ("api_token" = []),
         ("cookie" = []),

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -1383,6 +1383,23 @@ expression: response.json()
           "authors"
         ],
         "type": "object"
+      },
+      "VersionUpdate": {
+        "properties": {
+          "yank_message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "yanked": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -3264,6 +3281,24 @@ expression: response.json()
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "version": {
+                    "$ref": "#/components/schemas/VersionUpdate"
+                  }
+                },
+                "required": [
+                  "version"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -1383,6 +1383,23 @@ expression: response.json()
           "authors"
         ],
         "type": "object"
+      },
+      "VersionUpdate": {
+        "properties": {
+          "yank_message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "yanked": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -2911,6 +2928,24 @@ expression: response.json()
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "version": {
+                    "$ref": "#/components/schemas/VersionUpdate"
+                  }
+                },
+                "required": [
+                  "version"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {


### PR DESCRIPTION
This adds the version update request body to the generated OpenAPI operation. It regenerates the public and internal API snapshots and the TypeScript client schema so consumers can infer yank update payloads.