### PR TITLE
Generate db-dump.tar.gz that supports multithreaded extract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chapter-tgz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d3b546f2d916ddf609e8f8e271c93c9dcd66d7500a87ee8d81d4c159839d7c"
+dependencies = [
+ "flate2",
+ "tar",
+]
+
+[[package]]
 name = "chinese-number"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,6 +1886,7 @@ name = "crates_io_database_dump"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "chapter-tgz",
  "chrono",
  "crates_io_env_vars",
  "crates_io_test_db",

--- a/crates/crates_io_database_dump/Cargo.toml
+++ b/crates/crates_io_database_dump/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 anyhow = "=1.0.104"
+chapter-tgz = "0.1"
 chrono = { version = "=0.4.45", default-features = false, features = ["clock", "serde"] }
 crates_io_version = { path = "../crates_io_version" }
 flate2 = "=1.1.9"

--- a/crates/crates_io_database_dump/src/lib.rs
+++ b/crates/crates_io_database_dump/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use anyhow::{Context, anyhow};
+use chapter_tgz::TgzWriter;
 use serde::Serialize;
 use std::fs;
 use std::fs::File;
@@ -194,16 +195,18 @@ pub struct Archives {
 pub fn create_archives(export_dir: &Path, tarball_prefix: &Path) -> anyhow::Result<Archives> {
     debug!("Creating tarball file…");
     let tar_tempfile = tempfile::NamedTempFile::new()?;
-    let encoder =
-        flate2::write::GzEncoder::new(tar_tempfile.as_file(), flate2::Compression::default());
-    let mut tar = tar::Builder::new(encoder);
+    let mut tar = TgzWriter::new(tar_tempfile.as_file(), flate2::Compression::default());
 
     debug!("Creating zip file…");
     let zip_tempfile = tempfile::NamedTempFile::new()?;
     let mut zip = zip::ZipWriter::new(zip_tempfile.as_file());
 
+    // Everything other than data files go in a single chapter. These files are
+    // small.
+    let mut nondata_chapter = tar.create_chapter();
+
     debug!("Appending `{tarball_prefix:?}` directory to tarball…");
-    tar.append_dir(tarball_prefix, export_dir)?;
+    nondata_chapter.append_dir(tarball_prefix, export_dir)?;
 
     // Append readme, metadata, schemas.
     let mut paths = Vec::new();
@@ -219,7 +222,7 @@ pub fn create_archives(export_dir: &Path, tarball_prefix: &Path) -> anyhow::Resu
     for (path, file_name) in paths {
         let name = tarball_prefix.join(&file_name);
         debug!("Appending `{name:?}` file to tarball…");
-        tar.append_path_with_name(&path, name)?;
+        nondata_chapter.append_path_with_name(&path, name)?;
 
         debug!("Appending `{file_name:?}` file to zip file…");
         zip.start_file_from_path(&file_name, SimpleFileOptions::default())?;
@@ -235,7 +238,8 @@ pub fn create_archives(export_dir: &Path, tarball_prefix: &Path) -> anyhow::Resu
 
     let path = tarball_prefix.join("data");
     debug!("Appending `data` directory to tarball…");
-    tar.append_dir(path, export_dir.join("data"))?;
+    nondata_chapter.append_dir(path, export_dir.join("data"))?;
+    drop(nondata_chapter);
 
     debug!("Appending `data` directory to zip file…");
     zip.add_directory("data", SimpleFileOptions::default())?;
@@ -243,12 +247,18 @@ pub fn create_archives(export_dir: &Path, tarball_prefix: &Path) -> anyhow::Resu
     for table in sorted_tables {
         let csv_path = export_dir.join("data").join(table).with_extension("csv");
         if csv_path.exists() {
+            // Data files each get a dedicated chapter. This supports extracting
+            // single files without performing gzip decompression for everything
+            // in front of it, and it supports extracting different data files
+            // in parallel on separate threads.
+            let mut data_chapter = tar.create_chapter();
+
             let name = tarball_prefix
                 .join("data")
                 .join(table)
                 .with_extension("csv");
             debug!("Appending `{name:?}` file to tarball…");
-            tar.append_path_with_name(&csv_path, name)?;
+            data_chapter.append_path_with_name(&csv_path, name)?;
 
             let name = PathBuf::from("data").join(table).with_extension("csv");
             debug!("Appending `{name:?}` file to zip file…");


### PR DESCRIPTION
As part of optimizing https://github.com/dtolnay/db-dump, I came up with a way that db-dump.tar.gz would be able to support reading files in parallel and efficiently skipping files. See https://github.com/dtolnay/chapter-tgz.

On my machine, reading the existing db-dump.tar.gz files currently takes about 6.5 seconds using the following program.

```rust
use std::fs::File;
use std::io::Cursor;

// 6.5 seconds
fn main() -> anyhow::Result<()> {
    let file = File::open("db-dump-original.tar.gz")?;
    let data = unsafe { memmap2::Mmap::map(&file)? };
    let mut tgz = tar::Archive::new(flate2::read::GzDecoder::new(Cursor::new(&*data)));
    for _entry in tgz.entries()? {}
    Ok(())
}
```

With the new approach, the above program continues to take 6.5 seconds, but it becomes possible to extract different data files simultaneously on different threads, which takes only 3.1 seconds. Instead of decompressing everything serially as usually required by tgz, the runtime becomes governed by the largest file in the tgz, which is currently dependencies.csv (43.6% of the total csv size &mdash; that closely matches the ratio of the speedup).

```rust
use std::fs::File;
use std::io::{self, Cursor};
use std::thread;

// 3.1 seconds
fn main() -> anyhow::Result<()> {
    let file = File::open("db-dump-with-chapters.tar.gz")?;
    let data = unsafe { memmap2::Mmap::map(&file)? };
    let tgz = chapter_tgz::TgzReader::open(Cursor::new(&*data))?;
    let mut chapters = Vec::new();
    for i in 0..tgz.chapters() {
        let chapter = tgz.independent_read_chapter(i)?;
        chapters.push(chapter);
    }

    thread::scope(|scope| {
        for mut chapter in chapters {
            scope.spawn(move || {
                if let Err(err) = (|| -> io::Result<()> {
                    for _entry in chapter.entries()? {}
                    Ok(())
                })() {
                    eprintln!("Error: {err}");
                }
            });
        }
    });

    Ok(())
}
```

But most uses of `db_dump` do not require all of the data files. The API of `db_dump` was already designed from the beginning to stop reading as soon as all of the files needed in the user's code were found. However, it was not possible to _jump ahead_ in the tgz directly to the needed files, so a prefix of the tgz always had to be read, including files that were not needed. The new approach supports jumping directly to specific files, as in the following code which reads users.csv in 0.01 seconds.

```rust
use anyhow::Context as _;
use std::fs::File;
use std::io::{BufRead as _, BufReader, Cursor};

// 0.01 seconds
fn main() -> anyhow::Result<()> {
    let file = File::open("db-dump-with-chapters.tar.gz")?;
    let data = unsafe { memmap2::Mmap::map(&file)? };
    let mut tgz = chapter_tgz::TgzReader::open(Cursor::new(&*data))?;
    while let Some(mut chapter) = tgz.next_chapter() {
        let mut entries = chapter.entries()?;
        let entry = entries.next().context("expected at least one entry in chapter")??;
        let path = entry.path()?;
        let file_name = path.file_name().context("tar entry should have filename")?;
        if file_name == "users.csv" {
            println!("{} lines", BufReader::new(entry).lines().count());
        }
    }
    Ok(())
}
```