### PR TITLE
Refactor crate owner queries

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -551,44 +551,35 @@ pub struct EncodableOwner {
     pub avatar: Option<String>,
 }
 
+impl EncodableOwner {
+    pub fn from_user(user: User) -> Self {
+        Self {
+            id: user.id,
+            url: Some(format!("https://github.com/{}", user.gh_login)),
+            login: user.gh_login,
+            avatar: user.gh_avatar,
+            name: user.name,
+            kind: String::from("user"),
+        }
+    }
+
+    pub fn from_team(team: Team) -> Self {
+        Self {
+            id: team.id,
+            url: team.url(),
+            login: team.login,
+            avatar: team.avatar,
+            name: team.name,
+            kind: String::from("team"),
+        }
+    }
+}
+
 impl From<Owner> for EncodableOwner {
     fn from(owner: Owner) -> Self {
         match owner {
-            Owner::User(User {
-                id,
-                name,
-                gh_login,
-                gh_avatar,
-                ..
-            }) => {
-                let url = format!("https://github.com/{gh_login}");
-                Self {
-                    id,
-                    login: gh_login,
-                    avatar: gh_avatar,
-                    url: Some(url),
-                    name,
-                    kind: String::from("user"),
-                }
-            }
-            Owner::Team(team) => {
-                let url = team.url();
-                let Team {
-                    id,
-                    name,
-                    login,
-                    avatar,
-                    ..
-                } = team;
-                Self {
-                    id,
-                    login,
-                    url,
-                    avatar,
-                    name,
-                    kind: String::from("team"),
-                }
-            }
+            Owner::User(user) => Self::from_user(user),
+            Owner::Team(team) => Self::from_team(team),
         }
     }
 }

--- a/crates/crates_io_database/Cargo.toml
+++ b/crates/crates_io_database/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "=1.0.229", features = ["derive"] }
 serde_json = "=1.0.151"
 sha2 = "=0.11.0"
 thiserror = "=2.0.19"
+tokio = { version = "=1.53.1", features = ["macros"] }
 tracing = "=0.1.44"
 utoipa = { version = "=5.5.0", features = ["chrono"] }
 

--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -205,8 +205,10 @@ impl Crate {
     }
 
     pub async fn owners(&self, conn: &AsyncPgConnection) -> QueryResult<Vec<Owner>> {
-        let users = User::owning(self, conn).await?.into_iter().map(Owner::User);
-        let teams = Team::owning(self, conn).await?.into_iter().map(Owner::Team);
+        let (users, teams) = tokio::try_join!(User::owning(self, conn), Team::owning(self, conn))?;
+
+        let users = users.into_iter().map(Owner::User);
+        let teams = teams.into_iter().map(Owner::Team);
 
         Ok(users.chain(teams).collect())
     }

--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -1,6 +1,6 @@
 use crate::fns::canon_crate_name;
 use crate::models::version::TopVersions;
-use crate::models::{CrateOwner, Owner, OwnerKind, User, Version};
+use crate::models::{CrateOwner, Owner, User, Version};
 use crate::schema::*;
 use chrono::{DateTime, Utc};
 use diesel::associations::Identifiable;
@@ -204,24 +204,9 @@ impl Crate {
         ))
     }
 
-    pub async fn owners(&self, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Owner>> {
-        let users = CrateOwner::by_owner_kind(OwnerKind::User)
-            .filter(crate_owners::crate_id.eq(self.id))
-            .inner_join(users::table.left_join(oauth_github::table))
-            .select(User::as_select())
-            .load(&mut conn)
-            .await?
-            .into_iter()
-            .map(Owner::User);
-
-        let teams = CrateOwner::by_owner_kind(OwnerKind::Team)
-            .filter(crate_owners::crate_id.eq(self.id))
-            .inner_join(teams::table)
-            .select(Team::as_select())
-            .load(&mut conn)
-            .await?
-            .into_iter()
-            .map(Owner::Team);
+    pub async fn owners(&self, conn: &AsyncPgConnection) -> QueryResult<Vec<Owner>> {
+        let users = User::owning(self, conn).await?.into_iter().map(Owner::User);
+        let teams = Team::owning(self, conn).await?.into_iter().map(Owner::Team);
 
         Ok(users.chain(teams).collect())
     }

--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -207,7 +207,6 @@ impl Crate {
     pub async fn owners(&self, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Owner>> {
         let users = CrateOwner::by_owner_kind(OwnerKind::User)
             .filter(crate_owners::crate_id.eq(self.id))
-            .order((crate_owners::owner_id, crate_owners::owner_kind))
             .inner_join(users::table.left_join(oauth_github::table))
             .select(User::as_select())
             .load(&mut conn)
@@ -217,7 +216,6 @@ impl Crate {
 
         let teams = CrateOwner::by_owner_kind(OwnerKind::Team)
             .filter(crate_owners::crate_id.eq(self.id))
-            .order((crate_owners::owner_id, crate_owners::owner_kind))
             .inner_join(teams::table)
             .select(Team::as_select())
             .load(&mut conn)

--- a/crates/crates_io_database/src/models/team.rs
+++ b/crates/crates_io_database/src/models/team.rs
@@ -53,11 +53,10 @@ impl NewTeam<'_> {
 
 impl Team {
     pub async fn owning(krate: &Crate, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Self>> {
-        let base_query = CrateOwner::belonging_to(krate).filter(crate_owners::deleted.eq(false));
-        base_query
+        CrateOwner::by_owner_kind(OwnerKind::Team)
             .inner_join(teams::table)
             .select(Team::as_select())
-            .filter(crate_owners::owner_kind.eq(OwnerKind::Team))
+            .filter(crate_owners::crate_id.eq(krate.id))
             .load(&mut conn)
             .await
     }

--- a/crates/crates_io_database/src/models/team.rs
+++ b/crates/crates_io_database/src/models/team.rs
@@ -2,7 +2,7 @@ use bon::Builder;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
-use crate::models::{Crate, CrateOwner, Owner, OwnerKind};
+use crate::models::{Crate, CrateOwner, OwnerKind};
 use crate::schema::{crate_owners, teams};
 
 /// For now, just a GitHub Team. Can be upgraded to other teams
@@ -52,18 +52,14 @@ impl NewTeam<'_> {
 }
 
 impl Team {
-    pub async fn owning(krate: &Crate, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Owner>> {
+    pub async fn owning(krate: &Crate, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Self>> {
         let base_query = CrateOwner::belonging_to(krate).filter(crate_owners::deleted.eq(false));
-        let teams = base_query
+        base_query
             .inner_join(teams::table)
             .select(Team::as_select())
             .filter(crate_owners::owner_kind.eq(OwnerKind::Team))
             .load(&mut conn)
-            .await?
-            .into_iter()
-            .map(Owner::Team);
-
-        Ok(teams.collect())
+            .await
     }
 
     /// Splits the login into provider, organization, and team name.

--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -8,7 +8,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::Serialize;
 
 use crate::fns::lower;
-use crate::models::{Crate, CrateOwner, Email, Owner, OwnerKind};
+use crate::models::{Crate, CrateOwner, Email, OwnerKind};
 use crate::schema::{crate_owners, emails, oauth_github, users};
 
 /// The model representing a row in the `users` database table.
@@ -52,17 +52,13 @@ impl User {
             .await
     }
 
-    pub async fn owning(krate: &Crate, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Owner>> {
-        let users = CrateOwner::by_owner_kind(OwnerKind::User)
+    pub async fn owning(krate: &Crate, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Self>> {
+        CrateOwner::by_owner_kind(OwnerKind::User)
             .inner_join(users::table.left_join(oauth_github::table))
             .select(User::as_select())
             .filter(crate_owners::crate_id.eq(krate.id))
             .load(&mut conn)
-            .await?
-            .into_iter()
-            .map(Owner::User);
-
-        Ok(users.collect())
+            .await
     }
 
     /// Queries the database for the verified emails

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -74,8 +74,8 @@ pub async fn get_team_owners(state: AppState, path: CratePath) -> AppResult<Json
     let teams = Team::owning(&krate, &conn)
         .await?
         .into_iter()
-        .map(Owner::into)
-        .collect::<Vec<EncodableOwner>>();
+        .map(EncodableOwner::from_team)
+        .collect::<Vec<_>>();
 
     Ok(Json(TeamsResponse { teams }))
 }

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -44,9 +44,13 @@ pub async fn list_owners(state: AppState, path: CratePath) -> AppResult<Json<Use
 
     let krate = path.load_crate(&conn).await?;
 
-    let users = krate
-        .owners(&conn)
-        .await?
+    let mut users = krate.owners(&conn).await?;
+    users.sort_by_key(|owner| match owner {
+        Owner::User(user) => (0, user.id),
+        Owner::Team(team) => (1, team.id),
+    });
+
+    let users = users
         .into_iter()
         .map(Owner::into)
         .collect::<Vec<EncodableOwner>>();

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -96,8 +96,8 @@ pub async fn get_user_owners(state: AppState, path: CratePath) -> AppResult<Json
     let users = User::owning(&krate, &conn)
         .await?
         .into_iter()
-        .map(Owner::into)
-        .collect::<Vec<EncodableOwner>>();
+        .map(EncodableOwner::from_user)
+        .collect::<Vec<_>>();
 
     Ok(Json(UsersResponse { users }))
 }

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -75,8 +75,10 @@ pub async fn get_team_owners(state: AppState, path: CratePath) -> AppResult<Json
     let conn = state.db_read().await?;
     let krate = path.load_crate(&conn).await?;
 
-    let teams = Team::owning(&krate, &conn)
-        .await?
+    let mut teams = Team::owning(&krate, &conn).await?;
+    teams.sort_by_key(|team| team.id);
+
+    let teams = teams
         .into_iter()
         .map(EncodableOwner::from_team)
         .collect::<Vec<_>>();
@@ -97,8 +99,10 @@ pub async fn get_user_owners(state: AppState, path: CratePath) -> AppResult<Json
 
     let krate = path.load_crate(&conn).await?;
 
-    let users = User::owning(&krate, &conn)
-        .await?
+    let mut users = User::owning(&krate, &conn).await?;
+    users.sort_by_key(|user| user.id);
+
+    let users = users
         .into_iter()
         .map(EncodableOwner::from_user)
         .collect::<Vec<_>>();

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -44,13 +44,13 @@ pub async fn list_owners(state: AppState, path: CratePath) -> AppResult<Json<Use
 
     let krate = path.load_crate(&conn).await?;
 
-    let mut users = krate.owners(&conn).await?;
-    users.sort_by_key(|owner| match owner {
+    let mut owners = krate.owners(&conn).await?;
+    owners.sort_by_key(|owner| match owner {
         Owner::User(user) => (0, user.id),
         Owner::Team(team) => (1, team.id),
     });
 
-    let users = users
+    let users = owners
         .into_iter()
         .map(Owner::into)
         .collect::<Vec<EncodableOwner>>();

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -16,10 +16,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 #[derive(Deserialize)]
-struct TeamResponse {
-    teams: Vec<EncodableOwner>,
-}
-#[derive(Deserialize)]
 struct UserResponse {
     users: Vec<EncodableOwner>,
 }
@@ -327,19 +323,13 @@ async fn check_ownership_one_crate() -> anyhow::Result<()> {
         .await;
     add_team_to_crate(&team, &krate, user.id, &mut conn).await?;
 
-    let json: TeamResponse = anon
-        .get("/api/v1/crates/best_crate/owner_team")
-        .await
-        .good();
-    assert_eq!(json.teams[0].kind, "team");
-    assert_eq!(json.teams[0].name, team.name);
+    let response = anon.get::<()>("/api/v1/crates/best_crate/owner_team").await;
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_json_snapshot!(response.json());
 
-    let json: UserResponse = anon
-        .get("/api/v1/crates/best_crate/owner_user")
-        .await
-        .good();
-    assert_eq!(json.users[0].kind, "user");
-    assert_eq!(json.users[0].name, user.name);
+    let response = anon.get::<()>("/api/v1/crates/best_crate/owner_user").await;
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_json_snapshot!(response.json());
 
     Ok(())
 }

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -303,7 +303,7 @@ async fn check_ownership_two_crates() -> anyhow::Result<()> {
 }
 
 /// Given a crate owned by both a team and a user, check that the
-/// JSON returned by the `/owner_team` route and `/owner_user` route
+/// JSON returned by the `/owners`, `/owner_team` and `/owner_user`
 /// contains the correct kind of owner
 ///
 /// Note that in this case function `new_team` must take a team name
@@ -322,6 +322,10 @@ async fn check_ownership_one_crate() -> anyhow::Result<()> {
         .expect_build(&mut conn)
         .await;
     add_team_to_crate(&team, &krate, user.id, &mut conn).await?;
+
+    let response = anon.get::<()>("/api/v1/crates/best_crate/owners").await;
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_json_snapshot!(response.json());
 
     let response = anon.get::<()>("/api/v1/crates/best_crate/owner_team").await;
     assert_snapshot!(response.status(), @"200 OK");

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -1,7 +1,7 @@
 use crate::builders::{CrateBuilder, PublishBuilder};
 use crate::util::{MockAnonymousUser, MockCookieUser, MockTokenUser, RequestHelper, Response};
 use crate::{TestApp, add_team_to_crate, new_team};
-use crates_io::models::Crate;
+use crates_io::models::{Crate, CrateOwner};
 use crates_io::schema::emails;
 use crates_io::views::{
     EncodableCrateOwnerInvitationV1, EncodableOwner, EncodablePublicUser, InvitationResponse,
@@ -302,9 +302,9 @@ async fn check_ownership_two_crates() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Given a crate owned by both a team and a user, check that the
-/// JSON returned by the `/owners`, `/owner_team` and `/owner_user`
-/// contains the correct kind of owner
+/// Given a crate owned by two teams and two users, check that the JSON
+/// returned by `/owners`, `/owner_team`, and `/owner_user` contains all
+/// owners of the expected kind.
 ///
 /// Note that in this case function `new_team` must take a team name
 /// of form `github:org_name:team_name` as that is the format
@@ -313,15 +313,32 @@ async fn check_ownership_two_crates() -> anyhow::Result<()> {
 async fn check_ownership_one_crate() -> anyhow::Result<()> {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn().await;
+
     let user = user.as_model();
+    let user2 = app.db_new_user("bar").await;
 
     let team = new_team("github:test_org:team_sloth")
         .create_or_update(&conn)
         .await?;
+
+    let team2 = new_team("github:test_org:team_ferret")
+        .create_or_update(&conn)
+        .await?;
+
     let krate = CrateBuilder::new("best_crate", user.id)
         .expect_build(&mut conn)
         .await;
+
+    add_team_to_crate(&team2, &krate, user.id, &mut conn).await?;
     add_team_to_crate(&team, &krate, user.id, &mut conn).await?;
+
+    CrateOwner::builder()
+        .crate_id(krate.id)
+        .user_id(user2.as_model().id)
+        .created_by(user.id)
+        .build()
+        .insert(&conn)
+        .await?;
 
     let response = anon.get::<()>("/api/v1/crates/best_crate/owners").await;
     assert_snapshot!(response.status(), @"200 OK");

--- a/src/tests/snapshots/integration__owners__check_ownership_one_crate-2.snap
+++ b/src/tests/snapshots/integration__owners__check_ownership_one_crate-2.snap
@@ -14,9 +14,25 @@ expression: response.json()
     },
     {
       "avatar": null,
+      "id": 2,
+      "kind": "user",
+      "login": "bar",
+      "name": null,
+      "url": "https://github.com/bar"
+    },
+    {
+      "avatar": null,
       "id": 1,
       "kind": "team",
       "login": "github:test_org:team_sloth",
+      "name": null,
+      "url": "https://github.com/test_org"
+    },
+    {
+      "avatar": null,
+      "id": 2,
+      "kind": "team",
+      "login": "github:test_org:team_ferret",
       "name": null,
       "url": "https://github.com/test_org"
     }

--- a/src/tests/snapshots/integration__owners__check_ownership_one_crate-2.snap
+++ b/src/tests/snapshots/integration__owners__check_ownership_one_crate-2.snap
@@ -1,0 +1,16 @@
+---
+source: src/tests/owners.rs
+expression: response.json()
+---
+{
+  "teams": [
+    {
+      "avatar": null,
+      "id": 1,
+      "kind": "team",
+      "login": "github:test_org:team_sloth",
+      "name": null,
+      "url": "https://github.com/test_org"
+    }
+  ]
+}

--- a/src/tests/snapshots/integration__owners__check_ownership_one_crate-4.snap
+++ b/src/tests/snapshots/integration__owners__check_ownership_one_crate-4.snap
@@ -1,0 +1,16 @@
+---
+source: src/tests/owners.rs
+expression: response.json()
+---
+{
+  "users": [
+    {
+      "avatar": null,
+      "id": 1,
+      "kind": "user",
+      "login": "foo",
+      "name": null,
+      "url": "https://github.com/foo"
+    }
+  ]
+}

--- a/src/tests/snapshots/integration__owners__check_ownership_one_crate-4.snap
+++ b/src/tests/snapshots/integration__owners__check_ownership_one_crate-4.snap
@@ -3,14 +3,14 @@ source: src/tests/owners.rs
 expression: response.json()
 ---
 {
-  "users": [
+  "teams": [
     {
       "avatar": null,
       "id": 1,
-      "kind": "user",
-      "login": "foo",
+      "kind": "team",
+      "login": "github:test_org:team_sloth",
       "name": null,
-      "url": "https://github.com/foo"
+      "url": "https://github.com/test_org"
     }
   ]
 }

--- a/src/tests/snapshots/integration__owners__check_ownership_one_crate-4.snap
+++ b/src/tests/snapshots/integration__owners__check_ownership_one_crate-4.snap
@@ -11,6 +11,14 @@ expression: response.json()
       "login": "github:test_org:team_sloth",
       "name": null,
       "url": "https://github.com/test_org"
+    },
+    {
+      "avatar": null,
+      "id": 2,
+      "kind": "team",
+      "login": "github:test_org:team_ferret",
+      "name": null,
+      "url": "https://github.com/test_org"
     }
   ]
 }

--- a/src/tests/snapshots/integration__owners__check_ownership_one_crate-6.snap
+++ b/src/tests/snapshots/integration__owners__check_ownership_one_crate-6.snap
@@ -11,14 +11,6 @@ expression: response.json()
       "login": "foo",
       "name": null,
       "url": "https://github.com/foo"
-    },
-    {
-      "avatar": null,
-      "id": 1,
-      "kind": "team",
-      "login": "github:test_org:team_sloth",
-      "name": null,
-      "url": "https://github.com/test_org"
     }
   ]
 }

--- a/src/tests/snapshots/integration__owners__check_ownership_one_crate-6.snap
+++ b/src/tests/snapshots/integration__owners__check_ownership_one_crate-6.snap
@@ -11,6 +11,14 @@ expression: response.json()
       "login": "foo",
       "name": null,
       "url": "https://github.com/foo"
+    },
+    {
+      "avatar": null,
+      "id": 2,
+      "kind": "user",
+      "login": "bar",
+      "name": null,
+      "url": "https://github.com/bar"
     }
   ]
 }


### PR DESCRIPTION
This extracts a set of owner query changes from #14384 into a dedicated PR and builds on them with related cleanup. `User::owning()` and `Team::owning()` now return their concrete model types, explicit `EncodableOwner` constructors handle serialization, and `Crate::owners()` reuses and pipelines both queries.

Owner ordering moves out of the database queries and into the API handlers. This preserves the established ordering of `/owners` while introducing deterministic ordering for `/owner_user` and `/owner_team`, which previously had no explicit ordering. `Crate::owners()` users that don't need the deterministic ordering no longer have to pay the price for it.

The owner endpoint tests now use JSON snapshots and cover multiple user and team owners across all three endpoints.

### Related

- #14384