### PR TITLE
Use `serde_json` stream parser for index JSONL

### DIFF
--- a/crates/crates_io_index/src/testing.rs
+++ b/crates/crates_io_index/src/testing.rs
@@ -101,8 +101,9 @@ impl UpstreamIndex {
 
         // The index format consists of one JSON object per line
         // It is not a JSON array
-        let lines = std::str::from_utf8(content)?.lines();
-        let versions = lines.map(serde_json::from_str).collect::<Result<_, _>>()?;
+        let versions = serde_json::Deserializer::from_slice(content)
+            .into_iter::<crate::Crate>()
+            .collect::<Result<_, _>>()?;
 
         Ok(versions)
     }

--- a/crates/crates_io_smoke_test/src/api.rs
+++ b/crates/crates_io_smoke_test/src/api.rs
@@ -72,9 +72,10 @@ impl ApiClient {
         let response = response.error_for_status()?;
         let text = response.text().await?;
 
-        text.lines()
-            .map(|line| serde_json::from_str(line).map_err(Into::into))
-            .collect()
+        serde_json::Deserializer::from_str(&text)
+            .into_iter::<crates_io_index::Crate>()
+            .collect::<Result<_, _>>()
+            .map_err(Into::into)
     }
 
     pub async fn load_from_git_index(
@@ -91,9 +92,10 @@ impl ApiClient {
         let response = response.error_for_status()?;
         let text = response.text().await?;
 
-        text.lines()
-            .map(|line| serde_json::from_str(line).map_err(Into::into))
-            .collect()
+        serde_json::Deserializer::from_str(&text)
+            .into_iter::<crates_io_index::Crate>()
+            .collect::<Result<_, _>>()
+            .map_err(Into::into)
     }
 }
 

--- a/src/worker/jobs/index/normalize.rs
+++ b/src/worker/jobs/index/normalize.rs
@@ -71,12 +71,8 @@ impl BackgroundJob for NormalizeIndex {
 /// deps), and returns the rewritten bytes.
 fn normalize_entry(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
     let mut versions = Vec::new();
-    for line in bytes.split(|&b| b == b'\n') {
-        if line.is_empty() {
-            continue;
-        }
-
-        let mut krate: Crate = serde_json::from_slice(line)?;
+    for krate in serde_json::Deserializer::from_slice(bytes).into_iter::<Crate>() {
+        let mut krate = krate?;
         for dep in &mut krate.deps {
             // Remove deps with empty features
             dep.features.retain(|d| !d.is_empty());

--- a/src/worker/jobs/index/normalize.rs
+++ b/src/worker/jobs/index/normalize.rs
@@ -83,10 +83,7 @@ fn normalize_entry(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
         versions.push(krate);
     }
 
-    let mut body: Vec<u8> = Vec::new();
-    for version in versions {
-        serde_json::to_writer(&mut body, &version)?;
-        body.push(b'\n');
-    }
+    let mut body = Vec::new();
+    crates_io_index::write_crates(&versions, &mut body)?;
     Ok(body)
 }


### PR DESCRIPTION
This removes manual UTF-8 decoding and line splitting when reading index entries.