### PR TITLE
msw: Type API error responses from OpenAPI

### DIFF
--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -977,6 +977,14 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** @description The JSON envelope returned for API errors. */
+        ApiErrorResponse: {
+            /** @description The errors that prevented the request from succeeding. */
+            errors: {
+                /** @description A description of the error. */
+                detail: string;
+            }[];
+        };
         /** @description The model representing a row in the `api_tokens` database table. */
         ApiToken: {
             /**
@@ -1909,6 +1917,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     end_session: {
@@ -1930,6 +1956,24 @@ export interface operations {
                         /** @example true */
                         ok: boolean;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -1986,6 +2030,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     begin_session: {
@@ -2009,6 +2071,24 @@ export interface operations {
                         /** @example https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg */
                         url: string;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2071,6 +2151,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     find_category: {
@@ -2096,6 +2194,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_category_slugs: {
@@ -2117,6 +2233,24 @@ export interface operations {
                         /** @description The list of category slugs. */
                         category_slugs: components["schemas"]["Slug"][];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2143,6 +2277,24 @@ export interface operations {
                         /** @example true */
                         ok: boolean;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2268,6 +2420,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     find_new_crate: {
@@ -2306,6 +2476,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     publish: {
@@ -2327,6 +2515,24 @@ export interface operations {
                         crate: components["schemas"]["Crate"];
                         warnings: components["schemas"]["PublishWarnings"];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2384,6 +2590,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     delete_crate: {
@@ -2406,6 +2630,24 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
             };
         };
     };
@@ -2441,6 +2683,24 @@ export interface operations {
                         /** @description The updated crate metadata. */
                         crate: components["schemas"]["Crate"];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2500,6 +2760,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     follow_crate: {
@@ -2524,6 +2802,24 @@ export interface operations {
                         /** @example true */
                         ok: boolean;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2552,6 +2848,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     get_following_crate: {
@@ -2576,6 +2890,24 @@ export interface operations {
                         /** @description Whether the authenticated user is following the crate. */
                         following: boolean;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2603,6 +2935,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     get_user_owners: {
@@ -2628,6 +2978,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_owners: {
@@ -2651,6 +3019,24 @@ export interface operations {
                     "application/json": {
                         users: components["schemas"]["Owner"][];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2700,6 +3086,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     remove_owners: {
@@ -2745,6 +3149,24 @@ export interface operations {
                         /** @example true */
                         ok: boolean;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2800,6 +3222,24 @@ export interface operations {
                         /** @description The versions referenced in the `dependencies` field. */
                         versions: components["schemas"]["Version"][];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2887,6 +3327,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     find_version: {
@@ -2915,6 +3373,24 @@ export interface operations {
                     "application/json": {
                         version: components["schemas"]["Version"];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -2953,6 +3429,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     get_version_authors: {
@@ -2978,6 +3472,24 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
             };
         };
     };
@@ -3007,6 +3519,24 @@ export interface operations {
                     "application/json": {
                         dependencies: components["schemas"]["Dependency"][];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3052,6 +3582,24 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     get_version_downloads: {
@@ -3086,6 +3634,24 @@ export interface operations {
                     "application/json": {
                         version_downloads: components["schemas"]["VersionDownload"][];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3131,6 +3697,24 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     rebuild_version_docs: {
@@ -3156,6 +3740,24 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
             };
         };
     };
@@ -3188,6 +3790,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     yank_version: {
@@ -3217,6 +3837,24 @@ export interface operations {
                         /** @example true */
                         ok: boolean;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3279,6 +3917,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     find_keyword: {
@@ -3302,6 +3958,24 @@ export interface operations {
                     "application/json": {
                         keyword: components["schemas"]["Keyword"];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3343,6 +4017,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     list_crate_owner_invitations_for_user: {
@@ -3366,6 +4058,24 @@ export interface operations {
                         /** @description The list of users referenced in the crate owner invitations. */
                         users: components["schemas"]["User"][];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3403,6 +4113,24 @@ export interface operations {
                             crate_id: number;
                         };
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3460,6 +4188,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     update_email_notifications: {
@@ -3481,6 +4227,24 @@ export interface operations {
                         /** @example true */
                         ok: boolean;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3510,6 +4274,24 @@ export interface operations {
                     "application/json": {
                         api_tokens: components["schemas"]["ApiToken"][];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3547,6 +4329,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     find_api_token: {
@@ -3572,6 +4372,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     revoke_api_token: {
@@ -3593,6 +4411,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": Record<string, never>;
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3620,6 +4456,24 @@ export interface operations {
                         /** @description The list of recent versions of crates that the authenticated user follows. */
                         versions: components["schemas"]["Version"][];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3660,6 +4514,24 @@ export interface operations {
                         /** @description Whether the crates.io service is in read-only mode. */
                         read_only: boolean;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -3707,6 +4579,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     find_team: {
@@ -3735,6 +4625,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     revoke_current_api_token: {
@@ -3752,6 +4660,24 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
             };
         };
     };
@@ -3813,6 +4739,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     create_trustpub_github_config: {
@@ -3852,6 +4796,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     delete_trustpub_github_config: {
@@ -3872,6 +4834,24 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
             };
         };
     };
@@ -3933,6 +4913,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     create_trustpub_gitlab_config: {
@@ -3972,6 +4970,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     delete_trustpub_gitlab_config: {
@@ -3992,6 +5008,24 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
             };
         };
     };
@@ -4021,6 +5055,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     revoke_trustpub_token: {
@@ -4038,6 +5090,24 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
             };
         };
     };
@@ -4063,6 +5133,24 @@ export interface operations {
                         /** @example true */
                         ok: boolean;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -4095,6 +5183,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
         };
     };
     find_user: {
@@ -4118,6 +5224,24 @@ export interface operations {
                     "application/json": {
                         user: components["schemas"]["User"];
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };
@@ -4153,6 +5277,24 @@ export interface operations {
                         /** @example true */
                         ok: boolean;
                     };
+                };
+            };
+            /** @description Client Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
         };

--- a/packages/crates-io-msw/handlers/api-tokens/create.ts
+++ b/packages/crates-io-msw/handlers/api-tokens/create.ts
@@ -11,16 +11,14 @@ const endpointScopesSchema = v.nullish(v.array(v.picklist(endpointScopeValues)))
 export default http.put('/api/v1/me/tokens', async ({ request, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let json = await request.json();
 
   let endpointScopes = v.safeParse(endpointScopesSchema, json.api_token.endpoint_scopes);
   if (!endpointScopes.success) {
-    return response.untyped(Response.json({ errors: [{ detail: 'invalid endpoint scope' }] }, { status: 400 }));
+    return response('4XX').json({ errors: [{ detail: 'invalid endpoint scope' }] }, { status: 400 });
   }
 
   let token = await db.apiToken.create({

--- a/packages/crates-io-msw/handlers/api-tokens/delete.ts
+++ b/packages/crates-io-msw/handlers/api-tokens/delete.ts
@@ -5,9 +5,7 @@ import { getSession } from '../../utils/session.js';
 export default http.delete('/api/v1/me/tokens/{id}', ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   db.apiToken.delete(q => q.where(token => token.id === parseInt(params.id) && token.user.id === user.id));

--- a/packages/crates-io-msw/handlers/api-tokens/get.ts
+++ b/packages/crates-io-msw/handlers/api-tokens/get.ts
@@ -1,21 +1,19 @@
 import { db } from '../../index.js';
 import { serializeApiToken } from '../../serializers/api-token.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.get('/api/v1/me/tokens/{id}', ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let token = db.apiToken.findFirst(q =>
     q.where(token => token.id === parseInt(params.id) && token.user.id === user.id),
   );
-  if (!token) return response.untyped(notFound());
+  if (!token) return response('4XX').json(notFoundError(), { status: 404 });
 
   return response(200).json({
     api_token: serializeApiToken(token),

--- a/packages/crates-io-msw/handlers/api-tokens/list.ts
+++ b/packages/crates-io-msw/handlers/api-tokens/list.ts
@@ -6,9 +6,7 @@ import { getSession } from '../../utils/session.js';
 export default http.get('/api/v1/me/tokens', ({ query, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let expiredAfter = new Date();

--- a/packages/crates-io-msw/handlers/categories/get.ts
+++ b/packages/crates-io-msw/handlers/categories/get.ts
@@ -1,13 +1,13 @@
 import { db } from '../../index.js';
 import { serializeCategory } from '../../serializers/category.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/categories/{category}', ({ params, response }) => {
   let catId = params.category;
   let category = db.category.findFirst(q => q.where({ id: catId }));
   if (!category) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   return response(200).json({ category: serializeCategory(category) });

--- a/packages/crates-io-msw/handlers/crates/add-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/add-owners.ts
@@ -1,19 +1,17 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.put('/api/v1/crates/{name}/owners', async ({ request, params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
   if (!crate) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   let body = await request.json();
@@ -26,7 +24,7 @@ export default http.put('/api/v1/crates/{name}/owners', async ({ request, params
       let team = db.team.findFirst(q => q.where({ login }));
       if (!team) {
         let errorMessage = `could not find team with login \`${login}\``;
-        return response.untyped(Response.json({ errors: [{ detail: errorMessage }] }, { status: 404 }));
+        return response('4XX').json({ errors: [{ detail: errorMessage }] }, { status: 404 });
       }
 
       teams.push(team);
@@ -35,7 +33,7 @@ export default http.put('/api/v1/crates/{name}/owners', async ({ request, params
       let user = db.user.findFirst(q => q.where({ login }));
       if (!user) {
         let errorMessage = `could not find user with login \`${login}\``;
-        return response.untyped(Response.json({ errors: [{ detail: errorMessage }] }, { status: 404 }));
+        return response('4XX').json({ errors: [{ detail: errorMessage }] }, { status: 404 });
       }
 
       users.push(user);

--- a/packages/crates-io-msw/handlers/crates/delete.ts
+++ b/packages/crates-io-msw/handlers/crates/delete.ts
@@ -5,16 +5,12 @@ import { getSession } from '../../utils/session.js';
 export default http.delete('/api/v1/crates/{name}', ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
   if (!crate) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: `crate \`${params.name}\` does not exist` }] }, { status: 404 }),
-    );
+    return response('4XX').json({ errors: [{ detail: `crate \`${params.name}\` does not exist` }] }, { status: 404 });
   }
 
   db.crate.delete(q => q.where({ id: crate.id }));

--- a/packages/crates-io-msw/handlers/crates/downloads.ts
+++ b/packages/crates-io-msw/handlers/crates/downloads.ts
@@ -1,11 +1,11 @@
 import { db } from '../../index.js';
 import { serializeVersion } from '../../serializers/version.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/crates/{name}/downloads', ({ params, query, response }) => {
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let downloads = db.versionDownload.findMany(q => q.where(download => download.version.crate.id === crate.id));
   let include = query.get('include') ?? '';

--- a/packages/crates-io-msw/handlers/crates/follow.ts
+++ b/packages/crates-io-msw/handlers/crates/follow.ts
@@ -1,19 +1,17 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.put('/api/v1/crates/{name}/follow', async ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
   if (!crate) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   await db.user.update(q => q.where({ id: user.id }), {

--- a/packages/crates-io-msw/handlers/crates/following.ts
+++ b/packages/crates-io-msw/handlers/crates/following.ts
@@ -1,21 +1,19 @@
 import type { Crate } from '../../models/index.js';
 
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.get('/api/v1/crates/{name}/following', ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
   if (!crate) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   let following = (user.followedCrates as Crate[]).some(followedCrate => followedCrate.id === crate.id);

--- a/packages/crates-io-msw/handlers/crates/get.ts
+++ b/packages/crates-io-msw/handlers/crates/get.ts
@@ -3,7 +3,7 @@ import { serializeCategory } from '../../serializers/category.js';
 import { serializeCrate } from '../../serializers/crate.js';
 import { serializeKeyword } from '../../serializers/keyword.js';
 import { serializeVersion } from '../../serializers/version.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 const DEFAULT_INCLUDES = ['versions', 'keywords', 'categories'];
@@ -12,7 +12,7 @@ export default http.get('/api/v1/crates/{name}', ({ request, params, response })
   let { name } = params;
   let canonicalName = toCanonicalName(name);
   let crate = db.crate.findFirst(q => q.where(crate => toCanonicalName(crate.name) === canonicalName));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let versions = db.version.findMany(q => q.where(version => version.crate?.id === crate.id));
   versions.sort((a, b) => b.id - a.id);

--- a/packages/crates-io-msw/handlers/crates/list-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/list-owners.ts
@@ -1,11 +1,11 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/crates/{name}/owners', ({ params, response }) => {
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
   if (!crate) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.crate.id === crate.id));

--- a/packages/crates-io-msw/handlers/crates/list.ts
+++ b/packages/crates-io-msw/handlers/crates/list.ts
@@ -14,8 +14,9 @@ export default http.get('/api/v1/crates', ({ request, response }) => {
   if (url.searchParams.get('following') === '1') {
     let { user } = getSession();
     if (!user) {
-      return response.untyped(
-        Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
+      return response('4XX').json(
+        { errors: [{ detail: 'must be logged in to perform that action' }] },
+        { status: 403 },
       );
     }
 

--- a/packages/crates-io-msw/handlers/crates/patch.ts
+++ b/packages/crates-io-msw/handlers/crates/patch.ts
@@ -6,16 +6,12 @@ import { getSession } from '../../utils/session.js';
 export default http.patch('/api/v1/crates/{name}', async ({ request, params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
   if (!crate) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: `crate \`${params.name}\` does not exist` }] }, { status: 404 }),
-    );
+    return response('4XX').json({ errors: [{ detail: `crate \`${params.name}\` does not exist` }] }, { status: 404 });
   }
 
   let body = await request.json();

--- a/packages/crates-io-msw/handlers/crates/remove-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/remove-owners.ts
@@ -1,19 +1,17 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.delete('/api/v1/crates/{name}/owners', async ({ request, params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
   if (!crate) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   let body = await request.json();
@@ -24,7 +22,7 @@ export default http.delete('/api/v1/crates/{name}/owners', async ({ request, par
         ? q => q.where(ownership => ownership.team?.login === owner)
         : q => q.where(ownership => ownership.user?.login === owner),
     );
-    if (!ownership) return response.untyped(notFound());
+    if (!ownership) return response('4XX').json(notFoundError(), { status: 404 });
     db.crateOwnership.delete(q => q.where({ id: ownership.id }));
   }
 

--- a/packages/crates-io-msw/handlers/crates/reverse-dependencies.ts
+++ b/packages/crates-io-msw/handlers/crates/reverse-dependencies.ts
@@ -1,12 +1,12 @@
 import { db } from '../../index.js';
 import { serializeDependency } from '../../serializers/dependency.js';
 import { serializeVersion } from '../../serializers/version.js';
-import { notFound, pageParams } from '../../utils/handlers.js';
+import { notFoundError, pageParams } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/crates/{name}/reverse_dependencies', ({ request, params, response }) => {
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let { start, end } = pageParams(request);
 

--- a/packages/crates-io-msw/handlers/crates/team-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/team-owners.ts
@@ -1,12 +1,12 @@
 import { db } from '../../index.js';
 import { serializeTeam } from '../../serializers/team.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/crates/{name}/owner_team', ({ params, response }) => {
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
   if (!crate) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.crate.id === crate.id));

--- a/packages/crates-io-msw/handlers/crates/unfollow.ts
+++ b/packages/crates-io-msw/handlers/crates/unfollow.ts
@@ -1,19 +1,17 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.delete('/api/v1/crates/{name}/follow', async ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
   if (!crate) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   await db.user.update(q => q.where({ id: user.id }), {

--- a/packages/crates-io-msw/handlers/crates/user-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/user-owners.ts
@@ -1,12 +1,12 @@
 import { db } from '../../index.js';
 import { serializeUser } from '../../serializers/user.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/crates/{name}/owner_user', ({ params, response }) => {
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
   if (!crate) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.crate.id === crate.id));

--- a/packages/crates-io-msw/handlers/invites/legacy-list.ts
+++ b/packages/crates-io-msw/handlers/invites/legacy-list.ts
@@ -7,9 +7,7 @@ import { getSession } from '../../utils/session.js';
 export default http.get('/api/v1/me/crate_owner_invitations', ({ response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let invites = db.crateOwnerInvitation.findMany(q => q.where(invite => invite.invitee.id === user.id));

--- a/packages/crates-io-msw/handlers/invites/list.ts
+++ b/packages/crates-io-msw/handlers/invites/list.ts
@@ -1,7 +1,7 @@
 import { db } from '../../index.js';
 import { serializeInvite } from '../../serializers/invite.js';
 import { serializeUser } from '../../serializers/user.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
@@ -10,28 +10,27 @@ export default http.get('/api/private/crate_owner_invitations', ({ request, resp
 
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let invites;
   if (url.searchParams.has('crate_name')) {
     let crate = db.crate.findFirst(q => q.where({ name: url.searchParams.get('crate_name')! }));
-    if (!crate) return response.untyped(notFound());
+    if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
     invites = db.crateOwnerInvitation.findMany(q => q.where(invite => invite.crate.id === crate.id));
   } else if (url.searchParams.has('invitee_id')) {
     let inviteeId = parseInt(url.searchParams.get('invitee_id')!);
     if (inviteeId !== user.id) {
-      return response.untyped(
-        Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
+      return response('4XX').json(
+        { errors: [{ detail: 'must be logged in to perform that action' }] },
+        { status: 403 },
       );
     }
 
     invites = db.crateOwnerInvitation.findMany(q => q.where(invite => invite.invitee.id === inviteeId));
   } else {
-    return response.untyped(Response.json({ errors: [{ detail: 'missing or invalid filter' }] }, { status: 400 }));
+    return response('4XX').json({ errors: [{ detail: 'missing or invalid filter' }] }, { status: 400 });
   }
 
   let perPage = 10;

--- a/packages/crates-io-msw/handlers/invites/redeem-by-crate-id.ts
+++ b/packages/crates-io-msw/handlers/invites/redeem-by-crate-id.ts
@@ -1,14 +1,12 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.put('/api/v1/me/crate_owner_invitations/{crate_id}', async ({ request, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let body = await request.json();
@@ -17,7 +15,7 @@ export default http.put('/api/v1/me/crate_owner_invitations/{crate_id}', async (
   let invite = db.crateOwnerInvitation.findFirst(q =>
     q.where(invite => invite.crate.id === crateId && invite.invitee.id === user.id),
   );
-  if (!invite) return response.untyped(notFound());
+  if (!invite) return response('4XX').json(notFoundError(), { status: 404 });
 
   if (accepted) {
     await db.crateOwnership.create({ crate: invite.crate, user });

--- a/packages/crates-io-msw/handlers/invites/redeem-by-token.ts
+++ b/packages/crates-io-msw/handlers/invites/redeem-by-token.ts
@@ -1,12 +1,12 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.put('/api/v1/me/crate_owner_invitations/accept/{token}', async ({ params, response }) => {
   let { token } = params;
 
   let invite = db.crateOwnerInvitation.findFirst(q => q.where({ token }));
-  if (!invite) return response.untyped(notFound());
+  if (!invite) return response('4XX').json(notFoundError(), { status: 404 });
 
   await db.crateOwnership.create({ crate: invite.crate, user: invite.invitee });
   db.crateOwnerInvitation.delete(q => q.where({ id: invite.id }));

--- a/packages/crates-io-msw/handlers/keywords/get.ts
+++ b/packages/crates-io-msw/handlers/keywords/get.ts
@@ -1,12 +1,12 @@
 import { db } from '../../index.js';
 import { serializeKeyword } from '../../serializers/keyword.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/keywords/{keyword}', ({ params, response }) => {
   let keyword = db.keyword.findFirst(q => q.where({ id: params.keyword }));
   if (!keyword) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   return response(200).json({ keyword: serializeKeyword(keyword) });

--- a/packages/crates-io-msw/handlers/teams/get.ts
+++ b/packages/crates-io-msw/handlers/teams/get.ts
@@ -1,12 +1,12 @@
 import { db } from '../../index.js';
 import { serializeTeam } from '../../serializers/team.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/teams/{team}', ({ params, response }) => {
   let team = db.team.findFirst(q => q.where({ login: params.team }));
   if (!team) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   return response(200).json({ team: serializeTeam(team) });

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/create.ts
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/create.ts
@@ -1,47 +1,43 @@
 import { db } from '../../../index.js';
 import { serializeGitHubConfig } from '../../../serializers/trustpub/github-config.js';
-import { notFound } from '../../../utils/handlers.js';
+import { notFoundError } from '../../../utils/handlers.js';
 import { http } from '../../../utils/openapi-http.js';
 import { getSession } from '../../../utils/session.js';
 
 export default http.post('/api/v1/trusted_publishing/github_configs', async ({ request, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let body = await request.json();
 
   let { github_config } = body;
   if (!github_config) {
-    return response.untyped(Response.json({ errors: [{ detail: 'invalid request body' }] }, { status: 400 }));
+    return response('4XX').json({ errors: [{ detail: 'invalid request body' }] }, { status: 400 });
   }
 
   let { crate: crateName, repository_owner, repository_name, workflow_filename, environment } = github_config;
   if (!crateName || !repository_owner || !repository_name || !workflow_filename) {
-    return response.untyped(Response.json({ errors: [{ detail: 'missing required fields' }] }, { status: 400 }));
+    return response('4XX').json({ errors: [{ detail: 'missing required fields' }] }, { status: 400 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: crateName }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   // Check if the user is an owner of the crate
   let isOwner = db.crateOwnership.findFirst(q =>
     q.where(ownership => ownership.crate.id === crate.id && ownership.user?.id === user.id),
   );
   if (!isOwner) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
   }
 
   // Check if the user has a verified email
   let hasVerifiedEmail = user.emailVerified;
   if (!hasVerifiedEmail) {
     let detail = 'You must verify your email address to create a Trusted Publishing config';
-    return response.untyped(Response.json({ errors: [{ detail }] }, { status: 403 }));
+    return response('4XX').json({ errors: [{ detail }] }, { status: 403 });
   }
 
   // Create a new GitHub config

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/delete.ts
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/delete.ts
@@ -1,28 +1,24 @@
 import { db } from '../../../index.js';
-import { notFound } from '../../../utils/handlers.js';
+import { notFoundError } from '../../../utils/handlers.js';
 import { http } from '../../../utils/openapi-http.js';
 import { getSession } from '../../../utils/session.js';
 
 export default http.delete('/api/v1/trusted_publishing/github_configs/{id}', ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let id = parseInt(params.id);
   let config = db.trustpubGithubConfig.findFirst(q => q.where({ id }));
-  if (!config) return response.untyped(notFound());
+  if (!config) return response('4XX').json(notFoundError(), { status: 404 });
 
   // Check if the user is an owner of the crate
   let isOwner = db.crateOwnership.findFirst(q =>
     q.where(ownership => ownership.crate.id === config.crate.id && ownership.user?.id === user.id),
   );
   if (!isOwner) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
   }
 
   // Delete the config

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/list.ts
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/list.ts
@@ -1,33 +1,29 @@
 import { db } from '../../../index.js';
 import { serializeGitHubConfig } from '../../../serializers/trustpub/github-config.js';
-import { notFound } from '../../../utils/handlers.js';
+import { notFoundError } from '../../../utils/handlers.js';
 import { http } from '../../../utils/openapi-http.js';
 import { getSession } from '../../../utils/session.js';
 
 export default http.get('/api/v1/trusted_publishing/github_configs', ({ query, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crateName = query.get('crate');
   if (!crateName) {
-    return response.untyped(Response.json({ errors: [{ detail: 'missing or invalid filter' }] }, { status: 400 }));
+    return response('4XX').json({ errors: [{ detail: 'missing or invalid filter' }] }, { status: 400 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: crateName }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   // Check if the user is an owner of the crate
   let isOwner = db.crateOwnership.findFirst(q =>
     q.where(ownership => ownership.crate.id === crate.id && ownership.user?.id === user.id),
   );
   if (!isOwner) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
   }
 
   let configs = db.trustpubGithubConfig.findMany(q => q.where(config => config.crate.id === crate.id));

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/create.ts
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/create.ts
@@ -1,47 +1,43 @@
 import { db } from '../../../index.js';
 import { serializeGitLabConfig } from '../../../serializers/trustpub/gitlab-config.js';
-import { notFound } from '../../../utils/handlers.js';
+import { notFoundError } from '../../../utils/handlers.js';
 import { http } from '../../../utils/openapi-http.js';
 import { getSession } from '../../../utils/session.js';
 
 export default http.post('/api/v1/trusted_publishing/gitlab_configs', async ({ request, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let body = await request.json();
 
   let { gitlab_config } = body;
   if (!gitlab_config) {
-    return response.untyped(Response.json({ errors: [{ detail: 'invalid request body' }] }, { status: 400 }));
+    return response('4XX').json({ errors: [{ detail: 'invalid request body' }] }, { status: 400 });
   }
 
   let { crate: crateName, namespace, project, workflow_filepath, environment } = gitlab_config;
   if (!crateName || !namespace || !project || !workflow_filepath) {
-    return response.untyped(Response.json({ errors: [{ detail: 'missing required fields' }] }, { status: 400 }));
+    return response('4XX').json({ errors: [{ detail: 'missing required fields' }] }, { status: 400 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: crateName }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   // Check if the user is an owner of the crate
   let isOwner = db.crateOwnership.findFirst(q =>
     q.where(ownership => ownership.crate.id === crate.id && ownership.user?.id === user.id),
   );
   if (!isOwner) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
   }
 
   // Check if the user has a verified email
   let hasVerifiedEmail = user.emailVerified;
   if (!hasVerifiedEmail) {
     let detail = 'You must verify your email address to create a Trusted Publishing config';
-    return response.untyped(Response.json({ errors: [{ detail }] }, { status: 403 }));
+    return response('4XX').json({ errors: [{ detail }] }, { status: 403 });
   }
 
   // Create a new GitLab config

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/delete.ts
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/delete.ts
@@ -1,28 +1,24 @@
 import { db } from '../../../index.js';
-import { notFound } from '../../../utils/handlers.js';
+import { notFoundError } from '../../../utils/handlers.js';
 import { http } from '../../../utils/openapi-http.js';
 import { getSession } from '../../../utils/session.js';
 
 export default http.delete('/api/v1/trusted_publishing/gitlab_configs/{id}', ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let id = parseInt(params.id);
   let config = db.trustpubGitlabConfig.findFirst(q => q.where({ id }));
-  if (!config) return response.untyped(notFound());
+  if (!config) return response('4XX').json(notFoundError(), { status: 404 });
 
   // Check if the user is an owner of the crate
   let isOwner = db.crateOwnership.findFirst(q =>
     q.where(ownership => ownership.crate.id === config.crate.id && ownership.user?.id === user.id),
   );
   if (!isOwner) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
   }
 
   // Delete the config

--- a/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.ts
+++ b/packages/crates-io-msw/handlers/trustpub/gitlab-configs/list.ts
@@ -1,33 +1,29 @@
 import { db } from '../../../index.js';
 import { serializeGitLabConfig } from '../../../serializers/trustpub/gitlab-config.js';
-import { notFound } from '../../../utils/handlers.js';
+import { notFoundError } from '../../../utils/handlers.js';
 import { http } from '../../../utils/openapi-http.js';
 import { getSession } from '../../../utils/session.js';
 
 export default http.get('/api/v1/trusted_publishing/gitlab_configs', ({ query, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crateName = query.get('crate');
   if (!crateName) {
-    return response.untyped(Response.json({ errors: [{ detail: 'missing or invalid filter' }] }, { status: 400 }));
+    return response('4XX').json({ errors: [{ detail: 'missing or invalid filter' }] }, { status: 400 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: crateName }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   // Check if the user is an owner of the crate
   let isOwner = db.crateOwnership.findFirst(q =>
     q.where(ownership => ownership.crate.id === crate.id && ownership.user?.id === user.id),
   );
   if (!isOwner) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
   }
 
   let configs = db.trustpubGitlabConfig.findMany(q => q.where(config => config.crate.id === crate.id));

--- a/packages/crates-io-msw/handlers/users/confirm-email.ts
+++ b/packages/crates-io-msw/handlers/users/confirm-email.ts
@@ -4,9 +4,7 @@ import { http } from '../../utils/openapi-http.js';
 export default http.put('/api/v1/confirm/{email_token}', async ({ params, response }) => {
   let user = db.user.findFirst(q => q.where({ emailVerificationToken: params.email_token }));
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'Email belonging to token not found.' }] }, { status: 400 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'Email belonging to token not found.' }] }, { status: 400 });
   }
 
   await db.user.update(q => q.where({ id: user.id }), {

--- a/packages/crates-io-msw/handlers/users/get.ts
+++ b/packages/crates-io-msw/handlers/users/get.ts
@@ -1,12 +1,12 @@
 import { db } from '../../index.js';
 import { serializeUser } from '../../serializers/user.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/users/{user}', ({ params, response }) => {
   let user = db.user.findFirst(q => q.where({ login: params.user }));
   if (!user) {
-    return response.untyped(notFound());
+    return response('4XX').json(notFoundError(), { status: 404 });
   }
 
   return response(200).json({ user: serializeUser(user) });

--- a/packages/crates-io-msw/handlers/users/me.ts
+++ b/packages/crates-io-msw/handlers/users/me.ts
@@ -6,9 +6,7 @@ import { getSession } from '../../utils/session.js';
 export default http.get('/api/v1/me', ({ response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.user?.id === user.id));

--- a/packages/crates-io-msw/handlers/users/resend.ts
+++ b/packages/crates-io-msw/handlers/users/resend.ts
@@ -4,14 +4,13 @@ import { getSession } from '../../utils/session.js';
 export default http.put('/api/v1/users/{id}/resend', ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   if (user.id.toString() !== params.id) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'current user does not match requested user' }] }, { status: 400 }),
+    return response('4XX').json(
+      { errors: [{ detail: 'current user does not match requested user' }] },
+      { status: 400 },
     );
   }
 

--- a/packages/crates-io-msw/handlers/users/stats.ts
+++ b/packages/crates-io-msw/handlers/users/stats.ts
@@ -1,11 +1,11 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/users/{id}/stats', ({ params, response }) => {
   let userId = parseInt(params.id);
   let user = db.user.findFirst(q => q.where({ id: userId }));
-  if (!user) return response.untyped(notFound());
+  if (!user) return response('4XX').json(notFoundError(), { status: 404 });
 
   let ownerships = db.crateOwnership.findMany(q => q.where(o => o.user?.id === userId));
   let total_downloads = ownerships.reduce((sum, o) => sum + o.crate.downloads, 0);

--- a/packages/crates-io-msw/handlers/users/update.ts
+++ b/packages/crates-io-msw/handlers/users/update.ts
@@ -5,20 +5,19 @@ import { getSession } from '../../utils/session.js';
 export default http.put('/api/v1/users/{user}', async ({ params, request, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   if (user.id.toString() !== params.user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'current user does not match requested user' }] }, { status: 400 }),
+    return response('4XX').json(
+      { errors: [{ detail: 'current user does not match requested user' }] },
+      { status: 400 },
     );
   }
 
   let json = await request.json();
   if (!json || !json.user) {
-    return response.untyped(Response.json({ errors: [{ detail: 'invalid json request' }] }, { status: 400 }));
+    return response('4XX').json({ errors: [{ detail: 'invalid json request' }] }, { status: 400 });
   }
   let userUpdate = json.user;
 
@@ -33,7 +32,7 @@ export default http.put('/api/v1/users/{user}', async ({ params, request, respon
 
   if (userUpdate.email != null) {
     if (!userUpdate.email) {
-      return response.untyped(Response.json({ errors: [{ detail: 'empty email rejected' }] }, { status: 400 }));
+      return response('4XX').json({ errors: [{ detail: 'empty email rejected' }] }, { status: 400 });
     }
 
     let email = userUpdate.email;

--- a/packages/crates-io-msw/handlers/versions/dependencies.ts
+++ b/packages/crates-io-msw/handlers/versions/dependencies.ts
@@ -1,18 +1,18 @@
 import { db } from '../../index.js';
 import { serializeDependency } from '../../serializers/dependency.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/crates/{name}/{version}/dependencies', ({ params, response }) => {
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let version = db.version.findFirst(q =>
     q.where(version => version.crate.id === crate.id && version.num === params.version),
   );
   if (!version) {
     let errorMessage = `crate \`${crate.name}\` does not have a version \`${params.version}\``;
-    return response.untyped(Response.json({ errors: [{ detail: errorMessage }] }, { status: 404 }));
+    return response('4XX').json({ errors: [{ detail: errorMessage }] }, { status: 404 });
   }
 
   let dependencies = db.dependency.findMany(q => q.where(dep => dep.version.id === version.id));

--- a/packages/crates-io-msw/handlers/versions/downloads.ts
+++ b/packages/crates-io-msw/handlers/versions/downloads.ts
@@ -1,17 +1,17 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/crates/{name}/{version}/downloads', ({ params, response }) => {
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let version = db.version.findFirst(q =>
     q.where(version => version.crate.id === crate.id && version.num === params.version),
   );
   if (!version) {
     let errorMessage = `crate \`${crate.name}\` does not have a version \`${params.version}\``;
-    return response.untyped(Response.json({ errors: [{ detail: errorMessage }] }, { status: 404 }));
+    return response('4XX').json({ errors: [{ detail: errorMessage }] }, { status: 404 });
   }
 
   let downloads = db.versionDownload.findMany(q => q.where(download => download.version.id === version.id));

--- a/packages/crates-io-msw/handlers/versions/follow-updates.ts
+++ b/packages/crates-io-msw/handlers/versions/follow-updates.ts
@@ -9,9 +9,7 @@ import { getSession } from '../../utils/session.js';
 export default http.get('/api/v1/me/updates', ({ request, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let allVersions = (user.followedCrates as Crate[])

--- a/packages/crates-io-msw/handlers/versions/get.ts
+++ b/packages/crates-io-msw/handlers/versions/get.ts
@@ -1,18 +1,18 @@
 import { db } from '../../index.js';
 import { serializeVersion } from '../../serializers/version.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
 export default http.get('/api/v1/crates/{name}/{version}', ({ params, response }) => {
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let version = db.version.findFirst(q =>
     q.where(version => version.crate.id === crate.id && version.num === params.version),
   );
   if (!version) {
     let errorMessage = `crate \`${crate.name}\` does not have a version \`${params.version}\``;
-    return response.untyped(Response.json({ errors: [{ detail: errorMessage }] }, { status: 404 }));
+    return response('4XX').json({ errors: [{ detail: errorMessage }] }, { status: 404 });
   }
 
   return response(200).json({

--- a/packages/crates-io-msw/handlers/versions/list.ts
+++ b/packages/crates-io-msw/handlers/versions/list.ts
@@ -2,14 +2,14 @@ import compareSemver from 'semver/functions/compare-loose.js';
 
 import { db } from '../../index.js';
 import { serializeVersion } from '../../serializers/version.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { calculateReleaseTracks } from '../../utils/release-tracks.js';
 
 export default http.get('/api/v1/crates/{name}/versions', ({ request, params, response }) => {
   let { name } = params;
   let crate = db.crate.findFirst(q => q.where({ name }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let versions = db.version.findMany(q => q.where(version => version.crate.id === crate.id));
 

--- a/packages/crates-io-msw/handlers/versions/patch.ts
+++ b/packages/crates-io-msw/handlers/versions/patch.ts
@@ -1,24 +1,22 @@
 import { db } from '../../index.js';
 import { serializeVersion } from '../../serializers/version.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.patch('/api/v1/crates/{name}/{version}', async ({ request, params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let version = db.version.findFirst(q =>
     q.where(version => version.crate.id === crate.id && version.num === params.version),
   );
-  if (!version) return response.untyped(notFound());
+  if (!version) return response('4XX').json(notFoundError(), { status: 404 });
 
   let body = await request.json();
 

--- a/packages/crates-io-msw/handlers/versions/rebuild-docs.ts
+++ b/packages/crates-io-msw/handlers/versions/rebuild-docs.ts
@@ -1,23 +1,21 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.post('/api/v1/crates/{name}/{version}/rebuild_docs', ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let version = db.version.findFirst(q =>
     q.where(version => version.crate.id === crate.id && version.num === params.version),
   );
-  if (!version) return response.untyped(notFound());
+  if (!version) return response('4XX').json(notFoundError(), { status: 404 });
 
   return response(201).empty();
 });

--- a/packages/crates-io-msw/handlers/versions/unyank.ts
+++ b/packages/crates-io-msw/handlers/versions/unyank.ts
@@ -1,23 +1,21 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.put('/api/v1/crates/{name}/{version}/unyank', async ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let version = db.version.findFirst(q =>
     q.where(version => version.crate.id === crate.id && version.num === params.version),
   );
-  if (!version) return response.untyped(notFound());
+  if (!version) return response('4XX').json(notFoundError(), { status: 404 });
 
   await db.version.update(q => q.where({ id: version.id }), {
     data(version) {

--- a/packages/crates-io-msw/handlers/versions/yank.ts
+++ b/packages/crates-io-msw/handlers/versions/yank.ts
@@ -1,23 +1,21 @@
 import { db } from '../../index.js';
-import { notFound } from '../../utils/handlers.js';
+import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 import { getSession } from '../../utils/session.js';
 
 export default http.delete('/api/v1/crates/{name}/{version}/yank', async ({ params, response }) => {
   let { user } = getSession();
   if (!user) {
-    return response.untyped(
-      Response.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 }),
-    );
+    return response('4XX').json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
   }
 
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
-  if (!crate) return response.untyped(notFound());
+  if (!crate) return response('4XX').json(notFoundError(), { status: 404 });
 
   let version = db.version.findFirst(q =>
     q.where(version => version.crate.id === crate.id && version.num === params.version),
   );
-  if (!version) return response.untyped(notFound());
+  if (!version) return response('4XX').json(notFoundError(), { status: 404 });
 
   await db.version.update(q => q.where({ id: version.id }), {
     data(version) {

--- a/packages/crates-io-msw/utils/handlers.ts
+++ b/packages/crates-io-msw/utils/handlers.ts
@@ -1,9 +1,8 @@
 import type { DefaultBodyType, StrictRequest } from 'msw';
 
-import { HttpResponse } from 'msw';
-
-export function notFound() {
-  return HttpResponse.json({ errors: [{ detail: 'Not Found' }] }, { status: 404 });
+/** The standard JSON body for a 404 API error. */
+export function notFoundError() {
+  return { errors: [{ detail: 'Not Found' }] };
 }
 
 export function pageParams(request: StrictRequest<DefaultBodyType>) {

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -48,7 +48,11 @@ pub struct CategoryListMeta {
     path = "/api/v1/categories",
     params(CategoryListQueryParams, PaginationQueryParams),
     tag = "categories",
-    responses((status = 200, description = "Successful Response", body = inline(CategoryListResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(CategoryListResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_categories(
     app: AppState,
@@ -91,7 +95,11 @@ pub struct CategoryGetResponse {
         ("category" = String, Path, description = "Name of the category"),
     ),
     tag = "categories",
-    responses((status = 200, description = "Successful Response", body = inline(CategoryGetResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(CategoryGetResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn find_category(
     state: AppState,
@@ -152,7 +160,11 @@ pub struct ListSlugsResponse {
     get,
     path = "/api/v1/category_slugs",
     tag = "categories",
-    responses((status = 200, description = "Successful Response", body = inline(ListSlugsResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(ListSlugsResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_category_slugs(state: AppState) -> AppResult<Json<ListSlugsResponse>> {
     let mut conn = state.db_read().await?;

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -44,7 +44,11 @@ pub struct LegacyListResponse {
     security(("cookie" = [])),
     tag = "owners",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(LegacyListResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(LegacyListResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_crate_owner_invitations_for_user(
     app: AppState,
@@ -113,7 +117,11 @@ pub struct CrateOwnerInvitationListQueryParams {
     security(("cookie" = [])),
     tag = "owners",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(PrivateListResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(PrivateListResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_crate_owner_invitations(
     app: AppState,
@@ -357,7 +365,11 @@ pub struct HandleResponse {
         ("cookie" = []),
     ),
     tag = "owners",
-    responses((status = 200, description = "Successful Response", body = inline(HandleResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(HandleResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn handle_crate_owner_invitation(
     state: AppState,
@@ -393,7 +405,11 @@ pub async fn handle_crate_owner_invitation(
         ("token" = String, Path, description = "Secret token sent to the user's email address"),
     ),
     tag = "owners",
-    responses((status = 200, description = "Successful Response", body = inline(HandleResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(HandleResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn accept_crate_owner_invitation_with_token(
     state: AppState,

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -47,7 +47,11 @@ pub struct KeywordListMeta {
     path = "/api/v1/keywords",
     params(KeywordListQueryParams, PaginationQueryParams),
     tag = "keywords",
-    responses((status = 200, description = "Successful Response", body = inline(KeywordListResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(KeywordListResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_keywords(
     state: AppState,
@@ -88,7 +92,11 @@ pub struct KeywordGetResponse {
         ("keyword" = String, Path, description = "The keyword to find"),
     ),
     tag = "keywords",
-    responses((status = 200, description = "Successful Response", body = inline(KeywordGetResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(KeywordGetResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn find_keyword(
     Path(name): Path<String>,

--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -53,7 +53,11 @@ impl DeleteQueryParams {
     security(("cookie" = [])),
     tag = "crates",
     extensions(("x-internal" = json!(true))),
-    responses((status = 204, description = "Successful Response")),
+    responses(
+        (status = 204, description = "Successful Response"),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn delete_crate(
     path: CratePath,

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -75,7 +75,11 @@ pub struct ExtraDownload {
     path = "/api/v1/crates/{name}/downloads",
     params(CratePath, DownloadsQueryParams),
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(DownloadsResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(DownloadsResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_crate_downloads(
     state: AppState,

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -41,7 +41,11 @@ async fn follow_target(
         ("cookie" = []),
     ),
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(OkResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(OkResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn follow_crate(app: AppState, path: CratePath, req: Parts) -> AppResult<OkResponse> {
     let mut conn = app.db_write().await?;
@@ -66,7 +70,11 @@ pub async fn follow_crate(app: AppState, path: CratePath, req: Parts) -> AppResu
         ("cookie" = []),
     ),
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(OkResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(OkResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn unfollow_crate(app: AppState, path: CratePath, req: Parts) -> AppResult<OkResponse> {
     let mut conn = app.db_write().await?;
@@ -91,7 +99,11 @@ pub struct FollowingResponse {
     security(("cookie" = [])),
     tag = "crates",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(FollowingResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(FollowingResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_following_crate(
     app: AppState,

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -67,7 +67,11 @@ pub struct CrateGetResponse {
     get,
     path = "/api/v1/crates/new",
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(CrateGetResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(CrateGetResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn find_new_crate(
     app: AppState,
@@ -83,7 +87,11 @@ pub async fn find_new_crate(
     path = "/api/v1/crates/{name}",
     params(CratePath, FindQueryParams),
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(CrateGetResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(CrateGetResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn find_crate(
     app: AppState,

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -37,7 +37,11 @@ pub struct UsersResponse {
     path = "/api/v1/crates/{name}/owners",
     params(CratePath),
     tag = "owners",
-    responses((status = 200, description = "Successful Response", body = inline(UsersResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(UsersResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_owners(state: AppState, path: CratePath) -> AppResult<Json<UsersResponse>> {
     let conn = state.db_read().await?;
@@ -71,7 +75,11 @@ pub struct TeamsResponse {
     path = "/api/v1/crates/{name}/owner_team",
     params(CratePath),
     tag = "owners",
-    responses((status = 200, description = "Successful Response", body = inline(TeamsResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(TeamsResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_team_owners(state: AppState, path: CratePath) -> AppResult<Json<TeamsResponse>> {
     let conn = state.db_read().await?;
@@ -94,7 +102,11 @@ pub async fn get_team_owners(state: AppState, path: CratePath) -> AppResult<Json
     path = "/api/v1/crates/{name}/owner_user",
     params(CratePath),
     tag = "owners",
-    responses((status = 200, description = "Successful Response", body = inline(UsersResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(UsersResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_user_owners(state: AppState, path: CratePath) -> AppResult<Json<UsersResponse>> {
     let conn = state.db_read().await?;
@@ -133,7 +145,11 @@ pub struct ModifyResponse {
         ("cookie" = []),
     ),
     tag = "owners",
-    responses((status = 200, description = "Successful Response", body = inline(ModifyResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(ModifyResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn add_owners(
     app: AppState,
@@ -155,7 +171,11 @@ pub async fn add_owners(
         ("cookie" = []),
     ),
     tag = "owners",
-    responses((status = 200, description = "Successful Response", body = inline(ModifyResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(ModifyResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn remove_owners(
     app: AppState,

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -96,7 +96,11 @@ impl AuthType {
         ("cookie" = []),
     ),
     tag = "publish",
-    responses((status = 200, description = "Successful Response", body = inline(GoodCrate))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(GoodCrate)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<GoodCrate>> {
     let stream = body.into_data_stream();

--- a/src/controllers/krate/rev_deps.rs
+++ b/src/controllers/krate/rev_deps.rs
@@ -35,7 +35,11 @@ pub struct RevDepsMeta {
     path = "/api/v1/crates/{name}/reverse_dependencies",
     params(CratePath, PaginationQueryParams),
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(RevDepsResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(RevDepsResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_reverse_dependencies(
     app: AppState,

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -80,7 +80,11 @@ pub struct CrateListMeta {
         ("cookie" = []),
     ),
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(CrateListResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(CrateListResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_crates(
     app: AppState,

--- a/src/controllers/krate/update.rs
+++ b/src/controllers/krate/update.rs
@@ -49,7 +49,11 @@ pub struct PatchResponse {
         ("cookie" = []),
     ),
     tag = "crates",
-    responses((status = 200, description = "Successful Response", body = inline(PatchResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(PatchResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn update_crate(
     app: AppState,

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -79,7 +79,11 @@ pub struct VersionListResponse {
     path = "/api/v1/crates/{name}/versions",
     params(CratePath, VersionListQueryParams, PaginationQueryParams),
     tag = "versions",
-    responses((status = 200, description = "Successful Response", body = inline(VersionListResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(VersionListResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_versions(
     state: AppState,

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -44,7 +44,11 @@ pub struct BeginResponse {
     path = "/api/private/session/begin",
     tag = "session",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(BeginResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(BeginResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn begin_session(app: AppState, session: SessionExtension) -> Json<BeginResponse> {
     let (url, state) = app
@@ -84,7 +88,11 @@ pub struct AuthorizeBody {
     tag = "session",
     request_body = inline(AuthorizeBody),
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(EncodableMe))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(EncodableMe)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn authorize_session(
     app: AppState,
@@ -307,7 +315,11 @@ async fn find_user_by_gh_id(mut conn: &AsyncPgConnection, gh_id: i32) -> QueryRe
     security(("cookie" = [])),
     tag = "session",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(OkResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(OkResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn end_session(session: SessionExtension) -> OkResponse {
     session.remove("user_id");

--- a/src/controllers/site_metadata.rs
+++ b/src/controllers/site_metadata.rs
@@ -36,7 +36,11 @@ pub struct MetadataResponse<'a> {
     get,
     path = "/api/v1/site_metadata",
     tag = "other",
-    responses((status = 200, description = "Successful Response", body = inline(MetadataResponse<'_>))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(MetadataResponse<'_>)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_site_metadata(state: AppState) -> impl IntoResponse {
     let read_only = state.config.db.are_all_read_only();

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -51,7 +51,11 @@ pub struct SummaryResponse {
     get,
     path = "/api/v1/summary",
     tag = "other",
-    responses((status = 200, description = "Successful Response", body = inline(SummaryResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(SummaryResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_summary(
     state: AppState,

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -22,7 +22,11 @@ pub struct TeamGetResponse {
         ("team" = String, Path, description = "Name of the team", example = "github:rust-lang:crates-io"),
     ),
     tag = "teams",
-    responses((status = 200, description = "Successful Response", body = inline(TeamGetResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(TeamGetResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn find_team(
     state: AppState,

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -64,7 +64,11 @@ pub struct ApiTokenListResponse {
     security(("cookie" = [])),
     tag = "api_tokens",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(ApiTokenListResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(ApiTokenListResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_api_tokens(
     app: AppState,
@@ -119,7 +123,11 @@ pub struct CreateResponse {
     security(("cookie" = [])),
     tag = "api_tokens",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(CreateResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(CreateResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn create_api_token(
     app: AppState,
@@ -250,7 +258,11 @@ pub struct ApiTokenGetResponse {
         ("cookie" = []),
     ),
     tag = "api_tokens",
-    responses((status = 200, description = "Successful Response", body = inline(ApiTokenGetResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(ApiTokenGetResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn find_api_token(
     app: AppState,
@@ -281,7 +293,11 @@ pub async fn find_api_token(
         ("cookie" = []),
     ),
     tag = "api_tokens",
-    responses((status = 200, description = "Successful Response", body = Object)),
+    responses(
+        (status = 200, description = "Successful Response", body = Object),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn revoke_api_token(
     app: AppState,
@@ -308,7 +324,11 @@ pub async fn revoke_api_token(
     path = "/api/v1/tokens/current",
     security(("api_token" = [])),
     tag = "api_tokens",
-    responses((status = 204, description = "Successful Response")),
+    responses(
+        (status = 204, description = "Successful Response"),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn revoke_current_api_token(app: AppState, req: Parts) -> AppResult<Response> {
     let mut conn = app.db_write().await?;

--- a/src/controllers/trustpub/github_configs/create.rs
+++ b/src/controllers/trustpub/github_configs/create.rs
@@ -28,7 +28,11 @@ const MAX_CONFIGS_PER_CRATE: usize = 5;
     security(("cookie" = []), ("api_token" = [])),
     request_body = inline(json::CreateRequest),
     tag = "trusted_publishing",
-    responses((status = 200, description = "Successful Response", body = inline(json::CreateResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(json::CreateResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn create_trustpub_github_config(
     state: AppState,

--- a/src/controllers/trustpub/github_configs/delete.rs
+++ b/src/controllers/trustpub/github_configs/delete.rs
@@ -23,7 +23,11 @@ use tracing::warn;
     ),
     security(("cookie" = []), ("api_token" = [])),
     tag = "trusted_publishing",
-    responses((status = 204, description = "Successful Response")),
+    responses(
+        (status = 204, description = "Successful Response"),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn delete_trustpub_github_config(
     state: AppState,

--- a/src/controllers/trustpub/github_configs/list.rs
+++ b/src/controllers/trustpub/github_configs/list.rs
@@ -45,7 +45,11 @@ pub struct GitHubConfigListQueryParams {
     params(GitHubConfigListQueryParams, PaginationQueryParams),
     security(("cookie" = []), ("api_token" = [])),
     tag = "trusted_publishing",
-    responses((status = 200, description = "Successful Response", body = inline(GitHubConfigListResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(GitHubConfigListResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_trustpub_github_configs(
     state: AppState,

--- a/src/controllers/trustpub/gitlab_configs/create.rs
+++ b/src/controllers/trustpub/gitlab_configs/create.rs
@@ -26,7 +26,11 @@ const MAX_CONFIGS_PER_CRATE: usize = 5;
     security(("cookie" = []), ("api_token" = [])),
     request_body = inline(json::CreateRequest),
     tag = "trusted_publishing",
-    responses((status = 200, description = "Successful Response", body = inline(json::CreateResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(json::CreateResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn create_trustpub_gitlab_config(
     state: AppState,

--- a/src/controllers/trustpub/gitlab_configs/delete.rs
+++ b/src/controllers/trustpub/gitlab_configs/delete.rs
@@ -23,7 +23,11 @@ use tracing::warn;
     ),
     security(("cookie" = []), ("api_token" = [])),
     tag = "trusted_publishing",
-    responses((status = 204, description = "Successful Response")),
+    responses(
+        (status = 204, description = "Successful Response"),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn delete_trustpub_gitlab_config(
     state: AppState,

--- a/src/controllers/trustpub/gitlab_configs/list.rs
+++ b/src/controllers/trustpub/gitlab_configs/list.rs
@@ -45,7 +45,11 @@ pub struct GitLabConfigListQueryParams {
     params(GitLabConfigListQueryParams, PaginationQueryParams),
     security(("cookie" = []), ("api_token" = [])),
     tag = "trusted_publishing",
-    responses((status = 200, description = "Successful Response", body = inline(GitLabConfigListResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(GitLabConfigListResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn list_trustpub_gitlab_configs(
     state: AppState,

--- a/src/controllers/trustpub/tokens/exchange/mod.rs
+++ b/src/controllers/trustpub/tokens/exchange/mod.rs
@@ -27,7 +27,11 @@ use tracing::warn;
     path = "/api/v1/trusted_publishing/tokens",
     request_body = inline(json::ExchangeRequest),
     tag = "trusted_publishing",
-    responses((status = 200, description = "Successful Response", body = inline(json::ExchangeResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(json::ExchangeResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn exchange_trustpub_token(
     state: AppState,

--- a/src/controllers/trustpub/tokens/revoke/mod.rs
+++ b/src/controllers/trustpub/tokens/revoke/mod.rs
@@ -17,7 +17,11 @@ use secrecy::ExposeSecret;
     path = "/api/v1/trusted_publishing/tokens",
     security(("trustpub_token" = [])),
     tag = "trusted_publishing",
-    responses((status = 204, description = "Successful Response")),
+    responses(
+        (status = 204, description = "Successful Response"),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn revoke_trustpub_token(app: AppState, auth: AuthHeader) -> AppResult<StatusCode> {
     let token = auth.token().expose_secret();

--- a/src/controllers/user/email_notifications.rs
+++ b/src/controllers/user/email_notifications.rs
@@ -29,7 +29,11 @@ pub struct CrateEmailNotifications {
         ("cookie" = []),
     ),
     tag = "users",
-    responses((status = 200, description = "Successful Response", body = inline(OkResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(OkResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 #[deprecated]
 pub async fn update_email_notifications(

--- a/src/controllers/user/email_verification.rs
+++ b/src/controllers/user/email_verification.rs
@@ -22,7 +22,11 @@ use secrecy::ExposeSecret;
         ("email_token" = String, Path, description = "Secret verification token sent to the user's email address"),
     ),
     tag = "users",
-    responses((status = 200, description = "Successful Response", body = inline(OkResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(OkResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn confirm_user_email(
     state: AppState,
@@ -54,7 +58,11 @@ pub async fn confirm_user_email(
         ("cookie" = []),
     ),
     tag = "users",
-    responses((status = 200, description = "Successful Response", body = inline(OkResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(OkResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn resend_email_verification(
     state: AppState,

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -24,7 +24,11 @@ use serde::Serialize;
     security(("cookie" = [])),
     tag = "users",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(EncodableMe))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(EncodableMe)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_authenticated_user(
     app: AppState,
@@ -105,7 +109,11 @@ pub struct UpdatesResponseMeta {
     security(("cookie" = [])),
     tag = "versions",
     extensions(("x-internal" = json!(true))),
-    responses((status = 200, description = "Successful Response", body = inline(UpdatesResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(UpdatesResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_authenticated_user_updates(
     app: AppState,

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -25,7 +25,11 @@ pub struct UserGetResponse {
         ("user" = String, Path, description = "Login name of the user"),
     ),
     tag = "users",
-    responses((status = 200, description = "Successful Response", body = inline(UserGetResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(UserGetResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn find_user(
     state: AppState,
@@ -63,7 +67,11 @@ pub struct StatsResponse {
         ("id" = i32, Path, description = "ID of the user"),
     ),
     tag = "users",
-    responses((status = 200, description = "Successful Response", body = inline(StatsResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(StatsResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_user_stats(
     state: AppState,

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -45,7 +45,11 @@ pub struct User {
         ("cookie" = []),
     ),
     tag = "users",
-    responses((status = 200, description = "Successful Response", body = inline(OkResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(OkResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn update_user(
     state: AppState,

--- a/src/controllers/version/authors.rs
+++ b/src/controllers/version/authors.rs
@@ -11,7 +11,11 @@ use axum_extra::response::ErasedJson;
     path = "/api/v1/crates/{name}/{version}/authors",
     params(CrateVersionPath),
     tag = "versions",
-    responses((status = 200, description = "Successful Response")),
+    responses(
+        (status = 200, description = "Successful Response"),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 #[deprecated]
 pub async fn get_version_authors() -> ErasedJson {

--- a/src/controllers/version/dependencies.rs
+++ b/src/controllers/version/dependencies.rs
@@ -26,7 +26,11 @@ pub struct Response {
     path = "/api/v1/crates/{name}/{version}/dependencies",
     params(CrateVersionPath),
     tag = "versions",
-    responses((status = 200, description = "Successful Response", body = inline(Response))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(Response)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_version_dependencies(
     state: AppState,

--- a/src/controllers/version/docs.rs
+++ b/src/controllers/version/docs.rs
@@ -21,7 +21,11 @@ use tracing::error;
     ),
     tag = "versions",
     extensions(("x-internal" = json!(true))),
-    responses((status = 201, description = "Successful Response")),
+    responses(
+        (status = 201, description = "Successful Response"),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn rebuild_version_docs(
     app: AppState,

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -39,6 +39,8 @@ pub struct UrlResponse {
     responses(
         (status = 302, description = "Successful Response (default)", headers(("location" = String, description = "The URL to the crate file."))),
         (status = 200, description = "Successful Response (for `content-type: application/json`)", body = inline(UrlResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
     ),
 )]
 pub async fn download_version(
@@ -85,7 +87,11 @@ pub struct DownloadsResponse {
     path = "/api/v1/crates/{name}/{version}/downloads",
     params(CrateVersionPath, DownloadsQueryParams),
     tag = "versions",
-    responses((status = 200, description = "Successful Response", body = inline(DownloadsResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(DownloadsResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn get_version_downloads(
     app: AppState,

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -25,7 +25,11 @@ pub struct VersionGetResponse {
     path = "/api/v1/crates/{name}/{version}",
     params(CrateVersionPath),
     tag = "versions",
-    responses((status = 200, description = "Successful Response", body = inline(VersionGetResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(VersionGetResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn find_version(
     state: AppState,

--- a/src/controllers/version/readme.rs
+++ b/src/controllers/version/readme.rs
@@ -24,6 +24,8 @@ pub struct UrlResponse {
     responses(
         (status = 302, description = "Successful Response (default)", headers(("location" = String, description = "The URL to the readme file."))),
         (status = 200, description = "Successful Response (for `content-type: application/json`)", body = inline(UrlResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
     ),
 )]
 pub async fn get_version_readme(app: AppState, path: CrateVersionPath, req: Parts) -> Response {

--- a/src/controllers/version/update.rs
+++ b/src/controllers/version/update.rs
@@ -46,7 +46,11 @@ pub struct UpdateResponse {
         ("cookie" = []),
     ),
     tag = "versions",
-    responses((status = 200, description = "Successful Response", body = inline(UpdateResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(UpdateResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn update_version(
     state: AppState,

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -28,7 +28,11 @@ use http::request::Parts;
         ("cookie" = []),
     ),
     tag = "versions",
-    responses((status = 200, description = "Successful Response", body = inline(OkResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(OkResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn yank_version(
     app: AppState,
@@ -48,7 +52,11 @@ pub async fn yank_version(
         ("cookie" = []),
     ),
     tag = "versions",
-    responses((status = 200, description = "Successful Response", body = inline(OkResponse))),
+    responses(
+        (status = 200, description = "Successful Response", body = inline(OkResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
 )]
 pub async fn unyank_version(
     app: AppState,

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -5,6 +5,32 @@ expression: response.json()
 {
   "components": {
     "schemas": {
+      "ApiErrorResponse": {
+        "description": "The JSON envelope returned for API errors.",
+        "properties": {
+          "errors": {
+            "description": "The errors that prevented the request from succeeding.",
+            "items": {
+              "description": "A human-readable API error.",
+              "properties": {
+                "detail": {
+                  "description": "A description of the error.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "detail"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "errors"
+        ],
+        "type": "object"
+      },
       "ApiToken": {
         "description": "The model representing a row in the `api_tokens` database table.",
         "properties": {
@@ -1537,6 +1563,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -1572,6 +1618,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -1664,6 +1730,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Complete authentication flow.",
@@ -1700,6 +1786,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Begin authentication flow.",
@@ -1792,6 +1898,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "List all categories.",
@@ -1833,6 +1959,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get category metadata.",
@@ -1866,6 +2012,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "List all available category slugs.",
@@ -1907,6 +2073,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Marks the email belonging to the given token as verified.",
@@ -2118,6 +2304,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2192,6 +2398,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Gets crate metadata (for the `new` crate).",
@@ -2224,6 +2450,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2269,6 +2515,26 @@ expression: response.json()
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2356,6 +2622,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Gets crate metadata.",
@@ -2427,6 +2713,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2531,6 +2837,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get the download counts for a crate.",
@@ -2572,6 +2898,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2619,6 +2965,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2668,6 +3034,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2716,6 +3102,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Lists team owners of a crate.",
@@ -2759,6 +3165,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Lists user owners of a crate.",
@@ -2832,6 +3258,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2881,6 +3327,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Lists crate owners.",
@@ -2952,6 +3418,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3057,6 +3543,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Lists reverse dependencies of a crate.",
@@ -3199,6 +3705,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "List all versions of a crate.",
@@ -3250,6 +3776,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get crate version metadata.",
@@ -3317,6 +3863,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3362,6 +3928,26 @@ expression: response.json()
         "responses": {
           "200": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get crate version authors.",
@@ -3416,6 +4002,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get crate version dependencies.",
@@ -3480,6 +4086,26 @@ expression: response.json()
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Download a crate version.",
@@ -3545,6 +4171,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get the download counts for a crate version.",
@@ -3608,6 +4254,26 @@ expression: response.json()
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get the readme of a crate version.",
@@ -3643,6 +4309,26 @@ expression: response.json()
         "responses": {
           "201": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3699,6 +4385,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3759,6 +4465,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3859,6 +4585,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "List all keywords.",
@@ -3900,6 +4646,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get keyword metadata.",
@@ -3960,6 +4726,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4006,6 +4792,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4068,6 +4874,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Accept a crate owner invitation with a token.",
@@ -4161,6 +4987,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4201,6 +5047,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4254,6 +5120,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4339,6 +5225,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4377,6 +5283,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4425,6 +5351,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4479,6 +5425,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4540,6 +5506,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get crates.io metadata.",
@@ -4628,6 +5614,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get front page data.",
@@ -4670,6 +5676,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Find team by login.",
@@ -4685,6 +5711,26 @@ expression: response.json()
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4799,6 +5845,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4883,6 +5949,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4917,6 +6003,26 @@ expression: response.json()
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -5034,6 +6140,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -5118,6 +6244,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -5151,6 +6297,26 @@ expression: response.json()
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -5174,6 +6340,26 @@ expression: response.json()
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -5224,6 +6410,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Exchange an OIDC token for a temporary access token.",
@@ -5266,6 +6472,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -5320,6 +6546,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get user stats.",
@@ -5361,6 +6607,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Find user by login.",
@@ -5434,6 +6700,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -5,6 +5,32 @@ expression: response.json()
 {
   "components": {
     "schemas": {
+      "ApiErrorResponse": {
+        "description": "The JSON envelope returned for API errors.",
+        "properties": {
+          "errors": {
+            "description": "The errors that prevented the request from succeeding.",
+            "items": {
+              "description": "A human-readable API error.",
+              "properties": {
+                "detail": {
+                  "description": "A description of the error.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "detail"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "errors"
+        ],
+        "type": "object"
+      },
       "ApiToken": {
         "description": "The model representing a row in the `api_tokens` database table.",
         "properties": {
@@ -1522,6 +1548,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "List all categories.",
@@ -1563,6 +1609,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get category metadata.",
@@ -1596,6 +1662,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "List all available category slugs.",
@@ -1637,6 +1723,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Marks the email belonging to the given token as verified.",
@@ -1848,6 +1954,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -1922,6 +2048,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Gets crate metadata (for the `new` crate).",
@@ -1954,6 +2100,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2049,6 +2215,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Gets crate metadata.",
@@ -2120,6 +2306,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2224,6 +2430,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get the download counts for a crate.",
@@ -2265,6 +2491,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2312,6 +2558,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2363,6 +2629,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Lists team owners of a crate.",
@@ -2406,6 +2692,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Lists user owners of a crate.",
@@ -2479,6 +2785,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2528,6 +2854,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Lists crate owners.",
@@ -2599,6 +2945,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -2704,6 +3070,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Lists reverse dependencies of a crate.",
@@ -2846,6 +3232,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "List all versions of a crate.",
@@ -2897,6 +3303,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get crate version metadata.",
@@ -2964,6 +3390,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3009,6 +3455,26 @@ expression: response.json()
         "responses": {
           "200": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get crate version authors.",
@@ -3063,6 +3529,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get crate version dependencies.",
@@ -3127,6 +3613,26 @@ expression: response.json()
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Download a crate version.",
@@ -3192,6 +3698,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get the download counts for a crate version.",
@@ -3255,6 +3781,26 @@ expression: response.json()
                 }
               }
             }
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get the readme of a crate version.",
@@ -3306,6 +3852,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3366,6 +3932,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3466,6 +4052,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "List all keywords.",
@@ -3507,6 +4113,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get keyword metadata.",
@@ -3564,6 +4190,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Accept a crate owner invitation with a token.",
@@ -3657,6 +4303,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3697,6 +4363,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3738,6 +4424,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3786,6 +4492,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -3850,6 +4576,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get crates.io metadata.",
@@ -3938,6 +4684,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get front page data.",
@@ -3980,6 +4746,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Find team by login.",
@@ -3995,6 +4781,26 @@ expression: response.json()
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4109,6 +4915,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4193,6 +5019,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4227,6 +5073,26 @@ expression: response.json()
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4344,6 +5210,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4428,6 +5314,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4461,6 +5367,26 @@ expression: response.json()
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4484,6 +5410,26 @@ expression: response.json()
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4534,6 +5480,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Exchange an OIDC token for a temporary access token.",
@@ -4576,6 +5542,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [
@@ -4630,6 +5616,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Get user stats.",
@@ -4671,6 +5677,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "summary": "Find user by login.",
@@ -4744,6 +5770,26 @@ expression: response.json()
               }
             },
             "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Client Error"
+          },
+          "5XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server Error"
           }
         },
         "security": [

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -32,6 +32,7 @@ mod json;
 use crate::email::EmailError;
 use crate::util::diesel::is_read_only_error;
 use crates_io_github::GitHubError;
+pub use json::ApiErrorResponse;
 pub use json::TOKEN_FORMAT_ERROR;
 pub(crate) use json::{InsecurelyGeneratedTokenRevoked, TooManyRequests, custom};
 

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -18,14 +18,15 @@ fn json_error(detail: &str, status: StatusCode) -> Response {
 }
 
 /// The JSON envelope returned for API errors.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ApiErrorResponse<'a> {
     /// The errors that prevented the request from succeeding.
+    #[schema(inline)]
     errors: [ApiErrorDetail<'a>; 1],
 }
 
 /// A human-readable API error.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 struct ApiErrorDetail<'a> {
     /// A description of the error.
     detail: &'a str,

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -1,6 +1,6 @@
-use axum::Extension;
 use axum::response::{IntoResponse, Response};
-use axum_extra::json;
+use axum::{Extension, Json};
+use serde::Serialize;
 use std::borrow::Cow;
 use std::fmt;
 
@@ -13,8 +13,34 @@ use http::{StatusCode, header};
 
 /// Generates a response with the provided status and description as JSON
 fn json_error(detail: &str, status: StatusCode) -> Response {
-    let json = json!({ "errors": [{ "detail": detail }] });
+    let json = Json(ApiErrorDetail::from(detail).into_response());
     (status, json).into_response()
+}
+
+/// The JSON envelope returned for API errors.
+#[derive(Debug, Serialize)]
+pub struct ApiErrorResponse<'a> {
+    /// The errors that prevented the request from succeeding.
+    errors: [ApiErrorDetail<'a>; 1],
+}
+
+/// A human-readable API error.
+#[derive(Debug, Serialize)]
+struct ApiErrorDetail<'a> {
+    /// A description of the error.
+    detail: &'a str,
+}
+
+impl<'a> ApiErrorDetail<'a> {
+    fn into_response(self) -> ApiErrorResponse<'a> {
+        ApiErrorResponse { errors: [self] }
+    }
+}
+
+impl<'a> From<&'a str> for ApiErrorDetail<'a> {
+    fn from(detail: &'a str) -> Self {
+        Self { detail }
+    }
 }
 
 // The following structs wrap owned data and provide a custom message to the user


### PR DESCRIPTION
MSW error handlers previously had to bypass OpenAPI response checking because the API specification only documented successful responses. This introduces a shared JSON error response type, uses it for runtime serialization, and declares `4XX` and `5XX` responses on every documented endpoint.

The regenerated client schema lets `openapi-msw` type-check error bodies and status classes. All internal error handlers now use typed responses while preserving their concrete HTTP status, leaving untyped handlers only for external services.