### PR TITLE
monitor: Add `PAGERDUTY_ENABLED` feature flag

### DIFF
--- a/src/bin/crates-io/monitor.rs
+++ b/src/bin/crates-io/monitor.rs
@@ -1,5 +1,6 @@
-//! Checks application invariants, pages whoever is on call when they fail, and
-//! optionally submits the results to Datadog as service checks.
+//! Checks application invariants and reports the results to configured monitoring providers.
+//!
+//! PagerDuty reporting can be disabled with `PAGERDUTY_ENABLED=false`.
 //!
 //! Usage:
 //!     cargo run -- monitor
@@ -45,8 +46,12 @@ struct CheckResult {
 
 #[tokio::main]
 pub async fn run() -> Result<()> {
-    let service_key = required_var("PAGERDUTY_INTEGRATION_KEY")?.into();
-    let pagerduty = PagerdutyClient::new(service_key);
+    let pagerduty = if var_parsed("PAGERDUTY_ENABLED")?.unwrap_or(true) {
+        let service_key = required_var("PAGERDUTY_INTEGRATION_KEY")?.into();
+        Some(PagerdutyClient::new(service_key))
+    } else {
+        None
+    };
 
     let datadog_service_checks_enabled = var_parsed("DD_SERVICE_CHECKS_ENABLED")?.unwrap_or(false);
     let datadog_client = if datadog_service_checks_enabled {
@@ -88,10 +93,14 @@ pub async fn run() -> Result<()> {
         }
     };
 
-    let pagerduty_reporting = report_to_pagerduty(&pagerduty, &results);
-    let (_, pagerduty_result) = tokio::join!(datadog_reporting, pagerduty_reporting);
-
-    pagerduty_result
+    if let Some(pagerduty) = pagerduty {
+        let pagerduty_reporting = report_to_pagerduty(&pagerduty, &results);
+        let (_, pagerduty_result) = tokio::join!(datadog_reporting, pagerduty_reporting);
+        pagerduty_result
+    } else {
+        datadog_reporting.await;
+        Ok(())
+    }
 }
 
 /// Checks for old background jobs that are not currently running.

--- a/src/bin/crates-io/monitor.rs
+++ b/src/bin/crates-io/monitor.rs
@@ -72,6 +72,10 @@ pub async fn run() -> Result<()> {
         check_spam_attack(conn).await?,
     ];
 
+    for result in &results {
+        println!("{}", format_check_result(result));
+    }
+
     let datadog_reporting = async {
         if let Some(datadog) = datadog_client {
             let domain_name = dotenvy::var("DOMAIN_NAME").unwrap_or_else(|_| "crates.io".into());
@@ -254,6 +258,14 @@ fn datadog_service_check(result: &CheckResult, host_name: &str, tags: &[String])
         .build()
 }
 
+/// Formats a provider-independent monitor result for command output.
+fn format_check_result(result: &CheckResult) -> String {
+    match result.status {
+        CheckStatus::Healthy => result.message.clone(),
+        CheckStatus::Unhealthy => format!("Monitor check failed: {}", result.message),
+    }
+}
+
 /// Reports monitor results to Datadog.
 async fn report_to_datadog(
     datadog: &DatadogClient,
@@ -272,11 +284,6 @@ async fn report_to_datadog(
 /// Reports monitor results to PagerDuty.
 async fn report_to_pagerduty(pagerduty: &PagerdutyClient, results: &[CheckResult]) -> Result<()> {
     for result in results {
-        match result.status {
-            CheckStatus::Healthy => println!("{}", result.message),
-            CheckStatus::Unhealthy => println!("Paging on-call: {}", result.message),
-        }
-
         let event = pagerduty_event(result);
         pagerduty.send(&event).await?;
     }


### PR DESCRIPTION
`PAGERDUTY_ENABLED` now controls whether the `monitor` configures PagerDuty and submits events, while remaining enabled by default for existing deployments. Disabling it skips the integration key lookup and PagerDuty submission without affecting invariant checks or Datadog service checks.

Monitor results are printed independently of provider reporting, using provider-neutral wording for unhealthy checks. This keeps command output available when PagerDuty is disabled.