### PR TITLE
Fix README Image Rendering

### DIFF
--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -122,7 +122,7 @@ impl Stack {
   </a>
 </h3>
 
-<a href="https://www.jetbrains.com/?from=rust-base64"><img src="/icon_CLion.svg" height="40px"/></a>
+<a href="https://www.jetbrains.com/?from=rust-base64"><img src="https://raw.githubusercontent.com/marshallpierce/rust-base64/069bf7067b949f5c0a92b6ceb82492920502f2c2/icon_CLion.svg" height="40px"/></a>
 
 <img src="https://raw.githubusercontent.com/scylladb/scylla-rust-driver/ff6415dcb3f2cb52bd5312c2ae99b063895a5f28/assets/monster%2Brust.png" height="150" align="right">
 

--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -124,7 +124,7 @@ impl Stack {
 
 <a href="https://www.jetbrains.com/?from=rust-base64"><img src="/icon_CLion.svg" height="40px"/></a>
 
-<img src="https://github.com/scylladb/scylla-rust-driver/raw/main/assets/monster+rust.png" height="150" align="right">
+<img src="https://raw.githubusercontent.com/scylladb/scylla-rust-driver/ff6415dcb3f2cb52bd5312c2ae99b063895a5f28/assets/monster%2Brust.png" height="150" align="right">
 
 This is a client-side driver for [ScyllaDB] written in pure Rust with a fully async API using [Tokio].
 Although optimized for ScyllaDB, the driver is also compatible with [Apache Cassandra®].

--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -121,6 +121,13 @@ impl Stack {
     <img width="1000" height="200" alt="Banner with Logo" src="https://static.rerun.io/d0f5443d4803cac65c73fcc064936c09f5e7f208_rerun_banner.png" />
   </a>
 </h3>
+
+<a href="https://www.jetbrains.com/?from=rust-base64"><img src="/icon_CLion.svg" height="40px"/></a>
+
+<img src="https://github.com/scylladb/scylla-rust-driver/raw/main/assets/monster+rust.png" height="150" align="right">
+
+This is a client-side driver for [ScyllaDB] written in pure Rust with a fully async API using [Tokio].
+Although optimized for ScyllaDB, the driver is also compatible with [Apache Cassandra®].
 `;
 
 test.describe('Acceptance | README rendering', { tag: '@acceptance' }, () => {

--- a/svelte/src/lib/components/TextContent.svelte
+++ b/svelte/src/lib/components/TextContent.svelte
@@ -42,8 +42,7 @@
 
     :global(img) {
       max-width: 100%;
-      /* see: https://github.com/rust-lang/crates.io/issues/14133 */
-      height: auto;
+      object-fit: contain;
     }
 
     :global(pre) {


### PR DESCRIPTION
## Summary 
- Removes `height:auto` and replaces it with `object-fit:contain` this fixes the bug introduced in #14261 and preserve regression change required for #14133.

- Added `base64` and `scylladb` README examples to Rendering Readme e2e test.


Thank you @Marcono1234 for the suggestion of using `object-fit:contain`

Fixes: #14426