### PR TITLE
Add `github_username_matches` field to user/owner responses

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -549,13 +549,20 @@ pub struct EncodableOwner {
     /// The avatar URL of the team or user.
     #[schema(example = "https://avatars2.githubusercontent.com/u/1234567?v=4")]
     pub avatar: Option<String>,
+
+    /// Whether a linked GitHub username exactly matches the crates.io username.
+    ///
+    /// This field is present only for user owners.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub github_username_matches: Option<bool>,
 }
 
 impl EncodableOwner {
     pub fn from_user(user: PublicUser) -> Self {
         Self {
-            id: user.id,
+            github_username_matches: Some(user.github_username_matches),
             url: Some(format!("https://github.com/{}", user.gh_login)),
+            id: user.id,
             login: user.username,
             avatar: user.gh_avatar,
             name: user.name,
@@ -571,6 +578,7 @@ impl EncodableOwner {
             avatar: team.avatar,
             name: team.name,
             kind: String::from("team"),
+            github_username_matches: None,
         }
     }
 }
@@ -769,6 +777,9 @@ pub struct EncodablePublicUser {
     #[schema(example = "https://github.com/ghost")]
     pub url: String,
 
+    /// Whether a linked GitHub username exactly matches the crates.io username.
+    pub github_username_matches: bool,
+
     /// The date and time the user was created.
     ///
     /// For users created before June 19, 2026, the creation time will be the
@@ -785,6 +796,7 @@ impl From<PublicUser> for EncodablePublicUser {
             name,
             gh_login,
             gh_avatar,
+            github_username_matches,
             username,
             created_at,
             ..
@@ -796,6 +808,7 @@ impl From<PublicUser> for EncodablePublicUser {
             login: username,
             name,
             url,
+            github_username_matches,
             created_at,
         }
     }
@@ -1153,6 +1166,7 @@ mod tests {
                     name: None,
                     avatar: None,
                     url: String::new(),
+                    github_username_matches: false,
                     created_at: None,
                 },
                 time: NaiveDate::from_ymd_opt(2017, 1, 6)

--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -1,6 +1,6 @@
 use bon::Builder;
 use chrono::{DateTime, Utc};
-use diesel::dsl::sql;
+use diesel::dsl::{exists, sql};
 use diesel::prelude::*;
 use diesel::sql_types::Integer;
 use diesel::upsert::excluded;
@@ -10,6 +10,24 @@ use serde::Serialize;
 use crate::fns::lower;
 use crate::models::{Crate, CrateOwner, Email, OwnerKind};
 use crate::schema::{crate_owners, emails, oauth_github, users};
+
+// Diesel validates a correlated subquery against the outer query source. `PublicUser` already
+// joins `oauth_github`, so reusing that table in this `EXISTS` expression would make it appear
+// twice and fail `AppearsInFromClause` validation. This alias gives the subquery a distinct
+// query-source identity.
+diesel::alias!(
+    pub const MATCHING_GITHUB_ACCOUNT: Alias<MatchingGithubAccount> =
+        oauth_github as matching_github_account;
+);
+
+#[diesel::dsl::auto_type]
+pub fn github_username_matches() -> _ {
+    let account = MATCHING_GITHUB_ACCOUNT;
+    let belongs_to_user = account.field(oauth_github::user_id).eq(users::id);
+    let username_matches = account.field(oauth_github::login).eq(users::username);
+
+    exists(account.filter(belongs_to_user).filter(username_matches))
+}
 
 /// Public data for a crates.io user.
 #[derive(Clone, Debug, HasQuery, Serialize)]
@@ -23,6 +41,8 @@ pub struct PublicUser {
     pub gh_login: String,
     #[diesel(select_expression = oauth_github::avatar.nullable())]
     pub gh_avatar: Option<String>,
+    #[diesel(select_expression = github_username_matches())]
+    pub github_username_matches: bool,
     pub username: String,
     pub created_at: Option<DateTime<Utc>>,
 }

--- a/crates/crates_io_test_utils/src/builders/user.rs
+++ b/crates/crates_io_test_utils/src/builders/user.rs
@@ -106,6 +106,10 @@ impl<'a> OauthGithubBuilder<'a> {
         }
     }
 
+    pub fn with_login(self, login: &'a str) -> Self {
+        Self { login, ..self }
+    }
+
     pub async fn insert(self, mut conn: &AsyncPgConnection) {
         diesel::insert_into(oauth_github::table)
             .values((

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -1507,6 +1507,12 @@ export interface components {
              */
             avatar?: string | null;
             /**
+             * @description Whether a linked GitHub username exactly matches the crates.io username.
+             *
+             *     This field is present only for user owners.
+             */
+            github_username_matches?: boolean | null;
+            /**
              * Format: int32
              * @description The opaque identifier for the team or user, depending on the `kind` field.
              * @example 42
@@ -1629,6 +1635,8 @@ export interface components {
              *     deleted before June 19, 2026, this field will be empty.
              */
             created_at?: string | null;
+            /** @description Whether a linked GitHub username exactly matches the crates.io username. */
+            github_username_matches: boolean;
             /**
              * Format: int32
              * @description An opaque identifier for the user.

--- a/packages/crates-io-msw/handlers/crates/list-owners.test.ts
+++ b/packages/crates-io-msw/handlers/crates/list-owners.test.ts
@@ -32,18 +32,24 @@ test('returns user owners', async function () {
   let user = await db.user.create({
     name: 'John Doe',
     login: 'crates-user',
-    githubAccounts: [{ accountId: '10', login: 'github-user', avatar: null }],
+    githubAccounts: [
+      { accountId: '10', login: 'github-user', avatar: null },
+      { accountId: '11', login: 'crates-user', avatar: null },
+    ],
   });
   let crate = await db.crate.create({ name: 'rand' });
   await db.crateOwnership.create({ crate, user });
 
   let response = await fetch('/api/v1/crates/rand/owners');
   expect(response.status).toBe(200);
-  expect(await response.json()).toMatchInlineSnapshot(`
+  let responsePayload = await response.json();
+  expect(responsePayload.users[0].github_username_matches).toBe(true);
+  expect(responsePayload).toMatchInlineSnapshot(`
     {
       "users": [
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 1,
           "kind": "user",
           "login": "crates-user",
@@ -62,7 +68,9 @@ test('returns team owners', async function () {
 
   let response = await fetch('/api/v1/crates/rand/owners');
   expect(response.status).toBe(200);
-  expect(await response.json()).toMatchInlineSnapshot(`
+  let responsePayload = await response.json();
+  expect(responsePayload.users[0]).not.toHaveProperty('github_username_matches');
+  expect(responsePayload).toMatchInlineSnapshot(`
     {
       "users": [
         {
@@ -87,11 +95,15 @@ test('returns user owners before team owners', async function () {
 
   let response = await fetch('/api/v1/crates/rand/owners');
   expect(response.status).toBe(200);
-  expect(await response.json()).toMatchInlineSnapshot(`
+  let responsePayload = await response.json();
+  expect(responsePayload.users[0].github_username_matches).toBe(true);
+  expect(responsePayload.users[1]).not.toHaveProperty('github_username_matches');
+  expect(responsePayload).toMatchInlineSnapshot(`
     {
       "users": [
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 1,
           "kind": "user",
           "login": "john-doe",

--- a/packages/crates-io-msw/handlers/crates/list-owners.test.ts
+++ b/packages/crates-io-msw/handlers/crates/list-owners.test.ts
@@ -29,7 +29,11 @@ test('empty case', async function () {
 });
 
 test('returns user owners', async function () {
-  let user = await db.user.create({ name: 'John Doe' });
+  let user = await db.user.create({
+    name: 'John Doe',
+    login: 'crates-user',
+    githubLogin: 'github-user',
+  });
   let crate = await db.crate.create({ name: 'rand' });
   await db.crateOwnership.create({ crate, user });
 
@@ -42,9 +46,9 @@ test('returns user owners', async function () {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
           "id": 1,
           "kind": "user",
-          "login": "john-doe",
+          "login": "crates-user",
           "name": "John Doe",
-          "url": "https://github.com/john-doe",
+          "url": "https://github.com/github-user",
         },
       ],
     }

--- a/packages/crates-io-msw/handlers/crates/list-owners.test.ts
+++ b/packages/crates-io-msw/handlers/crates/list-owners.test.ts
@@ -32,7 +32,7 @@ test('returns user owners', async function () {
   let user = await db.user.create({
     name: 'John Doe',
     login: 'crates-user',
-    githubLogin: 'github-user',
+    githubAccounts: [{ accountId: '10', login: 'github-user', avatar: null }],
   });
   let crate = await db.crate.create({ name: 'rand' });
   await db.crateOwnership.create({ crate, user });

--- a/packages/crates-io-msw/handlers/crates/list-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/list-owners.ts
@@ -17,7 +17,7 @@ export default http.get('/api/v1/crates/{name}/owners', ({ params, response }) =
         id: o.user.id,
         login: o.user.login,
         kind: 'user',
-        url: `https://github.com/${o.user.login}`,
+        url: o.user.url,
         name: o.user.name,
         avatar: o.user.avatar,
       })),

--- a/packages/crates-io-msw/handlers/crates/list-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/list-owners.ts
@@ -1,4 +1,5 @@
 import { db } from '../../index.js';
+import { serializeUser } from '../../serializers/user.js';
 import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
@@ -11,16 +12,7 @@ export default http.get('/api/v1/crates/{name}/owners', ({ params, response }) =
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.crate.id === crate.id));
 
   let users = [
-    ...ownerships
-      .filter(o => o.user)
-      .map(o => ({
-        id: o.user.id,
-        login: o.user.login,
-        kind: 'user',
-        url: o.user.url,
-        name: o.user.name,
-        avatar: o.user.avatar,
-      })),
+    ...ownerships.filter(o => o.user).map(o => ({ ...serializeUser(o.user), kind: 'user' })),
     ...ownerships
       .filter(o => o.team)
       .map(o => ({

--- a/packages/crates-io-msw/handlers/crates/team-owners.test.ts
+++ b/packages/crates-io-msw/handlers/crates/team-owners.test.ts
@@ -35,7 +35,9 @@ test('returns the list of teams that own the specified crate', async function ()
 
   let response = await fetch('/api/v1/crates/rand/owner_team');
   expect(response.status).toBe(200);
-  expect(await response.json()).toMatchInlineSnapshot(`
+  let responsePayload = await response.json();
+  expect(responsePayload.teams[0]).not.toHaveProperty('github_username_matches');
+  expect(responsePayload).toMatchInlineSnapshot(`
     {
       "teams": [
         {

--- a/packages/crates-io-msw/handlers/crates/user-owners.test.ts
+++ b/packages/crates-io-msw/handlers/crates/user-owners.test.ts
@@ -35,11 +35,14 @@ test('returns the list of users that own the specified crate', async function ()
 
   let response = await fetch('/api/v1/crates/rand/owner_user');
   expect(response.status).toBe(200);
-  expect(await response.json()).toMatchInlineSnapshot(`
+  let responsePayload = await response.json();
+  expect(responsePayload.users[0].github_username_matches).toBe(true);
+  expect(responsePayload).toMatchInlineSnapshot(`
     {
       "users": [
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 1,
           "kind": "user",
           "login": "john-doe",

--- a/packages/crates-io-msw/handlers/invites/legacy-list.test.ts
+++ b/packages/crates-io-msw/handlers/invites/legacy-list.test.ts
@@ -69,6 +69,7 @@ test('returns the list of invitations for the authenticated user', async functio
       "users": [
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 1,
           "login": "user-1",
           "name": "User 1",
@@ -76,6 +77,7 @@ test('returns the list of invitations for the authenticated user', async functio
         },
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 2,
           "login": "janed",
           "name": "janed",
@@ -83,6 +85,7 @@ test('returns the list of invitations for the authenticated user', async functio
         },
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 3,
           "login": "wycats",
           "name": "wycats",

--- a/packages/crates-io-msw/handlers/invites/list.test.ts
+++ b/packages/crates-io-msw/handlers/invites/list.test.ts
@@ -56,6 +56,7 @@ test('happy path (invitee_id)', async function () {
       "users": [
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 1,
           "login": "user-1",
           "name": "User 1",
@@ -63,6 +64,7 @@ test('happy path (invitee_id)', async function () {
         },
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 2,
           "login": "janed",
           "name": "janed",
@@ -70,6 +72,7 @@ test('happy path (invitee_id)', async function () {
         },
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 3,
           "login": "wycats",
           "name": "wycats",
@@ -168,6 +171,7 @@ test('happy path (crate_name)', async function () {
       "users": [
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 1,
           "login": "user-1",
           "name": "User 1",
@@ -175,6 +179,7 @@ test('happy path (crate_name)', async function () {
         },
         {
           "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "github_username_matches": true,
           "id": 3,
           "login": "wycats",
           "name": "wycats",

--- a/packages/crates-io-msw/handlers/users/get.test.ts
+++ b/packages/crates-io-msw/handlers/users/get.test.ts
@@ -19,7 +19,7 @@ test('returns 404 for unknown users', async function () {
 test('returns a user object for known users', async function () {
   await db.user.create({
     login: 'crates-user',
-    githubLogin: 'github-user',
+    githubAccounts: [{ accountId: '10', login: 'github-user', avatar: null }],
   });
 
   let response = await fetch('/api/v1/users/Crates_User');

--- a/packages/crates-io-msw/handlers/users/get.test.ts
+++ b/packages/crates-io-msw/handlers/users/get.test.ts
@@ -19,7 +19,10 @@ test('returns 404 for unknown users', async function () {
 test('returns a user object for known users', async function () {
   await db.user.create({
     login: 'crates-user',
-    githubAccounts: [{ accountId: '10', login: 'github-user', avatar: null }],
+    githubAccounts: [
+      { accountId: '10', login: 'github-user', avatar: null },
+      { accountId: '11', login: 'crates-user', avatar: null },
+    ],
   });
 
   let response = await fetch('/api/v1/users/Crates_User');
@@ -28,9 +31,33 @@ test('returns a user object for known users', async function () {
     {
       "user": {
         "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+        "github_username_matches": true,
         "id": 1,
         "login": "crates-user",
         "name": "User 1",
+        "url": "https://github.com/github-user",
+      },
+    }
+  `);
+
+  await db.user.create({
+    login: 'second-user',
+    githubAccounts: [
+      { accountId: '20', login: 'github-user', avatar: null },
+      { accountId: '21', login: 'SECOND-USER', avatar: null },
+    ],
+  });
+
+  response = await fetch('/api/v1/users/second-user');
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchInlineSnapshot(`
+    {
+      "user": {
+        "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+        "github_username_matches": false,
+        "id": 2,
+        "login": "second-user",
+        "name": "User 2",
         "url": "https://github.com/github-user",
       },
     }
@@ -53,6 +80,7 @@ test('returns the newest user for canonical username collisions', async function
     {
       "user": {
         "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+        "github_username_matches": true,
         "id": 2,
         "login": "FOO_BAR",
         "name": "Newer User",

--- a/packages/crates-io-msw/handlers/users/me.test.ts
+++ b/packages/crates-io-msw/handlers/users/me.test.ts
@@ -5,7 +5,7 @@ import { db } from '../../index.js';
 test('returns the `user` resource including the private fields', async function () {
   let user = await db.user.create({
     login: 'crates-user',
-    githubLogin: 'github-user',
+    githubAccounts: [{ accountId: '10', login: 'github-user', avatar: null }],
   });
   await db.mswSession.create({ user });
 

--- a/packages/crates-io-msw/handlers/users/me.test.ts
+++ b/packages/crates-io-msw/handlers/users/me.test.ts
@@ -11,7 +11,9 @@ test('returns the `user` resource including the private fields', async function 
 
   let response = await fetch('/api/v1/me');
   expect(response.status).toBe(200);
-  expect(await response.json()).toMatchInlineSnapshot(`
+  let responsePayload = await response.json();
+  expect(responsePayload.user).not.toHaveProperty('github_username_matches');
+  expect(responsePayload).toMatchInlineSnapshot(`
     {
       "owned_crates": [],
       "user": {

--- a/packages/crates-io-msw/handlers/versions/list.test.ts
+++ b/packages/crates-io-msw/handlers/versions/list.test.ts
@@ -124,6 +124,7 @@ test('returns all versions belonging to the specified crate', async function () 
           "num": "1.1.0",
           "published_by": {
             "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+            "github_username_matches": true,
             "id": 1,
             "login": "user-1",
             "name": "User 1",

--- a/packages/crates-io-msw/models/api-token.test.ts
+++ b/packages/crates-io-msw/models/api-token.test.ts
@@ -43,7 +43,13 @@ test('happy path', async ({ expect }) => {
         "emailVerificationToken": null,
         "emailVerified": true,
         "followedCrates": [],
-        "githubLogin": "user-1",
+        "githubAccounts": [
+          {
+            "accountId": "1",
+            "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+            "login": "user-1",
+          },
+        ],
         "id": 1,
         "isAdmin": false,
         "login": "user-1",

--- a/packages/crates-io-msw/models/crate-owner-invitation.test.ts
+++ b/packages/crates-io-msw/models/crate-owner-invitation.test.ts
@@ -62,7 +62,13 @@ test('happy path', async ({ expect }) => {
         "emailVerificationToken": null,
         "emailVerified": true,
         "followedCrates": [],
-        "githubLogin": "user-2",
+        "githubAccounts": [
+          {
+            "accountId": "2",
+            "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+            "login": "user-2",
+          },
+        ],
         "id": 2,
         "isAdmin": false,
         "login": "user-2",
@@ -76,7 +82,13 @@ test('happy path', async ({ expect }) => {
         "emailVerificationToken": null,
         "emailVerified": true,
         "followedCrates": [],
-        "githubLogin": "user-1",
+        "githubAccounts": [
+          {
+            "accountId": "1",
+            "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+            "login": "user-1",
+          },
+        ],
         "id": 1,
         "isAdmin": false,
         "login": "user-1",

--- a/packages/crates-io-msw/models/crate-ownership.test.ts
+++ b/packages/crates-io-msw/models/crate-ownership.test.ts
@@ -96,7 +96,13 @@ test('can set `user`', async ({ expect }) => {
         "emailVerificationToken": null,
         "emailVerified": true,
         "followedCrates": [],
-        "githubLogin": "user-1",
+        "githubAccounts": [
+          {
+            "accountId": "1",
+            "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+            "login": "user-1",
+          },
+        ],
         "id": 1,
         "isAdmin": false,
         "login": "user-1",

--- a/packages/crates-io-msw/models/msw-session.test.ts
+++ b/packages/crates-io-msw/models/msw-session.test.ts
@@ -21,7 +21,13 @@ test('happy path', async ({ expect }) => {
         "emailVerificationToken": null,
         "emailVerified": true,
         "followedCrates": [],
-        "githubLogin": "user-1",
+        "githubAccounts": [
+          {
+            "accountId": "1",
+            "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+            "login": "user-1",
+          },
+        ],
         "id": 1,
         "isAdmin": false,
         "login": "user-1",

--- a/packages/crates-io-msw/models/user.test.ts
+++ b/packages/crates-io-msw/models/user.test.ts
@@ -11,7 +11,13 @@ test('default are applied', async ({ expect }) => {
       "emailVerificationToken": null,
       "emailVerified": true,
       "followedCrates": [],
-      "githubLogin": "user-1",
+      "githubAccounts": [
+        {
+          "accountId": "1",
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "login": "user-1",
+        },
+      ],
       "id": 1,
       "isAdmin": false,
       "login": "user-1",
@@ -31,7 +37,13 @@ test('name can be set', async ({ expect }) => {
       "emailVerificationToken": null,
       "emailVerified": true,
       "followedCrates": [],
-      "githubLogin": "john-doe",
+      "githubAccounts": [
+        {
+          "accountId": "1",
+          "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+          "login": "john-doe",
+        },
+      ],
       "id": 1,
       "isAdmin": false,
       "login": "john-doe",

--- a/packages/crates-io-msw/models/user.ts
+++ b/packages/crates-io-msw/models/user.ts
@@ -4,13 +4,19 @@ import * as v from 'valibot';
 import * as counters from '../utils/counters.js';
 import { dasherize } from '../utils/strings.js';
 
+const githubAccountSchema = v.object({
+  accountId: v.string(),
+  login: v.string(),
+  avatar: v.nullable(v.string()),
+});
+
 const schema = v.pipe(
   v.object({
     id: v.optional(v.number()),
 
     name: v.optional(v.nullable(v.string())),
     login: v.optional(v.string()),
-    githubLogin: v.optional(v.string()),
+    githubAccounts: v.optional(v.array(githubAccountSchema)),
     url: v.optional(v.string()),
     avatar: v.optional(v.string(), 'https://avatars1.githubusercontent.com/u/14631425?v=4'),
     email: v.optional(v.nullable(v.string())),
@@ -27,10 +33,17 @@ const schema = v.pipe(
     let name = input.name === undefined ? `User ${id}` : input.name;
     let login = input.login ?? (name ? dasherize(name) : `user-${id}`);
     let email = input.email === undefined ? `${login}@crates.io` : input.email;
-    let githubLogin = input.githubLogin ?? login;
-    let url = input.url ?? `https://github.com/${githubLogin}`;
+    let githubAccounts = input.githubAccounts ?? [
+      {
+        accountId: String(id),
+        login,
+        avatar: input.avatar ?? null,
+      },
+    ];
+    let githubProfileLogin = githubAccounts[0]?.login ?? login;
+    let url = input.url ?? `https://github.com/${githubProfileLogin}`;
     let emailVerified = input.emailVerified ?? Boolean(email && !input.emailVerificationToken);
-    return { ...input, id, name, login, githubLogin, email, url, emailVerified };
+    return { ...input, id, name, login, githubAccounts, email, url, emailVerified };
   }),
 );
 

--- a/packages/crates-io-msw/serializers/user.ts
+++ b/packages/crates-io-msw/serializers/user.ts
@@ -11,13 +11,13 @@ export function serializeUser(
   user: User,
   { removePrivateData = true }: { removePrivateData?: boolean } = {},
 ): ApiUser | ApiAuthenticatedUser {
-  let serialized: ApiUser = {
+  let serialized = {
     id: user.id,
     login: user.login,
     name: user.name,
     url: user.url,
     avatar: user.avatar,
-  };
+  } satisfies Omit<ApiUser, 'github_username_matches'>;
 
   if (!removePrivateData) {
     return {
@@ -30,5 +30,8 @@ export function serializeUser(
     };
   }
 
-  return serialized;
+  return {
+    ...serialized,
+    github_username_matches: user.githubAccounts.some(account => account.login === user.login),
+  };
 }

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__edition__edition_is_saved-4.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__edition__edition_is_saved-4.snap
@@ -11,6 +11,7 @@ expression: response.json()
         "user": {
           "avatar": null,
           "created_at": "[datetime]",
+          "github_username_matches": true,
           "id": "[id]",
           "login": "foo",
           "name": null,
@@ -48,6 +49,7 @@ expression: response.json()
     "published_by": {
       "avatar": null,
       "created_at": "[datetime]",
+      "github_username_matches": true,
       "id": "[id]",
       "login": "foo",
       "name": null,

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__links__crate_with_links_field-3.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__links__crate_with_links_field-3.snap
@@ -11,6 +11,7 @@ expression: response.json()
         "user": {
           "avatar": null,
           "created_at": "[datetime]",
+          "github_username_matches": true,
           "id": 1,
           "login": "foo",
           "name": null,
@@ -48,6 +49,7 @@ expression: response.json()
     "published_by": {
       "avatar": null,
       "created_at": "[datetime]",
+      "github_username_matches": true,
       "id": "[id]",
       "login": "foo",
       "name": null,

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__boolean_readme-4.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__boolean_readme-4.snap
@@ -11,6 +11,7 @@ expression: response.json()
         "user": {
           "avatar": null,
           "created_at": "[datetime]",
+          "github_username_matches": true,
           "id": "[id]",
           "login": "foo",
           "name": null,
@@ -48,6 +49,7 @@ expression: response.json()
     "published_by": {
       "avatar": null,
       "created_at": "[datetime]",
+      "github_username_matches": true,
       "id": "[id]",
       "login": "foo",
       "name": null,

--- a/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__lib_and_bin_crate-4.snap
+++ b/src/tests/krate/publish/snapshots/integration__krate__publish__manifest__lib_and_bin_crate-4.snap
@@ -11,6 +11,7 @@ expression: response.json()
         "user": {
           "avatar": null,
           "created_at": "[datetime]",
+          "github_username_matches": true,
           "id": "[id]",
           "login": "foo",
           "name": null,
@@ -57,6 +58,7 @@ expression: response.json()
     "published_by": {
       "avatar": null,
       "created_at": "[datetime]",
+      "github_username_matches": true,
       "id": "[id]",
       "login": "foo",
       "name": null,

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-2.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-2.snap
@@ -29,6 +29,7 @@ expression: json
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     "audit_actions": [
@@ -40,6 +41,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -52,6 +54,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-3.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-3.snap
@@ -29,6 +29,7 @@ expression: json
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     "audit_actions": [
@@ -40,6 +41,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -52,6 +54,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -64,6 +67,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-4.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-4.snap
@@ -29,6 +29,7 @@ expression: json
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     "audit_actions": [
@@ -40,6 +41,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -52,6 +54,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -64,6 +67,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-5.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-5.snap
@@ -29,6 +29,7 @@ expression: json
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     "audit_actions": [
@@ -40,6 +41,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -52,6 +54,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -64,6 +67,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -76,6 +80,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-6.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank-6.snap
@@ -29,6 +29,7 @@ expression: json
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     "audit_actions": [
@@ -40,6 +41,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -52,6 +54,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -64,6 +67,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -76,6 +80,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"

--- a/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank.snap
+++ b/src/tests/krate/snapshots/integration__krate__yanking__patch_version_yank_unyank.snap
@@ -29,6 +29,7 @@ expression: json
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     "audit_actions": [
@@ -40,6 +41,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"
@@ -52,6 +54,7 @@ expression: json
           "name": null,
           "avatar": null,
           "url": "https://github.com/foo",
+          "github_username_matches": true,
           "created_at": "[datetime]"
         },
         "time": "[datetime]"

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__include_default_version-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__include_default_version-2.snap
@@ -70,6 +70,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__show-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__show-2.snap
@@ -83,6 +83,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,
@@ -128,6 +129,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__read__show_all_yanked-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__read__show_all_yanked-2.snap
@@ -82,6 +82,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,
@@ -127,6 +128,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies-2.snap
@@ -53,6 +53,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
@@ -53,6 +53,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present-2.snap
@@ -103,6 +103,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts-2.snap
@@ -53,6 +53,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does-2.snap
@@ -53,6 +53,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
@@ -53,6 +53,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-9.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__disable_trustpub_only-9.snap
@@ -72,6 +72,7 @@ expression: json
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-9.snap
+++ b/src/tests/routes/crates/snapshots/integration__routes__crates__update__enable_trustpub_only-9.snap
@@ -72,6 +72,7 @@ expression: json
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/versions/list.rs
+++ b/src/tests/routes/crates/versions/list.rs
@@ -1,5 +1,6 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
 use crate::util::{RequestHelper, TestApp};
+use crates_io::models::{NewVersionOwnerAction, Version, VersionAction};
 use crates_io::schema::versions;
 use crates_io::views::EncodableVersion;
 use diesel::{prelude::*, update};
@@ -22,6 +23,19 @@ async fn versions() -> anyhow::Result<()> {
         .expect_build(&mut conn)
         .await;
 
+    let published_version = versions::table
+        .filter(versions::num.eq("0.5.1"))
+        .select(Version::as_select())
+        .first(&mut conn)
+        .await?;
+    NewVersionOwnerAction::builder()
+        .version_id(published_version.id)
+        .user_id(user.id)
+        .action(VersionAction::Publish)
+        .build()
+        .insert(&conn)
+        .await?;
+
     // Make version 1.0.0 mimic a version published before we started recording who published
     // versions
     let none: Option<i32> = None;
@@ -37,6 +51,8 @@ async fn versions() -> anyhow::Result<()> {
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
         ".versions[].published_by.created_at" => "[datetime]",
+        ".versions[].audit_actions[].time" => "[datetime]",
+        ".versions[].audit_actions[].user.created_at" => "[datetime]",
     });
 
     Ok(())

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -1,6 +1,7 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
 use crate::util::insta::{self, assert_json_snapshot};
 use crate::util::{RequestHelper, TestApp};
+use crates_io::models::{NewVersionOwnerAction, VersionAction};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::StatusCode;
@@ -21,6 +22,14 @@ async fn show_by_crate_name_and_version() {
         .rust_version("1.64")
         .expect_build(krate.id, user.id, &mut conn)
         .await;
+    NewVersionOwnerAction::builder()
+        .version_id(v.id)
+        .user_id(user.id)
+        .action(VersionAction::Publish)
+        .build()
+        .insert(&conn)
+        .await
+        .unwrap();
 
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
     let json: Value = anon.get(url).await.good();
@@ -30,6 +39,9 @@ async fn show_by_crate_name_and_version() {
         ".version.updated_at" => "[datetime]",
         ".version.published_by.id" => insta::id_redaction(user.id),
         ".version.published_by.created_at" => "[datetime]",
+        ".version.audit_actions[].time" => "[datetime]",
+        ".version.audit_actions[].user.id" => insta::id_redaction(user.id),
+        ".version.audit_actions[].user.created_at" => "[datetime]",
     });
 }
 

--- a/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__list__versions-2.snap
+++ b/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__list__versions-2.snap
@@ -54,6 +54,7 @@ expression: response.json()
           "user": {
             "avatar": null,
             "created_at": "[datetime]",
+            "github_username_matches": true,
             "id": 1,
             "login": "foo",
             "name": null,
@@ -91,6 +92,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,
@@ -136,6 +138,7 @@ expression: response.json()
       "published_by": {
         "avatar": null,
         "created_at": "[datetime]",
+        "github_username_matches": true,
         "id": 1,
         "login": "foo",
         "name": null,

--- a/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__list__versions-2.snap
+++ b/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__list__versions-2.snap
@@ -47,7 +47,20 @@ expression: response.json()
       "yanked": false
     },
     {
-      "audit_actions": [],
+      "audit_actions": [
+        {
+          "action": "publish",
+          "time": "[datetime]",
+          "user": {
+            "avatar": null,
+            "created_at": "[datetime]",
+            "id": 1,
+            "login": "foo",
+            "name": null,
+            "url": "https://github.com/foo"
+          }
+        }
+      ],
       "bin_names": null,
       "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
       "crate": "foo_versions",

--- a/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__read__show_by_crate_name_and_version.snap
+++ b/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__read__show_by_crate_name_and_version.snap
@@ -11,6 +11,7 @@ expression: json
         "user": {
           "avatar": null,
           "created_at": "[datetime]",
+          "github_username_matches": true,
           "id": "[id]",
           "login": "foo",
           "name": null,
@@ -44,6 +45,7 @@ expression: json
     "published_by": {
       "avatar": null,
       "created_at": "[datetime]",
+      "github_username_matches": true,
       "id": "[id]",
       "login": "foo",
       "name": null,

--- a/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__read__show_by_crate_name_and_version.snap
+++ b/src/tests/routes/crates/versions/snapshots/integration__routes__crates__versions__read__show_by_crate_name_and_version.snap
@@ -4,7 +4,20 @@ expression: json
 ---
 {
   "version": {
-    "audit_actions": [],
+    "audit_actions": [
+      {
+        "action": "publish",
+        "time": "[datetime]",
+        "user": {
+          "avatar": null,
+          "created_at": "[datetime]",
+          "id": "[id]",
+          "login": "foo",
+          "name": null,
+          "url": "https://github.com/foo"
+        }
+      }
+    ],
     "bin_names": null,
     "checksum": "c241cd77c3723ccf1aa453f169ee60c0a888344da504bee0142adb859092acb4",
     "crate": "foo_vers_show",

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-2.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-2.snap
@@ -20,6 +20,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     {
@@ -28,6 +29,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/user_2",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     }
   ],

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-4.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-4.snap
@@ -28,6 +28,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     {
@@ -36,6 +37,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/user_1",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     {
@@ -44,6 +46,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/user_2",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     }
   ],

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-5.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list-5.snap
@@ -20,6 +20,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     {
@@ -28,6 +29,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/user_1",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     }
   ],

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitation_list.snap
@@ -28,6 +28,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     {
@@ -36,6 +37,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/user_1",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     }
   ],

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_does_not_include_expired_invites.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_does_not_include_expired_invites.snap
@@ -20,6 +20,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     {
@@ -28,6 +29,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/invited_user",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     }
   ],

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_paginated-2.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_paginated-2.snap
@@ -20,6 +20,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     {
@@ -28,6 +29,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/invited_user",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     }
   ],

--- a/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_paginated.snap
+++ b/src/tests/routes/private/snapshots/integration__routes__private__crate_owner_invitations__invitations_list_paginated.snap
@@ -20,6 +20,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     {
@@ -28,6 +29,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/invited_user",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     }
   ],

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -24,14 +24,21 @@ async fn show() {
         .execute(&mut conn)
         .await
         .unwrap();
+    let bar_model = bar.as_model();
+    OauthGithubBuilder::for_user(bar_model)
+        .with_login("CRATES-BAR")
+        .insert(&conn)
+        .await;
 
     let json: UserShowPublicResponse = anon.get("/api/v1/users/foo").await.good();
     assert_eq!(json.user.login, "foo");
+    assert!(json.user.github_username_matches);
 
     // Lookup by username is case insensitive; returned data uses capitalization in database
     let json: UserShowPublicResponse = anon.get("/api/v1/users/crates_bar").await.good();
     assert_eq!(json.user.login, "crates-Bar");
     assert_eq!(json.user.url, "https://github.com/github-Bar");
+    assert!(!json.user.github_username_matches);
 
     // GitHub logins are not used to resolve crates.io users
     let response = anon.get::<()>("/api/v1/users/github-Bar").await;
@@ -69,13 +76,17 @@ async fn show_latest_user_case_insensitively() {
         .new_user();
     let user2_id = user2.insert(&conn).await.unwrap();
     let user2 = User::find(&conn, user2_id).await.unwrap();
-    OauthGithubBuilder::for_user(&user2).insert(&conn).await;
+    OauthGithubBuilder::for_user(&user2)
+        .with_login("FOO-BAR")
+        .insert(&conn)
+        .await;
 
     let json: UserShowPublicResponse = anon.get("/api/v1/users/fOObAr").await.good();
     assert_eq!(
         "I was second, I took the foobar username on github",
         json.user.name.unwrap()
     );
+    assert!(!json.user.github_username_matches);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -97,4 +108,5 @@ async fn user_without_github_account() {
     // The crates.io username still exists
     let json: UserShowPublicResponse = anon.get("/api/v1/users/fOObAr").await.good();
     assert_eq!("I deleted my github account", json.user.name.unwrap());
+    assert!(!json.user.github_username_matches);
 }

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -838,6 +838,13 @@ expression: response.json()
               "null"
             ]
           },
+          "github_username_matches": {
+            "description": "Whether a linked GitHub username exactly matches the crates.io username.\n\nThis field is present only for user owners.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "id": {
             "description": "The opaque identifier for the team or user, depending on the `kind` field.",
             "example": 42,
@@ -1071,6 +1078,10 @@ expression: response.json()
               "null"
             ]
           },
+          "github_username_matches": {
+            "description": "Whether a linked GitHub username exactly matches the crates.io username.",
+            "type": "boolean"
+          },
           "id": {
             "description": "An opaque identifier for the user.",
             "example": 42,
@@ -1099,7 +1110,8 @@ expression: response.json()
         "required": [
           "id",
           "login",
-          "url"
+          "url",
+          "github_username_matches"
         ],
         "type": "object"
       },

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -838,6 +838,13 @@ expression: response.json()
               "null"
             ]
           },
+          "github_username_matches": {
+            "description": "Whether a linked GitHub username exactly matches the crates.io username.\n\nThis field is present only for user owners.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "id": {
             "description": "The opaque identifier for the team or user, depending on the `kind` field.",
             "example": 42,
@@ -1071,6 +1078,10 @@ expression: response.json()
               "null"
             ]
           },
+          "github_username_matches": {
+            "description": "Whether a linked GitHub username exactly matches the crates.io username.",
+            "type": "boolean"
+          },
           "id": {
             "description": "An opaque identifier for the user.",
             "example": 42,
@@ -1099,7 +1110,8 @@ expression: response.json()
         "required": [
           "id",
           "login",
-          "url"
+          "url",
+          "github_username_matches"
         ],
         "type": "object"
       },

--- a/src/tests/snapshots/integration__owners__check_ownership_one_crate-2.snap
+++ b/src/tests/snapshots/integration__owners__check_ownership_one_crate-2.snap
@@ -6,6 +6,7 @@ expression: response.json()
   "users": [
     {
       "avatar": null,
+      "github_username_matches": true,
       "id": 1,
       "kind": "user",
       "login": "foo",
@@ -14,6 +15,7 @@ expression: response.json()
     },
     {
       "avatar": null,
+      "github_username_matches": true,
       "id": 2,
       "kind": "user",
       "login": "bar",

--- a/src/tests/snapshots/integration__owners__check_ownership_one_crate-6.snap
+++ b/src/tests/snapshots/integration__owners__check_ownership_one_crate-6.snap
@@ -6,6 +6,7 @@ expression: response.json()
   "users": [
     {
       "avatar": null,
+      "github_username_matches": true,
       "id": 1,
       "kind": "user",
       "login": "foo",
@@ -14,6 +15,7 @@ expression: response.json()
     },
     {
       "avatar": null,
+      "github_username_matches": true,
       "id": 2,
       "kind": "user",
       "login": "bar",

--- a/src/tests/snapshots/integration__owners__invitations_list_does_not_include_expired_invites_v1.snap
+++ b/src/tests/snapshots/integration__owners__invitations_list_does_not_include_expired_invites_v1.snap
@@ -21,6 +21,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     {
@@ -29,6 +30,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/invited_user",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     }
   ]

--- a/src/tests/snapshots/integration__owners__invitations_list_v1-2.snap
+++ b/src/tests/snapshots/integration__owners__invitations_list_v1-2.snap
@@ -21,6 +21,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/foo",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     },
     {
@@ -29,6 +30,7 @@ expression: invitations
       "name": null,
       "avatar": null,
       "url": "https://github.com/invited_user",
+      "github_username_matches": true,
       "created_at": "[datetime]"
     }
   ]

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,11 +1,12 @@
 use crate::TestApp;
+use crate::builders::OauthGithubBuilder;
 use crate::util::github::next_gh_id;
 use crate::util::{MockCookieUser, RequestHelper};
 use chrono::{DateTime, Utc};
 use claims::{assert_err, assert_ok, assert_ok_eq};
 use crates_io::controllers::session;
-use crates_io::models::{ApiToken, Email, OauthGithub, User};
-use crates_io::schema::oauth_github;
+use crates_io::models::{ApiToken, Email, OauthGithub, PublicUser, User};
+use crates_io::schema::{oauth_github, users};
 use crates_io::util::token::HashedToken;
 use crates_io_encryption::TokenEncryption;
 use crates_io_github::GitHubUser;
@@ -21,6 +22,34 @@ impl crate::util::MockCookieUser {
         let response = self.put::<()>(&url, &[] as &[u8]).await;
         assert_snapshot!(response.status(), @"200 OK");
         assert_eq!(response.json(), json!({ "ok": true }));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn public_user_github_username_matches() {
+    let (app, _, matching_user) = TestApp::init().with_user().await;
+    let mut conn = app.db_conn().await;
+
+    let mismatching_user = app.db_new_user("bar").await;
+    OauthGithubBuilder::for_user(mismatching_user.as_model())
+        .with_login("BAR")
+        .insert(&conn)
+        .await;
+
+    let unlinked_user_id = crate::new_user("baz").insert(&conn).await.unwrap();
+
+    for (user_id, expected) in [
+        (matching_user.as_model().id, true),
+        (mismatching_user.as_model().id, false),
+        (unlinked_user_id, false),
+    ] {
+        let user = PublicUser::query()
+            .filter(users::id.eq(user_id))
+            .first(&mut conn)
+            .await
+            .unwrap();
+
+        assert_eq!(user.github_username_matches, expected);
     }
 }
 

--- a/svelte/src/lib/components/version-list/Row.stories.svelte
+++ b/svelte/src/lib/components/version-list/Row.stories.svelte
@@ -45,6 +45,7 @@
       published_by: {
         id: 1,
         login: 'dtolnay',
+        github_username_matches: true,
         name: 'David Tolnay',
         avatar: 'https://avatars.githubusercontent.com/u/1940490?v=4',
         url: 'https://github.com/dtolnay',


### PR DESCRIPTION
This adds `github_username_matches` to the shared public `User` schema and the user variant of `Owner`. The value comes from an exact, case-sensitive check across linked GitHub accounts.

Using the shared `PublicUser` struct keeps version publishers, audit users, invitations, crate owners, and Find User responses consistent, while private user responses avoid the additional query. The MSW models mirror the same linked-account behavior.

I opted to not add it to the private user responses, since the authenticated user already knows if they have a matching GitHub username or not and if they look at their profile page then the public user response would be used anyway.

Best reviewed commit-by-commit :)

### Related

- Resolves #14380
- https://github.com/rust-lang/crates.io/issues/13764