### PR TITLE
jobs/archive_index_branch: Show `git push` progress

### DIFF
--- a/src/worker/jobs/index/archive.rs
+++ b/src/worker/jobs/index/archive.rs
@@ -124,7 +124,7 @@ impl BackgroundJob for ArchiveIndexBranch {
         let push_start = Instant::now();
         let output = Command::new("git")
             .current_dir(tempdir.path())
-            .args(["push", REMOTE_NAME, &refspec])
+            .args(["push", "--progress", REMOTE_NAME, &refspec])
             .output()
             .await?;
 


### PR DESCRIPTION
This might help us debug why the `git push` is currently failing. The current theory is that we are hitting the 2 GiB upload limit on the GitHub side. This progress reporting might hopefully tell us if that theory holds or not.