### PR TITLE
Add button to copy dependency version only

### DIFF
--- a/svelte/src/lib/components/crate-sidebar/InstallInstructions.svelte
+++ b/svelte/src/lib/components/crate-sidebar/InstallInstructions.svelte
@@ -19,12 +19,18 @@
   let cargoInstallCommand = $derived(exactVersion ? `cargo install ${crate}@${version}` : `cargo install ${crate}`);
 
   let cargoAddCommand = $derived(exactVersion ? `cargo add ${crate}@=${version}` : `cargo add ${crate}`);
-
+  
   let tomlSnippet = $derived.by(() => {
     let v = version.split('+', 1)[0];
     let exact = exactVersion ? '=' : '';
     return `${crate} = "${exact}${v}"`;
   });
+
+  let cargoVersionCommand = $derived.by(() => {
+  let v = version.split('+', 1)[0];
+  return exactVersion ? `=${v}` : v;
+});
+  
 </script>
 
 <div class="install-instructions">
@@ -71,6 +77,7 @@
         <span class="selectable">{cargoAddCommand}</span>
         <Icon class="i-mdi:content-copy copy-icon" />
       </CopyButton>
+      
     {:else}
       <code class="copy-fallback">{cargoAddCommand}</code>
     {/if}
@@ -84,6 +91,16 @@
       </CopyButton>
     {:else}
       <code class="copy-fallback">{tomlSnippet}</code>
+    {/if}
+     <p class="copy-help">Or copy just the version:</p>
+
+    {#if isClipboardSupported}
+      <CopyButton copyText={cargoVersionCommand} title="Copy version to clipboard" class="copy-button">
+        <span class="selectable">{cargoVersionCommand}</span>
+        <Icon class="i-mdi:content-copy copy-icon" />
+      </CopyButton>
+    {:else}
+      <code class="copy-fallback">{cargoVersionCommand}</code>
     {/if}
   {/if}
 </div>


### PR DESCRIPTION
### Motivation

Sometimes users just need the version number on its own e.g. to update an existing dependency line, whether it's outdated because of an old snippet, an LLM suggestion, or just stale copy-pasted code. This avoids retyping or editing a full snippet just to grab the version.

### Changes

- Added `versionSnippet`, stripping build metadata (`+...`) like the existing `tomlSnippet`.
- Added a "Or copy just the version:" copy button using the existing `CopyButton` component, with clipboard-fallback support.

### Testing

- `pnpm --filter crates.io-svelte test` — 190 tests pass.