### PR TITLE
Add button to copy dependency version only

### DIFF
--- a/svelte/src/lib/components/crate-sidebar/InstallInstructions.svelte
+++ b/svelte/src/lib/components/crate-sidebar/InstallInstructions.svelte
@@ -25,6 +25,11 @@
     let exact = exactVersion ? '=' : '';
     return `${crate} = "${exact}${v}"`;
   });
+
+  let versionOnly = $derived.by(() => {
+    let v = version.split('+', 1)[0];
+    return exactVersion ? `=${v}` : v;
+  });
 </script>
 
 <div class="install-instructions">
@@ -84,6 +89,17 @@
       </CopyButton>
     {:else}
       <code class="copy-fallback">{tomlSnippet}</code>
+    {/if}
+
+    <p class="copy-help">Or copy just the version:</p>
+
+    {#if isClipboardSupported}
+      <CopyButton copyText={versionOnly} title="Copy version to clipboard" class="copy-button">
+        <span class="selectable">{versionOnly}</span>
+        <Icon class="i-mdi:content-copy copy-icon" />
+      </CopyButton>
+    {:else}
+      <code class="copy-fallback">{versionOnly}</code>
     {/if}
   {/if}
 </div>


### PR DESCRIPTION
### Motivation

Sometimes users just need the version number on its own  e.g. to update an existing dependency line, whether it's outdated because of an old snippet, an LLM suggestion, or just stale copy-pasted code. This avoids retyping or editing a full snippet just to grab the version.

### Changes

- Added `versionOnly`, stripping build metadata (`+...`) like the existing `tomlSnippet`.
- Added a "Or copy just the version:" copy button using the existing `CopyButton` component, with clipboard-fallback support.

### Testing

- `pnpm --filter crates.io-svelte test` — 190 tests pass.