### PR TITLE
OpenAPI: Mark `Owner.github_username_matches` as non-nullable

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -554,6 +554,7 @@ pub struct EncodableOwner {
     ///
     /// This field is present only for user owners.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
     pub github_username_matches: Option<bool>,
 }
 

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -1536,7 +1536,7 @@ export interface components {
              *
              *     This field is present only for user owners.
              */
-            github_username_matches?: boolean | null;
+            github_username_matches?: boolean;
             /**
              * Format: int32
              * @description The opaque identifier for the team or user, depending on the `kind` field.

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -840,10 +840,7 @@ expression: response.json()
           },
           "github_username_matches": {
             "description": "Whether a linked GitHub username exactly matches the crates.io username.\n\nThis field is present only for user owners.",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": "boolean"
           },
           "id": {
             "description": "The opaque identifier for the team or user, depending on the `kind` field.",

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -840,10 +840,7 @@ expression: response.json()
           },
           "github_username_matches": {
             "description": "Whether a linked GitHub username exactly matches the crates.io username.\n\nThis field is present only for user owners.",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": "boolean"
           },
           "id": {
             "description": "The opaque identifier for the team or user, depending on the `kind` field.",


### PR DESCRIPTION
The field is omitted for team owners and always contains a boolean for user owners. This aligns the OpenAPI schema with serialized responses and prevents generated clients from accepting `null`.