### PR TITLE
OpenAPI: Model `Owner` as user and team variants

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -527,66 +527,86 @@ pub struct EncodableCrateLinks {
     pub reverse_dependencies: String,
 }
 
+/// A user or team that owns a crate.
 #[derive(Serialize, Deserialize, Debug, utoipa::ToSchema)]
 #[schema(as = Owner)]
-pub struct EncodableOwner {
-    /// The opaque identifier for the team or user, depending on the `kind` field.
-    #[schema(example = 42)]
-    pub id: i32,
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum EncodableOwner {
+    /// A user owner.
+    User {
+        /// The opaque identifier for the user.
+        #[schema(example = 42)]
+        id: i32,
 
-    /// The login name of the team or user.
-    #[schema(example = "ghost")]
-    pub login: String,
+        /// The crates.io username.
+        #[schema(example = "ghost")]
+        login: String,
 
-    /// The kind of the owner (`user` or `team`).
-    #[schema(example = "user")]
-    pub kind: String,
+        /// The URL to the user's GitHub profile.
+        #[schema(example = "https://github.com/ghost")]
+        url: String,
 
-    /// The URL to the owner's profile.
-    #[schema(required = true, example = "https://github.com/ghost")]
-    pub url: Option<String>,
+        /// The user's display name.
+        #[schema(required, example = "Kate Morgan")]
+        name: Option<String>,
 
-    /// The display name of the team or user.
-    #[schema(required = true, example = "Kate Morgan")]
-    pub name: Option<String>,
+        /// The user's avatar URL.
+        #[schema(
+            required,
+            example = "https://avatars2.githubusercontent.com/u/1234567?v=4"
+        )]
+        avatar: Option<String>,
 
-    /// The avatar URL of the team or user.
-    #[schema(
-        required = true,
-        example = "https://avatars2.githubusercontent.com/u/1234567?v=4"
-    )]
-    pub avatar: Option<String>,
+        /// Whether a linked GitHub username exactly matches the crates.io username.
+        github_username_matches: bool,
+    },
 
-    /// Whether a linked GitHub username exactly matches the crates.io username.
-    ///
-    /// This field is present only for user owners.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(nullable = false)]
-    pub github_username_matches: Option<bool>,
+    /// A team owner.
+    Team {
+        /// The opaque identifier for the team.
+        #[schema(example = 42)]
+        id: i32,
+
+        /// The team's login name.
+        #[schema(example = "github:rust-lang:crates-io")]
+        login: String,
+
+        /// The URL to the team's GitHub profile.
+        #[schema(required, example = "https://github.com/rust-lang")]
+        url: Option<String>,
+
+        /// The team's display name.
+        #[schema(required, example = "Crates.io team")]
+        name: Option<String>,
+
+        /// The team's avatar URL.
+        #[schema(
+            required,
+            example = "https://avatars2.githubusercontent.com/u/1234567?v=4"
+        )]
+        avatar: Option<String>,
+    },
 }
 
 impl EncodableOwner {
     pub fn from_user(user: PublicUser) -> Self {
-        Self {
-            github_username_matches: Some(user.github_username_matches),
-            url: Some(format!("https://github.com/{}", user.gh_login)),
+        Self::User {
+            github_username_matches: user.github_username_matches,
+            url: format!("https://github.com/{}", user.gh_login),
             id: user.id,
             login: user.username,
             avatar: user.gh_avatar,
             name: user.name,
-            kind: String::from("user"),
         }
     }
 
     pub fn from_team(team: Team) -> Self {
-        Self {
+        Self::Team {
             id: team.id,
             url: team.url(),
             login: team.login,
             avatar: team.avatar,
             name: team.name,
-            kind: String::from("team"),
-            github_username_matches: None,
         }
     }
 }

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -1525,42 +1525,65 @@ export interface components {
              */
             inviter_id: number;
         };
+        /** @description A user or team that owns a crate. */
         Owner: {
             /**
-             * @description The avatar URL of the team or user.
+             * @description The user's avatar URL.
              * @example https://avatars2.githubusercontent.com/u/1234567?v=4
              */
             avatar: string | null;
-            /**
-             * @description Whether a linked GitHub username exactly matches the crates.io username.
-             *
-             *     This field is present only for user owners.
-             */
-            github_username_matches?: boolean;
+            /** @description Whether a linked GitHub username exactly matches the crates.io username. */
+            github_username_matches: boolean;
             /**
              * Format: int32
-             * @description The opaque identifier for the team or user, depending on the `kind` field.
+             * @description The opaque identifier for the user.
              * @example 42
              */
             id: number;
+            /** @enum {string} */
+            kind: "user";
             /**
-             * @description The kind of the owner (`user` or `team`).
-             * @example user
-             */
-            kind: string;
-            /**
-             * @description The login name of the team or user.
+             * @description The crates.io username.
              * @example ghost
              */
             login: string;
             /**
-             * @description The display name of the team or user.
+             * @description The user's display name.
              * @example Kate Morgan
              */
             name: string | null;
             /**
-             * @description The URL to the owner's profile.
+             * @description The URL to the user's GitHub profile.
              * @example https://github.com/ghost
+             */
+            url: string;
+        } | {
+            /**
+             * @description The team's avatar URL.
+             * @example https://avatars2.githubusercontent.com/u/1234567?v=4
+             */
+            avatar: string | null;
+            /**
+             * Format: int32
+             * @description The opaque identifier for the team.
+             * @example 42
+             */
+            id: number;
+            /** @enum {string} */
+            kind: "team";
+            /**
+             * @description The team's login name.
+             * @example github:rust-lang:crates-io
+             */
+            login: string;
+            /**
+             * @description The team's display name.
+             * @example Crates.io team
+             */
+            name: string | null;
+            /**
+             * @description The URL to the team's GitHub profile.
+             * @example https://github.com/rust-lang
              */
             url: string | null;
         };
@@ -5513,6 +5536,12 @@ export const pathsApiPrivateSessionAuthorizePostResponses200ContentApplicationJs
     status: unknown;
 }>["status"]> = ["signup_required"];
 export const endpointScopeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["EndpointScope"]> = ["publish-new", "publish-update", "trusted-publishing", "yank", "change-owners"];
+export const ownerOneOf0KindValues: ReadonlyArray<Extract<FlattenedDeepRequired<components>["schemas"]["Owner"], {
+    kind: unknown;
+}>["kind"]> = ["user"];
+export const ownerOneOf1KindValues: ReadonlyArray<Extract<FlattenedDeepRequired<components>["schemas"]["Owner"], {
+    kind: unknown;
+}>["kind"]> = ["team"];
 export const trustpubDataOneOf0ProviderValues: ReadonlyArray<Extract<FlattenedDeepRequired<components>["schemas"]["TrustpubData"], {
     provider: unknown;
 }>["provider"]> = ["github"];

--- a/packages/crates-io-msw/handlers/crates/list-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/list-owners.ts
@@ -1,7 +1,13 @@
+import type { components } from '@crates-io/api-client';
+
 import { db } from '../../index.js';
 import { serializeUser } from '../../serializers/user.js';
 import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
+
+type Owner = components['schemas']['Owner'];
+type UserOwner = Extract<Owner, { kind: 'user' }>;
+type TeamOwner = Extract<Owner, { kind: 'team' }>;
 
 export default http.get('/api/v1/crates/{name}/owners', ({ params, response }) => {
   let crate = db.crate.findFirst(q => q.where({ name: params.name }));
@@ -12,10 +18,15 @@ export default http.get('/api/v1/crates/{name}/owners', ({ params, response }) =
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.crate.id === crate.id));
 
   let users = [
-    ...ownerships.filter(o => o.user).map(o => ({ ...serializeUser(o.user), kind: 'user' })),
+    ...ownerships
+      .filter(o => o.user)
+      .map((o): UserOwner => {
+        let user = serializeUser(o.user);
+        return { ...user, name: user.name ?? null, avatar: user.avatar ?? null, kind: 'user' };
+      }),
     ...ownerships
       .filter(o => o.team)
-      .map(o => ({
+      .map((o): TeamOwner => ({
         id: o.team.id,
         login: o.team.login,
         kind: 'team',

--- a/packages/crates-io-msw/handlers/crates/team-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/team-owners.ts
@@ -12,6 +12,17 @@ export default http.get('/api/v1/crates/{name}/owner_team', ({ params, response 
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.crate.id === crate.id));
 
   return response(200).json({
-    teams: ownerships.filter(o => o.team).map(o => ({ ...serializeTeam(o.team), kind: 'team' })),
+    teams: ownerships
+      .filter(o => o.team)
+      .map(o => {
+        let team = serializeTeam(o.team);
+        return {
+          ...team,
+          name: team.name ?? null,
+          avatar: team.avatar ?? null,
+          url: team.url ?? null,
+          kind: 'team',
+        };
+      }),
   });
 });

--- a/packages/crates-io-msw/handlers/crates/user-owners.ts
+++ b/packages/crates-io-msw/handlers/crates/user-owners.ts
@@ -12,6 +12,11 @@ export default http.get('/api/v1/crates/{name}/owner_user', ({ params, response 
   let ownerships = db.crateOwnership.findMany(q => q.where(ownership => ownership.crate.id === crate.id));
 
   return response(200).json({
-    users: ownerships.filter(o => o.user).map(o => ({ ...serializeUser(o.user), kind: 'user' })),
+    users: ownerships
+      .filter(o => o.user)
+      .map(o => {
+        let user = serializeUser(o.user);
+        return { ...user, name: user.name ?? null, avatar: user.avatar ?? null, kind: 'user' };
+      }),
   });
 });

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -838,61 +838,121 @@ expression: response.json()
         "type": "object"
       },
       "Owner": {
-        "properties": {
-          "avatar": {
-            "description": "The avatar URL of the team or user.",
-            "example": "https://avatars2.githubusercontent.com/u/1234567?v=4",
-            "type": [
-              "string",
-              "null"
-            ]
+        "description": "A user or team that owns a crate.",
+        "oneOf": [
+          {
+            "description": "A user owner.",
+            "properties": {
+              "avatar": {
+                "description": "The user's avatar URL.",
+                "example": "https://avatars2.githubusercontent.com/u/1234567?v=4",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "github_username_matches": {
+                "description": "Whether a linked GitHub username exactly matches the crates.io username.",
+                "type": "boolean"
+              },
+              "id": {
+                "description": "The opaque identifier for the user.",
+                "example": 42,
+                "format": "int32",
+                "type": "integer"
+              },
+              "kind": {
+                "enum": [
+                  "user"
+                ],
+                "type": "string"
+              },
+              "login": {
+                "description": "The crates.io username.",
+                "example": "ghost",
+                "type": "string"
+              },
+              "name": {
+                "description": "The user's display name.",
+                "example": "Kate Morgan",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "url": {
+                "description": "The URL to the user's GitHub profile.",
+                "example": "https://github.com/ghost",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "login",
+              "url",
+              "name",
+              "avatar",
+              "github_username_matches",
+              "kind"
+            ],
+            "type": "object"
           },
-          "github_username_matches": {
-            "description": "Whether a linked GitHub username exactly matches the crates.io username.\n\nThis field is present only for user owners.",
-            "type": "boolean"
-          },
-          "id": {
-            "description": "The opaque identifier for the team or user, depending on the `kind` field.",
-            "example": 42,
-            "format": "int32",
-            "type": "integer"
-          },
-          "kind": {
-            "description": "The kind of the owner (`user` or `team`).",
-            "example": "user",
-            "type": "string"
-          },
-          "login": {
-            "description": "The login name of the team or user.",
-            "example": "ghost",
-            "type": "string"
-          },
-          "name": {
-            "description": "The display name of the team or user.",
-            "example": "Kate Morgan",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "url": {
-            "description": "The URL to the owner's profile.",
-            "example": "https://github.com/ghost",
-            "type": [
-              "string",
-              "null"
-            ]
+          {
+            "description": "A team owner.",
+            "properties": {
+              "avatar": {
+                "description": "The team's avatar URL.",
+                "example": "https://avatars2.githubusercontent.com/u/1234567?v=4",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "id": {
+                "description": "The opaque identifier for the team.",
+                "example": 42,
+                "format": "int32",
+                "type": "integer"
+              },
+              "kind": {
+                "enum": [
+                  "team"
+                ],
+                "type": "string"
+              },
+              "login": {
+                "description": "The team's login name.",
+                "example": "github:rust-lang:crates-io",
+                "type": "string"
+              },
+              "name": {
+                "description": "The team's display name.",
+                "example": "Crates.io team",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "url": {
+                "description": "The URL to the team's GitHub profile.",
+                "example": "https://github.com/rust-lang",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "login",
+              "url",
+              "name",
+              "avatar",
+              "kind"
+            ],
+            "type": "object"
           }
-        },
-        "required": [
-          "id",
-          "login",
-          "kind",
-          "url",
-          "name",
-          "avatar"
-        ],
-        "type": "object"
+        ]
       },
       "PublishWarnings": {
         "properties": {

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -838,61 +838,121 @@ expression: response.json()
         "type": "object"
       },
       "Owner": {
-        "properties": {
-          "avatar": {
-            "description": "The avatar URL of the team or user.",
-            "example": "https://avatars2.githubusercontent.com/u/1234567?v=4",
-            "type": [
-              "string",
-              "null"
-            ]
+        "description": "A user or team that owns a crate.",
+        "oneOf": [
+          {
+            "description": "A user owner.",
+            "properties": {
+              "avatar": {
+                "description": "The user's avatar URL.",
+                "example": "https://avatars2.githubusercontent.com/u/1234567?v=4",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "github_username_matches": {
+                "description": "Whether a linked GitHub username exactly matches the crates.io username.",
+                "type": "boolean"
+              },
+              "id": {
+                "description": "The opaque identifier for the user.",
+                "example": 42,
+                "format": "int32",
+                "type": "integer"
+              },
+              "kind": {
+                "enum": [
+                  "user"
+                ],
+                "type": "string"
+              },
+              "login": {
+                "description": "The crates.io username.",
+                "example": "ghost",
+                "type": "string"
+              },
+              "name": {
+                "description": "The user's display name.",
+                "example": "Kate Morgan",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "url": {
+                "description": "The URL to the user's GitHub profile.",
+                "example": "https://github.com/ghost",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "login",
+              "url",
+              "name",
+              "avatar",
+              "github_username_matches",
+              "kind"
+            ],
+            "type": "object"
           },
-          "github_username_matches": {
-            "description": "Whether a linked GitHub username exactly matches the crates.io username.\n\nThis field is present only for user owners.",
-            "type": "boolean"
-          },
-          "id": {
-            "description": "The opaque identifier for the team or user, depending on the `kind` field.",
-            "example": 42,
-            "format": "int32",
-            "type": "integer"
-          },
-          "kind": {
-            "description": "The kind of the owner (`user` or `team`).",
-            "example": "user",
-            "type": "string"
-          },
-          "login": {
-            "description": "The login name of the team or user.",
-            "example": "ghost",
-            "type": "string"
-          },
-          "name": {
-            "description": "The display name of the team or user.",
-            "example": "Kate Morgan",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "url": {
-            "description": "The URL to the owner's profile.",
-            "example": "https://github.com/ghost",
-            "type": [
-              "string",
-              "null"
-            ]
+          {
+            "description": "A team owner.",
+            "properties": {
+              "avatar": {
+                "description": "The team's avatar URL.",
+                "example": "https://avatars2.githubusercontent.com/u/1234567?v=4",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "id": {
+                "description": "The opaque identifier for the team.",
+                "example": 42,
+                "format": "int32",
+                "type": "integer"
+              },
+              "kind": {
+                "enum": [
+                  "team"
+                ],
+                "type": "string"
+              },
+              "login": {
+                "description": "The team's login name.",
+                "example": "github:rust-lang:crates-io",
+                "type": "string"
+              },
+              "name": {
+                "description": "The team's display name.",
+                "example": "Crates.io team",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "url": {
+                "description": "The URL to the team's GitHub profile.",
+                "example": "https://github.com/rust-lang",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "login",
+              "url",
+              "name",
+              "avatar",
+              "kind"
+            ],
+            "type": "object"
           }
-        },
-        "required": [
-          "id",
-          "login",
-          "kind",
-          "url",
-          "name",
-          "avatar"
-        ],
-        "type": "object"
+        ]
       },
       "PublishWarnings": {
         "properties": {

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -1,10 +1,18 @@
 use crate::builders::{CrateBuilder, PublishBuilder};
 use crate::{OwnerTeamsResponse, RequestHelper, TestApp, add_team_to_crate, new_team};
 use crates_io::models::{Crate, CrateOwner, NewTeam};
+use crates_io::views::EncodableOwner;
 
 use diesel::*;
 use diesel_async::RunQueryDsl;
 use insta::assert_snapshot;
+
+fn team_login(owner: &EncodableOwner) -> &str {
+    let EncodableOwner::Team { login, .. } = owner else {
+        panic!("expected a team owner");
+    };
+    login
+}
 
 impl crate::util::MockAnonymousUser {
     /// Lists the team owners of the specified crate.
@@ -119,7 +127,7 @@ async fn add_renamed_team() -> anyhow::Result<()> {
 
     let json = anon.crate_owner_teams("foo_renamed_team").await.good();
     assert_eq!(json.teams.len(), 1);
-    assert_eq!(json.teams[0].login, "github:test-org:core");
+    assert_eq!(team_login(&json.teams[0]), "github:test-org:core");
 
     Ok(())
 }
@@ -149,7 +157,7 @@ async fn add_team_mixed_case() -> anyhow::Result<()> {
 
     let json = anon.crate_owner_teams("foo_mixed_case").await.good();
     assert_eq!(json.teams.len(), 1);
-    assert_eq!(json.teams[0].login, "github:test-org:core");
+    assert_eq!(team_login(&json.teams[0]), "github:test-org:core");
 
     Ok(())
 }
@@ -178,7 +186,7 @@ async fn add_team_as_org_owner() -> anyhow::Result<()> {
 
     let json = anon.crate_owner_teams("foo_org_owner").await.good();
     assert_eq!(json.teams.len(), 1);
-    assert_eq!(json.teams[0].login, "github:test-org:core");
+    assert_eq!(team_login(&json.teams[0]), "github:test-org:core");
 
     Ok(())
 }

--- a/svelte/src/lib/components/CrateHeader.stories.svelte
+++ b/svelte/src/lib/components/CrateHeader.stories.svelte
@@ -40,6 +40,7 @@
       url: 'https://github.com/johndoe',
       name: 'John Doe',
       avatar: 'https://avatars.githubusercontent.com/u/1234567?v=4',
+      github_username_matches: true,
     },
   ];
 

--- a/svelte/src/lib/components/OwnersList.stories.svelte
+++ b/svelte/src/lib/components/OwnersList.stories.svelte
@@ -1,41 +1,48 @@
-<script module>
+<script module lang="ts">
+  import type { components } from '@crates-io/api-client';
+
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
   import OwnersList from './OwnersList.svelte';
+
+  type Owner = components['schemas']['Owner'];
 
   const { Story } = defineMeta({
     title: 'OwnersList',
     component: OwnersList,
   });
 
-  const JANE_DOE = {
+  const JANE_DOE: Owner = {
     id: 1,
     kind: 'user',
     name: 'Jane Doe',
     login: 'janedoe',
     avatar: 'https://avatars.githubusercontent.com/u/1?v=4',
     url: 'https://github.com/janedoe',
+    github_username_matches: true,
   };
 
-  const JOHN_SMITH = {
+  const JOHN_SMITH: Owner = {
     id: 2,
     kind: 'user',
     name: 'John Smith',
     login: 'johnsmith',
     avatar: 'https://avatars.githubusercontent.com/u/2?v=4',
     url: 'https://github.com/johnsmith',
+    github_username_matches: true,
   };
 
-  const ANONYMOUS = {
+  const ANONYMOUS: Owner = {
     id: 3,
     kind: 'user',
     name: null,
     login: 'anonymous',
     avatar: 'https://avatars.githubusercontent.com/u/3?v=4',
     url: 'https://github.com/anonymous',
+    github_username_matches: true,
   };
 
-  const RUST_TEAM = {
+  const RUST_TEAM: Owner = {
     id: 5_430_905,
     kind: 'team',
     name: 'core',
@@ -44,7 +51,7 @@
     url: 'https://github.com/crates-io',
   };
 
-  const ANOTHER_TEAM = {
+  const ANOTHER_TEAM: Owner = {
     id: 5_430_906,
     kind: 'team',
     name: 'admins',
@@ -53,52 +60,57 @@
     url: 'https://github.com/crates-io',
   };
 
-  const USER_4 = {
+  const USER_4: Owner = {
     id: 4,
     kind: 'user',
     name: 'User Four',
     login: 'user4',
     avatar: 'https://avatars.githubusercontent.com/u/4?v=4',
     url: 'https://github.com/user4',
+    github_username_matches: true,
   };
 
-  const USER_5 = {
+  const USER_5: Owner = {
     id: 5,
     kind: 'user',
     name: 'User Five',
     login: 'user5',
     avatar: 'https://avatars.githubusercontent.com/u/5?v=4',
     url: 'https://github.com/user5',
+    github_username_matches: true,
   };
 
-  const USER_6 = {
+  const USER_6: Owner = {
     id: 6,
     kind: 'user',
     name: 'User Six',
     login: 'user6',
     avatar: 'https://avatars.githubusercontent.com/u/6?v=4',
     url: 'https://github.com/user6',
+    github_username_matches: true,
   };
 
-  const NO_AVATAR_USER = {
+  const NO_AVATAR_USER: Owner = {
     id: 7,
     kind: 'user',
     name: 'Avatarless Andy',
     login: 'avatarless',
     avatar: null,
     url: 'https://github.com/avatarless',
+    github_username_matches: true,
   };
 
-  const NO_AVATAR_ANON = {
+  const NO_AVATAR_ANON: Owner = {
     id: 8,
     kind: 'user',
     name: null,
     login: 'noname',
     avatar: null,
     url: 'https://github.com/noname',
+    github_username_matches: true,
   };
 
-  const NO_AVATAR_TEAM = {
+  const NO_AVATAR_TEAM: Owner = {
     id: 9,
     kind: 'team',
     name: 'maintainers',

--- a/svelte/src/lib/components/OwnersList.svelte.test.ts
+++ b/svelte/src/lib/components/OwnersList.svelte.test.ts
@@ -18,6 +18,7 @@ function createUser(id: number, options: { name?: string | null; login?: string 
     name,
     avatar: `https://avatars.githubusercontent.com/u/${id}?v=4`,
     url: `https://github.com/${login}`,
+    github_username_matches: true,
   };
 }
 

--- a/svelte/src/lib/components/UserAvatar.stories.svelte
+++ b/svelte/src/lib/components/UserAvatar.stories.svelte
@@ -1,7 +1,11 @@
-<script module>
+<script module lang="ts">
+  import type { ComponentProps } from 'svelte';
+
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
   import UserAvatar from './UserAvatar.svelte';
+
+  type AvatarUser = ComponentProps<typeof UserAvatar>['user'];
 
   const { Story } = defineMeta({
     title: 'UserAvatar',
@@ -14,58 +18,46 @@
     },
   });
 
-  const JANE_DOE = {
-    id: 1,
+  const JANE_DOE: AvatarUser = {
     kind: 'user',
     name: 'Jane Doe',
     login: 'janedoe',
     avatar: 'https://avatars.githubusercontent.com/u/1?v=4',
-    url: 'https://github.com/janedoe',
   };
 
-  const ANON_123 = {
-    id: 2,
+  const ANON_123: AvatarUser = {
     kind: 'user',
     name: null,
     login: 'anon123',
     avatar: 'https://avatars.githubusercontent.com/u/2?v=4',
-    url: 'https://github.com/anon123',
   };
 
-  const RUST_TEAM = {
-    id: 5_430_905,
+  const RUST_TEAM: AvatarUser = {
     kind: 'team',
     name: 'Rust Team',
     login: 'rust-lang',
     avatar: 'https://avatars.githubusercontent.com/u/5430905?v=4',
-    url: 'https://github.com/rust-lang',
   };
 
-  const NO_AVATAR_USER = {
-    id: 3,
+  const NO_AVATAR_USER: AvatarUser = {
     kind: 'user',
     name: 'Jane Doe',
     login: 'janedoe',
     avatar: null,
-    url: 'https://github.com/janedoe',
   };
 
-  const NO_AVATAR_ANON = {
-    id: 4,
+  const NO_AVATAR_ANON: AvatarUser = {
     kind: 'user',
     name: null,
     login: 'anon123',
     avatar: null,
-    url: 'https://github.com/anon123',
   };
 
-  const NO_AVATAR_TEAM = {
-    id: 5,
+  const NO_AVATAR_TEAM: AvatarUser = {
     kind: 'team',
     name: 'Rust Team',
     login: 'rust-lang',
     avatar: null,
-    url: 'https://github.com/rust-lang',
   };
 </script>
 

--- a/svelte/src/lib/components/UserAvatar.svelte
+++ b/svelte/src/lib/components/UserAvatar.svelte
@@ -7,7 +7,7 @@
 
   interface AvatarUser {
     avatar?: string | null;
-    kind?: string;
+    kind: 'user' | 'team';
     login: string;
     name?: string | null;
   }
@@ -27,15 +27,7 @@
 
   let alt = $derived(user.name ? `${user.name} (${user.login})` : `(${user.login})`);
 
-  let title = $derived.by(() => {
-    if (!user.kind || user.kind === 'user') {
-      return user.name;
-    } else if (user.kind === 'team') {
-      return `${user.name} team`;
-    } else {
-      return `${user.name} (${user.kind})`;
-    }
-  });
+  let title = $derived(user.kind === 'team' ? `${user.name} team` : user.name);
 
   let src = $derived(user.avatar ? `${user.avatar}&s=${sizeValue * 2}` : avatarPlaceholder);
 </script>

--- a/svelte/src/lib/components/UserAvatar.svelte
+++ b/svelte/src/lib/components/UserAvatar.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
-  import type { components } from '@crates-io/api-client';
   import type { HTMLImgAttributes } from 'svelte/elements';
 
   import avatarPlaceholder from '$lib/assets/avatar-placeholder.svg';
 
   type Size = 'small' | 'medium-small' | 'medium';
-  type Owner = components['schemas']['Owner'];
+
+  interface AvatarUser {
+    avatar?: string | null;
+    kind?: string;
+    login: string;
+    name?: string | null;
+  }
 
   interface Props extends Omit<HTMLImgAttributes, 'src' | 'width' | 'height' | 'alt'> {
-    user: Owner;
+    user: AvatarUser;
     size?: Size;
   }
 

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebar.stories.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebar.stories.svelte
@@ -116,6 +116,7 @@
       login: 'dtolnay',
       avatar: 'https://avatars.githubusercontent.com/u/1940490?v=4',
       url: 'https://github.com/dtolnay',
+      github_username_matches: true,
     },
     {
       id: 2,
@@ -124,6 +125,7 @@
       login: 'erickt',
       avatar: 'https://avatars.githubusercontent.com/u/315?v=4',
       url: 'https://github.com/erickt',
+      github_username_matches: true,
     },
   ];
 
@@ -136,6 +138,7 @@
       login: 'alice',
       avatar: 'https://avatars.githubusercontent.com/u/3?v=4',
       url: 'https://github.com/alice',
+      github_username_matches: true,
     },
     {
       id: 4,
@@ -144,6 +147,7 @@
       login: 'bob',
       avatar: 'https://avatars.githubusercontent.com/u/4?v=4',
       url: 'https://github.com/bob',
+      github_username_matches: true,
     },
     {
       id: 5,
@@ -152,6 +156,7 @@
       login: 'charlie',
       avatar: 'https://avatars.githubusercontent.com/u/5?v=4',
       url: 'https://github.com/charlie',
+      github_username_matches: true,
     },
     {
       id: 6,
@@ -160,6 +165,7 @@
       login: 'diana',
       avatar: 'https://avatars.githubusercontent.com/u/6?v=4',
       url: 'https://github.com/diana',
+      github_username_matches: true,
     },
   ];
 </script>

--- a/svelte/src/lib/components/crate-sidebar/PlaygroundButton.svelte.test.ts
+++ b/svelte/src/lib/components/crate-sidebar/PlaygroundButton.svelte.test.ts
@@ -92,6 +92,7 @@ function createOwner(id: number): Owner {
     name: `User ${id}`,
     avatar: `https://avatars.githubusercontent.com/u/${id}?v=4`,
     url: `https://github.com/user-${id}`,
+    github_username_matches: true,
   };
 }
 

--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -21,7 +21,6 @@
 
   type Version = components['schemas']['Version'];
   type User = components['schemas']['User'];
-  type Owner = components['schemas']['Owner'];
 
   interface Feature {
     name: string;
@@ -98,7 +97,7 @@
     return null;
   });
 
-  let publishedBy = $derived.by((): Owner | null => {
+  let publishedBy = $derived.by(() => {
     let user = version.published_by as User | null | undefined;
     if (!user) return null;
     return { ...user, kind: 'user', url: user.url ?? null };

--- a/svelte/src/lib/components/version-list/Row.svelte
+++ b/svelte/src/lib/components/version-list/Row.svelte
@@ -21,6 +21,7 @@
 
   type Version = components['schemas']['Version'];
   type User = components['schemas']['User'];
+  type PublishedBy = User & { kind: 'user' };
 
   interface Feature {
     name: string;
@@ -97,7 +98,7 @@
     return null;
   });
 
-  let publishedBy = $derived.by(() => {
+  let publishedBy = $derived.by((): PublishedBy | null => {
     let user = version.published_by as User | null | undefined;
     if (!user) return null;
     return { ...user, kind: 'user', url: user.url ?? null };


### PR DESCRIPTION
Crate owner responses use `kind` to distinguish users from teams, but the generated `Owner` type currently combines both shapes and permits field combinations that the API cannot return. This models `EncodableOwner` as an internally tagged enum while preserving the serialized response shape, allowing generated clients to narrow owner-specific fields from `kind`.

`UserAvatar` now accepts only the shared avatar fields instead of depending on the complete `Owner` schema. Its `kind` property is limited to `user` and `team`, and the affected MSW handlers and frontend fixtures use the stricter variants.

### Related

- https://github.com/rust-lang/crates.io/pull/14509