### PR TITLE
controllers/user: Return requested linked accounts

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -853,6 +853,42 @@ impl From<PublicUser> for EncodablePublicUser {
     }
 }
 
+/// This type contains public data for an external account of a crates.io user.
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, utoipa::ToSchema)]
+#[schema(as = LinkedAccount)]
+#[serde(tag = "provider")]
+pub enum EncodableLinkedAccount {
+    /// A linked GitHub account.
+    #[serde(rename = "github")]
+    GitHub {
+        /// The stable GitHub account ID.
+        account_id: String,
+
+        /// The GitHub username.
+        login: String,
+
+        /// The GitHub avatar URL.
+        #[schema(required)]
+        avatar: Option<String>,
+
+        /// The GitHub profile URL.
+        url: String,
+    },
+}
+
+impl EncodableLinkedAccount {
+    /// Creates a public linked GitHub account.
+    pub fn github(account_id: i64, login: String, avatar: Option<String>) -> Self {
+        let url = format!("https://github.com/{login}");
+        Self::GitHub {
+            account_id: account_id.to_string(),
+            login,
+            avatar,
+            url,
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug, utoipa::ToSchema)]
 pub struct EncodableAuditAction {
     /// The action that was performed.

--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -870,21 +870,16 @@ pub enum EncodableLinkedAccount {
         /// The GitHub avatar URL.
         #[schema(required)]
         avatar: Option<String>,
-
-        /// The GitHub profile URL.
-        url: String,
     },
 }
 
 impl EncodableLinkedAccount {
     /// Creates a public linked GitHub account.
     pub fn github(account_id: i64, login: String, avatar: Option<String>) -> Self {
-        let url = format!("https://github.com/{login}");
         Self::GitHub {
             account_id: account_id.to_string(),
             login,
             avatar,
-            url,
         }
     }
 }

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -1526,6 +1526,19 @@ export interface components {
              */
             inviter_id: number;
         };
+        /** @description This type contains public data for an external account of a crates.io user. */
+        LinkedAccount: {
+            /** @description The stable GitHub account ID. */
+            account_id: string;
+            /** @description The GitHub avatar URL. */
+            avatar: string | null;
+            /** @description The GitHub username. */
+            login: string;
+            /** @enum {string} */
+            provider: "github";
+            /** @description The GitHub profile URL. */
+            url: string;
+        };
         /** @description A user or team that owns a crate. */
         Owner: {
             /**
@@ -5428,7 +5441,18 @@ export interface operations {
     };
     find_user: {
         parameters: {
-            query?: never;
+            query?: {
+                /**
+                 * @description Additional data to include in the response.
+                 *
+                 *     Valid values: `linked_accounts`.
+                 *
+                 *     Defaults to no additional data.
+                 *
+                 *     This parameter expects a comma-separated list of values.
+                 */
+                include?: string;
+            };
             header?: never;
             path: {
                 /** @description crates.io username */
@@ -5445,6 +5469,8 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
+                        /** @description Public linked accounts, if the client requested them. */
+                        linked_accounts?: components["schemas"]["LinkedAccount"][];
                         user: components["schemas"]["User"];
                     };
                 };
@@ -5538,6 +5564,9 @@ export const pathsApiPrivateSessionAuthorizePostResponses200ContentApplicationJs
     status: unknown;
 }>["status"]> = ["signup_required"];
 export const endpointScopeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["EndpointScope"]> = ["publish-new", "publish-update", "trusted-publishing", "yank", "change-owners"];
+export const linkedAccountOneOf0ProviderValues: ReadonlyArray<Extract<FlattenedDeepRequired<components>["schemas"]["LinkedAccount"], {
+    provider: unknown;
+}>["provider"]> = ["github"];
 export const ownerOneOf0KindValues: ReadonlyArray<Extract<FlattenedDeepRequired<components>["schemas"]["Owner"], {
     kind: unknown;
 }>["kind"]> = ["user"];

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -1536,8 +1536,6 @@ export interface components {
             login: string;
             /** @enum {string} */
             provider: "github";
-            /** @description The GitHub profile URL. */
-            url: string;
         };
         /** @description A user or team that owns a crate. */
         Owner: {

--- a/packages/crates-io-msw/handlers/users/get.test.ts
+++ b/packages/crates-io-msw/handlers/users/get.test.ts
@@ -27,8 +27,42 @@ test('returns a user object for known users', async function () {
 
   let response = await fetch('/api/v1/users/Crates_User');
   expect(response.status).toBe(200);
-  expect(await response.json()).toMatchInlineSnapshot(`
+  let body = await response.json();
+  expect(body).not.toHaveProperty('linked_accounts');
+  expect(body).toMatchInlineSnapshot(`
     {
+      "user": {
+        "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
+        "created_at": null,
+        "github_username_matches": true,
+        "id": 1,
+        "login": "crates-user",
+        "name": "User 1",
+        "url": "https://github.com/github-user",
+      },
+    }
+  `);
+
+  let expandedResponse = await fetch('/api/v1/users/Crates_User?include=linked_accounts');
+  expect(expandedResponse.status).toBe(200);
+  expect(await expandedResponse.json()).toMatchInlineSnapshot(`
+    {
+      "linked_accounts": [
+        {
+          "account_id": "10",
+          "avatar": null,
+          "login": "github-user",
+          "provider": "github",
+          "url": "https://github.com/github-user",
+        },
+        {
+          "account_id": "11",
+          "avatar": null,
+          "login": "crates-user",
+          "provider": "github",
+          "url": "https://github.com/crates-user",
+        },
+      ],
       "user": {
         "avatar": "https://avatars1.githubusercontent.com/u/14631425?v=4",
         "created_at": null,

--- a/packages/crates-io-msw/handlers/users/get.test.ts
+++ b/packages/crates-io-msw/handlers/users/get.test.ts
@@ -53,14 +53,12 @@ test('returns a user object for known users', async function () {
           "avatar": null,
           "login": "github-user",
           "provider": "github",
-          "url": "https://github.com/github-user",
         },
         {
           "account_id": "11",
           "avatar": null,
           "login": "crates-user",
           "provider": "github",
-          "url": "https://github.com/crates-user",
         },
       ],
       "user": {

--- a/packages/crates-io-msw/handlers/users/get.ts
+++ b/packages/crates-io-msw/handlers/users/get.ts
@@ -1,5 +1,5 @@
 import { db } from '../../index.js';
-import { serializeUser } from '../../serializers/user.js';
+import { serializeLinkedAccount, serializeUser } from '../../serializers/user.js';
 import { notFoundError } from '../../utils/handlers.js';
 import { http } from '../../utils/openapi-http.js';
 
@@ -7,7 +7,9 @@ function canonUsername(username: string) {
   return username.toLowerCase().replaceAll('-', '_');
 }
 
-export default http.get('/api/v1/users/{user}', ({ params, response }) => {
+export default http.get('/api/v1/users/{user}', ({ params, request, response }) => {
+  let includeLinkedAccounts = new URL(request.url).searchParams.get('include')?.split(',').includes('linked_accounts');
+
   let name = canonUsername(params.user);
   let user = db.user.findMany(q => q.where(user => canonUsername(user.login) === name), {
     orderBy: { id: 'desc' },
@@ -16,5 +18,10 @@ export default http.get('/api/v1/users/{user}', ({ params, response }) => {
     return response('4XX').json(notFoundError(), { status: 404 });
   }
 
-  return response(200).json({ user: serializeUser(user) });
+  return response(200).json({
+    user: serializeUser(user),
+    ...(includeLinkedAccounts && {
+      linked_accounts: user.githubAccounts.map(serializeLinkedAccount),
+    }),
+  });
 });

--- a/packages/crates-io-msw/serializers/user.ts
+++ b/packages/crates-io-msw/serializers/user.ts
@@ -11,7 +11,6 @@ export function serializeLinkedAccount(account: User['githubAccounts'][number]):
     account_id: account.accountId,
     login: account.login,
     avatar: account.avatar,
-    url: `https://github.com/${account.login}`,
   };
 }
 

--- a/packages/crates-io-msw/serializers/user.ts
+++ b/packages/crates-io-msw/serializers/user.ts
@@ -3,6 +3,17 @@ import type { User } from '../models/index.js';
 
 type ApiUser = components['schemas']['User'];
 type ApiAuthenticatedUser = components['schemas']['AuthenticatedUser'];
+type ApiLinkedAccount = components['schemas']['LinkedAccount'];
+
+export function serializeLinkedAccount(account: User['githubAccounts'][number]): ApiLinkedAccount {
+  return {
+    provider: 'github',
+    account_id: account.accountId,
+    login: account.login,
+    avatar: account.avatar,
+    url: `https://github.com/${account.login}`,
+  };
+}
 
 export function serializeUser(user: User): ApiUser;
 export function serializeUser(user: User, options: { removePrivateData?: true }): ApiUser;

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -1,19 +1,41 @@
 use crate::app::AppState;
 use crate::models::{CrateOwner, OwnerKind, PublicUser, users_by_username};
 use crate::schema::{crate_downloads, crate_owners, crates, oauth_github};
-use crate::util::errors::AppResult;
-use crate::views::EncodablePublicUser;
+use crate::util::errors::{AppResult, BoxedAppError, bad_request};
+use crate::views::{EncodableLinkedAccount, EncodablePublicUser};
 use axum::Json;
-use axum::extract::Path;
+use axum::extract::{FromRequestParts, Path};
+use axum_extra::extract::Query;
 use bigdecimal::{BigDecimal, ToPrimitive};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// Query parameters for finding a user.
+#[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
+#[from_request(via(Query))]
+#[into_params(parameter_in = Query)]
+pub struct UserQueryParams {
+    /// Additional data to include in the response.
+    ///
+    /// Valid values: `linked_accounts`.
+    ///
+    /// Defaults to no additional data.
+    ///
+    /// This parameter expects a comma-separated list of values.
+    include: Option<String>,
+}
 
 /// Response returned when getting a user by login.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct UserGetResponse {
     pub user: EncodablePublicUser,
+
+    /// Public linked accounts, if the client requested them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub linked_accounts: Option<Vec<EncodableLinkedAccount>>,
 }
 
 /// Find user by login.
@@ -22,6 +44,7 @@ pub struct UserGetResponse {
     path = "/api/v1/users/{user}",
     params(
         ("user" = String, Path, description = "crates.io username"),
+        UserQueryParams,
     ),
     tag = "users",
     responses(
@@ -33,8 +56,15 @@ pub struct UserGetResponse {
 pub async fn find_user(
     state: AppState,
     Path(user_name): Path<String>,
+    params: UserQueryParams,
 ) -> AppResult<Json<UserGetResponse>> {
     let mut conn = state.db_read_prefer_primary().await?;
+    let include = params
+        .include
+        .as_deref()
+        .map(ShowIncludeMode::from_str)
+        .transpose()?
+        .unwrap_or_default();
 
     let user = users_by_username(&user_name)
         .left_join(oauth_github::table)
@@ -42,7 +72,56 @@ pub async fn find_user(
         .first(&mut conn)
         .await?;
 
-    Ok(Json(UserGetResponse { user: user.into() }))
+    let linked_accounts = if include.linked_accounts {
+        let accounts = oauth_github::table
+            .filter(oauth_github::user_id.eq(user.id))
+            .select((
+                oauth_github::account_id,
+                oauth_github::login,
+                oauth_github::avatar,
+            ))
+            .order(oauth_github::account_id.asc())
+            .load(&mut conn)
+            .await?;
+
+        let accounts = accounts
+            .into_iter()
+            .map(|(account_id, login, avatar)| {
+                EncodableLinkedAccount::github(account_id, login, avatar)
+            })
+            .collect();
+        Some(accounts)
+    } else {
+        None
+    };
+    Ok(Json(UserGetResponse {
+        user: user.into(),
+        linked_accounts,
+    }))
+}
+
+#[derive(Debug, Default)]
+struct ShowIncludeMode {
+    linked_accounts: bool,
+}
+
+impl FromStr for ShowIncludeMode {
+    type Err = BoxedAppError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        const INVALID_COMPONENT: &str =
+            "invalid component for ?include= (expected 'linked_accounts')";
+
+        let mut mode = Self::default();
+        for component in value.split(',') {
+            match component {
+                "" => {}
+                "linked_accounts" => mode.linked_accounts = true,
+                _ => return Err(bad_request(INVALID_COMPONENT)),
+            }
+        }
+        Ok(mode)
+    }
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -1,13 +1,15 @@
 use crate::util::{RequestHelper, TestApp};
+use claims::{assert_none, assert_ok, assert_some, assert_some_eq};
 use crates_io::models::{NewUser, User};
-use crates_io::views::EncodablePublicUser;
+use crates_io::views::{EncodableLinkedAccount, EncodablePublicUser};
 use crates_io_test_utils::builders::{OauthGithubBuilder, UserBuilder};
-use insta::assert_snapshot;
+use insta::{assert_json_snapshot, assert_snapshot};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct UserShowPublicResponse {
     pub user: EncodablePublicUser,
+    pub linked_accounts: Option<Vec<EncodableLinkedAccount>>,
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -23,6 +25,26 @@ async fn show() {
     let json: UserShowPublicResponse = anon.get("/api/v1/users/foo").await.good();
     assert_eq!(json.user.login, "foo");
     assert!(json.user.github_username_matches);
+    assert_none!(json.linked_accounts);
+
+    let url = "/api/v1/users/foo?include=linked_accounts";
+    let response = anon.get::<()>(url).await;
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_json_snapshot!(response.json(), {
+        ".user.created_at" => "[datetime]",
+        ".linked_accounts[].account_id" => insta::dynamic_redaction(|value, _path| {
+            let account_id = assert_some!(value.as_str());
+            assert_ok!(account_id.parse::<i64>());
+            "[account-id]"
+        }),
+    });
+
+    let response = anon.get::<()>("/api/v1/users/foo?include=unknown").await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(
+        response.text(),
+        @r#"{"errors":[{"detail":"invalid component for ?include= (expected 'linked_accounts')"}]}"#
+    );
 
     // Lookup by username is case insensitive; returned data uses capitalization in database
     let json: UserShowPublicResponse = anon.get("/api/v1/users/crates_bar").await.good();
@@ -96,7 +118,9 @@ async fn user_without_github_account() {
     // This user doesn't have a linked record in `oauth_github`
 
     // The crates.io username still exists
-    let json: UserShowPublicResponse = anon.get("/api/v1/users/fOObAr").await.good();
+    let url = "/api/v1/users/fOObAr?include=linked_accounts";
+    let json: UserShowPublicResponse = anon.get(url).await.good();
     assert_eq!("I deleted my github account", json.user.name.unwrap());
     assert!(!json.user.github_username_matches);
+    assert_some_eq!(json.linked_accounts, Vec::new());
 }

--- a/src/tests/routes/users/snapshots/integration__routes__users__read__show-2.snap
+++ b/src/tests/routes/users/snapshots/integration__routes__users__read__show-2.snap
@@ -8,8 +8,7 @@ expression: response.json()
       "account_id": "[account-id]",
       "avatar": null,
       "login": "foo",
-      "provider": "github",
-      "url": "https://github.com/foo"
+      "provider": "github"
     }
   ],
   "user": {

--- a/src/tests/routes/users/snapshots/integration__routes__users__read__show-2.snap
+++ b/src/tests/routes/users/snapshots/integration__routes__users__read__show-2.snap
@@ -1,0 +1,24 @@
+---
+source: src/tests/routes/users/read.rs
+expression: response.json()
+---
+{
+  "linked_accounts": [
+    {
+      "account_id": "[account-id]",
+      "avatar": null,
+      "login": "foo",
+      "provider": "github",
+      "url": "https://github.com/foo"
+    }
+  ],
+  "user": {
+    "avatar": null,
+    "created_at": "[datetime]",
+    "github_username_matches": true,
+    "id": 1,
+    "login": "foo",
+    "name": null,
+    "url": "https://github.com/foo"
+  }
+}

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -864,17 +864,12 @@ expression: response.json()
                   "github"
                 ],
                 "type": "string"
-              },
-              "url": {
-                "description": "The GitHub profile URL.",
-                "type": "string"
               }
             },
             "required": [
               "account_id",
               "login",
               "avatar",
-              "url",
               "provider"
             ],
             "type": "object"

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -838,6 +838,49 @@ expression: response.json()
         ],
         "type": "object"
       },
+      "LinkedAccount": {
+        "description": "This type contains public data for an external account of a crates.io user.",
+        "oneOf": [
+          {
+            "description": "A linked GitHub account.",
+            "properties": {
+              "account_id": {
+                "description": "The stable GitHub account ID.",
+                "type": "string"
+              },
+              "avatar": {
+                "description": "The GitHub avatar URL.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "login": {
+                "description": "The GitHub username.",
+                "type": "string"
+              },
+              "provider": {
+                "enum": [
+                  "github"
+                ],
+                "type": "string"
+              },
+              "url": {
+                "description": "The GitHub profile URL.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "account_id",
+              "login",
+              "avatar",
+              "url",
+              "provider"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "Owner": {
         "description": "A user or team that owns a crate.",
         "oneOf": [
@@ -6972,6 +7015,15 @@ expression: response.json()
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Additional data to include in the response.\n\nValid values: `linked_accounts`.\n\nDefaults to no additional data.\n\nThis parameter expects a comma-separated list of values.",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6981,6 +7033,13 @@ expression: response.json()
                 "schema": {
                   "description": "Response returned when getting a user by login.",
                   "properties": {
+                    "linked_accounts": {
+                      "description": "Public linked accounts, if the client requested them.",
+                      "items": {
+                        "$ref": "#/components/schemas/LinkedAccount"
+                      },
+                      "type": "array"
+                    },
                     "user": {
                       "$ref": "#/components/schemas/User"
                     }

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -838,6 +838,49 @@ expression: response.json()
         ],
         "type": "object"
       },
+      "LinkedAccount": {
+        "description": "This type contains public data for an external account of a crates.io user.",
+        "oneOf": [
+          {
+            "description": "A linked GitHub account.",
+            "properties": {
+              "account_id": {
+                "description": "The stable GitHub account ID.",
+                "type": "string"
+              },
+              "avatar": {
+                "description": "The GitHub avatar URL.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "login": {
+                "description": "The GitHub username.",
+                "type": "string"
+              },
+              "provider": {
+                "enum": [
+                  "github"
+                ],
+                "type": "string"
+              },
+              "url": {
+                "description": "The GitHub profile URL.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "account_id",
+              "login",
+              "avatar",
+              "url",
+              "provider"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "Owner": {
         "description": "A user or team that owns a crate.",
         "oneOf": [
@@ -5782,6 +5825,15 @@ expression: response.json()
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Additional data to include in the response.\n\nValid values: `linked_accounts`.\n\nDefaults to no additional data.\n\nThis parameter expects a comma-separated list of values.",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5791,6 +5843,13 @@ expression: response.json()
                 "schema": {
                   "description": "Response returned when getting a user by login.",
                   "properties": {
+                    "linked_accounts": {
+                      "description": "Public linked accounts, if the client requested them.",
+                      "items": {
+                        "$ref": "#/components/schemas/LinkedAccount"
+                      },
+                      "type": "array"
+                    },
                     "user": {
                       "$ref": "#/components/schemas/User"
                     }

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -864,17 +864,12 @@ expression: response.json()
                   "github"
                 ],
                 "type": "string"
-              },
-              "url": {
-                "description": "The GitHub profile URL.",
-                "type": "string"
               }
             },
             "required": [
               "account_id",
               "login",
               "avatar",
-              "url",
               "provider"
             ],
             "type": "object"


### PR DESCRIPTION
The Find User endpoint now accepts `include=linked_accounts` and returns public GitHub account details. Requests without the parameter keep the existing response shape, while users without linked accounts receive an empty array.

The OpenAPI schema, API client types, and MSW handler expose the same optional query and response data.

### Related

- Resolves https://github.com/rust-lang/crates.io/issues/14382