### PR TITLE
Extract user and team page header components

### DIFF
--- a/svelte/src/lib/components/TeamPageHeader.stories.svelte
+++ b/svelte/src/lib/components/TeamPageHeader.stories.svelte
@@ -1,0 +1,61 @@
+<script module lang="ts">
+  import type { ComponentProps } from 'svelte';
+
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import TeamPageHeader from './TeamPageHeader.svelte';
+
+  type Team = ComponentProps<typeof TeamPageHeader>['team'];
+
+  const { Story } = defineMeta({
+    title: 'TeamPageHeader',
+    component: TeamPageHeader,
+    tags: ['autodocs'],
+  });
+
+  const TEAM: Team = {
+    avatar: 'https://avatars.githubusercontent.com/u/5430905?v=4',
+    login: 'github:rust-lang:libs',
+    name: 'libs',
+    url: 'https://github.com/rust-lang',
+  };
+
+  const TEAM_WITHOUT_AVATAR: Team = {
+    ...TEAM,
+    avatar: null,
+  };
+
+  const TEAM_WITH_LONG_IDENTITY: Team = {
+    ...TEAM,
+    login: 'github:averylonggithuborganizationnamethatcannotfitintheavailableheaderwidth:maintainers',
+    name: 'A Very Long Team Name That Exceeds the Available Header Width',
+  };
+</script>
+
+<!-- This is using a single Story with multiple examples to reduce the amount of snapshots generated for visual regression testing -->
+<Story name="Combined" asChild>
+  <h1>Default</h1>
+  <TeamPageHeader team={TEAM} />
+
+  <h1>Without Avatar</h1>
+  <TeamPageHeader team={TEAM_WITHOUT_AVATAR} />
+
+  <h1>Long Identity</h1>
+  <div class="long-identity">
+    <TeamPageHeader team={TEAM_WITH_LONG_IDENTITY} />
+  </div>
+</Story>
+
+<style>
+  h1 {
+    font-size: 0.875rem;
+    font-weight: normal;
+    opacity: 0.2;
+    margin: 1rem 0 0.25rem;
+  }
+
+  .long-identity {
+    width: 500px;
+    max-width: 100%;
+  }
+</style>

--- a/svelte/src/lib/components/TeamPageHeader.svelte
+++ b/svelte/src/lib/components/TeamPageHeader.svelte
@@ -1,0 +1,79 @@
+<!--
+  @component
+  Renders the public team identity header.
+-->
+<script lang="ts">
+  import Icon from './Icon.svelte';
+  import PageHeader from './PageHeader.svelte';
+  import UserAvatar from './UserAvatar.svelte';
+
+  interface TeamPageHeaderTeam {
+    /** The team's avatar URL, if available. */
+    avatar?: string | null;
+
+    /** The team login in `github:organization:team` format. */
+    login: string;
+
+    /** The team name displayed below the organization. */
+    name: string | null;
+
+    /** The URL of the team's GitHub organization. */
+    url: string | null;
+  }
+
+  interface Props {
+    /** The public team identity displayed in the header. */
+    team: TeamPageHeaderTeam;
+  }
+
+  let { team }: Props = $props();
+
+  let orgName = $derived(team.login.split(':', 2)[1]);
+</script>
+
+<PageHeader style="display: flex; align-items: center;" data-test-heading>
+  <UserAvatar
+    user={{ avatar: team.avatar, kind: 'team', login: team.login, name: team.name }}
+    size="medium"
+    style="margin-right: var(--space-m)"
+    data-test-avatar
+  />
+  <div>
+    <div class="header-row">
+      <h1 data-test-org-name>{orgName}</h1>
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+      <a href={team.url} title={team.login} class="github-link" data-test-github-link>
+        <Icon class="i-simple-icons:github" label="GitHub profile" />
+      </a>
+    </div>
+    <h2 data-test-team-name>{team.name}</h2>
+  </div>
+</PageHeader>
+
+<style>
+  h1,
+  h2 {
+    margin: 0;
+    padding: 0;
+  }
+
+  h2 {
+    margin-top: var(--space-2xs);
+    color: var(--main-color-light);
+  }
+
+  .header-row {
+    display: flex;
+    align-items: center;
+  }
+
+  .github-link {
+    margin-left: var(--space-s);
+    --icon-size: 32px;
+
+    &,
+    &:hover {
+      color: var(--main-color);
+    }
+  }
+</style>

--- a/svelte/src/lib/components/UserPageHeader.stories.svelte
+++ b/svelte/src/lib/components/UserPageHeader.stories.svelte
@@ -1,0 +1,69 @@
+<script module lang="ts">
+  import type { ComponentProps } from 'svelte';
+
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import UserPageHeader from './UserPageHeader.svelte';
+
+  type User = ComponentProps<typeof UserPageHeader>['user'];
+
+  const { Story } = defineMeta({
+    title: 'UserPageHeader',
+    component: UserPageHeader,
+    tags: ['autodocs'],
+  });
+
+  const USER: User = {
+    avatar: 'https://avatars.githubusercontent.com/u/1?v=4',
+    login: 'janedoe',
+    name: 'Jane Doe',
+    url: 'https://github.com/janedoe',
+  };
+
+  const USER_WITHOUT_NAME: User = {
+    ...USER,
+    name: null,
+  };
+
+  const USER_WITHOUT_AVATAR: User = {
+    ...USER,
+    avatar: null,
+  };
+
+  const USER_WITH_LONG_IDENTITY: User = {
+    ...USER,
+    login: 'averylongcratesiousernamethatcannotfitintheavailableheaderwidth',
+    name: 'Alexandria Cassandra Montgomery-Worthington the Third',
+  };
+</script>
+
+<!-- This is using a single Story with multiple examples to reduce the amount of snapshots generated for visual regression testing -->
+<Story name="Combined" asChild>
+  <h1>Default</h1>
+  <UserPageHeader user={USER} />
+
+  <h1>Without Name</h1>
+  <UserPageHeader user={USER_WITHOUT_NAME} />
+
+  <h1>Without Avatar</h1>
+  <UserPageHeader user={USER_WITHOUT_AVATAR} />
+
+  <h1>Long Identity</h1>
+  <div class="long-identity">
+    <UserPageHeader user={USER_WITH_LONG_IDENTITY} />
+  </div>
+</Story>
+
+<style>
+  h1 {
+    font-size: 0.875rem;
+    font-weight: normal;
+    opacity: 0.2;
+    margin: 1rem 0 0.25rem;
+  }
+
+  .long-identity {
+    width: 500px;
+    max-width: 100%;
+  }
+</style>

--- a/svelte/src/lib/components/UserPageHeader.svelte
+++ b/svelte/src/lib/components/UserPageHeader.svelte
@@ -1,0 +1,58 @@
+<!--
+  @component
+  Renders the public user identity header.
+-->
+<script lang="ts">
+  import Icon from './Icon.svelte';
+  import PageHeader from './PageHeader.svelte';
+  import UserAvatar from './UserAvatar.svelte';
+
+  interface UserPageHeaderUser {
+    /** The user's avatar URL, if available. */
+    avatar?: string | null;
+
+    /** The username displayed in the page heading. */
+    login: string;
+
+    /** The user's optional display name. */
+    name?: string | null;
+
+    /** The URL of the user's GitHub profile. */
+    url: string;
+  }
+
+  interface Props {
+    /** The public user identity displayed in the header. */
+    user: UserPageHeaderUser;
+  }
+
+  let { user }: Props = $props();
+</script>
+
+<PageHeader style="display: flex; align-items: center; gap: var(--space-xs);" data-test-heading>
+  <UserAvatar
+    user={{ avatar: user.avatar, kind: 'user', login: user.login, name: user.name }}
+    size="medium"
+    data-test-avatar
+  />
+  <h1 data-test-username>{user.login}</h1>
+  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+  <a href={user.url} title={user.login} class="github-link" data-test-user-link>
+    <Icon class="i-simple-icons:github" label="GitHub profile" />
+  </a>
+</PageHeader>
+
+<style>
+  h1 {
+    margin: 0;
+  }
+
+  .github-link {
+    --icon-size: 32px;
+
+    &,
+    &:hover {
+      color: var(--main-color);
+    }
+  }
+</style>

--- a/svelte/src/routes/teams/[team_id]/+page.svelte
+++ b/svelte/src/routes/teams/[team_id]/+page.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import CrateList from '$lib/components/CrateList.svelte';
-  import Icon from '$lib/components/Icon.svelte';
-  import PageHeader from '$lib/components/PageHeader.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import ResultsCount from '$lib/components/ResultsCount.svelte';
   import * as SortDropdown from '$lib/components/sort-dropdown';
-  import UserAvatar from '$lib/components/UserAvatar.svelte';
+  import TeamPageHeader from '$lib/components/TeamPageHeader.svelte';
   import { calculatePagination } from '$lib/utils/pagination';
 
   const MAX_PAGES = 50;
@@ -13,9 +11,6 @@
   let { data } = $props();
 
   let pagination = $derived(calculatePagination(data.page, data.perPage, data.cratesResponse.meta.total, MAX_PAGES));
-
-  // login format is "github:org_name:team_name"
-  let orgName = $derived(data.team.login.split(':', 2)[1]);
 
   let currentSortBy = $derived.by(() => {
     if (data.sort === 'downloads') return 'All-Time Downloads';
@@ -26,24 +21,7 @@
   });
 </script>
 
-<PageHeader style="display: flex; align-items: center;" data-test-heading>
-  <UserAvatar
-    user={{ ...data.team, kind: 'team' }}
-    size="medium"
-    style="margin-right: var(--space-m)"
-    data-test-avatar
-  />
-  <div>
-    <div class="header-row">
-      <h1 data-test-org-name>{orgName}</h1>
-      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-      <a href={data.team.url} title={data.team.login} class="github-link" data-test-github-link>
-        <Icon class="i-simple-icons:github" label="GitHub profile" />
-      </a>
-    </div>
-    <h2 data-test-team-name>{data.team.name}</h2>
-  </div>
-</PageHeader>
+<TeamPageHeader team={data.team} />
 
 <div class="results-meta">
   <ResultsCount
@@ -69,32 +47,6 @@
 <Pagination {pagination} />
 
 <style>
-  h1,
-  h2 {
-    margin: 0;
-    padding: 0;
-  }
-
-  h2 {
-    margin-top: var(--space-2xs);
-    color: var(--main-color-light);
-  }
-
-  .header-row {
-    display: flex;
-    align-items: center;
-  }
-
-  .github-link {
-    margin-left: var(--space-s);
-    --icon-size: 32px;
-
-    &,
-    &:hover {
-      color: var(--main-color);
-    }
-  }
-
   .results-meta {
     display: flex;
     align-items: center;

--- a/svelte/src/routes/users/[user_id]/+page.svelte
+++ b/svelte/src/routes/users/[user_id]/+page.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import CrateList from '$lib/components/CrateList.svelte';
-  import Icon from '$lib/components/Icon.svelte';
-  import PageHeader from '$lib/components/PageHeader.svelte';
   import Pagination from '$lib/components/Pagination.svelte';
   import ResultsCount from '$lib/components/ResultsCount.svelte';
   import * as SortDropdown from '$lib/components/sort-dropdown';
-  import UserAvatar from '$lib/components/UserAvatar.svelte';
+  import UserPageHeader from '$lib/components/UserPageHeader.svelte';
   import { calculatePagination } from '$lib/utils/pagination';
 
   const MAX_PAGES = 50;
@@ -23,14 +21,7 @@
   });
 </script>
 
-<PageHeader style="display: flex; align-items: center; gap: var(--space-xs);" data-test-heading>
-  <UserAvatar user={{ ...data.user, kind: 'user' }} size="medium" data-test-avatar />
-  <h1 data-test-username>{data.user.login}</h1>
-  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-  <a href={data.user.url} title={data.user.login} class="github-link" data-test-user-link>
-    <Icon class="i-simple-icons:github" label="GitHub profile" />
-  </a>
-</PageHeader>
+<UserPageHeader user={data.user} />
 
 <div class="results-meta">
   <ResultsCount
@@ -56,19 +47,6 @@
 <Pagination {pagination} />
 
 <style>
-  h1 {
-    margin: 0;
-  }
-
-  .github-link {
-    --icon-size: 32px;
-
-    &,
-    &:hover {
-      color: var(--main-color);
-    }
-  }
-
   .results-meta {
     display: flex;
     align-items: center;


### PR DESCRIPTION
This PR extracts the user and team page headers into dedicated `UserPageHeader` and `TeamPageHeader` components. I've also added a couple of Storybook stories to provide baseline coverage for default, missing-avatar, missing-name, and long-identity states.

This also revealed a few layout bugs that I'll fix in one of the follow-up PRs:

<img width="976" height="514" alt="Bildschirmfoto 2026-08-25 um 19 43 49" src="https://github.com/user-attachments/assets/2085a643-59f0-46aa-8911-db917097ce6b" />
