### PR TITLE
docs: Use Datadog's standard `duration` field

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -45,7 +45,9 @@ nothing. Say which operation failed for what input.
   a reserved word in Rust.
 - Use the same name for the same thing everywhere, so a single query finds every
   occurrence.
-- Put the unit in the name for measurements: `duration_ms`, `size_bytes`.
+- Use Datadog's standard `duration` field for durations, expressed in
+  nanoseconds. Put the unit in the name for other measurements, such as
+  `size_bytes`.
 - Use `tracing`'s sigils to control how a value is recorded: `%value` for its
   `Display` representation, `?value` for its `Debug` representation.
 


### PR DESCRIPTION
Datadog treats `duration` as a standard log attribute measured in nanoseconds. Document that convention explicitly instead of recommending unit-suffixed duration fields such as `duration_ms`.

Other measurements should continue to include their units in their field names, such as `size_bytes`, when no corresponding standard Datadog attribute applies.