### PR TITLE
admin/delete-crate: Use crates.io username for `--deleted-by`

### DIFF
--- a/crates/crates_io_database/src/models/mod.rs
+++ b/crates/crates_io_database/src/models/mod.rs
@@ -18,7 +18,7 @@ pub use self::owner::{CrateOwner, Owner, OwnerKind};
 pub use self::team::{NewTeam, Team};
 pub use self::token::ApiToken;
 pub use self::trustpub::TrustpubData;
-pub use self::user::{NewOauthGithub, NewUser, OauthGithub, PublicUser, User};
+pub use self::user::{NewOauthGithub, NewUser, OauthGithub, PublicUser, User, users_by_username};
 pub use self::version::{NewVersion, TopVersions, Version};
 
 pub mod helpers;

--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -7,7 +7,7 @@ use diesel::upsert::excluded;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::Serialize;
 
-use crate::fns::lower;
+use crate::fns::{canon_username, lower};
 use crate::models::{Crate, CrateOwner, Email, OwnerKind};
 use crate::schema::{crate_owners, emails, oauth_github, users};
 
@@ -27,6 +27,14 @@ pub fn github_username_matches() -> _ {
     let username_matches = account.field(oauth_github::login).eq(users::username);
 
     exists(account.filter(belongs_to_user).filter(username_matches))
+}
+
+/// Finds users whose crates.io username matches the given name.
+#[diesel::dsl::auto_type]
+pub fn users_by_username<'a>(username: &'a str) -> _ {
+    users::table
+        .filter(canon_username(users::username).eq(canon_username(username)))
+        .order(users::id.desc())
 }
 
 /// Public data for a crates.io user.

--- a/crates/crates_io_database/tests/user.rs
+++ b/crates/crates_io_database/tests/user.rs
@@ -1,0 +1,38 @@
+use crates_io_database::models::{NewUser, users_by_username};
+use crates_io_database::schema::users;
+use crates_io_test_db::TestDatabase;
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+
+#[tokio::test]
+async fn find_latest_user_by_canonical_username() {
+    let test_db = TestDatabase::new();
+    let mut conn = test_db.async_connect().await;
+
+    let first_id = NewUser::builder()
+        .gh_id(1)
+        .gh_login("foo-bar")
+        .username("foo-bar")
+        .build()
+        .insert(&conn)
+        .await
+        .unwrap();
+    let second_id = NewUser::builder()
+        .gh_id(2)
+        .gh_login("FOO_BAR")
+        .username("FOO_BAR")
+        .build()
+        .insert(&conn)
+        .await
+        .unwrap();
+
+    assert!(second_id > first_id);
+
+    let user_id: i32 = users_by_username("Foo-Bar")
+        .select(users::id)
+        .first(&mut conn)
+        .await
+        .unwrap();
+
+    assert_eq!(user_id, second_id);
+}

--- a/src/bin/crates-io/admin/delete_crate.rs
+++ b/src/bin/crates-io/admin/delete_crate.rs
@@ -3,10 +3,10 @@ use anyhow::Context;
 use chrono::{DateTime, Utc};
 use colored::Colorize;
 use crates_io::controllers::krate::delete::max_downloads;
-use crates_io::models::{NewDeletedCrate, User};
-use crates_io::schema::{crate_downloads, deleted_crates};
+use crates_io::db;
+use crates_io::models::{NewDeletedCrate, users_by_username};
+use crates_io::schema::{crate_downloads, crates, deleted_crates, users};
 use crates_io::worker::jobs;
-use crates_io::{db, schema::crates};
 use crates_io_database::schema::dependencies;
 use crates_io_worker::BackgroundJob;
 use diesel::dsl::{count_star, sql};
@@ -31,7 +31,7 @@ pub struct Opts {
     #[arg(short, long)]
     yes: bool,
 
-    /// Your GitHub username.
+    /// Your crates.io username.
     #[arg(long)]
     deleted_by: String,
 
@@ -59,7 +59,9 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         .await
         .context("Failed to look up crate name from the database")?;
 
-    let deleted_by = User::find_by_login(&conn, &opts.deleted_by)
+    let deleted_by_id: i32 = users_by_username(&opts.deleted_by)
+        .select(users::id)
+        .first(&mut conn)
         .await
         .context("Failed to look up `--deleted-by` user from the database")?;
 
@@ -87,7 +89,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
             let deleted_crate = NewDeletedCrate::builder(name)
                 .created_at(&crate_info.created_at)
                 .deleted_at(&now)
-                .deleted_by(deleted_by.id)
+                .deleted_by(deleted_by_id)
                 .maybe_message(opts.message.as_deref())
                 .available_at(&available_at)
                 .build();

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -1,12 +1,11 @@
 use crate::app::AppState;
-use crate::models::{CrateOwner, OwnerKind, PublicUser};
-use crate::schema::{crate_downloads, crate_owners, crates};
+use crate::models::{CrateOwner, OwnerKind, PublicUser, users_by_username};
+use crate::schema::{crate_downloads, crate_owners, crates, oauth_github};
 use crate::util::errors::AppResult;
 use crate::views::EncodablePublicUser;
 use axum::Json;
 use axum::extract::Path;
 use bigdecimal::{BigDecimal, ToPrimitive};
-use crates_io_database::fns::canon_username;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use serde::Serialize;
@@ -37,12 +36,9 @@ pub async fn find_user(
 ) -> AppResult<Json<UserGetResponse>> {
     let mut conn = state.db_read_prefer_primary().await?;
 
-    use crate::schema::users::dsl::{id, username};
-
-    let name = canon_username(&user_name);
-    let user: PublicUser = PublicUser::query()
-        .filter(canon_username(username).eq(name))
-        .order(id.desc())
+    let user = users_by_username(&user_name)
+        .left_join(oauth_github::table)
+        .select(PublicUser::as_select())
         .first(&mut conn)
         .await?;
 


### PR DESCRIPTION
`delete-crate --deleted-by` currently resolves its value as a legacy GitHub login. This changes the option to resolve canonical crates.io usernames and selects only the matching user ID, avoiding the OAuth join required by the full `User` model.

The canonical username query is shared with the public user endpoint so matching and newest-user ordering remain defined in one place. This was extracted from #14213 as an independently reviewable PR.

/cc @moskirathe 

### Related

- #13769
- #14213