### PR TITLE
Remove `ZIP_ARCHIVES_ENABLED` feature flag

### DIFF
--- a/src/config/features.rs
+++ b/src/config/features.rs
@@ -7,11 +7,6 @@ pub struct FeaturesConfig {
     /// Read from the `EXPLICIT_SIGNUP_ENABLED` environment variable.
     pub explicit_signup_enabled: bool,
 
-    /// Enable enqueueing of `BuildCrateZip` jobs in the publish flow.
-    ///
-    /// Read from the `ZIP_ARCHIVES_ENABLED` environment variable.
-    pub zip_archives_enabled: bool,
-
     /// Emit CDN cache tags as storage metadata on uploads.
     ///
     /// Read from the `CACHE_TAGS_ENABLED` environment variable.
@@ -26,7 +21,6 @@ pub struct FeaturesConfig {
 impl FeaturesConfig {
     pub fn from_env() -> anyhow::Result<Self> {
         let explicit_signup_enabled = var_parsed("EXPLICIT_SIGNUP_ENABLED")?.unwrap_or(false);
-        let zip_archives_enabled = var_parsed("ZIP_ARCHIVES_ENABLED")?.unwrap_or(false);
         let cache_tags_enabled = var_parsed("CACHE_TAGS_ENABLED")?.unwrap_or(false);
         let cache_tag_invalidations_enabled =
             var_parsed("CACHE_TAG_INVALIDATIONS_ENABLED")?.unwrap_or(false);
@@ -37,7 +31,6 @@ impl FeaturesConfig {
 
         Ok(Self {
             explicit_signup_enabled,
-            zip_archives_enabled,
             cache_tags_enabled,
             cache_tag_invalidations_enabled,
         })

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -672,18 +672,11 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
         let analyze_crate_file_job = AnalyzeCrateFile::new(version.id);
         let build_crate_zip_job = BuildCrateZip::new(version.id);
 
-        let build_crate_zip = async {
-            if app.config.features.zip_archives_enabled {
-                build_crate_zip_job.enqueue(&*conn).await?;
-            }
-            Ok(())
-        };
-
         tokio::try_join!(
             sync_git_index,
             sparse_index_job.enqueue(&*conn),
             publish_notifications_job.enqueue(&*conn),
-            build_crate_zip,
+            build_crate_zip_job.enqueue(&*conn),
             enqueue_or_log(&crate_feed_job, &*conn),
             enqueue_or_log(&updates_feed_job, &*conn),
             enqueue_or_log(&analyze_crate_file_job, &*conn),

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -601,7 +601,6 @@ fn simple_config() -> config::Server {
         banner_message: None,
         features: FeaturesConfig {
             explicit_signup_enabled: true,
-            zip_archives_enabled: true,
             cache_tags_enabled: true,
             cache_tag_invalidations_enabled: true,
         },


### PR DESCRIPTION
This removes the `ZIP_ARCHIVES_ENABLED` rollout flag and enqueues `BuildCrateZip` for every successful publication.

Existing crate versions have been backfilled, so new publications no longer need an inactive path that omits their source archives.