### PR TITLE
test-utils: Use legacy GitHub login for OAuth fixtures

### DIFF
--- a/crates/crates_io_test_utils/src/builders/user.rs
+++ b/crates/crates_io_test_utils/src/builders/user.rs
@@ -94,7 +94,7 @@ impl<'a> OauthGithubBuilder<'a> {
             user_id: user.id,
             account_id: user.gh_id as i64,
             encrypted_token: &ENCRYPTED_TOKEN,
-            login: &user.username,
+            login: &user.gh_login,
             avatar: None,
         }
     }


### PR DESCRIPTION
`OauthGithubBuilder::for_user()` now copies `User::gh_login` into `oauth_github.login` instead of using the crates.io username.

The legacy column remains the matching source until GitHub logins live exclusively in `oauth_github`. Using `User::username` creates inconsistent fixtures when the two names differ.