### PR TITLE
svelte: Frame user and team page avatars

### DIFF
--- a/svelte/src/lib/components/TeamPageHeader.svelte
+++ b/svelte/src/lib/components/TeamPageHeader.svelte
@@ -35,6 +35,7 @@
   <UserAvatar
     user={{ avatar: team.avatar, kind: 'team', login: team.login, name: team.name }}
     size="medium"
+    class="team-page-avatar"
     style="margin-right: var(--space-m)"
     data-test-avatar
   />
@@ -60,6 +61,14 @@
   h2 {
     margin-top: var(--space-2xs);
     color: var(--main-color-light);
+  }
+
+  :global(.team-page-avatar) {
+    border-radius: 4px;
+    object-fit: cover;
+    background: white;
+    padding: 3px;
+    box-shadow: 1px 2px 2px 0 light-dark(hsla(51, 50%, 44%, 0.35), #232321);
   }
 
   .header-row {

--- a/svelte/src/lib/components/UserPageHeader.svelte
+++ b/svelte/src/lib/components/UserPageHeader.svelte
@@ -33,6 +33,7 @@
   <UserAvatar
     user={{ avatar: user.avatar, kind: 'user', login: user.login, name: user.name }}
     size="medium"
+    class="user-page-avatar"
     data-test-avatar
   />
   <h1 data-test-username>{user.login}</h1>
@@ -45,6 +46,14 @@
 <style>
   h1 {
     margin: 0;
+  }
+
+  :global(.user-page-avatar) {
+    border-radius: 50%;
+    object-fit: cover;
+    background: white;
+    padding: 3px;
+    box-shadow: 1px 2px 2px 0 light-dark(hsla(51, 50%, 44%, 0.35), #232321);
   }
 
   .github-link {


### PR DESCRIPTION
This adds white padding and a color-scheme-aware warm shadow to the user and team page avatars. User portraits use a circular crop, while team artwork keeps a rounded-square shape so the two identity types remain visually distinct. This essentially matches the styling used on the crate sidebar already, but scaled up a bit.

### Before

<img width="336" height="109" alt="Bildschirmfoto 2026-08-27 um 09 54 07" src="https://github.com/user-attachments/assets/0c89b709-48ca-49f4-bcc0-e507f7eddcbd" />
<img width="372" height="112" alt="Bildschirmfoto 2026-08-27 um 09 54 23" src="https://github.com/user-attachments/assets/22dc9efe-9baf-4b39-8f57-d35aa295bcdb" />


### After

<img width="322" height="112" alt="Bildschirmfoto 2026-08-27 um 09 53 58" src="https://github.com/user-attachments/assets/23635f0c-f399-4145-a27d-0d7890cabb25" />
<img width="360" height="117" alt="Bildschirmfoto 2026-08-27 um 09 54 31" src="https://github.com/user-attachments/assets/8bb127eb-bb84-422e-9b29-d2a029f406dc" />


### Related

- #14517