### PR TITLE
test_utils: Support distinct crates.io and GitHub usernames

### DIFF
--- a/crates/crates_io_test_utils/src/builders/user.rs
+++ b/crates/crates_io_test_utils/src/builders/user.rs
@@ -23,6 +23,7 @@ static ENCRYPTED_TOKEN: LazyLock<Vec<u8>> = LazyLock::new(|| {
 pub struct UserBuilder<'a> {
     username: &'a str,
     display_name: Option<&'a str>,
+    gh_login: &'a str,
 }
 
 impl<'a> UserBuilder<'a> {
@@ -32,11 +33,16 @@ impl<'a> UserBuilder<'a> {
         Self {
             username: "octocat",
             display_name: None,
+            gh_login: "octocat",
         }
     }
 
     pub fn with_username(self, username: &'a str) -> Self {
-        Self { username, ..self }
+        Self {
+            username,
+            gh_login: username,
+            ..self
+        }
     }
 
     pub fn with_display_name(self, display_name: &'a str) -> Self {
@@ -46,10 +52,15 @@ impl<'a> UserBuilder<'a> {
         }
     }
 
+    /// Sets the legacy GitHub login independently from the crates.io username.
+    pub fn with_gh_login(self, gh_login: &'a str) -> Self {
+        Self { gh_login, ..self }
+    }
+
     pub fn build(self) -> User {
         User {
             id: 1,
-            gh_login: self.username.into(),
+            gh_login: self.gh_login.into(),
             name: self.display_name.map(ToString::to_string),
             gh_id: 123,
             gh_avatar: None,
@@ -66,7 +77,7 @@ impl<'a> UserBuilder<'a> {
     pub fn new_user(self) -> NewUser<'a> {
         NewUser::builder()
             .gh_id(next_gh_id())
-            .gh_login(self.username)
+            .gh_login(self.gh_login)
             .username(self.username)
             .maybe_name(self.display_name)
             .build()

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -1,10 +1,7 @@
 use crate::util::{RequestHelper, TestApp};
 use crates_io::models::{NewUser, User};
-use crates_io::schema::users;
 use crates_io::views::EncodablePublicUser;
 use crates_io_test_utils::builders::{OauthGithubBuilder, UserBuilder};
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
 use insta::assert_snapshot;
 use serde::Deserialize;
 
@@ -16,19 +13,12 @@ pub struct UserShowPublicResponse {
 #[tokio::test(flavor = "multi_thread")]
 async fn show() {
     let (app, anon, _) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn().await;
 
-    let bar = app.db_new_user("github-Bar").await;
-    diesel::update(users::table.find(bar.as_model().id))
-        .set(users::username.eq("crates-Bar"))
-        .execute(&mut conn)
-        .await
-        .unwrap();
-    let bar_model = bar.as_model();
-    OauthGithubBuilder::for_user(bar_model)
-        .with_login("CRATES-BAR")
-        .insert(&conn)
-        .await;
+    let builder = UserBuilder::new()
+        .with_username("crates-Bar")
+        .with_gh_login("github-Bar");
+
+    app.db_new_user_from_builder(builder).await;
 
     let json: UserShowPublicResponse = anon.get("/api/v1/users/foo").await.good();
     assert_eq!(json.user.login, "foo");

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -23,7 +23,7 @@ use crates_io_index::{Credentials, RepositoryConfig};
 use crates_io_og_image::OgImageGenerator;
 use crates_io_team_repo::MockTeamRepo;
 use crates_io_test_db::TestDatabase;
-use crates_io_test_utils::builders::OauthGithubBuilder;
+use crates_io_test_utils::builders::{OauthGithubBuilder, UserBuilder};
 use crates_io_trustpub::github::test_helpers::AUDIENCE;
 use crates_io_trustpub::keystore::{MockOidcKeyStore, OidcKeyStore};
 use crates_io_worker::Runner;
@@ -151,11 +151,17 @@ impl TestApp {
     ///
     /// This method updates the database directly
     pub async fn db_new_user(&self, username: &str) -> MockCookieUser {
+        let builder = UserBuilder::new().with_username(username);
+        self.db_new_user_from_builder(builder).await
+    }
+
+    /// Create a new user from a builder with a verified email address in the
+    /// database (`<username>@example.com`) and return a mock user session.
+    pub async fn db_new_user_from_builder(&self, builder: UserBuilder<'_>) -> MockCookieUser {
         let conn = self.db_conn().await;
 
-        let email = format!("{username}@example.com");
-
-        let new_user = crate::new_user(username);
+        let new_user = builder.new_user();
+        let email = format!("{}@example.com", new_user.username);
         let id = new_user.insert(&conn).await.unwrap();
         let user = User::find(&conn, id).await.unwrap();
 


### PR DESCRIPTION
Test user fixtures can now assign a GitHub login independently from the crates.io username. The new `db_new_user_from_builder()` helper carries this configuration through user creation and related setup, allowing the user route test to avoid post-insert database mutations.

### Related

- #14533