### PR TITLE
Remove cache-tag feature flags

### DIFF
--- a/src/bin/crates-io/admin/delete_version.rs
+++ b/src/bin/crates-io/admin/delete_version.rs
@@ -4,7 +4,7 @@ use crates_io::models::update_default_version;
 use crates_io::schema::crates;
 use crates_io::storage::{Storage, StorageKey, release_cache_tag};
 use crates_io::worker::jobs;
-use crates_io::{config::FeaturesConfig, db, schema::versions};
+use crates_io::{db, schema::versions};
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::{AsyncConnection, RunQueryDsl};
@@ -29,8 +29,6 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
-    let features = FeaturesConfig::from_env().context("Failed to load features config")?;
-
     let mut conn = db::oneoff_connection()
         .await
         .context("Failed to establish database connection")?;
@@ -106,17 +104,11 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         warn!(%crate_name, "Failed to enqueue background job: {error}");
     }
 
-    let mut paths = Vec::new();
     for version in &opts.versions {
         debug!(%crate_name, %version, "Deleting crate file from S3");
         let crate_file_key = StorageKey::for_crate_file(crate_name, version);
-        match store.delete(&crate_file_key).await {
-            Err(error) => {
-                warn!(%crate_name, %version, "Failed to delete crate file from S3: {error}");
-            }
-            Ok(()) => {
-                paths.push(crate_file_key.path());
-            }
+        if let Err(error) = store.delete(&crate_file_key).await {
+            warn!(%crate_name, %version, "Failed to delete crate file from S3: {error}");
         }
 
         debug!(%crate_name, %version, "Deleting zip source archive from S3");
@@ -126,9 +118,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
             Err(error) => {
                 warn!(%crate_name, %version, "Failed to delete zip source archive from S3: {error}")
             }
-            Ok(()) => {
-                paths.push(zip_key.path());
-            }
+            Ok(()) => {}
         }
 
         debug!(%crate_name, %version, "Deleting zip source archive manifest from S3");
@@ -138,9 +128,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
             Err(error) => {
                 warn!(%crate_name, %version, "Failed to delete zip source archive manifest from S3: {error}")
             }
-            Ok(()) => {
-                paths.push(manifest_key.path());
-            }
+            Ok(()) => {}
         }
 
         debug!(%crate_name, %version, "Deleting readme file from S3");
@@ -150,21 +138,15 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
             Err(error) => {
                 warn!(%crate_name, %version, "Failed to delete readme file from S3: {error}")
             }
-            Ok(()) => {
-                paths.push(readme_key.path());
-            }
+            Ok(()) => {}
         }
     }
 
-    let job = if features.cache_tag_invalidations_enabled {
-        jobs::InvalidateCdns::cache_tags(
-            opts.versions
-                .iter()
-                .map(|version| release_cache_tag(crate_name, version)),
-        )
-    } else {
-        jobs::InvalidateCdns::paths(paths.into_iter())
-    };
+    let job = jobs::InvalidateCdns::cache_tags(
+        opts.versions
+            .iter()
+            .map(|version| release_cache_tag(crate_name, version)),
+    );
 
     if let Err(e) = job.enqueue(&conn).await {
         warn!("{crate_name}: Failed to enqueue CDN invalidation background job: {e}");

--- a/src/config/features.rs
+++ b/src/config/features.rs
@@ -7,11 +7,6 @@ pub struct FeaturesConfig {
     /// Read from the `EXPLICIT_SIGNUP_ENABLED` environment variable.
     pub explicit_signup_enabled: bool,
 
-    /// Emit CDN cache tags as storage metadata on uploads.
-    ///
-    /// Read from the `CACHE_TAGS_ENABLED` environment variable.
-    pub cache_tags_enabled: bool,
-
     /// Invalidate deleted crate objects using CDN cache tags instead of URLs.
     ///
     /// Read from the `CACHE_TAG_INVALIDATIONS_ENABLED` environment variable.
@@ -21,17 +16,11 @@ pub struct FeaturesConfig {
 impl FeaturesConfig {
     pub fn from_env() -> anyhow::Result<Self> {
         let explicit_signup_enabled = var_parsed("EXPLICIT_SIGNUP_ENABLED")?.unwrap_or(false);
-        let cache_tags_enabled = var_parsed("CACHE_TAGS_ENABLED")?.unwrap_or(false);
         let cache_tag_invalidations_enabled =
             var_parsed("CACHE_TAG_INVALIDATIONS_ENABLED")?.unwrap_or(false);
 
-        if cache_tag_invalidations_enabled && !cache_tags_enabled {
-            anyhow::bail!("CACHE_TAG_INVALIDATIONS_ENABLED requires CACHE_TAGS_ENABLED");
-        }
-
         Ok(Self {
             explicit_signup_enabled,
-            cache_tags_enabled,
             cache_tag_invalidations_enabled,
         })
     }

--- a/src/config/features.rs
+++ b/src/config/features.rs
@@ -6,22 +6,13 @@ pub struct FeaturesConfig {
     ///
     /// Read from the `EXPLICIT_SIGNUP_ENABLED` environment variable.
     pub explicit_signup_enabled: bool,
-
-    /// Invalidate deleted crate objects using CDN cache tags instead of URLs.
-    ///
-    /// Read from the `CACHE_TAG_INVALIDATIONS_ENABLED` environment variable.
-    pub cache_tag_invalidations_enabled: bool,
 }
 
 impl FeaturesConfig {
     pub fn from_env() -> anyhow::Result<Self> {
         let explicit_signup_enabled = var_parsed("EXPLICIT_SIGNUP_ENABLED")?.unwrap_or(false);
-        let cache_tag_invalidations_enabled =
-            var_parsed("CACHE_TAG_INVALIDATIONS_ENABLED")?.unwrap_or(false);
-
         Ok(Self {
             explicit_signup_enabled,
-            cache_tag_invalidations_enabled,
         })
     }
 }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -122,8 +122,7 @@ impl Server {
 
         let features = FeaturesConfig::from_env()?;
 
-        let mut storage = StorageConfig::from_environment();
-        storage.cache_tags_enabled = features.cache_tags_enabled;
+        let storage = StorageConfig::from_environment();
 
         let domain_name = dotenvy::var("DOMAIN_NAME").unwrap_or_else(|_| "crates.io".into());
         let trustpub_audience = var("TRUSTPUB_AUDIENCE")?.unwrap_or_else(|| domain_name.clone());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -41,7 +41,6 @@ pub fn release_cache_tag(name: &str, version: &str) -> String {
 pub struct StorageConfig {
     backend: StorageBackend,
     pub cdn_prefix: Option<String>,
-    pub cache_tags_enabled: bool,
 }
 
 #[derive(Debug)]
@@ -65,7 +64,6 @@ impl StorageConfig {
         Self {
             backend: StorageBackend::InMemory,
             cdn_prefix: None,
-            cache_tags_enabled: false,
         }
     }
 
@@ -99,7 +97,6 @@ impl StorageConfig {
             return Self {
                 backend,
                 cdn_prefix,
-                cache_tags_enabled: false,
             };
         }
 
@@ -114,7 +111,6 @@ impl StorageConfig {
         Self {
             backend,
             cdn_prefix: None,
-            cache_tags_enabled: false,
         }
     }
 }
@@ -124,7 +120,6 @@ pub struct Storage {
     store: Arc<dyn ObjectStore>,
     index_store: Arc<dyn ObjectStore>,
     supports_attributes: bool,
-    cache_tags_enabled: bool,
 }
 
 impl Storage {
@@ -160,7 +155,6 @@ impl Storage {
                     store: Arc::new(store),
                     index_store: Arc::new(index_store),
                     supports_attributes: true,
-                    cache_tags_enabled: config.cache_tags_enabled,
                 }
             }
 
@@ -189,7 +183,6 @@ impl Storage {
                     store,
                     index_store,
                     supports_attributes: false,
-                    cache_tags_enabled: config.cache_tags_enabled,
                 }
             }
 
@@ -202,7 +195,6 @@ impl Storage {
                     store: store.clone(),
                     index_store: Arc::new(PrefixStore::new(store, "index")),
                     supports_attributes: true,
-                    cache_tags_enabled: config.cache_tags_enabled,
                 }
             }
         }
@@ -286,9 +278,7 @@ impl Storage {
 
         let mut attributes = key.attributes();
 
-        if self.cache_tags_enabled
-            && let Some(cache_tags) = key.cache_tags()
-        {
+        if let Some(cache_tags) = key.cache_tags() {
             attributes.insert(Attribute::Metadata("cache-tags".into()), cache_tags.into());
         }
 
@@ -702,9 +692,7 @@ mod tests {
     async fn upload_sets_cache_tags_metadata() {
         use claims::{assert_none, assert_some_eq};
 
-        let mut config = StorageConfig::in_memory();
-        config.cache_tags_enabled = true;
-        let s = Storage::from_config(&config);
+        let s = Storage::from_config(&StorageConfig::in_memory());
 
         let key = StorageKey::for_crate_file("foo", "1.2.3");
         s.upload(&key, Bytes::new().into()).await.unwrap();

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -600,7 +600,6 @@ fn simple_config() -> config::Server {
         banner_message: None,
         features: FeaturesConfig {
             explicit_signup_enabled: true,
-            cache_tag_invalidations_enabled: true,
         },
         fastly: None,
         sync_git_index: false,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -551,7 +551,6 @@ fn simple_config() -> config::Server {
 
     let mut storage = StorageConfig::in_memory();
     storage.cdn_prefix = Some("static.crates.io".to_string());
-    storage.cache_tags_enabled = true;
 
     config::Server {
         base,
@@ -601,7 +600,6 @@ fn simple_config() -> config::Server {
         banner_message: None,
         features: FeaturesConfig {
             explicit_signup_enabled: true,
-            cache_tags_enabled: true,
             cache_tag_invalidations_enabled: true,
         },
         fastly: None,

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -31,7 +31,7 @@ impl BackgroundJob for DeleteCrateFromStorage {
         let og_image_key = StorageKey::for_og_image(name);
         let feed_key = StorageKey::CrateFeed { name };
 
-        let (crate_file_paths, readme_paths, _, _) = try_join!(
+        try_join!(
             async {
                 info!("{name}: Deleting crate files from S3…");
                 let result = ctx.storage.delete_all_crate_files(name).await;
@@ -59,17 +59,7 @@ impl BackgroundJob for DeleteCrateFromStorage {
         info!("{name}: Enqueuing CDN invalidations");
 
         let conn = ctx.deadpool.get().await?;
-        let job = if ctx.config.features.cache_tag_invalidations_enabled {
-            InvalidateCdns::cache_tags([crate_cache_tag(name)])
-        } else {
-            InvalidateCdns::paths(
-                crate_file_paths
-                    .into_iter()
-                    .chain(readme_paths)
-                    .chain(std::iter::once(og_image_key.path()))
-                    .chain(std::iter::once(feed_key.path())),
-            )
-        };
+        let job = InvalidateCdns::cache_tags([crate_cache_tag(name)]);
         job.enqueue(&conn).await?;
 
         info!("{name}: Successfully enqueued CDN invalidations.");


### PR DESCRIPTION
This removes the `CACHE_TAGS_ENABLED` and `CACHE_TAG_INVALIDATIONS_ENABLED` rollout flags. Supported uploads now always include cache-tag metadata, while crate and release deletions always enqueue cache-tag invalidations instead of collecting fallback URL paths.

The metadata backfill and cache-tag invalidation rollout have been completed, so the disabled code paths and their configuration plumbing are obsolete.

### Related

- #14075
- #14250
- #14341