### PR TITLE
OpenAPI: Deprecate `User.url` and `AuthenticatedUser.url`

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -732,7 +732,7 @@ pub struct EncodablePrivateUser {
     pub avatar: Option<String>,
 
     /// The user's GitHub profile URL.
-    #[schema(example = "https://github.com/ghost")]
+    #[schema(example = "https://github.com/ghost", deprecated)]
     pub url: String,
 
     /// Whether the user is a crates.io administrator.
@@ -812,7 +812,7 @@ pub struct EncodablePublicUser {
     pub avatar: Option<String>,
 
     /// The user's GitHub profile URL.
-    #[schema(example = "https://github.com/ghost")]
+    #[schema(example = "https://github.com/ghost", deprecated)]
     pub url: String,
 
     /// Whether a linked GitHub username exactly matches the crates.io username.

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -1122,6 +1122,7 @@ export interface components {
              */
             publish_notifications: boolean;
             /**
+             * @deprecated
              * @description The user's GitHub profile URL.
              * @example https://github.com/ghost
              */
@@ -1709,6 +1710,7 @@ export interface components {
              */
             name: string | null;
             /**
+             * @deprecated
              * @description The user's GitHub profile URL.
              * @example https://github.com/ghost
              */

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -193,6 +193,7 @@ expression: response.json()
             "type": "boolean"
           },
           "url": {
+            "deprecated": true,
             "description": "The user's GitHub profile URL.",
             "example": "https://github.com/ghost",
             "type": "string"
@@ -1195,6 +1196,7 @@ expression: response.json()
             ]
           },
           "url": {
+            "deprecated": true,
             "description": "The user's GitHub profile URL.",
             "example": "https://github.com/ghost",
             "type": "string"

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -193,6 +193,7 @@ expression: response.json()
             "type": "boolean"
           },
           "url": {
+            "deprecated": true,
             "description": "The user's GitHub profile URL.",
             "example": "https://github.com/ghost",
             "type": "string"
@@ -1195,6 +1196,7 @@ expression: response.json()
             ]
           },
           "url": {
+            "deprecated": true,
             "description": "The user's GitHub profile URL.",
             "example": "https://github.com/ghost",
             "type": "string"


### PR DESCRIPTION
This marks both user profile URL fields as deprecated in OpenAPI and the generated TypeScript client now that linked GitHub profiles are available through `linked_accounts`.

### Related

- Resolves https://github.com/rust-lang/crates.io/issues/14381