### PR TITLE
svelte: Compare profile users by ID

### DIFF
--- a/e2e/routes/user/yanked-crates.spec.ts
+++ b/e2e/routes/user/yanked-crates.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@/e2e/helper';
 
 test.describe('Route | user | yanked crates visibility', { tag: '@routes' }, () => {
   async function prepare(msw: AppFixtures['msw']) {
-    let user1 = await msw.db.user.create({ login: 'alice', name: 'Alice' });
+    let user1 = await msw.db.user.create({ login: 'alice_user', name: 'Alice' });
     let user2 = await msw.db.user.create({ login: 'bob', name: 'Bob' });
 
     // Alice owns "alpha" (not yanked) and "alpha-yanked" (all versions yanked)
@@ -28,11 +28,11 @@ test.describe('Route | user | yanked crates visibility', { tag: '@routes' }, () 
     return { user1, user2 };
   }
 
-  test('own profile shows yanked crates', async ({ page, msw }) => {
+  test('own profile through a canonical alias shows yanked crates', async ({ page, msw }) => {
     let { user1 } = await prepare(msw);
     await msw.authenticateAs(user1);
 
-    await page.goto('/users/alice');
+    await page.goto('/users/ALICE-USER');
     await expect(page.locator('[data-test-crate-row]')).toHaveCount(2);
     await expect(page.locator('[data-test-crate-link]')).toContainText(['alpha', 'alpha-yanked']);
   });
@@ -49,7 +49,7 @@ test.describe('Route | user | yanked crates visibility', { tag: '@routes' }, () 
   test('unauthenticated view hides yanked crates', async ({ page, msw }) => {
     await prepare(msw);
 
-    await page.goto('/users/alice');
+    await page.goto('/users/alice_user');
     await expect(page.locator('[data-test-crate-row]')).toHaveCount(1);
     await expect(page.locator('[data-test-crate-link]')).toContainText(['alpha']);
   });

--- a/svelte/src/routes/users/[user_id]/+page.ts
+++ b/svelte/src/routes/users/[user_id]/+page.ts
@@ -27,7 +27,7 @@ export async function load({ fetch, params, parent, url }) {
   if (isLoggedIn()) {
     let { userPromise } = await parent();
     let currentUser = await userPromise;
-    isOwnProfile = currentUser?.login === params.user_id;
+    isOwnProfile = currentUser?.id === user.id;
   }
 
   let cratesResponse = await loadCrates(client, params.user_id, {


### PR DESCRIPTION
Canonical username aliases can make the route parameter differ from the authenticated login. Comparing resolved numeric IDs keeps yanked crates visible when users open their own profile through an alias.