### PR TITLE
svelte: Display linked accounts on user pages

### DIFF
--- a/e2e/acceptance/user-page.spec.ts
+++ b/e2e/acceptance/user-page.spec.ts
@@ -9,6 +9,7 @@ test.describe('Acceptance | user page', { tag: '@acceptance' }, () => {
 
   test('has user display', async ({ page, percy, a11y }) => {
     await expect(page.locator('[data-test-heading] [data-test-username]')).toHaveText('thehydroimpulse');
+    await expect(page.locator('[data-test-heading] [data-test-display-name]')).toHaveText('Daniel Fagnan');
 
     await percy.snapshot();
     await expect(page).toMatchAriaSnapshot({ name: 'aria.yml' });

--- a/e2e/acceptance/user-page.spec.ts
+++ b/e2e/acceptance/user-page.spec.ts
@@ -15,11 +15,11 @@ test.describe('Acceptance | user page', { tag: '@acceptance' }, () => {
     await a11y.audit();
   });
 
-  test('has link to github in user header', async ({ page }) => {
-    await expect(page.locator('[data-test-heading] [data-test-user-link]')).toHaveAttribute(
-      'href',
-      'https://github.com/thehydroimpulse',
-    );
+  test('has GitHub account chip in user header', async ({ page }) => {
+    let accountChip = page.locator('[data-test-heading] [data-test-account-chip]');
+
+    await expect(accountChip).toHaveAttribute('href', 'https://github.com/thehydroimpulse');
+    await expect(accountChip.locator('[data-test-handle]')).toHaveText('thehydroimpulse');
   });
 
   test('user details has github profile icon', async ({ page }) => {

--- a/e2e/acceptance/user-page.spec.ts
+++ b/e2e/acceptance/user-page.spec.ts
@@ -16,11 +16,23 @@ test.describe('Acceptance | user page', { tag: '@acceptance' }, () => {
     await a11y.audit();
   });
 
-  test('has GitHub account chip in user header', async ({ page }) => {
-    let accountChip = page.locator('[data-test-heading] [data-test-account-chip]');
+  test('has GitHub account chips in user header', async ({ page, msw }) => {
+    await msw.db.user.update(q => q.where({ id: 2 }), {
+      data(user) {
+        user.githubAccounts = [
+          { accountId: '1', login: 'github-user', avatar: null },
+          { accountId: '2', login: 'thehydroimpulse', avatar: null },
+        ];
+      },
+    });
+    await page.reload();
 
-    await expect(accountChip).toHaveAttribute('href', 'https://github.com/thehydroimpulse');
-    await expect(accountChip.locator('[data-test-handle]')).toHaveText('thehydroimpulse');
+    let accountChips = page.locator('[data-test-heading] [data-test-account-chip]');
+    await expect(accountChips).toHaveCount(2);
+    await expect(accountChips.locator('[data-test-handle]')).toHaveText(['github-user', 'thehydroimpulse']);
+    await expect(accountChips.nth(0)).toHaveAttribute('href', 'https://github.com/github-user');
+    await expect(accountChips.nth(1)).toHaveAttribute('href', 'https://github.com/thehydroimpulse');
+    await expect(page.locator('[data-test-heading] [data-test-mismatch-marker]')).toHaveCount(0);
   });
 
   test('user details has github profile icon', async ({ page }) => {

--- a/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/user-page.spec.ts-snapshots/aria.yml
@@ -11,9 +11,10 @@
 - main:
   - img "Daniel Fagnan (thehydroimpulse)"
   - heading "thehydroimpulse" [level=1]
-  - link "GitHub profile":
+  - link "GitHub thehydroimpulse":
     - /url: https://github.com/thehydroimpulse
-    - img "GitHub profile"
+    - img "GitHub"
+    - text: thehydroimpulse
   - text: Displaying 1-1 of 1 total results Sort by
   - button "Alphabetical"
   - list:

--- a/svelte/src/lib/components/AccountChip.stories.svelte
+++ b/svelte/src/lib/components/AccountChip.stories.svelte
@@ -1,0 +1,46 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import AccountChip from './AccountChip.svelte';
+
+  const { Story } = defineMeta({
+    title: 'AccountChip',
+    component: AccountChip,
+    tags: ['autodocs'],
+  });
+
+  const LONG_HANDLE = 'averylonggithubhandlethatdoesnotfitintheavailablewidth';
+</script>
+
+<!-- This is using a single Story with multiple examples to reduce the amount of snapshots generated for visual regression testing -->
+<Story name="Combined" asChild>
+  <h1>Matching</h1>
+  <AccountChip provider="github" handle="tbieniek" href="https://github.com/tbieniek" />
+
+  <h1>Mismatched</h1>
+  <AccountChip provider="github" handle="Turbo87" href="https://github.com/Turbo87" mismatched />
+
+  <h1>Long Handle</h1>
+  <div class="constrained">
+    <AccountChip provider="github" handle={LONG_HANDLE} href={`https://github.com/${LONG_HANDLE}`} />
+  </div>
+
+  <h1>Long Mismatched Handle</h1>
+  <div class="constrained">
+    <AccountChip provider="github" handle={LONG_HANDLE} href={`https://github.com/${LONG_HANDLE}`} mismatched />
+  </div>
+</Story>
+
+<style>
+  h1 {
+    font-size: 0.875rem;
+    font-weight: normal;
+    opacity: 0.2;
+    margin: 1rem 0 0.25rem;
+  }
+
+  .constrained {
+    width: 220px;
+    max-width: 100%;
+  }
+</style>

--- a/svelte/src/lib/components/AccountChip.svelte
+++ b/svelte/src/lib/components/AccountChip.svelte
@@ -1,0 +1,90 @@
+<!--
+  @component
+  Renders a linked external account as a provider-labelled chip.
+-->
+<script lang="ts">
+  import Icon from './Icon.svelte';
+  import Tooltip from './Tooltip.svelte';
+
+  /** Extend this union when support for other linked-account providers is added. */
+  type Provider = 'github';
+
+  interface Props {
+    /** The linked-account provider. */
+    provider: Provider;
+
+    /** The account handle displayed in the chip. */
+    handle: string;
+
+    /** The URL of the linked account. */
+    href: string;
+
+    /** Whether the account handle differs from the crates.io username. */
+    mismatched?: boolean;
+  }
+
+  let { provider, handle, href, mismatched = false }: Props = $props();
+
+  let handleElement = $state<HTMLSpanElement>();
+</script>
+
+<!-- eslint-disable svelte/no-navigation-without-resolve -->
+<a {href} class={['account-chip', mismatched && 'mismatched']} data-test-account-chip>
+  {#if provider === 'github'}
+    <Icon class="i-simple-icons:github" label="GitHub" data-test-provider-icon />
+  {/if}
+  <span bind:this={handleElement} class="handle" data-test-handle>{handle}</span>
+  {#if mismatched}
+    <span class="mismatch-marker" aria-hidden="true" data-test-mismatch-marker>≠</span>
+    <span class="sr-only" data-test-mismatch-description> does not match the crates.io username</span>
+  {/if}
+  <Tooltip onlyWhenTruncated={!mismatched} truncationTarget={handleElement}>
+    <span class="tooltip-text">{mismatched ? `${handle} does not match the crates.io username` : handle}</span>
+  </Tooltip>
+</a>
+
+<!-- eslint-enable svelte/no-navigation-without-resolve -->
+
+<style>
+  .account-chip {
+    --icon-size: 1.125em;
+
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    max-width: 100%;
+    min-width: 0;
+    border: 1px solid var(--gray-border);
+    border-radius: 99999px;
+    padding: 0.375em 0.625em;
+    font-size: var(--space-xs);
+    color: var(--main-color);
+
+    &:hover {
+      background: light-dark(white, #232321);
+    }
+  }
+
+  .mismatched {
+    border-color: light-dark(var(--orange-700), var(--orange-300));
+  }
+
+  .handle {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mismatch-marker {
+    flex-shrink: 0;
+    color: light-dark(var(--orange-700), var(--orange-300));
+    font-family: var(--font-monospace);
+    font-weight: 700;
+  }
+
+  .tooltip-text {
+    display: block;
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/svelte/src/lib/components/AccountChip.svelte.test.ts
+++ b/svelte/src/lib/components/AccountChip.svelte.test.ts
@@ -1,0 +1,65 @@
+import { tick } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page, userEvent } from 'vitest/browser';
+
+import AccountChipTestWrapper from './AccountChipTestWrapper.svelte';
+
+describe('AccountChip', () => {
+  it('renders a GitHub account link', async () => {
+    await render(AccountChipTestWrapper, {
+      handle: 'tbieniek',
+      href: 'https://github.com/tbieniek',
+    });
+
+    let chip = page.getByCSS('[data-test-account-chip]');
+    await expect.element(chip).toHaveAttribute('href', 'https://github.com/tbieniek');
+    await expect.element(page.getByCSS('[data-test-provider-icon]')).toHaveAttribute('aria-label', 'GitHub');
+    await expect.element(page.getByCSS('[data-test-handle]')).toHaveTextContent('tbieniek');
+  });
+
+  it('does not show a tooltip when the matching handle fits', async () => {
+    await render(AccountChipTestWrapper, {
+      handle: 'tbieniek',
+      href: 'https://github.com/tbieniek',
+      width: '500px',
+    });
+
+    await userEvent.hover(page.getByCSS('[data-test-account-chip]'));
+    await tick();
+
+    expect(document.querySelector('.tooltip')).toBeNull();
+  });
+
+  it('shows the complete matching handle when it is truncated', async () => {
+    let handle = 'averylonggithubhandlethatdoesnotfit';
+    await render(AccountChipTestWrapper, {
+      handle,
+      href: `https://github.com/${handle}`,
+      width: '150px',
+    });
+
+    await userEvent.hover(page.getByCSS('[data-test-account-chip]'));
+
+    await expect.element(page.getByCSS('.tooltip')).toHaveTextContent(handle);
+  });
+
+  it('marks a mismatch and explains it in the tooltip', async () => {
+    await render(AccountChipTestWrapper, {
+      handle: 'Turbo87',
+      href: 'https://github.com/Turbo87',
+      mismatched: true,
+    });
+
+    let marker = page.getByCSS('[data-test-mismatch-marker]');
+    await expect.element(marker).toHaveTextContent('≠');
+    await expect.element(marker).toHaveAttribute('aria-hidden', 'true');
+    await expect
+      .element(page.getByCSS('[data-test-mismatch-description]'))
+      .toHaveTextContent('does not match the crates.io username');
+
+    await userEvent.hover(page.getByCSS('[data-test-account-chip]'));
+
+    await expect.element(page.getByCSS('.tooltip')).toHaveTextContent('Turbo87 does not match the crates.io username');
+  });
+});

--- a/svelte/src/lib/components/AccountChipTestWrapper.svelte
+++ b/svelte/src/lib/components/AccountChipTestWrapper.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { setTooltipContext } from '$lib/tooltip.svelte';
+  import AccountChip from './AccountChip.svelte';
+  import TooltipContainer from './TooltipContainer.svelte';
+
+  interface Props {
+    handle: string;
+    href: string;
+    mismatched?: boolean;
+    width?: string;
+  }
+
+  let { handle, href, mismatched = false, width = 'max-content' }: Props = $props();
+  let propsId = $props.id();
+
+  setTooltipContext({ containerId: `tooltip-container-${propsId}` });
+</script>
+
+<div style:width>
+  <AccountChip provider="github" {handle} {href} {mismatched} />
+</div>
+
+<TooltipContainer />

--- a/svelte/src/lib/components/Tooltip.svelte
+++ b/svelte/src/lib/components/Tooltip.svelte
@@ -19,6 +19,8 @@
      * redundant tooltip that merely repeats fully visible text.
      */
     onlyWhenTruncated?: boolean;
+    /** Element checked for truncation instead of the tooltip anchor. */
+    truncationTarget?: HTMLElement | null;
   }
 
   interface TextProps extends BaseProps {
@@ -33,7 +35,7 @@
 
   type Props = TextProps | ChildrenProps;
 
-  let { text, children, side = 'top', delay = 0, onlyWhenTruncated = false }: Props = $props();
+  let { text, children, side = 'top', delay = 0, onlyWhenTruncated = false, truncationTarget }: Props = $props();
 
   let anchorElement = $state<HTMLElement | null>(null);
   let visible = $state(false);
@@ -44,7 +46,8 @@
     // Sub-pixel rounding can leave `scrollWidth` 1px above `clientWidth`
     // without any visible clipping, so require more than that before treating
     // the content as truncated.
-    if (onlyWhenTruncated && anchorElement && anchorElement.scrollWidth - anchorElement.clientWidth <= 1) {
+    let overflowElement = truncationTarget ?? anchorElement;
+    if (onlyWhenTruncated && overflowElement && overflowElement.scrollWidth - overflowElement.clientWidth <= 1) {
       return;
     }
 

--- a/svelte/src/lib/components/Tooltip.svelte.test.ts
+++ b/svelte/src/lib/components/Tooltip.svelte.test.ts
@@ -48,5 +48,18 @@ describe('Tooltip', () => {
 
       expect(document.querySelector('.tooltip')).toBeNull();
     });
+
+    it('checks a separate truncation target when provided', async () => {
+      await render(TooltipTestWrapper, {
+        text: 'A very long string that does not fit into the narrow target element',
+        width: '500px',
+        truncationTargetWidth: '50px',
+        onlyWhenTruncated: true,
+      });
+
+      await userEvent.hover(page.getByCSS('[data-test-anchor]'));
+
+      await expect.element(page.getByCSS('.tooltip')).toBeVisible();
+    });
   });
 });

--- a/svelte/src/lib/components/TooltipTestWrapper.svelte
+++ b/svelte/src/lib/components/TooltipTestWrapper.svelte
@@ -8,17 +8,32 @@
     width: string;
     delay?: number;
     onlyWhenTruncated?: boolean;
+    truncationTargetWidth?: string;
   }
 
-  let { text, width, delay = 0, onlyWhenTruncated = false }: Props = $props();
+  let { text, width, delay = 0, onlyWhenTruncated = false, truncationTargetWidth }: Props = $props();
   let propsId = $props.id();
+  let truncationTarget = $state<HTMLSpanElement>();
 
   setTooltipContext({ containerId: `tooltip-container-${propsId}` });
 </script>
 
 <div data-test-anchor style:width style:overflow="hidden" style:white-space="nowrap" style:text-overflow="ellipsis">
-  {text}
-  <Tooltip {text} {delay} {onlyWhenTruncated} />
+  {#if truncationTargetWidth}
+    <span
+      bind:this={truncationTarget}
+      style:display="inline-block"
+      style:width={truncationTargetWidth}
+      style:overflow="hidden"
+      style:white-space="nowrap"
+      style:text-overflow="ellipsis"
+    >
+      {text}
+    </span>
+  {:else}
+    {text}
+  {/if}
+  <Tooltip {text} {delay} {onlyWhenTruncated} {truncationTarget} />
 </div>
 
 <TooltipContainer />

--- a/svelte/src/lib/components/UserPageHeader.stories.svelte
+++ b/svelte/src/lib/components/UserPageHeader.stories.svelte
@@ -6,6 +6,7 @@
   import UserPageHeader from './UserPageHeader.svelte';
 
   type User = ComponentProps<typeof UserPageHeader>['user'];
+  type LinkedAccount = ComponentProps<typeof UserPageHeader>['linkedAccounts'][number];
 
   const { Story } = defineMeta({
     title: 'UserPageHeader',
@@ -15,9 +16,21 @@
 
   const USER: User = {
     avatar: 'https://avatars.githubusercontent.com/u/1?v=4',
+    github_username_matches: true,
     login: 'janedoe',
     name: 'Jane Doe',
-    url: 'https://github.com/janedoe',
+  };
+
+  const LINKED_ACCOUNT: LinkedAccount = {
+    account_id: '1',
+    login: 'janedoe',
+    provider: 'github',
+  };
+
+  const OTHER_LINKED_ACCOUNT: LinkedAccount = {
+    account_id: '2',
+    login: 'jane-doe',
+    provider: 'github',
   };
 
   const USER_WITHOUT_NAME: User = {
@@ -35,22 +48,52 @@
     login: 'averylongcratesiousernamethatcannotfitintheavailableheaderwidth',
     name: 'Alexandria Cassandra Montgomery-Worthington the Third',
   };
+
+  const LONG_LINKED_ACCOUNT: LinkedAccount = {
+    account_id: '3',
+    login: USER_WITH_LONG_IDENTITY.login,
+    provider: 'github',
+  };
+
+  const FOO_LINKED_ACCOUNT: LinkedAccount = {
+    account_id: '4',
+    login: 'foo',
+    provider: 'github',
+  };
+
+  const BAR_LINKED_ACCOUNT: LinkedAccount = {
+    account_id: '5',
+    login: 'bar',
+    provider: 'github',
+  };
 </script>
 
 <!-- This is using a single Story with multiple examples to reduce the amount of snapshots generated for visual regression testing -->
 <Story name="Combined" asChild>
   <h1>Default</h1>
-  <UserPageHeader user={USER} />
+  <UserPageHeader user={USER} linkedAccounts={[LINKED_ACCOUNT]} />
 
   <h1>Without Name</h1>
-  <UserPageHeader user={USER_WITHOUT_NAME} />
+  <UserPageHeader user={USER_WITHOUT_NAME} linkedAccounts={[LINKED_ACCOUNT]} />
 
   <h1>Without Avatar</h1>
-  <UserPageHeader user={USER_WITHOUT_AVATAR} />
+  <UserPageHeader user={USER_WITHOUT_AVATAR} linkedAccounts={[LINKED_ACCOUNT]} />
+
+  <h1>Multiple Accounts</h1>
+  <UserPageHeader user={USER} linkedAccounts={[OTHER_LINKED_ACCOUNT, LINKED_ACCOUNT]} />
+
+  <h1>Mismatched Account</h1>
+  <UserPageHeader user={{ ...USER, github_username_matches: false }} linkedAccounts={[OTHER_LINKED_ACCOUNT]} />
+
+  <h1>Without Accounts</h1>
+  <UserPageHeader user={USER} linkedAccounts={[]} />
 
   <h1>Long Identity</h1>
   <div class="long-identity">
-    <UserPageHeader user={USER_WITH_LONG_IDENTITY} />
+    <UserPageHeader
+      user={USER_WITH_LONG_IDENTITY}
+      linkedAccounts={[LONG_LINKED_ACCOUNT, FOO_LINKED_ACCOUNT, BAR_LINKED_ACCOUNT]}
+    />
   </div>
 </Story>
 

--- a/svelte/src/lib/components/UserPageHeader.svelte
+++ b/svelte/src/lib/components/UserPageHeader.svelte
@@ -3,7 +3,7 @@
   Renders the public user identity header.
 -->
 <script lang="ts">
-  import Icon from './Icon.svelte';
+  import AccountChip from './AccountChip.svelte';
   import PageHeader from './PageHeader.svelte';
   import UserAvatar from './UserAvatar.svelte';
 
@@ -29,39 +29,55 @@
   let { user }: Props = $props();
 </script>
 
-<PageHeader style="display: flex; align-items: center; gap: var(--space-xs);" data-test-heading>
-  <UserAvatar
-    user={{ avatar: user.avatar, kind: 'user', login: user.login, name: user.name }}
-    size="medium"
-    class="user-page-avatar"
-    data-test-avatar
-  />
-  <h1 data-test-username>{user.login}</h1>
-  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-  <a href={user.url} title={user.login} class="github-link" data-test-user-link>
-    <Icon class="i-simple-icons:github" label="GitHub profile" />
-  </a>
+<PageHeader data-test-heading>
+  <div class="layout">
+    <UserAvatar
+      user={{ avatar: user.avatar, kind: 'user', login: user.login, name: user.name }}
+      size="medium"
+      class="user-page-avatar"
+      data-test-avatar
+    />
+    <div class="identity">
+      <h1 data-test-username>{user.login}</h1>
+      <div class="accounts">
+        <AccountChip provider="github" handle={user.login} href={user.url} />
+      </div>
+    </div>
+  </div>
 </PageHeader>
 
 <style>
+  .layout {
+    display: flex;
+    align-items: center;
+    gap: var(--space-s);
+  }
+
+  .identity {
+    flex: 1;
+    min-width: 0;
+  }
+
   h1 {
     margin: 0;
+    line-height: 1.1;
+    overflow-wrap: anywhere;
+  }
+
+  .accounts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2xs);
+    margin-top: var(--space-2xs);
   }
 
   :global(.user-page-avatar) {
+    align-self: start;
+    flex-shrink: 0;
     border-radius: 50%;
     object-fit: cover;
     background: white;
     padding: 3px;
     box-shadow: 1px 2px 2px 0 light-dark(hsla(51, 50%, 44%, 0.35), #232321);
-  }
-
-  .github-link {
-    --icon-size: 32px;
-
-    &,
-    &:hover {
-      color: var(--main-color);
-    }
   }
 </style>

--- a/svelte/src/lib/components/UserPageHeader.svelte
+++ b/svelte/src/lib/components/UserPageHeader.svelte
@@ -39,6 +39,9 @@
     />
     <div class="identity">
       <h1 data-test-username>{user.login}</h1>
+      {#if user.name}
+        <div class="display-name" data-test-display-name>{user.name}</div>
+      {/if}
       <div class="accounts">
         <AccountChip provider="github" handle={user.login} href={user.url} />
       </div>
@@ -61,6 +64,13 @@
   h1 {
     margin: 0;
     line-height: 1.1;
+    overflow-wrap: anywhere;
+  }
+
+  .display-name {
+    margin-top: var(--space-3xs);
+    color: var(--main-color-light);
+    font-size: 0.9375em;
     overflow-wrap: anywhere;
   }
 

--- a/svelte/src/lib/components/UserPageHeader.svelte
+++ b/svelte/src/lib/components/UserPageHeader.svelte
@@ -3,9 +3,13 @@
   Renders the public user identity header.
 -->
 <script lang="ts">
+  import type { components } from '@crates-io/api-client';
+
   import AccountChip from './AccountChip.svelte';
   import PageHeader from './PageHeader.svelte';
   import UserAvatar from './UserAvatar.svelte';
+
+  type LinkedAccount = Pick<components['schemas']['LinkedAccount'], 'account_id' | 'login' | 'provider'>;
 
   interface UserPageHeaderUser {
     /** The user's avatar URL, if available. */
@@ -14,19 +18,29 @@
     /** The username displayed in the page heading. */
     login: string;
 
+    /** Whether a linked GitHub username exactly matches the crates.io username. */
+    github_username_matches: boolean;
+
     /** The user's optional display name. */
     name?: string | null;
-
-    /** The URL of the user's GitHub profile. */
-    url: string;
   }
 
   interface Props {
     /** The public user identity displayed in the header. */
     user: UserPageHeaderUser;
+
+    /** The external accounts linked to the user. */
+    linkedAccounts: LinkedAccount[];
   }
 
-  let { user }: Props = $props();
+  let { user, linkedAccounts }: Props = $props();
+
+  function buildUrl(account: LinkedAccount): string {
+    switch (account.provider) {
+      case 'github':
+        return `https://github.com/${account.login}`;
+    }
+  }
 </script>
 
 <PageHeader data-test-heading>
@@ -42,9 +56,18 @@
       {#if user.name}
         <div class="display-name" data-test-display-name>{user.name}</div>
       {/if}
-      <div class="accounts">
-        <AccountChip provider="github" handle={user.login} href={user.url} />
-      </div>
+      {#if linkedAccounts.length !== 0}
+        <div class="accounts">
+          {#each linkedAccounts as account (account.account_id)}
+            <AccountChip
+              provider={account.provider}
+              handle={account.login}
+              href={buildUrl(account)}
+              mismatched={account.provider === 'github' && !user.github_username_matches}
+            />
+          {/each}
+        </div>
+      {/if}
     </div>
   </div>
 </PageHeader>

--- a/svelte/src/lib/components/UserPageHeader.svelte.test.ts
+++ b/svelte/src/lib/components/UserPageHeader.svelte.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+import UserPageHeader from './UserPageHeader.svelte';
+
+const USER = {
+  avatar: null,
+  github_username_matches: true,
+  login: 'crates-user',
+  name: 'Crates User',
+};
+
+const LINKED_ACCOUNTS = [
+  {
+    account_id: '1',
+    avatar: null,
+    login: 'github-user',
+    provider: 'github' as const,
+  },
+  {
+    account_id: '2',
+    avatar: null,
+    login: 'crates-user',
+    provider: 'github' as const,
+  },
+];
+
+describe('UserPageHeader', () => {
+  it('renders every linked account', async () => {
+    await render(UserPageHeader, { user: USER, linkedAccounts: LINKED_ACCOUNTS });
+
+    let chips = page.getByCSS('[data-test-account-chip]');
+    expect(chips.elements()).toHaveLength(2);
+    expect(chips.elements().map(chip => chip.getAttribute('href'))).toEqual([
+      'https://github.com/github-user',
+      'https://github.com/crates-user',
+    ]);
+  });
+
+  it('does not mark GitHub accounts when one matches', async () => {
+    await render(UserPageHeader, { user: USER, linkedAccounts: LINKED_ACCOUNTS });
+
+    expect(page.getByCSS('[data-test-mismatch-marker]').elements()).toHaveLength(0);
+  });
+
+  it('marks every GitHub account when none match', async () => {
+    await render(UserPageHeader, {
+      user: { ...USER, github_username_matches: false },
+      linkedAccounts: LINKED_ACCOUNTS,
+    });
+
+    expect(page.getByCSS('[data-test-mismatch-marker]').elements()).toHaveLength(2);
+  });
+
+  it('omits the account row when there are no linked accounts', async () => {
+    await render(UserPageHeader, { user: USER, linkedAccounts: [] });
+
+    expect(page.getByCSS('.accounts').elements()).toHaveLength(0);
+  });
+});

--- a/svelte/src/routes/users/[user_id]/+page.svelte
+++ b/svelte/src/routes/users/[user_id]/+page.svelte
@@ -21,7 +21,7 @@
   });
 </script>
 
-<UserPageHeader user={data.user} />
+<UserPageHeader user={data.user} linkedAccounts={data.linkedAccounts ?? []} />
 
 <div class="results-meta">
   <ResultsCount

--- a/svelte/src/routes/users/[user_id]/+page.ts
+++ b/svelte/src/routes/users/[user_id]/+page.ts
@@ -13,7 +13,7 @@ export async function load({ fetch, params, parent, url }) {
   let perPage = 10;
   let sort = url.searchParams.get('sort') ?? 'alpha';
 
-  let user = await loadUser(client, params.user_id);
+  let { user, linked_accounts: linkedAccounts } = await loadUser(client, params.user_id);
 
   // Check if the logged-in user is viewing their own profile, so that
   // yanked crates are included in the results. We gate the `parent()`
@@ -38,7 +38,7 @@ export async function load({ fetch, params, parent, url }) {
     include_yanked: isOwnProfile ? 'yes' : 'n',
   });
 
-  return { user, cratesResponse, page, perPage, sort };
+  return { user, linkedAccounts, cratesResponse, page, perPage, sort };
 }
 
 function loadUserError(login: string, status: number): never {
@@ -52,7 +52,12 @@ function loadUserError(login: string, status: number): never {
 async function loadUser(client: ReturnType<typeof createClient>, login: string) {
   let response;
   try {
-    response = await client.GET('/api/v1/users/{user}', { params: { path: { user: login } } });
+    response = await client.GET('/api/v1/users/{user}', {
+      params: {
+        path: { user: login },
+        query: { include: 'linked_accounts' },
+      },
+    });
   } catch {
     // Network errors are treated as `504 Gateway Timeout`
     loadUserError(login, 504);
@@ -63,7 +68,7 @@ async function loadUser(client: ReturnType<typeof createClient>, login: string) 
     loadUserError(login, status);
   }
 
-  return response.data.user;
+  return response.data;
 }
 
 async function loadCrates(


### PR DESCRIPTION
User pages now display the crates.io username as the primary identity and render every requested linked account as a provider-labelled chip beneath it. They request the `linked_accounts` expansion, display the optional user name, and mark GitHub accounts when none of their usernames match the crates.io username.

The account row wraps for long identities, truncated handles use a tooltip, and pages without linked accounts omit the row entirely.

<img width="1968" height="2630" alt="Screen Shot 2026-08-27 at 12 52 15-fullpage" src="https://github.com/user-attachments/assets/dafcf856-d02f-4768-8cc1-fe5df7c004a5" />

<img width="391" height="178" alt="Bildschirmfoto 2026-08-27 um 12 57 54" src="https://github.com/user-attachments/assets/7f8308da-cdca-4ff3-93c4-b601f2cda934" />



### Related

- Resolves #13770
- Resolves #14383
- Resolves (partially) https://github.com/rust-lang/crates.io/issues/13764