### PR TITLE
renovate: Add 3 day cooldown for crates.io dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
     ':semanticCommitsDisabled',
     ':automergeLinters',
     ':automergeTesters',
+    'security:minimumReleaseAgeCrate',
     'customManagers:dockerfileVersions',
     'customManagers:githubActionsVersions',
   ],


### PR DESCRIPTION
This aligns us with what the best-practices preset is already applying to the npm dependencies and gives us a better chance of avoiding malicious dependency updates.


### Related 

- renovatebot/renovate#44659