### PR TITLE
Update `astral-tokio-tar` to v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,17 +411,18 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
+checksum = "6f2e989b33246fe9240d39accf4dd9a01e0b6c1f3ce9dd095e0a47fa02505523"
 dependencies = [
- "filetime",
  "futures-core",
  "libc",
  "portable-atomic",
  "rustc-hash",
+ "rustix",
  "tokio",
  "tokio-stream",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/tests/mod.rs"
 
 [dependencies]
 anyhow = "=1.0.104"
-astral-tokio-tar = { version = "=0.6.2", default-features = false }
+astral-tokio-tar = { version = "=0.7.0", default-features = false }
 async-compression = { version = "=0.4.43", default-features = false, features = ["gzip", "tokio"] }
 async-trait = "=0.1.92"
 aws-credential-types = { version = "=1.3.0", features = ["hardcoded-credentials"] }

--- a/crates/crates_io_tarball/Cargo.toml
+++ b/crates/crates_io_tarball/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 builder = ["dep:flate2", "dep:tar"]
 
 [dependencies]
-astral-tokio-tar = { version = "=0.6.2", default-features = false }
+astral-tokio-tar = { version = "=0.7.0", default-features = false }
 crates_io_cargo_toml = { path = "../crates_io_cargo_toml" }
 flate2 = { version = "=1.1.10", optional = true }
 serde = { version = "=1.0.229", features = ["derive"] }

--- a/crates/crates_io_tarball/src/lib.rs
+++ b/crates/crates_io_tarball/src/lib.rs
@@ -607,6 +607,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn process_tarball_test_repeated_pax_size_mismatch() {
+        let manifest_size = MANIFEST.len().to_string();
+        // The final size matches the tar header, but every size record must match.
+        let tarball = TarballBuilder::new()
+            .add_pax_extensions([
+                ("size", "2048".as_bytes()),
+                ("size", manifest_size.as_bytes()),
+            ])
+            .add_file("foo-0.0.1/Cargo.toml", MANIFEST)
+            .add_symlink("smuggled", "/etc/issue")
+            .build();
+
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, LIMITS).await);
+        assert_snapshot!(err, @"mismatched pax and tar header sizes");
+    }
+
+    #[tokio::test]
     async fn test_lib() {
         let tarball = TarballBuilder::new()
             .add_file("foo-0.0.1/Cargo.toml", MANIFEST)

--- a/crates/crates_io_tarball/src/lib.rs
+++ b/crates/crates_io_tarball/src/lib.rs
@@ -213,7 +213,10 @@ async fn validate_pax_size<R: tokio::io::AsyncRead + Unpin>(
     // legacy tar headers, which is 8 GiB. In practice, this should not be an
     // issue for crates.io given our other limits.
 
-    let tar_size = entry.header().size().map_err(TarballError::Malformed)?;
+    let tar_size = entry
+        .header()
+        .raw_file_size()
+        .map_err(TarballError::Malformed)?;
 
     if let Some(pax) = entry.pax_extensions().await? {
         for ext_result in pax {


### PR DESCRIPTION
Use the renamed `Header::raw_file_size()` API so PAX size validation continues to compare extensions against the raw tar header.

Thank you, @woodruffw! :)

### Related

- https://github.com/rust-lang/crates.io/pull/14064
- https://github.com/astral-sh/tokio-tar/issues/113
- https://github.com/astral-sh/tokio-tar/issues/114