### PR TITLE
Simplify owner handlers for username disambiguation

### DIFF
--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -8,7 +8,7 @@ use crate::models::{
     CrateOwner, NewCrateOwnerInvitation, NewCrateOwnerInvitationOutcome, NewTeam,
     krate::NewOwnerInvite, token::EndpointScope,
 };
-use crate::util::errors::{AppResult, BoxedAppError, bad_request, custom};
+use crate::util::errors::{AppResult, BoxedAppError, bad_request, custom, forbidden};
 use crate::views::EncodableOwner;
 use crate::{App, app::AppState};
 use crate::{auth::AuthCheck, email::EmailMessage};
@@ -329,14 +329,10 @@ async fn modify_owners(
 async fn check_owner_permissions(app: &App, user: &User, owners: &[Owner]) -> AppResult<()> {
     match Rights::get(user, &*app.github, owners, &app.config.token_encryption).await? {
         Rights::Full => Ok(()),
-        Rights::Publish => Err(custom(
-            StatusCode::FORBIDDEN,
+        Rights::Publish => Err(forbidden(
             "team members don't have permission to modify owners",
         )),
-        Rights::None => Err(custom(
-            StatusCode::FORBIDDEN,
-            "only owners have permission to modify owners",
-        )),
+        Rights::None => Err(forbidden("only owners have permission to modify owners")),
     }
 }
 

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -21,7 +21,7 @@ use diesel_async::{AsyncConnection, AsyncPgConnection};
 use http::StatusCode;
 use http::request::Parts;
 use minijinja::context;
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
@@ -208,15 +208,7 @@ pub async fn add_owners(
                         ));
 
                         if let Some(recipient) = invitee.verified_email(conn).await.ok().flatten() {
-                            let email = EmailMessage::from_template(
-                                "owner_invite",
-                                context! {
-                                    inviter => user.gh_login,
-                                    domain => app.emails.domain,
-                                    crate_name => krate.name,
-                                    token => token.expose_secret()
-                                },
-                            );
+                            let email = render_owner_invite_email(&app, user, &krate, &token);
 
                             match email {
                                 Ok(email_msg) => emails.push((recipient, email_msg)),
@@ -342,6 +334,24 @@ async fn check_owner_permissions(app: &App, user: &User, owners: &[Owner]) -> Ap
         Rights::Publish => Err(forbidden(TEAM_MEMBER_ERROR)),
         Rights::None => Err(forbidden(NOT_OWNER_ERROR)),
     }
+}
+
+/// Renders an owner invitation email with a token for accepting the invitation.
+fn render_owner_invite_email(
+    app: &App,
+    inviter: &User,
+    krate: &Crate,
+    token: &SecretString,
+) -> Result<EmailMessage, minijinja::Error> {
+    EmailMessage::from_template(
+        "owner_invite",
+        context! {
+            inviter => inviter.gh_login,
+            domain => app.emails.domain,
+            crate_name => krate.name,
+            token => token.expose_secret()
+        },
+    )
 }
 
 /// Invites `login` as an owner of this crate, returning the created

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -157,53 +157,6 @@ pub async fn add_owners(
     parts: Parts,
     Json(body): Json<ChangeOwnersRequest>,
 ) -> AppResult<Json<ModifyResponse>> {
-    modify_owners(app, path, parts, body, true).await
-}
-
-/// Removes crate owners.
-#[utoipa::path(
-    delete,
-    path = "/api/v1/crates/{name}/owners",
-    params(CratePath),
-    request_body = inline(ChangeOwnersRequest),
-    security(
-        ("api_token" = []),
-        ("cookie" = []),
-    ),
-    tag = "owners",
-    responses(
-        (status = 200, description = "Successful Response", body = inline(ModifyResponse)),
-        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
-        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
-    ),
-)]
-pub async fn remove_owners(
-    app: AppState,
-    path: CratePath,
-    parts: Parts,
-    Json(body): Json<ChangeOwnersRequest>,
-) -> AppResult<Json<ModifyResponse>> {
-    modify_owners(app, path, parts, body, false).await
-}
-
-#[derive(Deserialize, utoipa::ToSchema)]
-pub struct ChangeOwnersRequest {
-    /// List of owner login names to add or remove.
-    ///
-    /// For users, use just the username (e.g., `"octocat"`).
-    /// For GitHub teams, use the format `github:org:team` (e.g., `"github:rust-lang:owners"`).
-    #[schema(example = json!(["octocat", "github:rust-lang:owners"]))]
-    #[serde(alias = "users")]
-    owners: Vec<String>,
-}
-
-async fn modify_owners(
-    app: AppState,
-    path: CratePath,
-    parts: Parts,
-    body: ChangeOwnersRequest,
-    add: bool,
-) -> AppResult<Json<ModifyResponse>> {
     let logins = body.owners;
 
     // Bound the number of invites processed per request to limit the cost of
@@ -235,82 +188,65 @@ async fn modify_owners(
             // the database transaction has committed.
             let mut emails = Vec::with_capacity(logins.len());
 
-            let comma_sep_msg = if add {
-                let mut msgs = Vec::with_capacity(logins.len());
-                for login in &logins {
-                    let login_test =
-                        |owner: &Owner| owner.login().to_lowercase() == *login.to_lowercase();
-                    if owners.iter().any(login_test) {
-                        return Err(bad_request(format_args!("`{login}` is already an owner")));
-                    }
+            let mut msgs = Vec::with_capacity(logins.len());
+            for login in &logins {
+                let login_test =
+                    |owner: &Owner| owner.login().to_lowercase() == *login.to_lowercase();
+                if owners.iter().any(login_test) {
+                    return Err(bad_request(format_args!("`{login}` is already an owner")));
+                }
 
-                    match add_owner(&app, conn, user, &krate, login).await {
-                        // A user was successfully invited, and they must accept
-                        // the invite, and a best-effort attempt should be made
-                        // to email them the invite token for one-click
-                        // acceptance.
-                        Ok(NewOwnerInvite::User(invitee, token)) => {
-                            msgs.push(format!(
-                                "user {} has been invited to be an owner of crate {}",
-                                invitee.gh_login, krate.name,
-                            ));
+                match add_owner(&app, conn, user, &krate, login).await {
+                    // A user was successfully invited, and they must accept
+                    // the invite, and a best-effort attempt should be made
+                    // to email them the invite token for one-click
+                    // acceptance.
+                    Ok(NewOwnerInvite::User(invitee, token)) => {
+                        msgs.push(format!(
+                            "user {} has been invited to be an owner of crate {}",
+                            invitee.gh_login, krate.name,
+                        ));
 
-                            if let Some(recipient) =
-                                invitee.verified_email(conn).await.ok().flatten()
-                            {
-                                let email = EmailMessage::from_template(
-                                    "owner_invite",
-                                    context! {
-                                        inviter => user.gh_login,
-                                        domain => app.emails.domain,
-                                        crate_name => krate.name,
-                                        token => token.expose_secret()
-                                    },
-                                );
+                        if let Some(recipient) = invitee.verified_email(conn).await.ok().flatten() {
+                            let email = EmailMessage::from_template(
+                                "owner_invite",
+                                context! {
+                                    inviter => user.gh_login,
+                                    domain => app.emails.domain,
+                                    crate_name => krate.name,
+                                    token => token.expose_secret()
+                                },
+                            );
 
-                                match email {
-                                    Ok(email_msg) => emails.push((recipient, email_msg)),
-                                    Err(error) => warn!(
-                                        "Failed to render owner invite email template: {error}"
-                                    ),
+                            match email {
+                                Ok(email_msg) => emails.push((recipient, email_msg)),
+                                Err(error) => {
+                                    warn!("Failed to render owner invite email template: {error}")
                                 }
                             }
                         }
-
-                        // A team was successfully invited. They are immediately
-                        // added, and do not have an invite token.
-                        Ok(NewOwnerInvite::Team(team)) => msgs.push(format!(
-                            "team {} has been added as an owner of crate {}",
-                            team.login, krate.name
-                        )),
-
-                        // This user has a pending invite.
-                        Err(OwnerAddError::AlreadyInvited(user)) => msgs.push(format!(
-                            "user {} already has a pending invitation to be an owner of crate {}",
-                            user.gh_login, krate.name
-                        )),
-
-                        // An opaque error occurred.
-                        Err(OwnerAddError::Diesel(e)) => return Err(e.into()),
-                        Err(OwnerAddError::AppError(e)) => return Err(e),
                     }
-                }
-                msgs.join(",")
-            } else {
-                for login in &logins {
-                    krate.owner_remove(conn, login).await?;
-                }
-                if User::owning(&krate, conn).await?.is_empty() {
-                    return Err(bad_request(
-                        "cannot remove all individual owners of a crate. \
-                     Team member don't have permission to modify owners, so \
-                     at least one individual owner is required.",
-                    ));
-                }
-                "owners successfully removed".to_owned()
-            };
 
-            Ok((comma_sep_msg, emails))
+                    // A team was successfully invited. They are immediately
+                    // added, and do not have an invite token.
+                    Ok(NewOwnerInvite::Team(team)) => msgs.push(format!(
+                        "team {} has been added as an owner of crate {}",
+                        team.login, krate.name
+                    )),
+
+                    // This user has a pending invite.
+                    Err(OwnerAddError::AlreadyInvited(user)) => msgs.push(format!(
+                        "user {} already has a pending invitation to be an owner of crate {}",
+                        user.gh_login, krate.name
+                    )),
+
+                    // An opaque error occurred.
+                    Err(OwnerAddError::Diesel(e)) => return Err(e.into()),
+                    Err(OwnerAddError::AppError(e)) => return Err(e),
+                }
+            }
+
+            Ok((msgs.join(","), emails))
         })
         .await?;
 
@@ -323,6 +259,77 @@ async fn modify_owners(
     }
 
     Ok(Json(ModifyResponse { msg, ok: true }))
+}
+
+/// Removes crate owners.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/crates/{name}/owners",
+    params(CratePath),
+    request_body = inline(ChangeOwnersRequest),
+    security(
+        ("api_token" = []),
+        ("cookie" = []),
+    ),
+    tag = "owners",
+    responses(
+        (status = 200, description = "Successful Response", body = inline(ModifyResponse)),
+        (status = "4XX", description = "Client Error", body = crate::util::errors::ApiErrorResponse<'_>),
+        (status = "5XX", description = "Server Error", body = crate::util::errors::ApiErrorResponse<'_>),
+    ),
+)]
+pub async fn remove_owners(
+    app: AppState,
+    path: CratePath,
+    parts: Parts,
+    Json(body): Json<ChangeOwnersRequest>,
+) -> AppResult<Json<ModifyResponse>> {
+    let mut conn = app.db_write().await?;
+    let auth = AuthCheck::default()
+        .with_endpoint_scope(EndpointScope::ChangeOwners)
+        .for_crate(&path.name)
+        .check(&parts, &mut conn)
+        .await?;
+
+    let user = auth.user();
+
+    let krate = path.load_crate(&conn).await?;
+
+    let owners = krate.owners(&conn).await?;
+
+    check_owner_permissions(&app, user, &owners).await?;
+
+    conn.transaction(async |conn| {
+        for login in &body.owners {
+            krate.owner_remove(conn, login).await?;
+        }
+        if User::owning(&krate, conn).await?.is_empty() {
+            return Err(bad_request(
+                "cannot remove all individual owners of a crate. \
+                 Team member don't have permission to modify owners, so \
+                 at least one individual owner is required.",
+            ));
+        }
+
+        Ok(())
+    })
+    .await?;
+
+    Ok(Json(ModifyResponse {
+        msg: "owners successfully removed".to_owned(),
+        ok: true,
+    }))
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct ChangeOwnersRequest {
+    /// List of owner login names to add or remove.
+    ///
+    /// For users, use just the username (e.g., `"octocat"`).
+    /// For GitHub teams, use the format `github:org:team` (e.g., `"github:rust-lang:owners"`).
+    #[schema(example = json!(["octocat", "github:rust-lang:owners"]))]
+    #[serde(alias = "users")]
+    owners: Vec<String>,
 }
 
 /// Checks whether the user has permission to modify the crate's owners.

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -327,12 +327,13 @@ async fn modify_owners(
 
 /// Checks whether the user has permission to modify the crate's owners.
 async fn check_owner_permissions(app: &App, user: &User, owners: &[Owner]) -> AppResult<()> {
+    const TEAM_MEMBER_ERROR: &str = "team members don't have permission to modify owners";
+    const NOT_OWNER_ERROR: &str = "only owners have permission to modify owners";
+
     match Rights::get(user, &*app.github, owners, &app.config.token_encryption).await? {
         Rights::Full => Ok(()),
-        Rights::Publish => Err(forbidden(
-            "team members don't have permission to modify owners",
-        )),
-        Rights::None => Err(forbidden("only owners have permission to modify owners")),
+        Rights::Publish => Err(forbidden(TEAM_MEMBER_ERROR)),
+        Rights::None => Err(forbidden(NOT_OWNER_ERROR)),
     }
 }
 

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -8,7 +8,7 @@ use crate::models::{
     CrateOwner, NewCrateOwnerInvitation, NewCrateOwnerInvitationOutcome, NewTeam,
     krate::NewOwnerInvite, token::EndpointScope,
 };
-use crate::util::errors::{AppResult, BoxedAppError, bad_request, crate_not_found, custom};
+use crate::util::errors::{AppResult, BoxedAppError, bad_request, custom};
 use crate::views::EncodableOwner;
 use crate::{App, app::AppState};
 use crate::{auth::AuthCheck, email::EmailMessage};
@@ -17,7 +17,7 @@ use chrono::Utc;
 use crates_io_encryption::TokenEncryption;
 use crates_io_github::{GitHubAuth, GitHubClient, GitHubError};
 use diesel::prelude::*;
-use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use diesel_async::{AsyncConnection, AsyncPgConnection};
 use http::StatusCode;
 use http::request::Parts;
 use minijinja::context;
@@ -157,7 +157,7 @@ pub async fn add_owners(
     parts: Parts,
     Json(body): Json<ChangeOwnersRequest>,
 ) -> AppResult<Json<ModifyResponse>> {
-    modify_owners(app, path.name, parts, body, true).await
+    modify_owners(app, path, parts, body, true).await
 }
 
 /// Removes crate owners.
@@ -183,7 +183,7 @@ pub async fn remove_owners(
     parts: Parts,
     Json(body): Json<ChangeOwnersRequest>,
 ) -> AppResult<Json<ModifyResponse>> {
-    modify_owners(app, path.name, parts, body, false).await
+    modify_owners(app, path, parts, body, false).await
 }
 
 #[derive(Deserialize, utoipa::ToSchema)]
@@ -199,7 +199,7 @@ pub struct ChangeOwnersRequest {
 
 async fn modify_owners(
     app: AppState,
-    crate_name: String,
+    path: CratePath,
     parts: Parts,
     body: ChangeOwnersRequest,
     add: bool,
@@ -217,7 +217,7 @@ async fn modify_owners(
     let mut conn = app.db_write().await?;
     let auth = AuthCheck::default()
         .with_endpoint_scope(EndpointScope::ChangeOwners)
-        .for_crate(&crate_name)
+        .for_crate(&path.name)
         .check(&parts, &mut conn)
         .await?;
 
@@ -225,11 +225,7 @@ async fn modify_owners(
 
     let (msg, emails) = conn
         .transaction(async |conn| {
-            let krate: Crate = Crate::by_name(&crate_name)
-                .first(conn)
-                .await
-                .optional()?
-                .ok_or_else(|| crate_not_found(&crate_name))?;
+            let krate = path.load_crate(conn).await?;
 
             let owners = krate.owners(conn).await?;
 

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -229,22 +229,7 @@ async fn modify_owners(
 
             let owners = krate.owners(conn).await?;
 
-            match Rights::get(user, &*app.github, &owners, &app.config.token_encryption).await? {
-                Rights::Full => {}
-                // Yes!
-                Rights::Publish => {
-                    return Err(custom(
-                        StatusCode::FORBIDDEN,
-                        "team members don't have permission to modify owners",
-                    ));
-                }
-                Rights::None => {
-                    return Err(custom(
-                        StatusCode::FORBIDDEN,
-                        "only owners have permission to modify owners",
-                    ));
-                }
-            }
+            check_owner_permissions(&app, user, &owners).await?;
 
             // The set of emails to send out after invite processing is complete and
             // the database transaction has committed.
@@ -338,6 +323,21 @@ async fn modify_owners(
     }
 
     Ok(Json(ModifyResponse { msg, ok: true }))
+}
+
+/// Checks whether the user has permission to modify the crate's owners.
+async fn check_owner_permissions(app: &App, user: &User, owners: &[Owner]) -> AppResult<()> {
+    match Rights::get(user, &*app.github, owners, &app.config.token_encryption).await? {
+        Rights::Full => Ok(()),
+        Rights::Publish => Err(custom(
+            StatusCode::FORBIDDEN,
+            "team members don't have permission to modify owners",
+        )),
+        Rights::None => Err(custom(
+            StatusCode::FORBIDDEN,
+            "only owners have permission to modify owners",
+        )),
+    }
 }
 
 /// Invites `login` as an owner of this crate, returning the created

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -223,14 +223,14 @@ async fn modify_owners(
 
     let user = auth.user();
 
+    let krate = path.load_crate(&conn).await?;
+
+    let owners = krate.owners(&conn).await?;
+
+    check_owner_permissions(&app, user, &owners).await?;
+
     let (msg, emails) = conn
         .transaction(async |conn| {
-            let krate = path.load_crate(conn).await?;
-
-            let owners = krate.owners(conn).await?;
-
-            check_owner_permissions(&app, user, &owners).await?;
-
             // The set of emails to send out after invite processing is complete and
             // the database transaction has committed.
             let mut emails = Vec::with_capacity(logins.len());


### PR DESCRIPTION
Adding and removing owners follow different workflows, but `modify_owners()` combines them behind an `add` flag. Splitting them into their endpoint handlers makes each workflow easier to read and lets us change their username resolution independently for #14213. Small helpers keep permission checks and invitation email rendering out of the main flow.

Crate loading and permission checks also move before the transaction, so GitHub calls during permission checks no longer keep a transaction open. Ownership changes and the check that at least one individual owner remains stay in one transaction. The ten-entry limit now applies only to additions.

### Related

- #14213