### PR TITLE
Hide the report button for logged-out users

### DIFF
--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-latest.yml
@@ -48,8 +48,6 @@
     - button "nanomsg = \"0.6.1\""
     - heading "Owners" [level=2]
     - list
-    - link "Report crate":
-      - /url: /support?crate=nanomsg&inquire=crate-violation
   - heading "Stats Overview" [level=3]
   - text: /\d+,\d+ Downloads all time 2 Versions published/
   - heading /Downloads over the last \d+ days/ [level=4]

--- a/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
+++ b/e2e/acceptance/crate.spec.ts-snapshots/aria-version.yml
@@ -48,8 +48,6 @@
     - button "nanomsg = \"=0.6.0\""
     - heading "Owners" [level=2]
     - list
-    - link "Report crate":
-      - /url: /support?crate=nanomsg&inquire=crate-violation
   - heading "Stats Overview for 0.6.0 (see all)" [level=3]:
     - text: ""
     - link "(see all)":

--- a/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
+++ b/e2e/acceptance/readme-rendering.spec.ts-snapshots/aria.yml
@@ -144,8 +144,6 @@
     - button "serde = \"1.0.0\""
     - heading "Owners" [level=2]
     - list
-    - link "Report crate":
-      - /url: /support?crate=serde&inquire=crate-violation
   - heading "Stats Overview" [level=3]
   - text: /\d+,\d+ Downloads all time 1 Versions published/
   - heading /Downloads over the last \d+ days/ [level=4]

--- a/e2e/acceptance/support.spec.ts
+++ b/e2e/acceptance/support.spec.ts
@@ -199,8 +199,17 @@ test detail
     });
   });
 
+  test('hides the report crate button when logged out', async ({ page }) => {
+    await page.goto('/crates/nanomsg');
+    await expect(page.locator('[data-test-heading] [data-test-crate-name]')).toHaveText('nanomsg');
+    await expect(page.getByTestId('link-crate-report')).toHaveCount(0);
+  });
+
   test.describe('reporting a crate from crate page', () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page, msw }) => {
+      let user = await msw.db.user.create({});
+      await msw.authenticateAs(user);
+
       await page.goto('/crates/nanomsg');
       await page.getByTestId('link-crate-report').click();
       await expect(page).toHaveURL('/support?crate=nanomsg&inquire=crate-violation');

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebar.svelte
@@ -16,6 +16,7 @@
   import { formatShortNum } from '$lib/utils/format-short-num';
   import { buildPlaygroundLink } from '$lib/utils/playground';
   import { getPurl } from '$lib/utils/purl';
+  import { getSession } from '$lib/utils/session.svelte';
   import Edition from './Edition.svelte';
   import InstallInstructions from './InstallInstructions.svelte';
   import Link, { simplifyUrl } from './Link.svelte';
@@ -49,6 +50,7 @@
     docsRsStatusPromise,
   }: Props = $props();
 
+  let session = getSession();
   let canHover = new MediaQuery('hover: hover', false);
 
   let showHomepage = $derived.by(() => {
@@ -252,10 +254,12 @@
       <!-- Silently ignore playground loading failures -->
     {/await}
 
-    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-    <a href={reportUrl} data-test-id="link-crate-report" class="report-button button button--red button--small">
-      Report crate
-    </a>
+    {#if session.currentUser}
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+      <a href={reportUrl} data-test-id="link-crate-report" class="report-button button button--red button--small">
+        Report crate
+      </a>
+    {/if}
   </div>
 </section>
 

--- a/svelte/src/lib/components/crate-sidebar/CrateSidebarTestWrapper.svelte
+++ b/svelte/src/lib/components/crate-sidebar/CrateSidebarTestWrapper.svelte
@@ -3,7 +3,10 @@
   import type { DocsRsStatus } from '$lib/utils/docs-rs';
   import type { PlaygroundCrate } from '$lib/utils/playground';
 
+  import { createClient } from '@crates-io/api-client';
+
   import { NotificationsState, setNotifications } from '$lib/notifications.svelte';
+  import { SessionState, setSession } from '$lib/utils/session.svelte';
   import CrateSidebar from './CrateSidebar.svelte';
 
   type Crate = components['schemas']['Crate'];
@@ -33,6 +36,7 @@
 
   let notifications = new NotificationsState();
   setNotifications(notifications);
+  setSession(new SessionState(createClient({ fetch })));
 </script>
 
 <CrateSidebar


### PR DESCRIPTION
The "Report crate" button is now only shown to logged-in users as an experiment to reduce spam reports. The support page and its footer link remain accessible to everyone.

This extracts the button visibility change from #13023. I was skeptical of the extra friction at the time, but the spam situation seems to have gotten worse, so I've changed my mind about trying this narrower change.

### Related

- #13023