### PR TITLE
worker: Consume jobs in `BackgroundJob::run()`

### DIFF
--- a/crates/crates_io_worker/README.md
+++ b/crates/crates_io_worker/README.md
@@ -84,7 +84,7 @@ impl BackgroundJob for SendEmailJob {
 
     type Context = AppContext;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         // Job implementation
         ctx.email_service.send(&self.to, &self.subject, &self.body).await?;
         Ok(())

--- a/crates/crates_io_worker/src/background_job.rs
+++ b/crates/crates_io_worker/src/background_job.rs
@@ -34,7 +34,7 @@ pub trait BackgroundJob: Serialize + DeserializeOwned + Send + Sync + 'static {
     type Context: Clone + Send + 'static;
 
     /// Executes the task. This method should define its logic.
-    fn run(&self, ctx: Self::Context) -> impl Future<Output = anyhow::Result<()>> + Send;
+    fn run(self, ctx: Self::Context) -> impl Future<Output = anyhow::Result<()>> + Send;
 
     #[instrument(name = "swirl.enqueue", skip(self, conn), fields(message = Self::JOB_NAME))]
     fn enqueue<'a>(

--- a/crates/crates_io_worker/src/job_registry.rs
+++ b/crates/crates_io_worker/src/job_registry.rs
@@ -57,7 +57,7 @@ mod tests {
         impl BackgroundJob for TestJob {
             const JOB_NAME: &'static str = "test";
             type Context = ();
-            async fn run(&self, _: Self::Context) -> anyhow::Result<()> {
+            async fn run(self, _: Self::Context) -> anyhow::Result<()> {
                 Ok(())
             }
         }

--- a/crates/crates_io_worker/tests/runner.rs
+++ b/crates/crates_io_worker/tests/runner.rs
@@ -60,7 +60,7 @@ async fn jobs_are_locked_when_fetched() -> anyhow::Result<()> {
         const JOB_NAME: &'static str = "test";
         type Context = TestContext;
 
-        async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+        async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
             ctx.job_started_barrier.wait().await;
             ctx.assertions_finished_barrier.wait().await;
             Ok(())
@@ -107,7 +107,7 @@ async fn jobs_are_deleted_when_successfully_run() -> anyhow::Result<()> {
         const JOB_NAME: &'static str = "test";
         type Context = ();
 
-        async fn run(&self, _ctx: Self::Context) -> anyhow::Result<()> {
+        async fn run(self, _ctx: Self::Context) -> anyhow::Result<()> {
             Ok(())
         }
     }
@@ -149,7 +149,7 @@ async fn failed_jobs_do_not_release_lock_before_updating_retry_time() -> anyhow:
         const JOB_NAME: &'static str = "test";
         type Context = TestContext;
 
-        async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+        async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
             ctx.job_started_barrier.wait().await;
             panic!();
         }
@@ -205,7 +205,7 @@ async fn panicking_in_jobs_updates_retry_counter() -> anyhow::Result<()> {
         const JOB_NAME: &'static str = "test";
         type Context = ();
 
-        async fn run(&self, _ctx: Self::Context) -> anyhow::Result<()> {
+        async fn run(self, _ctx: Self::Context) -> anyhow::Result<()> {
             panic!()
         }
     }
@@ -259,7 +259,7 @@ async fn jobs_can_be_deduplicated() -> anyhow::Result<()> {
         const DEDUPLICATED: bool = true;
         type Context = TestContext;
 
-        async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+        async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
             let runs = ctx.runs.fetch_add(1, Ordering::SeqCst);
             if runs == 0 {
                 ctx.job_started_barrier.wait().await;
@@ -329,7 +329,7 @@ async fn enqueueing_a_job_emits_a_notification() -> anyhow::Result<()> {
         const JOB_NAME: &'static str = "test";
         type Context = ();
 
-        async fn run(&self, _ctx: Self::Context) -> anyhow::Result<()> {
+        async fn run(self, _ctx: Self::Context) -> anyhow::Result<()> {
             Ok(())
         }
     }
@@ -379,7 +379,7 @@ async fn workers_wake_up_on_notification() -> anyhow::Result<()> {
         const JOB_NAME: &'static str = "test";
         type Context = TestContext;
 
-        async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+        async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
             ctx.job_ran.notify_one();
             Ok(())
         }

--- a/src/worker/jobs/analyze_crate_file.rs
+++ b/src/worker/jobs/analyze_crate_file.rs
@@ -36,7 +36,7 @@ impl BackgroundJob for AnalyzeCrateFile {
     type Context = Arc<Environment>;
 
     #[instrument(skip_all, fields(version_id = ?self.version_id))]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         let version_id = self.version_id;
 
         info!("Starting crate file analysis… (version_id={version_id})");

--- a/src/worker/jobs/archive_version_downloads.rs
+++ b/src/worker/jobs/archive_version_downloads.rs
@@ -51,7 +51,7 @@ impl BackgroundJob for ArchiveVersionDownloads {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         info!("Archiving old version downloads…");
 
         let Some(downloads_archive_store) = env.downloads_archive_store.as_ref() else {

--- a/src/worker/jobs/build_crate_zip.rs
+++ b/src/worker/jobs/build_crate_zip.rs
@@ -38,7 +38,7 @@ impl BackgroundJob for BuildCrateZip {
     type Context = Arc<Environment>;
 
     #[instrument(skip_all, fields(version_id = ?self.version_id))]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         let version_id = self.version_id;
 
         info!("Starting zip build… (version_id={version_id})");

--- a/src/worker/jobs/daily_db_maintenance.rs
+++ b/src/worker/jobs/daily_db_maintenance.rs
@@ -24,7 +24,7 @@ impl BackgroundJob for DailyDbMaintenance {
     /// We only need to keep 90 days of entries in `version_downloads`. Once we have a mechanism to
     /// archive daily download counts and drop historical data, we can drop this task and rely on
     /// auto-vacuum again.
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         let mut conn = env.deadpool.get().await?;
 
         info!("Running VACUUM on version_downloads table");

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -26,7 +26,7 @@ impl BackgroundJob for DeleteCrateFromStorage {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let name = &self.name;
         let og_image_key = StorageKey::for_og_image(name);
         let feed_key = StorageKey::CrateFeed { name };

--- a/src/worker/jobs/docs_rs_queue_rebuild.rs
+++ b/src/worker/jobs/docs_rs_queue_rebuild.rs
@@ -25,7 +25,7 @@ impl BackgroundJob for DocsRsQueueRebuild {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let Some(docs_rs) = ctx.docs_rs.as_ref() else {
             warn!("docs.rs not configured, skipping rebuild");
             return Ok(());

--- a/src/worker/jobs/downloads/clean_processed_log_files.rs
+++ b/src/worker/jobs/downloads/clean_processed_log_files.rs
@@ -20,7 +20,7 @@ impl BackgroundJob for CleanProcessedLogFiles {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         let mut conn = env.deadpool.get().await?;
         Ok(run(&mut conn).await?)
     }

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -48,7 +48,7 @@ impl BackgroundJob for ProcessCdnLog {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         // The store is rebuilt for each run because we don't want to assume
         // that all log files live in the same AWS region or bucket, and those
         // two pieces are necessary for the store construction.

--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -31,7 +31,7 @@ impl BackgroundJob for ProcessCdnLogQueue {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         info!("Processing messages from the CDN log queue…");
 
         let queue = build_queue(&ctx.config.cdn_log_queue);

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -18,7 +18,7 @@ impl BackgroundJob for UpdateDownloads {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         let mut conn = env.deadpool.get().await?;
         Ok(update(&mut conn).await?)
     }

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -43,7 +43,7 @@ impl BackgroundJob for DumpDb {
         let db_pool_config = db_config.replica.as_ref().unwrap_or(&db_config.primary);
         let database_url = db_pool_config.url.clone();
         let postgres_bin_dir = env.config.postgres_bin_dir.clone();
-        let schema = self.schema.clone();
+        let schema = self.schema;
 
         let archives = spawn_blocking(move || {
             let directory = DumpDirectory::create(postgres_bin_dir)?;

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -38,7 +38,7 @@ impl BackgroundJob for DumpDb {
 
     /// Creates CSV dumps of the public information in the database, wraps them in a
     /// tarball and uploads to S3.
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         let db_config = &env.config.db;
         let db_pool_config = db_config.replica.as_ref().unwrap_or(&db_config.primary);
         let database_url = db_pool_config.url.clone();

--- a/src/worker/jobs/expiry_notification.rs
+++ b/src/worker/jobs/expiry_notification.rs
@@ -28,7 +28,7 @@ impl BackgroundJob for SendTokenExpiryNotifications {
     type Context = Arc<Environment>;
 
     #[instrument(skip(env), err)]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         let mut conn = env.deadpool.get().await?;
 
         // Check if the token is about to expire

--- a/src/worker/jobs/generate_og_image.rs
+++ b/src/worker/jobs/generate_og_image.rs
@@ -43,7 +43,7 @@ impl BackgroundJob for GenerateOgImage {
     type Context = Arc<Environment>;
 
     #[instrument(skip_all, fields(krate.name = %self.crate_name))]
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let crate_name = &self.crate_name;
 
         let Some(option) = &ctx.og_image_generator else {

--- a/src/worker/jobs/index/archive.rs
+++ b/src/worker/jobs/index/archive.rs
@@ -66,7 +66,7 @@ impl BackgroundJob for ArchiveIndexBranch {
     /// snapshot branch in a `TempDir`. The job does not share state with the
     /// long-lived bare clone behind `Environment::lock_index()`.
     #[instrument(skip_all, fields(branch = self.branch))]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         let Some(archive_url) = env.config.index_archive_url.as_ref() else {
             info!("`index_archive_url` not configured, skipping archive push");
             return Ok(());

--- a/src/worker/jobs/index/normalize.rs
+++ b/src/worker/jobs/index/normalize.rs
@@ -23,7 +23,7 @@ impl BackgroundJob for NormalizeIndex {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         info!("Normalizing the index");
 
         let dry_run = self.dry_run;

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -52,7 +52,7 @@ impl BackgroundJob for SquashIndex {
     type Context = Arc<Environment>;
 
     #[instrument(skip_all)]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         info!("Squashing the index into a single commit via the GitHub API");
 
         let index_sync_github_app = env

--- a/src/worker/jobs/index/sync.rs
+++ b/src/worker/jobs/index/sync.rs
@@ -34,7 +34,7 @@ impl BackgroundJob for SyncToGitIndex {
 
     /// Regenerates or removes an index file for a single crate.
     #[instrument(skip_all, fields(krate.name = self.krate))]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         info!("Syncing to git index");
 
         let crate_name = self.krate.clone();
@@ -104,7 +104,7 @@ impl BackgroundJob for BulkSyncToGitIndex {
     type Context = Arc<Environment>;
 
     #[instrument(skip_all, fields(num_crates = self.crate_names.len()))]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         info!(commit_message = ?self.commit_message, "Syncing {} crates to git index", self.crate_names.len());
 
         let crate_names = self.crate_names.clone();
@@ -179,7 +179,7 @@ impl BackgroundJob for SyncToSparseIndex {
 
     /// Regenerates or removes an index file for a single crate.
     #[instrument(skip_all, fields(krate.name = self.krate))]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         info!("Syncing to sparse index");
 
         let crate_name = self.krate.clone();

--- a/src/worker/jobs/index/sync.rs
+++ b/src/worker/jobs/index/sync.rs
@@ -37,7 +37,7 @@ impl BackgroundJob for SyncToGitIndex {
     async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         info!("Syncing to git index");
 
-        let crate_name = self.krate.clone();
+        let crate_name = self.krate;
         let mut conn = env.deadpool.get().await?;
 
         let new = get_index_data(&crate_name, &mut conn)
@@ -107,8 +107,8 @@ impl BackgroundJob for BulkSyncToGitIndex {
     async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         info!(commit_message = ?self.commit_message, "Syncing {} crates to git index", self.crate_names.len());
 
-        let crate_names = self.crate_names.clone();
-        let commit_message = self.commit_message.clone();
+        let crate_names = self.crate_names;
+        let commit_message = self.commit_message;
 
         let handle = Handle::current();
         spawn_blocking(move || {
@@ -182,17 +182,17 @@ impl BackgroundJob for SyncToSparseIndex {
     async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         info!("Syncing to sparse index");
 
-        let crate_name = self.krate.clone();
+        let crate_name = self.krate;
         let mut conn = env.deadpool.get().await?;
 
         let content = get_index_data(&crate_name, &mut conn)
             .await
             .context("Failed to get index data")?;
 
-        let future = env.storage.sync_index(&self.krate, content);
+        let future = env.storage.sync_index(&crate_name, content);
         future.await.context("Failed to sync index data")?;
 
-        let path = Repository::relative_index_file_for_url(&self.krate);
+        let path = Repository::relative_index_file_for_url(&crate_name);
 
         if let Some(fastly) = env.fastly() {
             let domain_name = &env.config.domain_name;

--- a/src/worker/jobs/index_version_downloads_archive/mod.rs
+++ b/src/worker/jobs/index_version_downloads_archive/mod.rs
@@ -22,7 +22,7 @@ impl BackgroundJob for IndexVersionDownloadsArchive {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         info!("Indexing old version downloads…");
 
         let Some(downloads_archive_store) = env.downloads_archive_store.as_ref() else {

--- a/src/worker/jobs/invalidate_cdns.rs
+++ b/src/worker/jobs/invalidate_cdns.rs
@@ -61,7 +61,7 @@ impl BackgroundJob for InvalidateCdns {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         // We won't parallelise: most crate deletions are for new crates with one (or very few)
         // versions, so the number of invalidations is likely to be small.
         if let Some(fastly) = ctx.fastly()

--- a/src/worker/jobs/process_cloudfront_invalidation_queue.rs
+++ b/src/worker/jobs/process_cloudfront_invalidation_queue.rs
@@ -117,7 +117,7 @@ impl BackgroundJob for ProcessCloudfrontInvalidationQueue {
     type Context = Arc<Environment>;
 
     #[instrument(skip_all)]
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let Some(cloudfront) = ctx.cloudfront() else {
             warn!("CloudFront not configured, skipping queue processing");
             return Ok(());

--- a/src/worker/jobs/readmes.rs
+++ b/src/worker/jobs/readmes.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{info, instrument, warn};
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct RenderAndUploadReadme {
     version_id: i32,
     text: String,
@@ -54,13 +54,12 @@ impl BackgroundJob for RenderAndUploadReadme {
 
         info!(version_id = ?self.version_id, "Rendering README");
 
-        let job = self.clone();
         let rendered = spawn_blocking(move || {
             text_to_html(
-                &job.text,
-                &job.readme_path,
-                job.base_url.as_deref(),
-                job.pkg_path_in_vcs.as_ref(),
+                &self.text,
+                &self.readme_path,
+                self.base_url.as_deref(),
+                self.pkg_path_in_vcs.as_ref(),
             )
         })
         .await?;
@@ -71,26 +70,26 @@ impl BackgroundJob for RenderAndUploadReadme {
 
         let mut conn = env.deadpool.get().await?;
         conn.transaction(async |conn| {
-            match Version::record_readme_rendering(job.version_id, conn).await {
+            match Version::record_readme_rendering(self.version_id, conn).await {
                 Ok(_) => {}
                 Err(DatabaseError(DatabaseErrorKind::ForeignKeyViolation, ..)) => {
                     warn!(
                         "Skipping README rendering recording for version {}: version not found",
-                        job.version_id
+                        self.version_id
                     );
                     return Ok(());
                 }
                 Err(err) => {
                     warn!(
                         "Failed to record README rendering for version {}: {err}",
-                        job.version_id,
+                        self.version_id,
                     );
                     return Err(err.into());
                 }
             }
 
             let result = versions::table
-                .find(job.version_id)
+                .find(self.version_id)
                 .inner_join(crates::table)
                 .select((crates::name, versions::num))
                 .first::<(String, String)>(conn)
@@ -100,7 +99,7 @@ impl BackgroundJob for RenderAndUploadReadme {
             let Some((crate_name, vers)) = result else {
                 warn!(
                     "Skipping README rendering for version {}: version not found",
-                    job.version_id
+                    self.version_id
                 );
                 return Ok(());
             };

--- a/src/worker/jobs/readmes.rs
+++ b/src/worker/jobs/readmes.rs
@@ -47,7 +47,7 @@ impl BackgroundJob for RenderAndUploadReadme {
     type Context = Arc<Environment>;
 
     #[instrument(skip_all, fields(krate.name))]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         use crate::schema::*;
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -38,7 +38,7 @@ impl BackgroundJob for SyncCrateFeed {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let name = &self.name;
         let domain = &ctx.config.domain_name;
 

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -30,7 +30,7 @@ impl BackgroundJob for SyncCratesFeed {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let key = StorageKey::CratesFeed;
         let domain = &ctx.config.domain_name;
 

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -30,7 +30,7 @@ impl BackgroundJob for SyncUpdatesFeed {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let key = StorageKey::UpdatesFeed;
         let domain = &ctx.config.domain_name;
 

--- a/src/worker/jobs/send_publish_notifications.rs
+++ b/src/worker/jobs/send_publish_notifications.rs
@@ -31,7 +31,7 @@ impl BackgroundJob for SendPublishNotificationsJob {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let version_id = self.version_id;
 
         info!("Sending publish notifications for version {version_id}…");

--- a/src/worker/jobs/sync_admins.rs
+++ b/src/worker/jobs/sync_admins.rs
@@ -23,7 +23,7 @@ impl BackgroundJob for SyncAdmins {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         info!("Syncing admins from rust-lang/team repo…");
 
         let repo_admins = ctx.team_repo.get_permission(PERMISSION_NAME).await?.people;

--- a/src/worker/jobs/trustpub/delete_jtis.rs
+++ b/src/worker/jobs/trustpub/delete_jtis.rs
@@ -17,7 +17,7 @@ impl BackgroundJob for DeleteExpiredJtis {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let mut conn = ctx.deadpool.get().await?;
 
         diesel::delete(trustpub_used_jtis::table)

--- a/src/worker/jobs/trustpub/delete_tokens.rs
+++ b/src/worker/jobs/trustpub/delete_tokens.rs
@@ -16,7 +16,7 @@ impl BackgroundJob for DeleteExpiredTokens {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let mut conn = ctx.deadpool.get().await?;
 
         diesel::delete(trustpub_tokens::table)

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -34,7 +34,7 @@ impl BackgroundJob for CheckTyposquat {
 
     #[instrument(skip(env), err)]
     async fn run(self, env: Self::Context) -> anyhow::Result<()> {
-        let crate_name = self.name.clone();
+        let crate_name = self.name;
 
         let mut conn = env.deadpool.get().await?;
 

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -33,7 +33,7 @@ impl BackgroundJob for CheckTyposquat {
     type Context = Arc<Environment>;
 
     #[instrument(skip(env), err)]
-    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, env: Self::Context) -> anyhow::Result<()> {
         let crate_name = self.name.clone();
 
         let mut conn = env.deadpool.get().await?;

--- a/src/worker/jobs/update_default_version.rs
+++ b/src/worker/jobs/update_default_version.rs
@@ -27,7 +27,7 @@ impl BackgroundJob for UpdateDefaultVersion {
 
     type Context = Arc<Environment>;
 
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let crate_id = self.crate_id;
 
         info!("Updating default version for crate {crate_id}");

--- a/src/worker/jobs/update_user_from_github.rs
+++ b/src/worker/jobs/update_user_from_github.rs
@@ -33,7 +33,7 @@ impl BackgroundJob for UpdateUserFromGithub {
     /// For the specified user, queries the GitHub API for the user's current information to see if
     /// their account has been deleted or renamed. Updates the `users` and `oauth_github` tables,
     /// saving the current time in `last_sync` even if the user information hasn't changed.
-    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: Self::Context) -> anyhow::Result<()> {
         let mut conn = ctx.deadpool.get().await?;
 
         // If no oauth_github info with this account id is found, then the record has been deleted


### PR DESCRIPTION
`BackgroundJob::run()` now takes `self`, allowing job implementations to move their payloads into blocking tasks without cloning them. The worker already deserializes a fresh job for each execution, so it does not need to retain the value after running it.

This also removes unnecessary payload clones from the existing jobs.