### PR TITLE
Use crates.io username in admin contexts

### DIFF
--- a/src/bin/crates-io/admin/verify_token.rs
+++ b/src/bin/crates-io/admin/verify_token.rs
@@ -6,9 +6,9 @@ use crates_io::{db, models::User};
 #[derive(clap::Parser, Debug)]
 #[command(
     name = "verify-token",
-    about = "Look up a username by API token.",
-    long_about = "Look up a username by API token. Used by staff to verify someone's identity \
-        by having an API token given. If an error occurs, including being unable to \
+    about = "Look up a crates.io username by API token.",
+    long_about = "Look up a crates.io username by API token. Used by staff to verify someone's \
+        identity by having an API token given. If an error occurs, including being unable to \
         find a user with that API token, the error will be displayed."
 )]
 pub struct Opts {
@@ -23,6 +23,6 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
     let token = HashedToken::parse(&opts.api_token)?;
     let token = ApiToken::find_by_api_token(&mut conn, &token).await?;
     let user = User::find(&conn, token.user_id).await?;
-    println!("The token belongs to user {}", user.gh_login);
+    println!("The token belongs to crates.io user {}", user.username);
     Ok(())
 }

--- a/src/controllers/admin.rs
+++ b/src/controllers/admin.rs
@@ -1,7 +1,7 @@
 use crate::{
     app::AppState,
     auth::AuthCheck,
-    models::{OwnerKind, User},
+    models::{OwnerKind, User, users_by_username},
     schema::*,
     util::errors::{AppResult, custom},
     util::no_store,
@@ -79,10 +79,9 @@ pub async fn list(
         ));
     }
 
-    let (user, verified, user_email) = users::table
+    let (user, verified, user_email) = users_by_username(&username)
         .left_join(emails::table)
         .left_join(oauth_github::table)
-        .filter(users::gh_login.eq(username))
         .select((
             User::as_select(),
             emails::verified.nullable(),

--- a/src/controllers/krate/update.rs
+++ b/src/controllers/krate/update.rs
@@ -125,9 +125,9 @@ async fn update_inner(
             krate.name = %krate.name,
             network.client.ip = %**real_ip,
             usr.id = user.id,
-            usr.name = %user.gh_login,
-            "User {} set trustpub_only={trustpub_only} for crate {}",
-            user.gh_login,
+            usr.name = %user.username,
+            "Crates.io user {} set trustpub_only={trustpub_only} for crate {}",
+            user.username,
             krate.name
         );
 

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -161,8 +161,9 @@ pub async fn create_api_token(
         warn!(
             network.client.ip = client_ip,
             http.headers = ?headers,
-            "Blocked token creation for user `{}` (id: {}) due to disabled flag (token name: `{}`)",
-            user.gh_login, user.id, new.api_token.name
+            "Blocked token creation for crates.io user `{}` (id: {}) \
+            due to disabled flag (token name: `{}`)",
+            user.username, user.id, new.api_token.name
         );
 
         let message = disable_message.clone();

--- a/src/controllers/version/update.rs
+++ b/src/controllers/version/update.rs
@@ -135,8 +135,8 @@ pub async fn perform_version_yank_update(
         if user.is_admin {
             let action = if yanked { "yanking" } else { "unyanking" };
             warn!(
-                "Admin {} is {action} {}@{}",
-                user.gh_login, krate.name, version.num
+                "Admin crates.io user {} is {action} {}@{}",
+                user.username, krate.name, version.num
             );
         } else {
             return Err(custom(

--- a/src/tests/caching.rs
+++ b/src/tests/caching.rs
@@ -104,7 +104,7 @@ async fn admin_list_is_not_cached() {
         .await
         .unwrap();
 
-    let response = user.admin_list::<()>(&user.as_model().gh_login).await;
+    let response = user.admin_list::<()>(&user.as_model().username).await;
     response.assert_cache_control("no-store");
 }
 

--- a/src/tests/routes/crates/admin.rs
+++ b/src/tests/routes/crates/admin.rs
@@ -62,7 +62,7 @@ async fn index_include_yanked() -> anyhow::Result<()> {
         .await;
 
     // Include fully yanked (all versions were yanked) crates
-    let username = &user.gh_login;
+    let username = &user.username;
     let response = admin.admin_list::<()>(username).await;
 
     assert_json_snapshot!(response.json(), {


### PR DESCRIPTION
As part of the transition to crates.io usernames, change admin commands and APIs to use `users.username` rather than `users.gh_login`.

End users of crates.io should not see any observable effects of this PR.

Admins will need to remember that:

- Looking up a user by their token with the `verify-token` command will return the user's crates.io username, which currently always matches their GitHub username, but that will not necessarily be the case in the future.
- Using the `list_admin` API will look up users by their crates.io username (I think I might be the only one who uses this)
- Usernames in some log messages will now be crates.io usernames (I added "crates.io username" to the log messages as a clarification)

Extracted from https://github.com/rust-lang/crates.io/pull/14575. Shouldn't conflict with https://github.com/rust-lang/crates.io/pull/14213.