### PR TITLE
In tests, where appropriate, use `users.username`

### DIFF
--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -175,7 +175,7 @@ async fn create_and_add_owner(
 async fn owners_can_remove_self() {
     let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn().await;
-    let username = &user.as_model().gh_login;
+    let username = &user.as_model().username;
 
     let krate = CrateBuilder::new("owners_selfremove", user.as_model().id)
         .expect_build(&mut conn)
@@ -210,7 +210,7 @@ async fn owners_can_remove_self() {
 async fn modify_multiple_owners() -> anyhow::Result<()> {
     let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn().await;
-    let username = &user.as_model().gh_login;
+    let username = &user.as_model().username;
 
     let krate = CrateBuilder::new("owners_multiple", user.as_model().id)
         .expect_build(&mut conn)
@@ -393,7 +393,7 @@ async fn deleted_ownership_isnt_in_owner_user() {
     let krate = CrateBuilder::new("foo_my_packages", user.id)
         .expect_build(&mut conn)
         .await;
-    krate.owner_remove(&conn, &user.gh_login).await.unwrap();
+    krate.owner_remove(&conn, &user.username).await.unwrap();
 
     let json: UserResponse = anon
         .get("/api/v1/crates/foo_my_packages/owner_user")

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -19,7 +19,7 @@ async fn test_cargo_invite_owners() {
         .await;
 
     let json = owner
-        .add_named_owner("guacamole", &new_user.as_model().gh_login)
+        .add_named_owner("guacamole", &new_user.as_model().username)
         .await
         .good();
 
@@ -47,7 +47,7 @@ async fn owner_change_via_cookie() {
         .expect_build(&mut conn)
         .await;
 
-    let response = cookie.add_named_owner(&krate.name, &user2.gh_login).await;
+    let response = cookie.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"200 OK");
     assert_snapshot!(response.text(), @r#"{"msg":"user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
 }
@@ -179,7 +179,7 @@ async fn owner_change_via_token() {
         .expect_build(&mut conn)
         .await;
 
-    let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
+    let response = token.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"200 OK");
     assert_snapshot!(response.text(), @r#"{"msg":"user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
 }
@@ -199,7 +199,7 @@ async fn owner_change_via_change_owner_token() {
         .expect_build(&mut conn)
         .await;
 
-    let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
+    let response = token.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"200 OK");
     assert_snapshot!(response.text(), @r#"{"msg":"user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
 }
@@ -220,7 +220,7 @@ async fn owner_change_via_change_owner_token_with_matching_crate_scope() {
         .expect_build(&mut conn)
         .await;
 
-    let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
+    let response = token.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"200 OK");
     assert_snapshot!(response.text(), @r#"{"msg":"user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
 }
@@ -241,7 +241,7 @@ async fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
         .expect_build(&mut conn)
         .await;
 
-    let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
+    let response = token.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"403 Forbidden");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"#);
 }
@@ -261,7 +261,7 @@ async fn owner_change_via_publish_token() {
         .expect_build(&mut conn)
         .await;
 
-    let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
+    let response = token.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"403 Forbidden");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"#);
 }
@@ -278,7 +278,7 @@ async fn owner_change_without_auth() {
         .expect_build(&mut conn)
         .await;
 
-    let response = anon.add_named_owner(&krate.name, &user2.gh_login).await;
+    let response = anon.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"403 Forbidden");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 }

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -62,7 +62,7 @@ async fn test_user_owned_crates_doesnt_include_deleted_ownership() {
         .expect_build(&mut conn)
         .await;
     krate
-        .owner_remove(&conn, &user_model.gh_login)
+        .owner_remove(&conn, &user_model.username)
         .await
         .unwrap();
 

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -81,7 +81,7 @@ async fn following() {
         .unwrap();
     assert_eq!(
         bar_version.published_by.as_ref().unwrap().login,
-        user_model.gh_login
+        user_model.username
     );
 
     let r: R = user

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -53,7 +53,7 @@ async fn user_total_downloads() -> anyhow::Result<()> {
         .execute(&mut conn)
         .await?;
     no_longer_my_krate
-        .owner_remove(&conn, &user.gh_login)
+        .owner_remove(&conn, &user.username)
         .await
         .unwrap();
 

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -81,7 +81,7 @@ async fn updating_existing_user_doesnt_change_api_token() -> anyhow::Result<()> 
     let api_token = assert_ok!(ApiToken::find_by_api_token(&mut conn, &hashed_token).await);
     let user = assert_ok!(User::find(&conn, api_token.user_id).await);
 
-    assert_eq!(user.gh_login, "bar");
+    assert_eq!(user.username, "bar");
     let decrypted_token = encryption.decrypt(user.gh_encrypted_token.as_ref().unwrap())?;
     assert_eq!(decrypted_token.expose_secret(), "bar_token");
 


### PR DESCRIPTION
Instead of `users.gh_login`.

For now, these fields should always be the same, so there is no change in the test or implementation behavior coverage.

When we fully enable crates.io usernames as being independent of GitHub usernames, these tests should be using the crates.io username.

Extracted from https://github.com/rust-lang/crates.io/pull/14575. Might conflict with https://github.com/rust-lang/crates.io/pull/14213 a tiny bit.