### PR TITLE
middleware: Restrict legacy `/svelte` redirects

### DIFF
--- a/src/middleware/svelte_redirect.rs
+++ b/src/middleware/svelte_redirect.rs
@@ -39,6 +39,10 @@ fn redirect_target(path: &str, query: Option<&str>) -> Option<String> {
         return None;
     }
 
+    if new_path == "/api" || new_path.starts_with("/api/") {
+        return None;
+    }
+
     Some(match query {
         Some(query) => format!("{new_path}?{query}"),
         None => new_path.to_owned(),
@@ -78,6 +82,12 @@ mod tests {
                 Some("/crates/tokio?foo=1"),
             ),
             ("/svelte", Some("x=y"), Some("/?x=y")),
+            // API paths
+            ("/svelte/api", None, None),
+            ("/svelte/api/", None, None),
+            ("/svelte/api/v1/crates", Some("q=tokio"), None),
+            ("/svelte/apiculture", None, Some("/apiculture")),
+            ("/svelte/crates/api", None, Some("/crates/api")),
             // Non-matching paths
             ("/", None, None),
             ("/crates/tokio", None, None),

--- a/src/middleware/svelte_redirect.rs
+++ b/src/middleware/svelte_redirect.rs
@@ -22,7 +22,8 @@ pub async fn redirect(request: Request, next: Next) -> Response {
 /// Computes the redirect target for a request to a `/svelte/...` path.
 ///
 /// Returns [`None`] if the request should not be redirected. The result
-/// preserves the query string, if any.
+/// preserves the query string, if any. Non-root targets must start with an
+/// ASCII letter after the leading slash to keep redirects on the same origin.
 fn redirect_target(path: &str, query: Option<&str>) -> Option<String> {
     let stripped = path.strip_prefix(PREFIX)?;
 
@@ -33,6 +34,11 @@ fn redirect_target(path: &str, query: Option<&str>) -> Option<String> {
     }
 
     let new_path = if stripped.is_empty() { "/" } else { stripped };
+    let route_start = new_path.as_bytes().get(1);
+    if new_path != "/" && !route_start.is_some_and(u8::is_ascii_alphabetic) {
+        return None;
+    }
+
     Some(match query {
         Some(query) => format!("{new_path}?{query}"),
         None => new_path.to_owned(),
@@ -52,6 +58,19 @@ mod tests {
             // Deep paths
             ("/svelte/crates/tokio", None, Some("/crates/tokio")),
             ("/svelte/crates/tokio/", None, Some("/crates/tokio/")),
+            (
+                "/svelte/crates/serde_json/1.0.0/code/src/lib.rs",
+                None,
+                Some("/crates/serde_json/1.0.0/code/src/lib.rs"),
+            ),
+            ("/svelte/category_slugs", None, Some("/category_slugs")),
+            (
+                "/svelte/accept-invite/abc123",
+                None,
+                Some("/accept-invite/abc123"),
+            ),
+            ("/svelte/A", None, Some("/A")),
+            ("/svelte/z", None, Some("/z")),
             // Query string preserved
             (
                 "/svelte/crates/tokio",
@@ -64,10 +83,18 @@ mod tests {
             ("/crates/tokio", None, None),
             ("/sveltefoo", None, None),
             ("/sveltey/x", None, None),
+            // Invalid route prefixes
+            ("/svelte//evil.com", None, None),
+            ("/svelte/\\evil.com", None, None),
+            ("/svelte/%2fevil.com", None, None),
+            ("/svelte/%5cevil.com", None, None),
+            ("/svelte/1", None, None),
+            ("/svelte/_app", None, None),
+            ("/svelte/é", None, None),
         ];
 
         for (path, query, expected) in CASES.iter().copied() {
-            assert_eq!(redirect_target(path, query).as_deref(), expected);
+            assert_eq!(redirect_target(path, query).as_deref(), expected, "{path}");
         }
     }
 }

--- a/src/middleware/svelte_redirect.rs
+++ b/src/middleware/svelte_redirect.rs
@@ -2,7 +2,7 @@
 //!
 //! While the SvelteKit frontend was being developed, it was served at
 //! `/svelte/`. Now that Svelte is the default frontend at `/`, this
-//! middleware 307-redirects any leftover `/svelte/...` URL (bookmarks,
+//! middleware 308-redirects any leftover `/svelte/...` URL (bookmarks,
 //! external links, in-flight HTML pages cached by browsers/CDNs) back
 //! to the canonical un-prefixed location.
 
@@ -16,7 +16,7 @@ pub async fn redirect(request: Request, next: Next) -> Response {
     let Some(target) = redirect_target(request.uri().path(), request.uri().query()) else {
         return next.run(request).await;
     };
-    Redirect::temporary(&target).into_response()
+    Redirect::permanent(&target).into_response()
 }
 
 /// Computes the redirect target for a request to a `/svelte/...` path.


### PR DESCRIPTION
The frontend move is permanent now, so this PR changes the legacy `/svelte` redirects to use HTTP 308 to signal that search engines should prefer the unprefixed URLs.

Non-root redirect targets must now also start with an ASCII letter after the leading slash, preventing destinations that clients could interpret as another host. I've also excluded targets starting with `/api`.

### Related

- #13542