### PR TITLE
Deprecate user owners' url field

### DIFF
--- a/crates/crates_io_api_types/src/lib.rs
+++ b/crates/crates_io_api_types/src/lib.rs
@@ -543,7 +543,7 @@ pub enum EncodableOwner {
         login: String,
 
         /// The URL to the user's GitHub profile.
-        #[schema(example = "https://github.com/ghost")]
+        #[schema(example = "https://github.com/ghost", deprecated)]
         url: String,
 
         /// The user's display name.

--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -1565,6 +1565,7 @@ export interface components {
              */
             name: string | null;
             /**
+             * @deprecated
              * @description The URL to the user's GitHub profile.
              * @example https://github.com/ghost
              */

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -920,6 +920,7 @@ expression: response.json()
                 ]
               },
               "url": {
+                "deprecated": true,
                 "description": "The URL to the user's GitHub profile.",
                 "example": "https://github.com/ghost",
                 "type": "string"

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -920,6 +920,7 @@ expression: response.json()
                 ]
               },
               "url": {
+                "deprecated": true,
                 "description": "The URL to the user's GitHub profile.",
                 "example": "https://github.com/ghost",
                 "type": "string"


### PR DESCRIPTION
Similarly to https://github.com/rust-lang/crates.io/pull/14537 done for https://github.com/rust-lang/crates.io/issues/14381, I missed that user owners also have a `url` field.

I don't see anywhere this is used in the svelte UI (but I could be missing something).

Extracted from https://github.com/rust-lang/crates.io/pull/14575; shouldn't conflict with https://github.com/rust-lang/crates.io/pull/14213