### PR TITLE
In owner invite messages, use crates.io username

### DIFF
--- a/packages/crates-io-api-client/schema.ts
+++ b/packages/crates-io-api-client/schema.ts
@@ -3312,7 +3312,7 @@ export interface operations {
                     "application/json": {
                         /**
                          * @description A message describing the result of the operation.
-                         * @example user ghost has been invited to be an owner of crate serde
+                         * @example Crates.io user ghost has been invited to be an owner of crate serde
                          */
                         msg: string;
                         /** @example true */
@@ -3377,7 +3377,7 @@ export interface operations {
                     "application/json": {
                         /**
                          * @description A message describing the result of the operation.
-                         * @example user ghost has been invited to be an owner of crate serde
+                         * @example Crates.io user ghost has been invited to be an owner of crate serde
                          */
                         msg: string;
                         /** @example true */

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -127,7 +127,7 @@ pub async fn get_user_owners(state: AppState, path: CratePath) -> AppResult<Json
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ModifyResponse {
     /// A message describing the result of the operation.
-    #[schema(example = "user ghost has been invited to be an owner of crate serde")]
+    #[schema(example = "Crates.io user ghost has been invited to be an owner of crate serde")]
     pub msg: String,
 
     #[schema(example = true)]
@@ -203,8 +203,8 @@ pub async fn add_owners(
                     // acceptance.
                     Ok(NewOwnerInvite::User(invitee, token)) => {
                         msgs.push(format!(
-                            "user {} has been invited to be an owner of crate {}",
-                            invitee.gh_login, krate.name,
+                            "Crates.io user {} has been invited to be an owner of crate {}",
+                            invitee.username, krate.name,
                         ));
 
                         if let Some(recipient) = invitee.verified_email(conn).await.ok().flatten() {
@@ -228,8 +228,9 @@ pub async fn add_owners(
 
                     // This user has a pending invite.
                     Err(OwnerAddError::AlreadyInvited(user)) => msgs.push(format!(
-                        "user {} already has a pending invitation to be an owner of crate {}",
-                        user.gh_login, krate.name
+                        "Crates.io user {} already has a pending invitation \
+                        to be an owner of crate {}",
+                        user.username, krate.name
                     )),
 
                     // An opaque error occurred.

--- a/src/tests/issues/issue2736.rs
+++ b/src/tests/issues/issue2736.rs
@@ -62,7 +62,7 @@ async fn test_issue_2736() -> anyhow::Result<()> {
     // Once that removal works, it should be possible to add the new account as an owner
     let response = someone_else.add_named_owner("crate1", "foo").await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user foo has been invited to be an owner of crate crate1","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user foo has been invited to be an owner of crate crate1","ok":true}"#);
 
     Ok(())
 }

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -250,7 +250,7 @@ async fn modify_multiple_owners() -> anyhow::Result<()> {
         .add_named_owners("owners_multiple", &["user2", "user3"])
         .await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user user2 has been invited to be an owner of crate owners_multiple,user user3 has been invited to be an owner of crate owners_multiple","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user user2 has been invited to be an owner of crate owners_multiple,Crates.io user user3 has been invited to be an owner of crate owners_multiple","ok":true}"#);
 
     assert_snapshot!(app.emails_snapshot().await);
 

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -31,7 +31,7 @@ async fn test_cargo_invite_owners() {
     // version of cargo
     assert_eq!(
         json.msg,
-        "user cilantro has been invited to be an owner of crate guacamole"
+        "Crates.io user cilantro has been invited to be an owner of crate guacamole"
     )
 }
 
@@ -49,7 +49,7 @@ async fn owner_change_via_cookie() {
 
     let response = cookie.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
 }
 
 async fn invite_distinct_login_user(login: &str) -> Response<OwnerResp> {
@@ -94,14 +94,14 @@ async fn unprefixed_crates_io_username_separator_variant() {
 async fn unprefixed_github_login_verbatim() {
     let response = invite_distinct_login_user("github-user").await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user github-user has been invited to be an owner of crate foo","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user crates-user has been invited to be an owner of crate foo","ok":true}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn unprefixed_github_login_case_insensitive() {
     let response = invite_distinct_login_user("GITHUB-USER").await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user github-user has been invited to be an owner of crate foo","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user crates-user has been invited to be an owner of crate foo","ok":true}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -181,7 +181,7 @@ async fn owner_change_via_token() {
 
     let response = token.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -201,7 +201,7 @@ async fn owner_change_via_change_owner_token() {
 
     let response = token.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -222,7 +222,7 @@ async fn owner_change_via_change_owner_token_with_matching_crate_scope() {
 
     let response = token.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -298,7 +298,7 @@ async fn test_owner_change_with_legacy_field() {
         .put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user user2 has been invited to be an owner of crate foo","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user user2 has been invited to be an owner of crate foo","ok":true}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -352,7 +352,7 @@ async fn invite_already_invited_user() {
     // Invite the user the first time
     let response = owner.add_named_owner("crate_name", "invited_user").await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user invited_user has been invited to be an owner of crate crate_name","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user invited_user has been invited to be an owner of crate crate_name","ok":true}"#);
 
     // Check one email was sent, this will be the ownership invite email
     assert_eq!(app.emails().await.len(), 1);
@@ -360,7 +360,7 @@ async fn invite_already_invited_user() {
     // Then invite the user a second time, the message should point out the user is already invited
     let response = owner.add_named_owner("crate_name", "invited_user").await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user invited_user already has a pending invitation to be an owner of crate crate_name","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user invited_user already has a pending invitation to be an owner of crate crate_name","ok":true}"#);
 
     // Check that no new email is sent after the second invitation
     assert_eq!(app.emails().await.len(), 1);
@@ -382,7 +382,7 @@ async fn invite_with_existing_expired_invite() {
     // Invite the user the first time
     let response = owner.add_named_owner("crate_name", "invited_user").await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user invited_user has been invited to be an owner of crate crate_name","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user invited_user has been invited to be an owner of crate crate_name","ok":true}"#);
 
     // Check one email was sent, this will be the ownership invite email
     assert_eq!(app.emails().await.len(), 1);
@@ -393,7 +393,7 @@ async fn invite_with_existing_expired_invite() {
     // Then invite the user a second time, a new invite is created as the old one expired
     let response = owner.add_named_owner("crate_name", "invited_user").await;
     assert_snapshot!(response.status(), @"200 OK");
-    assert_snapshot!(response.text(), @r#"{"msg":"user invited_user has been invited to be an owner of crate crate_name","ok":true}"#);
+    assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user invited_user has been invited to be an owner of crate crate_name","ok":true}"#);
 
     // Check that the email for the second invite was sent
     assert_eq!(app.emails().await.len(), 2);

--- a/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_internal_snapshot-2.snap
@@ -3668,7 +3668,7 @@ expression: response.json()
                   "properties": {
                     "msg": {
                       "description": "A message describing the result of the operation.",
-                      "example": "user ghost has been invited to be an owner of crate serde",
+                      "example": "Crates.io user ghost has been invited to be an owner of crate serde",
                       "type": "string"
                     },
                     "ok": {
@@ -3828,7 +3828,7 @@ expression: response.json()
                   "properties": {
                     "msg": {
                       "description": "A message describing the result of the operation.",
-                      "example": "user ghost has been invited to be an owner of crate serde",
+                      "example": "Crates.io user ghost has been invited to be an owner of crate serde",
                       "type": "string"
                     },
                     "ok": {

--- a/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
+++ b/src/tests/snapshots/integration__openapi__openapi_snapshot-2.snap
@@ -2935,7 +2935,7 @@ expression: response.json()
                   "properties": {
                     "msg": {
                       "description": "A message describing the result of the operation.",
-                      "example": "user ghost has been invited to be an owner of crate serde",
+                      "example": "Crates.io user ghost has been invited to be an owner of crate serde",
                       "type": "string"
                     },
                     "ok": {
@@ -3095,7 +3095,7 @@ expression: response.json()
                   "properties": {
                     "msg": {
                       "description": "A message describing the result of the operation.",
-                      "example": "user ghost has been invited to be an owner of crate serde",
+                      "example": "Crates.io user ghost has been invited to be an owner of crate serde",
                       "type": "string"
                     },
                     "ok": {


### PR DESCRIPTION
These are messages that a user sees when they've invited other users to own a crate. Right now, there shouldn't be any confusion because `users.username` should always equal `users.gh_login`, but I've added "Crates.io user" to the message to hopefully clarify for the future when we have crates.io usernames independent of GitHub usernames.

Extracted from https://github.com/rust-lang/crates.io/pull/14575; will probably conflict with https://github.com/rust-lang/crates.io/pull/14213 a little bit.