### PR TITLE
controllers/owners: Compare user owners by ID

### DIFF
--- a/crates/crates_io_test_utils/src/builders/user.rs
+++ b/crates/crates_io_test_utils/src/builders/user.rs
@@ -24,6 +24,7 @@ pub struct UserBuilder<'a> {
     username: &'a str,
     display_name: Option<&'a str>,
     gh_login: &'a str,
+    gh_id: Option<i32>,
 }
 
 impl<'a> UserBuilder<'a> {
@@ -34,6 +35,7 @@ impl<'a> UserBuilder<'a> {
             username: "octocat",
             display_name: None,
             gh_login: "octocat",
+            gh_id: None,
         }
     }
 
@@ -57,12 +59,20 @@ impl<'a> UserBuilder<'a> {
         Self { gh_login, ..self }
     }
 
+    /// Sets the legacy GitHub account ID.
+    pub fn with_gh_id(self, gh_id: i32) -> Self {
+        Self {
+            gh_id: Some(gh_id),
+            ..self
+        }
+    }
+
     pub fn build(self) -> User {
         User {
             id: 1,
             gh_login: self.gh_login.into(),
             name: self.display_name.map(ToString::to_string),
-            gh_id: 123,
+            gh_id: self.gh_id.unwrap_or(123),
             gh_avatar: None,
             gh_encrypted_token: None,
             account_lock_reason: None,
@@ -76,7 +86,7 @@ impl<'a> UserBuilder<'a> {
 
     pub fn new_user(self) -> NewUser<'a> {
         NewUser::builder()
-            .gh_id(next_gh_id())
+            .gh_id(self.gh_id.unwrap_or_else(next_gh_id))
             .gh_login(self.gh_login)
             .username(self.username)
             .maybe_name(self.display_name)

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -357,7 +357,8 @@ async fn add_owner(
 ) -> Result<NewOwnerInvite, OwnerAddError> {
     match Login::parse(login)? {
         Login::GitHubTeam(team) => {
-            let login_test = |owner: &Owner| owner.login().to_lowercase() == *login.to_lowercase();
+            let lowercase_login = login.to_lowercase();
+            let login_test = |owner: &Owner| owner.login().to_lowercase() == lowercase_login;
             if owners.iter().any(login_test) {
                 return Err(bad_request(format_args!("`{login}` is already an owner")).into());
             }

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -188,13 +188,7 @@ pub async fn add_owners(
         .transaction(async |conn| {
             let mut msgs = Vec::with_capacity(logins.len());
             for login in &logins {
-                let login_test =
-                    |owner: &Owner| owner.login().to_lowercase() == *login.to_lowercase();
-                if owners.iter().any(login_test) {
-                    return Err(bad_request(format_args!("`{login}` is already an owner")));
-                }
-
-                match add_owner(&app, conn, user, &krate, login).await {
+                match add_owner(&app, conn, user, &krate, &owners, login).await {
                     // A user must accept the invitation through their account
                     // or with the emailed token.
                     Ok(NewOwnerInvite::User(invitee, token)) => {
@@ -358,10 +352,16 @@ async fn add_owner(
     conn: &mut AsyncPgConnection,
     req_user: &User,
     krate: &Crate,
+    owners: &[Owner],
     login: &str,
 ) -> Result<NewOwnerInvite, OwnerAddError> {
     match Login::parse(login)? {
         Login::GitHubTeam(team) => {
+            let login_test = |owner: &Owner| owner.login().to_lowercase() == *login.to_lowercase();
+            if owners.iter().any(login_test) {
+                return Err(bad_request(format_args!("`{login}` is already an owner")).into());
+            }
+
             let github = &*app.github;
             let encryption = &app.config.token_encryption;
             add_github_team_owner(github, conn, req_user, krate, team, encryption).await
@@ -371,6 +371,12 @@ async fn add_owner(
             let user = user.ok_or_else(|| {
                 bad_request(format_args!("could not find user with login `{login}`"))
             })?;
+
+            let is_owner =
+                |owner: &Owner| matches!(owner, Owner::User(owner) if owner.id == user.id);
+            if owners.iter().any(is_owner) {
+                return Err(bad_request(format_args!("`{login}` is already an owner")).into());
+            }
 
             invite_user_owner(app, conn, req_user, krate, user).await
         }

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -366,7 +366,14 @@ async fn add_owner(
             let encryption = &app.config.token_encryption;
             add_github_team_owner(github, conn, req_user, krate, team, encryption).await
         }
-        Login::Unprefixed(login) => invite_user_owner(app, conn, req_user, krate, login).await,
+        Login::Unprefixed(login) => {
+            let user = User::find_by_login(conn, login).await.optional()?;
+            let user = user.ok_or_else(|| {
+                bad_request(format_args!("could not find user with login `{login}`"))
+            })?;
+
+            invite_user_owner(app, conn, req_user, krate, user).await
+        }
     }
 }
 
@@ -416,18 +423,14 @@ impl<'a> GitHubTeamLogin<'a> {
     }
 }
 
+/// Creates an owner invitation for a resolved user.
 async fn invite_user_owner(
     app: &App,
     conn: &mut AsyncPgConnection,
     req_user: &User,
     krate: &Crate,
-    login: &str,
+    user: User,
 ) -> Result<NewOwnerInvite, OwnerAddError> {
-    let user = User::find_by_login(conn, login)
-        .await
-        .optional()?
-        .ok_or_else(|| bad_request(format_args!("could not find user with login `{login}`")))?;
-
     // Users are invited and must accept before being added
     let expires_at = Utc::now() + app.config.ownership_invitations_expiration;
     let invite = NewCrateOwnerInvitation {

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -382,6 +382,18 @@ async fn add_existing_team() {
         ret.text(),
         r#"{"errors":[{"detail":"`github:test_org:bananas` is already an owner"}]}"#
     );
+
+    let response = token
+        .add_named_owner("best_crate", "github:TEST_ORG:BANANAS")
+        .await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"`github:TEST_ORG:BANANAS` is already an owner"}]}"#);
+
+    let response = token
+        .add_named_owner("best_crate", "GITHUB:test_org:bananas")
+        .await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"unknown organization handler, only 'github:org:team' is supported"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -1,11 +1,11 @@
-use crate::OwnerResp;
 use crate::builders::{CrateBuilder, UserBuilder};
 use crate::owners::expire_invitation;
 use crate::util::github::next_gh_id;
 use crate::util::{RequestHelper, Response, TestApp};
+use crate::{OwnerResp, new_team};
 use crates_io::models::CrateOwner;
 use crates_io::models::token::{CrateScope, EndpointScope};
-use crates_io::schema::{crate_owner_invitations, emails};
+use crates_io::schema::{crate_owner_invitations, emails, teams};
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use insta::assert_snapshot;
@@ -88,9 +88,9 @@ async fn reused_github_login_invites_highest_github_id() {
     assert_eq!(invitees, [newer.as_model().id]);
 }
 
-/// The legacy duplicate check rejects a reused login before resolving its user.
+/// An older owner's cached GitHub login does not block inviting a different user.
 #[tokio::test(flavor = "multi_thread")]
-async fn reused_github_login_rejected_when_older_account_owns_crate() {
+async fn reused_github_login_invites_newer_account_when_older_owns_crate() {
     let (app, _, cookie) = TestApp::full().with_user().await;
     let mut conn = app.db_conn().await;
 
@@ -117,11 +117,67 @@ async fn reused_github_login_rejected_when_older_account_owns_crate() {
         .unwrap();
 
     let response = cookie.add_named_owner("foo", "SHARED").await;
-    assert_snapshot!(response.status(), @"400 Bad Request");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"`SHARED` is already an owner"}]}"#);
+    assert_snapshot!(response.status(), @"200 OK");
 
     let invitees = invited_user_ids(&mut conn, krate.id).await;
-    assert!(invitees.is_empty());
+    assert_eq!(invitees, [newer.as_model().id]);
+}
+
+/// An owner excluded from user lookup produces a lookup error, not a duplicate error.
+#[tokio::test(flavor = "multi_thread")]
+async fn owner_lookup_error_precedes_duplicate_check() {
+    let (app, _, cookie) = TestApp::full().with_user().await;
+    let mut conn = app.db_conn().await;
+    let inactive = UserBuilder::new().with_username("inactive").with_gh_id(-1);
+    let inactive = app.db_new_user_from_builder(inactive).await;
+
+    let krate = CrateBuilder::new("foo", cookie.as_model().id)
+        .expect_build(&mut conn)
+        .await;
+    CrateOwner::builder()
+        .crate_id(krate.id)
+        .user_id(inactive.as_model().id)
+        .created_by(cookie.as_model().id)
+        .build()
+        .insert(&conn)
+        .await
+        .unwrap();
+
+    let response = cookie.add_named_owner("foo", "INACTIVE").await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find user with login `INACTIVE`"}]}"#);
+    assert!(invited_user_ids(&mut conn, krate.id).await.is_empty());
+}
+
+/// User and team IDs belong to separate namespaces.
+#[tokio::test(flavor = "multi_thread")]
+async fn invite_user_with_same_id_as_team_owner() {
+    let (app, _, cookie) = TestApp::full().with_user().await;
+    let mut conn = app.db_conn().await;
+    let invitee = app.db_new_user("invitee").await;
+    let invitee_id = invitee.as_model().id;
+
+    diesel::insert_into(teams::table)
+        .values((teams::id.eq(invitee_id), new_team("github:org:team")))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let krate = CrateBuilder::new("foo", cookie.as_model().id)
+        .expect_build(&mut conn)
+        .await;
+    CrateOwner::builder()
+        .crate_id(krate.id)
+        .team_id(invitee_id)
+        .created_by(cookie.as_model().id)
+        .build()
+        .insert(&conn)
+        .await
+        .unwrap();
+
+    let response = cookie.add_named_owner("foo", "invitee").await;
+    assert_snapshot!(response.status(), @"200 OK");
+    assert_eq!(invited_user_ids(&mut conn, krate.id).await, [invitee_id]);
 }
 
 /// Returns the invited user IDs for a crate in ascending order.

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -1,11 +1,13 @@
 use crate::OwnerResp;
 use crate::builders::{CrateBuilder, UserBuilder};
 use crate::owners::expire_invitation;
+use crate::util::github::next_gh_id;
 use crate::util::{RequestHelper, Response, TestApp};
+use crates_io::models::CrateOwner;
 use crates_io::models::token::{CrateScope, EndpointScope};
-use crates_io::schema::emails;
+use crates_io::schema::{crate_owner_invitations, emails};
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use insta::assert_snapshot;
 
 // This is testing Cargo functionality! ! !
@@ -53,6 +55,84 @@ async fn owner_change_via_cookie() {
     let response = cookie.add_named_owner(&krate.name, &user2.username).await;
     assert_snapshot!(response.status(), @"200 OK");
     assert_snapshot!(response.text(), @r#"{"msg":"Crates.io user user-2 has been invited to be an owner of crate foo_crate","ok":true}"#);
+}
+
+/// Reused GitHub logins select the highest GitHub ID, regardless of crates.io ID.
+#[tokio::test(flavor = "multi_thread")]
+async fn reused_github_login_invites_highest_github_id() {
+    let (app, _, cookie) = TestApp::full().with_user().await;
+    let mut conn = app.db_conn().await;
+
+    let older_gh_id = next_gh_id();
+    let newer = UserBuilder::new()
+        .with_username("newer")
+        .with_gh_login("SHARED");
+    let newer = app.db_new_user_from_builder(newer).await;
+    let older = UserBuilder::new()
+        .with_username("older")
+        .with_gh_login("shared")
+        .with_gh_id(older_gh_id);
+    let older = app.db_new_user_from_builder(older).await;
+
+    assert!(newer.as_model().gh_id > older.as_model().gh_id);
+    assert!(newer.as_model().id < older.as_model().id);
+
+    let krate = CrateBuilder::new("foo", cookie.as_model().id)
+        .expect_build(&mut conn)
+        .await;
+
+    let response = cookie.add_named_owner("foo", "shared").await;
+    assert_snapshot!(response.status(), @"200 OK");
+
+    let invitees = invited_user_ids(&mut conn, krate.id).await;
+    assert_eq!(invitees, [newer.as_model().id]);
+}
+
+/// The legacy duplicate check rejects a reused login before resolving its user.
+#[tokio::test(flavor = "multi_thread")]
+async fn reused_github_login_rejected_when_older_account_owns_crate() {
+    let (app, _, cookie) = TestApp::full().with_user().await;
+    let mut conn = app.db_conn().await;
+
+    let older = UserBuilder::new()
+        .with_username("older")
+        .with_gh_login("shared");
+    let older = app.db_new_user_from_builder(older).await;
+    let newer = UserBuilder::new()
+        .with_username("newer")
+        .with_gh_login("SHARED");
+    let newer = app.db_new_user_from_builder(newer).await;
+    assert!(newer.as_model().gh_id > older.as_model().gh_id);
+
+    let krate = CrateBuilder::new("foo", cookie.as_model().id)
+        .expect_build(&mut conn)
+        .await;
+    CrateOwner::builder()
+        .crate_id(krate.id)
+        .user_id(older.as_model().id)
+        .created_by(cookie.as_model().id)
+        .build()
+        .insert(&conn)
+        .await
+        .unwrap();
+
+    let response = cookie.add_named_owner("foo", "SHARED").await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"`SHARED` is already an owner"}]}"#);
+
+    let invitees = invited_user_ids(&mut conn, krate.id).await;
+    assert!(invitees.is_empty());
+}
+
+/// Returns the invited user IDs for a crate in ascending order.
+async fn invited_user_ids(conn: &mut AsyncPgConnection, crate_id: i32) -> Vec<i32> {
+    crate_owner_invitations::table
+        .filter(crate_owner_invitations::crate_id.eq(crate_id))
+        .select(crate_owner_invitations::invited_user_id)
+        .order(crate_owner_invitations::invited_user_id)
+        .load(conn)
+        .await
+        .unwrap()
 }
 
 async fn invite_distinct_login_user(login: &str) -> Response<OwnerResp> {

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -1,7 +1,7 @@
 use crate::OwnerResp;
 use crate::builders::{CrateBuilder, UserBuilder};
 use crate::util::{RequestHelper, Response, TestApp};
-use crates_io::models::CrateOwner;
+use crates_io::models::{CrateOwner, User};
 use crates_io_github::{GitHubOrganization, GitHubTeam, GitHubTeamMembership, MockGitHubClient};
 use insta::assert_snapshot;
 
@@ -102,6 +102,38 @@ async fn test_remove_uppercase_user() {
     let response = cookie.remove_named_owner("foo", "USER2").await;
     assert_snapshot!(response.status(), @"200 OK");
     assert_snapshot!(response.text(), @r#"{"msg":"owners successfully removed","ok":true}"#);
+}
+
+/// One GitHub login can remove multiple owners while leaving another user owner.
+#[tokio::test(flavor = "multi_thread")]
+async fn reused_github_login_removes_all_matching_owners() {
+    let (app, _, cookie) = TestApp::full().with_user().await;
+    let mut conn = app.db_conn().await;
+    let krate = CrateBuilder::new("foo", cookie.as_model().id)
+        .expect_build(&mut conn)
+        .await;
+
+    for (username, login) in [("older", "shared"), ("newer", "SHARED")] {
+        let user = UserBuilder::new()
+            .with_username(username)
+            .with_gh_login(login);
+        let user = app.db_new_user_from_builder(user).await;
+        CrateOwner::builder()
+            .crate_id(krate.id)
+            .user_id(user.as_model().id)
+            .created_by(cookie.as_model().id)
+            .build()
+            .insert(&conn)
+            .await
+            .unwrap();
+    }
+
+    let response = cookie.remove_named_owner("foo", "shared").await;
+    assert_snapshot!(response.status(), @"200 OK");
+
+    let owners = User::owning(&krate, &conn).await.unwrap();
+    let owner_ids: Vec<_> = owners.iter().map(|owner| owner.id).collect();
+    assert_eq!(owner_ids, [cookie.as_model().id]);
 }
 
 async fn remove_distinct_login_user(login: &str) -> (Response<OwnerResp>, usize) {


### PR DESCRIPTION
User invitations now resolve the requested account before checking existing ownership and compare crates.io user IDs instead of login strings. This prevents a reused GitHub login from making a different account appear to already own the crate while preserving the existing team checks and lookup error precedence.

The test now also cover highest-ID account selection and removal of all owners matching a reused GitHub login. This work was partially extracted from #14213 so the identity fix can be reviewed independently from the username-prefix and disambiguation changes.

### Related

- #14213
- #13769