### PR TITLE
controllers/owners: split owner remove query to remove by username and remove by team name

### DIFF
--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -213,7 +213,53 @@ impl Crate {
         Ok(users.chain(teams).collect())
     }
 
-    pub async fn owner_remove(
+    pub async fn owner_remove_with_username(
+        &self,
+        mut conn: &AsyncPgConnection,
+        login: &str,
+    ) -> Result<(), OwnerRemoveError> {
+        let query = diesel::sql_query(
+            r#"WITH crate_owners_with_login AS (
+                SELECT
+                    crate_owners.*,
+                    CASE WHEN crate_owners.owner_kind = 1 THEN
+                         teams.login
+                    ELSE
+                         users.gh_login
+                    END AS login
+                FROM crate_owners
+                LEFT JOIN teams
+                    ON crate_owners.owner_id = teams.id
+                    AND crate_owners.owner_kind = 1
+                LEFT JOIN users
+                    ON crate_owners.owner_id = users.id
+                    AND crate_owners.owner_kind = 0
+                WHERE crate_owners.crate_id = $1
+                    AND crate_owners.deleted = false
+            )
+            UPDATE crate_owners
+            SET deleted = true
+            FROM crate_owners_with_login
+            WHERE crate_owners.crate_id = crate_owners_with_login.crate_id
+                AND crate_owners.owner_id = crate_owners_with_login.owner_id
+                AND crate_owners.owner_kind = crate_owners_with_login.owner_kind
+                AND lower(crate_owners_with_login.login) = lower($2);"#,
+        );
+
+        let num_updated_rows = query
+            .bind::<Integer, _>(self.id)
+            .bind::<Text, _>(login)
+            .execute(&mut conn)
+            .await?;
+
+        if num_updated_rows == 0 {
+            return Err(OwnerRemoveError::not_found(login));
+        }
+
+        Ok(())
+    }
+
+    pub async fn owner_remove_with_team_name(
         &self,
         mut conn: &AsyncPgConnection,
         login: &str,

--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -222,16 +222,9 @@ impl Crate {
             r#"WITH crate_owners_with_login AS (
                 SELECT
                     crate_owners.*,
-                    CASE WHEN crate_owners.owner_kind = 1 THEN
-                         teams.login
-                    ELSE
-                         users.gh_login
-                    END AS login
+                    users.gh_login
                 FROM crate_owners
-                LEFT JOIN teams
-                    ON crate_owners.owner_id = teams.id
-                    AND crate_owners.owner_kind = 1
-                LEFT JOIN users
+                JOIN users
                     ON crate_owners.owner_id = users.id
                     AND crate_owners.owner_kind = 0
                 WHERE crate_owners.crate_id = $1
@@ -243,7 +236,7 @@ impl Crate {
             WHERE crate_owners.crate_id = crate_owners_with_login.crate_id
                 AND crate_owners.owner_id = crate_owners_with_login.owner_id
                 AND crate_owners.owner_kind = crate_owners_with_login.owner_kind
-                AND lower(crate_owners_with_login.login) = lower($2);"#,
+                AND lower(crate_owners_with_login.gh_login) = lower($2);"#,
         );
 
         let num_updated_rows = query

--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -261,18 +261,11 @@ impl Crate {
             r#"WITH crate_owners_with_login AS (
                 SELECT
                     crate_owners.*,
-                    CASE WHEN crate_owners.owner_kind = 1 THEN
-                         teams.login
-                    ELSE
-                         users.gh_login
-                    END AS login
+                    teams.login
                 FROM crate_owners
-                LEFT JOIN teams
+                JOIN teams
                     ON crate_owners.owner_id = teams.id
                     AND crate_owners.owner_kind = 1
-                LEFT JOIN users
-                    ON crate_owners.owner_id = users.id
-                    AND crate_owners.owner_kind = 0
                 WHERE crate_owners.crate_id = $1
                     AND crate_owners.deleted = false
             )

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -290,7 +290,12 @@ pub async fn remove_owners(
 
     conn.transaction(async |conn| {
         for login in &body.owners {
-            krate.owner_remove(conn, login).await?;
+            match Login::parse(login)? {
+                Login::GitHubTeam(login) => {
+                    krate.owner_remove_with_team_name(conn, login.login).await?
+                }
+                Login::Unprefixed(login) => krate.owner_remove_with_username(conn, login).await?,
+            }
         }
         if User::owning(&krate, conn).await?.is_empty() {
             return Err(bad_request(

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -393,7 +393,10 @@ async fn deleted_ownership_isnt_in_owner_user() {
     let krate = CrateBuilder::new("foo_my_packages", user.id)
         .expect_build(&mut conn)
         .await;
-    krate.owner_remove_with_username(&conn, &user.username).await.unwrap();
+    krate
+        .owner_remove_with_username(&conn, &user.username)
+        .await
+        .unwrap();
 
     let json: UserResponse = anon
         .get("/api/v1/crates/foo_my_packages/owner_user")

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -393,7 +393,7 @@ async fn deleted_ownership_isnt_in_owner_user() {
     let krate = CrateBuilder::new("foo_my_packages", user.id)
         .expect_build(&mut conn)
         .await;
-    krate.owner_remove(&conn, &user.username).await.unwrap();
+    krate.owner_remove_with_username(&conn, &user.username).await.unwrap();
 
     let json: UserResponse = anon
         .get("/api/v1/crates/foo_my_packages/owner_user")

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -1372,7 +1372,10 @@ async fn crates_by_user_id_not_including_deleted_owners() -> anyhow::Result<()> 
     let krate = CrateBuilder::new("foo_my_packages", user.id)
         .expect_build(&mut conn)
         .await;
-    krate.owner_remove_with_username(&conn, "foo").await.unwrap();
+    krate
+        .owner_remove_with_username(&conn, "foo")
+        .await
+        .unwrap();
 
     for response in search_both_by_user_id(&anon, user.id).await {
         assert_eq!(response.crates.len(), 0);

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -1372,7 +1372,7 @@ async fn crates_by_user_id_not_including_deleted_owners() -> anyhow::Result<()> 
     let krate = CrateBuilder::new("foo_my_packages", user.id)
         .expect_build(&mut conn)
         .await;
-    krate.owner_remove(&conn, "foo").await.unwrap();
+    krate.owner_remove_with_username(&conn, "foo").await.unwrap();
 
     for response in search_both_by_user_id(&anon, user.id).await {
         assert_eq!(response.crates.len(), 0);

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -183,7 +183,7 @@ async fn unprefixed_github_login_separator_variant() {
 async fn crates_io_prefixed_username_verbatim() {
     let (response, owner_count) = remove_distinct_login_user("crates.io:crates-user").await;
     assert_snapshot!(response.status(), @"400 Bad Request");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `crates.io:crates-user`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"unknown organization handler, only 'github:org:team' is supported"}]}"#);
     assert_eq!(owner_count, 2);
 }
 
@@ -191,7 +191,7 @@ async fn crates_io_prefixed_username_verbatim() {
 async fn crates_io_prefixed_username_case_insensitive() {
     let (response, owner_count) = remove_distinct_login_user("crates.io:CRATES-USER").await;
     assert_snapshot!(response.status(), @"400 Bad Request");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `crates.io:CRATES-USER`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"unknown organization handler, only 'github:org:team' is supported"}]}"#);
     assert_eq!(owner_count, 2);
 }
 
@@ -199,7 +199,7 @@ async fn crates_io_prefixed_username_case_insensitive() {
 async fn crates_io_prefixed_username_separator_variant() {
     let (response, owner_count) = remove_distinct_login_user("crates.io:crates_user").await;
     assert_snapshot!(response.status(), @"400 Bad Request");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `crates.io:crates_user`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"unknown organization handler, only 'github:org:team' is supported"}]}"#);
     assert_eq!(owner_count, 2);
 }
 
@@ -207,7 +207,7 @@ async fn crates_io_prefixed_username_separator_variant() {
 async fn github_prefixed_login_verbatim() {
     let (response, owner_count) = remove_distinct_login_user("github:github-user").await;
     assert_snapshot!(response.status(), @"400 Bad Request");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `github:github-user`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"missing github team argument; format is github:org:team"}]}"#);
     assert_eq!(owner_count, 2);
 }
 
@@ -215,7 +215,7 @@ async fn github_prefixed_login_verbatim() {
 async fn github_prefixed_login_case_insensitive() {
     let (response, owner_count) = remove_distinct_login_user("github:GITHUB-USER").await;
     assert_snapshot!(response.status(), @"400 Bad Request");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `github:GITHUB-USER`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"missing github team argument; format is github:org:team"}]}"#);
     assert_eq!(owner_count, 2);
 }
 
@@ -223,7 +223,7 @@ async fn github_prefixed_login_case_insensitive() {
 async fn github_prefixed_login_separator_variant() {
     let (response, owner_count) = remove_distinct_login_user("github:github_user").await;
     assert_snapshot!(response.status(), @"400 Bad Request");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `github:github_user`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"missing github team argument; format is github:org:team"}]}"#);
     assert_eq!(owner_count, 2);
 }
 
@@ -231,7 +231,7 @@ async fn github_prefixed_login_separator_variant() {
 async fn crates_io_prefix_does_not_match_github_login() {
     let (response, owner_count) = remove_distinct_login_user("crates.io:github-user").await;
     assert_snapshot!(response.status(), @"400 Bad Request");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `crates.io:github-user`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"unknown organization handler, only 'github:org:team' is supported"}]}"#);
     assert_eq!(owner_count, 2);
 }
 
@@ -239,7 +239,7 @@ async fn crates_io_prefix_does_not_match_github_login() {
 async fn github_prefix_does_not_match_crates_io_username() {
     let (response, owner_count) = remove_distinct_login_user("github:crates-user").await;
     assert_snapshot!(response.status(), @"400 Bad Request");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `github:crates-user`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"missing github team argument; format is github:org:team"}]}"#);
     assert_eq!(owner_count, 2);
 }
 

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -62,7 +62,7 @@ async fn test_user_owned_crates_doesnt_include_deleted_ownership() {
         .expect_build(&mut conn)
         .await;
     krate
-        .owner_remove(&conn, &user_model.username)
+        .owner_remove_with_username(&conn, &user_model.username)
         .await
         .unwrap();
 

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -53,7 +53,7 @@ async fn user_total_downloads() -> anyhow::Result<()> {
         .execute(&mut conn)
         .await?;
     no_longer_my_krate
-        .owner_remove(&conn, &user.username)
+        .owner_remove_with_username(&conn, &user.username)
         .await
         .unwrap();
 

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -501,7 +501,7 @@ async fn crates_by_team_id_not_including_deleted_owners() -> anyhow::Result<()> 
         .expect_build(&mut conn)
         .await;
     add_team_to_crate(&t, &krate, user.id, &mut conn).await?;
-    krate.owner_remove_with_username(&conn, &t.login).await.unwrap();
+    krate.owner_remove_with_team_name(&conn, &t.login).await.unwrap();
 
     let json = anon.search(&format!("team_id={}", t.id)).await;
     assert_eq!(json.crates.len(), 0);

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -501,7 +501,7 @@ async fn crates_by_team_id_not_including_deleted_owners() -> anyhow::Result<()> 
         .expect_build(&mut conn)
         .await;
     add_team_to_crate(&t, &krate, user.id, &mut conn).await?;
-    krate.owner_remove(&conn, &t.login).await.unwrap();
+    krate.owner_remove_with_username(&conn, &t.login).await.unwrap();
 
     let json = anon.search(&format!("team_id={}", t.id)).await;
     assert_eq!(json.crates.len(), 0);

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -501,7 +501,10 @@ async fn crates_by_team_id_not_including_deleted_owners() -> anyhow::Result<()> 
         .expect_build(&mut conn)
         .await;
     add_team_to_crate(&t, &krate, user.id, &mut conn).await?;
-    krate.owner_remove_with_team_name(&conn, &t.login).await.unwrap();
+    krate
+        .owner_remove_with_team_name(&conn, &t.login)
+        .await
+        .unwrap();
 
     let json = anon.search(&format!("team_id={}", t.id)).await;
     assert_eq!(json.crates.len(), 0);


### PR DESCRIPTION
This PR is a partial extraction from https://github.com/rust-lang/crates.io/pull/14213. 

It splits the `owner_remove` query to `owner_remove_by_username` and `owner_remove_by_team_name`. This will allow us to change the behaviour of `ower_remove_by_username` so that we can compare usernames names using the canon_username function (which also normalizes hyphen to underscore), but keep comparing team names using `lower` - github allows separate team names that only differ by underscore and hyphens to exist.

**Tests:**
Owner remove is now routed through `Login:parse`, which rejects malformed logins before any DB lookup happens. `Login::parse` currently treats *any* login containing `:` as a team login and hands it to `GitHubTeamLogin::parse`, which rejects malformed ones with a `bad_request`.

Previously `remove_owners` passed the raw string straight to `krate.owner_remove`, which did the lookup, matched nothing (stored logins never contain `:`), and returned `OwnerRemoveError::not_found(login)`.

So the tests, which assert the old fall-through behavior, now get a parse error instead.
