### PR TITLE
Use crates.io username instead of gh_login in all emails

### DIFF
--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -164,7 +164,7 @@ pub async fn delete_crate(
             let email = EmailMessage::from_template(
                 "crate_deletion",
                 context! {
-                    user => user.gh_login,
+                    user => user.username,
                     krate => crate_name
                 },
             )?;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -337,7 +337,7 @@ fn render_owner_invite_email(
     EmailMessage::from_template(
         "owner_invite",
         context! {
-            inviter => inviter.gh_login,
+            inviter => inviter.username,
             domain => app.emails.domain,
             crate_name => krate.name,
             token => token.expose_secret()

--- a/src/controllers/krate/update.rs
+++ b/src/controllers/krate/update.rs
@@ -98,7 +98,7 @@ async fn update_inner(
         .filter(crate_owners::crate_id.eq(krate.id))
         .filter(crate_owners::deleted.eq(false))
         .filter(crate_owners::owner_kind.eq(crate::models::OwnerKind::User))
-        .select((users::id, users::gh_login, emails::email, emails::verified))
+        .select((users::id, users::username, emails::email, emails::verified))
         .load::<(i32, String, String, bool)>(conn)
         .await?;
 
@@ -132,10 +132,10 @@ async fn update_inner(
         );
 
         // Send email notifications to all crate owners
-        for (_, gh_login, email_address, email_verified) in &user_owners {
+        for (_, username, email_address, email_verified) in &user_owners {
             if *email_verified {
                 let email = TrustpubOnlyChangedEmail {
-                    recipient: gh_login,
+                    recipient: username,
                     auth_user: user,
                     krate,
                     trustpub_only,
@@ -195,7 +195,7 @@ async fn update_inner(
 
 #[derive(Serialize)]
 struct TrustpubOnlyChangedEmail<'a> {
-    /// The GitHub login of the email recipient.
+    /// The Crates.io username of the email recipient.
     recipient: &'a str,
     /// The user who changed the setting.
     auth_user: &'a User,

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -521,7 +521,7 @@ async fn create_user(
             let email = EmailMessage::from_template(
                 "user_confirm",
                 context! {
-                    user_name => new_user.gh_login,
+                    user_name => new_user.username,
                     domain => emails.domain,
                     token => token.expose_secret()
                 },

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -221,7 +221,7 @@ pub async fn create_api_token(
     if let Some(recipient) = recipient {
         let context = context! {
             token_name => &new.api_token.name,
-            user_name => &user.gh_login,
+            user_name => &user.username,
             domain => app.emails.domain,
         };
 

--- a/src/controllers/trustpub/emails.rs
+++ b/src/controllers/trustpub/emails.rs
@@ -11,7 +11,7 @@ pub enum ConfigType<'a> {
 
 #[derive(serde::Serialize)]
 pub struct ConfigCreatedEmail<'a> {
-    /// The GitHub login of the email recipient.
+    /// The Crates.io username of the email recipient.
     pub recipient: &'a str,
     /// The user who created the trusted publishing configuration.
     pub auth_user: &'a User,

--- a/src/controllers/trustpub/github_configs/create.rs
+++ b/src/controllers/trustpub/github_configs/create.rs
@@ -75,7 +75,7 @@ pub async fn create_trustpub_github_config(
         .filter(crate_owners::owner_kind.eq(OwnerKind::User))
         .inner_join(users::table)
         .inner_join(emails::table.on(users::id.eq(emails::user_id)))
-        .select((users::id, users::gh_login, emails::email, emails::verified))
+        .select((users::id, users::username, emails::email, emails::verified))
         .load::<(i32, String, String, bool)>(&mut conn)
         .await?;
 

--- a/src/controllers/trustpub/github_configs/delete.rs
+++ b/src/controllers/trustpub/github_configs/delete.rs
@@ -60,7 +60,7 @@ pub async fn delete_trustpub_github_config(
         .filter(crate_owners::owner_kind.eq(OwnerKind::User))
         .inner_join(users::table)
         .inner_join(emails::table.on(users::id.eq(emails::user_id)))
-        .select((users::id, users::gh_login, emails::email, emails::verified))
+        .select((users::id, users::username, emails::email, emails::verified))
         .load::<(i32, String, String, bool)>(&mut conn)
         .await?;
 

--- a/src/controllers/trustpub/gitlab_configs/create.rs
+++ b/src/controllers/trustpub/gitlab_configs/create.rs
@@ -73,7 +73,7 @@ pub async fn create_trustpub_gitlab_config(
         .filter(crate_owners::owner_kind.eq(OwnerKind::User))
         .inner_join(users::table)
         .inner_join(emails::table.on(users::id.eq(emails::user_id)))
-        .select((users::id, users::gh_login, emails::email, emails::verified))
+        .select((users::id, users::username, emails::email, emails::verified))
         .load::<(i32, String, String, bool)>(&mut conn)
         .await?;
 

--- a/src/controllers/trustpub/gitlab_configs/delete.rs
+++ b/src/controllers/trustpub/gitlab_configs/delete.rs
@@ -60,7 +60,7 @@ pub async fn delete_trustpub_gitlab_config(
         .filter(crate_owners::owner_kind.eq(OwnerKind::User))
         .inner_join(users::table)
         .inner_join(emails::table.on(users::id.eq(emails::user_id)))
-        .select((users::id, users::gh_login, emails::email, emails::verified))
+        .select((users::id, users::username, emails::email, emails::verified))
         .load::<(i32, String, String, bool)>(&mut conn)
         .await?;
 

--- a/src/controllers/user/email_verification.rs
+++ b/src/controllers/user/email_verification.rs
@@ -89,7 +89,7 @@ pub async fn resend_email_verification(
         let email_message = EmailMessage::from_template(
             "user_confirm",
             context! {
-                user_name => auth.user().gh_login,
+                user_name => auth.user().username,
                 domain => state.emails.domain,
                 token => email.token.expose_secret()
             },

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -82,7 +82,7 @@ pub async fn update_user(
                 let email = EmailMessage::from_template(
                     "unsubscribe_notifications",
                     context! {
-                        user_name => user.gh_login,
+                        user_name => user.username,
                         domain => state.emails.domain
                     },
                 );
@@ -127,7 +127,7 @@ pub async fn update_user(
         let email = EmailMessage::from_template(
             "user_confirm",
             context! {
-                user_name => user.gh_login,
+                user_name => user.username,
                 domain => state.emails.domain,
                 token => token.expose_secret()
             },

--- a/src/email.rs
+++ b/src/email.rs
@@ -386,7 +386,7 @@ mod tests {
 
         insta::assert_snapshot!(content, @"
 
-        <script>alert('xss');</script> has invited you to become an owner of the crate example-crate!
+        Crates.io user <script>alert('xss');</script> has invited you to become an owner of the crate example-crate!
 
         Visit https://crates.io/accept-invite/abc123 to accept this invitation.
 
@@ -408,7 +408,7 @@ mod tests {
 
         insta::assert_snapshot!(content, @r#"
 
-        <p>&lt;script&gt;alert(&#x27;xss&#x27;);&lt;&#x2f;script&gt; has invited you to become an owner of the crate <strong>example-crate</strong>!</p>
+        <p>Crates.io user &lt;script&gt;alert(&#x27;xss&#x27;);&lt;&#x2f;script&gt; has invited you to become an owner of the crate <strong>example-crate</strong>!</p>
 
         <p>Visit <a href="https://crates.io/accept-invite/abc123">https://crates.io/accept-invite/abc123</a> to accept this invitation.</p>
 

--- a/src/email/templates/owner_invite/body.html.j2
+++ b/src/email/templates/owner_invite/body.html.j2
@@ -5,7 +5,7 @@
 {% set invites_url = "https://" ~ domain ~ "/me/pending-invites" %}
 
 {% block content %}
-<p>{{ inviter }} has invited you to become an owner of the crate <strong>{{ crate_name }}</strong>!</p>
+<p>Crates.io user {{ inviter }} has invited you to become an owner of the crate <strong>{{ crate_name }}</strong>!</p>
 
 <p>Visit <a href="{{ accept_url | safe }}">{{ accept_url | safe }}</a> to accept this invitation.</p>
 

--- a/src/email/templates/owner_invite/body.txt.j2
+++ b/src/email/templates/owner_invite/body.txt.j2
@@ -1,7 +1,7 @@
 {% extends "base.txt.j2" %}
 
 {% block content %}
-{{ inviter }} has invited you to become an owner of the crate {{ crate_name }}!
+Crates.io user {{ inviter }} has invited you to become an owner of the crate {{ crate_name }}!
 
 Visit https://{{ domain }}/accept-invite/{{ token }} to accept this invitation.
 

--- a/src/email/templates/trustpub_config_created/body.html.j2
+++ b/src/email/templates/trustpub_config_created/body.html.j2
@@ -9,10 +9,10 @@
 {% block content %}
 <p>Hello {{ recipient }}!</p>
 
-{% if recipient == auth_user.gh_login -%}
+{% if recipient == auth_user.username -%}
 <p>You added a new "Trusted Publishing" configuration for {{ ci_provider }} to your crate "<strong>{{ krate.name }}</strong>". Trusted publishers act as trusted users and can publish new versions of the crate automatically.</p>
 {%- else -%}
-<p>crates.io user {{ auth_user.gh_login }} added a new "Trusted Publishing" configuration for {{ ci_provider }} to a crate that you manage ("<strong>{{ krate.name }}</strong>"). Trusted publishers act as trusted users and can publish new versions of the crate automatically.</p>
+<p>crates.io user {{ auth_user.username }} added a new "Trusted Publishing" configuration for {{ ci_provider }} to a crate that you manage ("<strong>{{ krate.name }}</strong>"). Trusted publishers act as trusted users and can publish new versions of the crate automatically.</p>
 {%- endif %}
 
 {% if saved_config.type == "GitHub" -%}

--- a/src/email/templates/trustpub_config_created/body.txt.j2
+++ b/src/email/templates/trustpub_config_created/body.txt.j2
@@ -9,10 +9,10 @@
 {% block content %}
 Hello {{ recipient }}!
 
-{% if recipient == auth_user.gh_login -%}
+{% if recipient == auth_user.username -%}
 You added a new "Trusted Publishing" configuration for {{ ci_provider }} to your crate "{{ krate.name }}". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 {%- else -%}
-crates.io user {{ auth_user.gh_login }} added a new "Trusted Publishing" configuration for {{ ci_provider }} to a crate that you manage ("{{ krate.name }}"). Trusted publishers act as trusted users and can publish new versions of the crate automatically.
+crates.io user {{ auth_user.username }} added a new "Trusted Publishing" configuration for {{ ci_provider }} to a crate that you manage ("{{ krate.name }}"). Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 {%- endif %}
 
 {% if saved_config.type == "GitHub" -%}

--- a/src/email/templates/trustpub_config_deleted/body.html.j2
+++ b/src/email/templates/trustpub_config_deleted/body.html.j2
@@ -9,10 +9,10 @@
 {% block content %}
 <p>Hello {{ recipient }}!</p>
 
-{% if recipient == auth_user.gh_login -%}
+{% if recipient == auth_user.username -%}
 <p>You removed a "Trusted Publishing" configuration for {{ ci_provider }} from your crate "<strong>{{ krate.name }}</strong>".</p>
 {%- else -%}
-<p>crates.io user {{ auth_user.gh_login }} removed a "Trusted Publishing" configuration for {{ ci_provider }} from a crate that you manage ("<strong>{{ krate.name }}</strong>").</p>
+<p>crates.io user {{ auth_user.username }} removed a "Trusted Publishing" configuration for {{ ci_provider }} from a crate that you manage ("<strong>{{ krate.name }}</strong>").</p>
 {%- endif %}
 
 {% if config.type == "GitHub" -%}

--- a/src/email/templates/trustpub_config_deleted/body.txt.j2
+++ b/src/email/templates/trustpub_config_deleted/body.txt.j2
@@ -9,10 +9,10 @@
 {% block content %}
 Hello {{ recipient }}!
 
-{% if recipient == auth_user.gh_login -%}
+{% if recipient == auth_user.username -%}
 You removed a "Trusted Publishing" configuration for {{ ci_provider }} from your crate "{{ krate.name }}".
 {%- else -%}
-crates.io user {{ auth_user.gh_login }} removed a "Trusted Publishing" configuration for {{ ci_provider }} from a crate that you manage ("{{ krate.name }}").
+crates.io user {{ auth_user.username }} removed a "Trusted Publishing" configuration for {{ ci_provider }} from a crate that you manage ("{{ krate.name }}").
 {%- endif %}
 
 {% if config.type == "GitHub" -%}

--- a/src/email/templates/trustpub_only_changed/body.html.j2
+++ b/src/email/templates/trustpub_only_changed/body.html.j2
@@ -3,10 +3,10 @@
 {% block content %}
 <p>Hello {{ recipient }}!</p>
 
-{% if recipient == auth_user.gh_login -%}
+{% if recipient == auth_user.username -%}
 <p>You changed the publishing method restriction for your crate "<strong>{{ krate.name }}</strong>".</p>
 {%- else -%}
-<p>crates.io user {{ auth_user.gh_login }} changed the publishing method restriction for a crate that you manage ("<strong>{{ krate.name }}</strong>").</p>
+<p>crates.io user {{ auth_user.username }} changed the publishing method restriction for a crate that you manage ("<strong>{{ krate.name }}</strong>").</p>
 {%- endif %}
 
 {% if trustpub_only -%}

--- a/src/email/templates/trustpub_only_changed/body.txt.j2
+++ b/src/email/templates/trustpub_only_changed/body.txt.j2
@@ -3,10 +3,10 @@
 {% block content %}
 Hello {{ recipient }}!
 
-{% if recipient == auth_user.gh_login -%}
+{% if recipient == auth_user.username -%}
 You changed the publishing method restriction for your crate "{{ krate.name }}".
 {%- else -%}
-crates.io user {{ auth_user.gh_login }} changed the publishing method restriction for a crate that you manage ("{{ krate.name }}").
+crates.io user {{ auth_user.username }} changed the publishing method restriction for a crate that you manage ("{{ krate.name }}").
 {%- endif %}
 
 {% if trustpub_only -%}

--- a/src/tests/snapshots/integration__owners__modify_multiple_owners-10.snap
+++ b/src/tests/snapshots/integration__owners__modify_multiple_owners-10.snap
@@ -14,7 +14,7 @@ Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-foo has invited you to become an owner of the crate owners_multiple!
+Crates.io user foo has invited you to become an owner of the crate owners_multiple!
 
 Visit https://crates.io/accept-invite/[invite-token] to accept this invitation.
 
@@ -27,7 +27,7 @@ Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-<p>foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
+<p>Crates.io user foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
 
 <p>Visit <a href="https://crates.io/accept-invite/[invite-token]">https://crates.io/accept-invite/[invite-token]</a> to accept this invitation.</p>
 
@@ -68,7 +68,7 @@ Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-foo has invited you to become an owner of the crate owners_multiple!
+Crates.io user foo has invited you to become an owner of the crate owners_multiple!
 
 Visit https://crates.io/accept-invite/[invite-token] to accept this invitation.
 
@@ -81,7 +81,7 @@ Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-<p>foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
+<p>Crates.io user foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
 
 <p>Visit <a href="https://crates.io/accept-invite/[invite-token]">https://crates.io/accept-invite/[invite-token]</a> to accept this invitation.</p>
 
@@ -122,7 +122,7 @@ Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-foo has invited you to become an owner of the crate owners_multiple!
+Crates.io user foo has invited you to become an owner of the crate owners_multiple!
 
 Visit https://crates.io/accept-invite/[invite-token] to accept this invitation.
 
@@ -135,7 +135,7 @@ Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-<p>foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
+<p>Crates.io user foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
 
 <p>Visit <a href="https://crates.io/accept-invite/[invite-token]">https://crates.io/accept-invite/[invite-token]</a> to accept this invitation.</p>
 
@@ -176,7 +176,7 @@ Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-foo has invited you to become an owner of the crate owners_multiple!
+Crates.io user foo has invited you to become an owner of the crate owners_multiple!
 
 Visit https://crates.io/accept-invite/[invite-token] to accept this invitation.
 
@@ -189,7 +189,7 @@ Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-<p>foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
+<p>Crates.io user foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
 
 <p>Visit <a href="https://crates.io/accept-invite/[invite-token]">https://crates.io/accept-invite/[invite-token]</a> to accept this invitation.</p>
 

--- a/src/tests/snapshots/integration__owners__modify_multiple_owners.snap
+++ b/src/tests/snapshots/integration__owners__modify_multiple_owners.snap
@@ -14,7 +14,7 @@ Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-foo has invited you to become an owner of the crate owners_multiple!
+Crates.io user foo has invited you to become an owner of the crate owners_multiple!
 
 Visit https://crates.io/accept-invite/[invite-token] to accept this invitation.
 
@@ -27,7 +27,7 @@ Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-<p>foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
+<p>Crates.io user foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
 
 <p>Visit <a href="https://crates.io/accept-invite/[invite-token]">https://crates.io/accept-invite/[invite-token]</a> to accept this invitation.</p>
 
@@ -68,7 +68,7 @@ Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-foo has invited you to become an owner of the crate owners_multiple!
+Crates.io user foo has invited you to become an owner of the crate owners_multiple!
 
 Visit https://crates.io/accept-invite/[invite-token] to accept this invitation.
 
@@ -81,7 +81,7 @@ Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-<p>foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
+<p>Crates.io user foo has invited you to become an owner of the crate <strong>owners_multiple</strong>!</p>
 
 <p>Visit <a href="https://crates.io/accept-invite/[invite-token]">https://crates.io/accept-invite/[invite-token]</a> to accept this invitation.</p>
 

--- a/src/tests/snapshots/integration__owners__new_crate_owner-2.snap
+++ b/src/tests/snapshots/integration__owners__new_crate_owner-2.snap
@@ -72,7 +72,7 @@ Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-foo has invited you to become an owner of the crate foo_owner!
+Crates.io user foo has invited you to become an owner of the crate foo_owner!
 
 Visit https://crates.io/accept-invite/[invite-token] to accept this invitation.
 
@@ -85,7 +85,7 @@ Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-<p>foo has invited you to become an owner of the crate <strong>foo_owner</strong>!</p>
+<p>Crates.io user foo has invited you to become an owner of the crate <strong>foo_owner</strong>!</p>
 
 <p>Visit <a href="https://crates.io/accept-invite/[invite-token]">https://crates.io/accept-invite/[invite-token]</a> to accept this invitation.</p>
 

--- a/src/tests/snapshots/integration__owners__new_crate_owner.snap
+++ b/src/tests/snapshots/integration__owners__new_crate_owner.snap
@@ -72,7 +72,7 @@ Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-foo has invited you to become an owner of the crate foo_owner!
+Crates.io user foo has invited you to become an owner of the crate foo_owner!
 
 Visit https://crates.io/accept-invite/[invite-token] to accept this invitation.
 
@@ -85,7 +85,7 @@ Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 
-<p>foo has invited you to become an owner of the crate <strong>foo_owner</strong>!</p>
+<p>Crates.io user foo has invited you to become an owner of the crate <strong>foo_owner</strong>!</p>
 
 <p>Visit <a href="https://crates.io/accept-invite/[invite-token]">https://crates.io/accept-invite/[invite-token]</a> to accept this invitation.</p>
 

--- a/src/worker/jobs/expiry_notification.rs
+++ b/src/worker/jobs/expiry_notification.rs
@@ -89,7 +89,7 @@ async fn handle_expiring_token(
         let email = EmailMessage::from_template(
             "expiry_notification",
             context! {
-                name => user.gh_login,
+                name => user.username,
                 token_id => token.id,
                 token_name => token.name,
                 expiry_date => token.expired_at.unwrap().to_rfc3339_opts(SecondsFormat::Secs, true)

--- a/src/worker/jobs/send_publish_notifications.rs
+++ b/src/worker/jobs/send_publish_notifications.rs
@@ -58,7 +58,7 @@ impl BackgroundJob for SendPublishNotificationsJob {
             .filter(users::publish_notifications.eq(true))
             .inner_join(emails::table.on(users::id.eq(emails::user_id)))
             .filter(emails::verified.eq(true))
-            .select((users::gh_login, emails::email))
+            .select((users::username, emails::email))
             .load::<(String, String)>(&mut conn)
             .await?;
 
@@ -181,7 +181,7 @@ struct PublishDetails {
     version: String,
     #[diesel(select_expression = versions::columns::created_at)]
     publish_time: DateTime<Utc>,
-    #[diesel(select_expression = users::columns::gh_login.nullable())]
+    #[diesel(select_expression = users::columns::username.nullable())]
     publisher: Option<String>,
     #[diesel(select_expression = versions::columns::trustpub_data.nullable())]
     trustpub_data: Option<TrustpubData>,

--- a/src/worker/jobs/sync_admins.rs
+++ b/src/worker/jobs/sync_admins.rs
@@ -47,8 +47,8 @@ impl BackgroundJob for SyncAdmins {
         struct UserData {
             #[diesel(select_expression = users::id)]
             id: i32,
-            #[diesel(select_expression = users::gh_login)]
-            gh_login: String,
+            #[diesel(select_expression = users::username)]
+            username: String,
             #[diesel(select_expression = users::is_admin)]
             is_admin: bool,
             #[diesel(select_expression = oauth_github::account_id.nullable())]
@@ -81,7 +81,7 @@ impl BackgroundJob for SyncAdmins {
                 .map(|u| {
                     format!(
                         "{} (github_id: {})",
-                        u.gh_login,
+                        u.username,
                         u.account_id
                             .map(|id| id.to_string())
                             .unwrap_or("None".into())
@@ -178,19 +178,22 @@ impl BackgroundJob for SyncAdmins {
         for database_admin in database_user_data.iter().filter(|u| u.is_admin) {
             let UserData {
                 account_id,
-                gh_login,
+                username,
                 email,
                 ..
             } = database_admin;
             if let Some(email_address) = email {
                 if let Err(error) = send_email(&ctx, email_address, &context).await {
                     warn!(
-                        "Failed to send email to admin {gh_login} \
+                        "Failed to send email to admin with crates.io username {username} \
                         ({email_address}, github_id: {account_id:?}): {error:?}"
                     );
                 }
             } else {
-                warn!("No email address found for admin {gh_login} (github_id: {account_id:?})",);
+                warn!(
+                    "No email address found for admin with crates.io username {username} \
+                    (github_id: {account_id:?})"
+                );
             }
         }
 


### PR DESCRIPTION
Add "crates.io username" disambiguation in emails that didn't already have it when it's referring to a user other than the recipient (who should hopefully know whether their own username is their crates.io username or github username).

Extracted from https://github.com/rust-lang/crates.io/pull/14575. I don't think it'll conflict with https://github.com/rust-lang/crates.io/pull/14213.