### PR TITLE
jobs/dump_db: Report dump metrics to Datadog

### DIFF
--- a/src/bin/crates-io/background_worker.rs
+++ b/src/bin/crates-io/background_worker.rs
@@ -109,6 +109,7 @@ pub fn run() -> anyhow::Result<()> {
         .maybe_cloudfront(cloudfront)
         .maybe_fastly(fastly)
         .storage(storage)
+        .maybe_datadog(datadog.clone())
         .downloads_archive_store(downloads_archive_store)
         .deadpool(deadpool.clone())
         .emails(emails)

--- a/src/bin/crates-io/background_worker.rs
+++ b/src/bin/crates-io/background_worker.rs
@@ -78,7 +78,7 @@ pub fn run() -> anyhow::Result<()> {
 
     let user_agent = crates_io_version::user_agent();
     let http_client = Client::builder().user_agent(user_agent).build()?;
-    let datadog = config.datadog.client(http_client.clone());
+    let datadog = config.datadog.client(http_client.clone()).map(Arc::new);
 
     let cloudfront = CloudFront::from_environment();
     let storage = Arc::new(Storage::from_config(&config.storage));

--- a/src/metrics/datadog.rs
+++ b/src/metrics/datadog.rs
@@ -15,6 +15,7 @@ use crates_io_datadog::{DatadogClient, MetricType as DatadogMetricType, Point, R
 use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::deadpool::Pool;
 use prometheus::proto::{MetricFamily, MetricType};
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::{info, warn};
 
@@ -28,7 +29,11 @@ const SUBMIT_INTERVAL: Duration = Duration::from_secs(5);
 /// `background_worker` dyno; scaling the worker horizontally would make every
 /// instance submit the same series (identical host and tags per environment),
 /// causing last-write-wins collisions.
-pub fn spawn(config: &Server, deadpool: Pool<AsyncPgConnection>, datadog: Option<DatadogClient>) {
+pub fn spawn(
+    config: &Server,
+    deadpool: Pool<AsyncPgConnection>,
+    datadog: Option<Arc<DatadogClient>>,
+) {
     let Some(datadog) = datadog else {
         info!("Datadog API key not configured, skipping Datadog metrics submission");
         return;

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -6,6 +6,7 @@ use crate::worker::jobs::ProcessCloudfrontInvalidationQueue;
 use anyhow::Context;
 use bon::Builder;
 use crates_io_database::models::{CloudFrontDistribution, CloudFrontInvalidationQueueItem};
+use crates_io_datadog::DatadogClient;
 use crates_io_docs_rs::DocsRsClient;
 use crates_io_fastly::Fastly;
 use crates_io_github::GitHubClient;
@@ -34,6 +35,8 @@ pub struct Environment {
     cloudfront: Option<CloudFront>,
     fastly: Option<Fastly>,
     pub storage: Arc<Storage>,
+    /// Shared client for reporting background job metrics to Datadog.
+    pub datadog: Option<Arc<DatadogClient>>,
     pub downloads_archive_store: Option<Box<dyn ObjectStore>>,
     pub deadpool: Pool<AsyncPgConnection>,
     pub emails: Emails,

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -1,13 +1,17 @@
+use crate::datadog::common_tags;
 use crate::storage::StorageKey;
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
+use chrono::{DateTime, Utc};
 use crates_io_database::models::CloudFrontDistribution;
 use crates_io_database_dump::{DumpDirectory, create_archives};
+use crates_io_datadog::{DatadogClient, MetricType, Point, Resource, Series};
 use crates_io_worker::BackgroundJob;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tracing::{info, warn};
 
 #[derive(Clone, Default, Serialize, Deserialize)]
@@ -61,7 +65,18 @@ impl BackgroundJob for DumpDb {
         info!("Uploading tarball…");
         let tar_key = StorageKey::DbDumpTar;
         let tar_file = tokio::fs::File::open(archives.tar.path()).await?;
+        let size = tar_file.metadata().await?.len();
+        let upload_start = Instant::now();
         env.storage.upload_stream(&tar_key, tar_file).await?;
+        let upload_duration = upload_start.elapsed();
+        if let Some(datadog) = &env.datadog {
+            let domain = &env.config.domain_name;
+            let result =
+                report_dump_metrics(datadog, domain, "tar.gz", size, upload_duration).await;
+            if let Err(error) = result {
+                warn!("Failed to submit database dump metrics: {error:#}");
+            }
+        }
         info!("Database dump tarball uploaded");
 
         info!("Invalidating CDN caches…");
@@ -75,7 +90,17 @@ impl BackgroundJob for DumpDb {
         info!("Uploading zip file…");
         let zip_key = StorageKey::DbDumpZip;
         let zip_file = tokio::fs::File::open(archives.zip.path()).await?;
+        let size = zip_file.metadata().await?.len();
+        let upload_start = Instant::now();
         env.storage.upload_stream(&zip_key, zip_file).await?;
+        let upload_duration = upload_start.elapsed();
+        if let Some(datadog) = &env.datadog {
+            let domain = &env.config.domain_name;
+            let result = report_dump_metrics(datadog, domain, "zip", size, upload_duration).await;
+            if let Err(error) = result {
+                warn!("Failed to submit database dump metrics: {error:#}");
+            }
+        }
         info!("Database dump zip file uploaded");
 
         info!("Invalidating CDN caches…");
@@ -84,5 +109,61 @@ impl BackgroundJob for DumpDb {
         }
 
         Ok(())
+    }
+}
+
+/// Submits the compressed archive size in bytes and successful upload time in nanoseconds.
+async fn report_dump_metrics(
+    datadog: &DatadogClient,
+    domain: &str,
+    format: &str,
+    size: u64,
+    upload_duration: Duration,
+) -> anyhow::Result<()> {
+    let timestamp = Utc::now();
+    let series = dump_metric_series(domain, format, size, upload_duration, timestamp);
+    datadog.submit_metrics(&series).await
+}
+
+/// Builds archive size and upload duration metrics at the supplied time.
+fn dump_metric_series(
+    domain: &str,
+    format: &str,
+    size: u64,
+    upload_duration: Duration,
+    timestamp: DateTime<Utc>,
+) -> [Series; 2] {
+    let timestamp = timestamp.timestamp();
+    let mut tags = common_tags(domain);
+    tags.push(format!("format:{format}"));
+    let host = Resource::builder().kind("host").name(domain).build();
+    let upload_ns = upload_duration.as_nanos() as f64;
+    [
+        ("crates_io.db_dump_size_bytes", size as f64),
+        ("crates_io.db_dump_upload_duration_ns", upload_ns),
+    ]
+    .map(|(metric, value)| {
+        let point = Point::builder().timestamp(timestamp).value(value).build();
+        Series::builder()
+            .metric(metric)
+            .kind(MetricType::Gauge)
+            .points(vec![point])
+            .resources(vec![host.clone()])
+            .tags(tags.clone())
+            .build()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Checks the archive measurements, units, timestamp, and identifying tags.
+    #[test]
+    fn builds_dump_metric_series() {
+        let duration = Duration::from_millis(1250);
+        let timestamp = DateTime::from_timestamp(1000, 0).unwrap();
+        let series = dump_metric_series("staging.crates.io", "tar.gz", 4096, duration, timestamp);
+        insta::assert_json_snapshot!(series);
     }
 }

--- a/src/worker/jobs/snapshots/crates_io__worker__jobs__dump_db__tests__builds_dump_metric_series.snap
+++ b/src/worker/jobs/snapshots/crates_io__worker__jobs__dump_db__tests__builds_dump_metric_series.snap
@@ -1,0 +1,48 @@
+---
+source: src/worker/jobs/dump_db.rs
+expression: series
+---
+[
+  {
+    "metric": "crates_io.db_dump_size_bytes",
+    "type": 3,
+    "points": [
+      {
+        "timestamp": 1000,
+        "value": 4096.0
+      }
+    ],
+    "resources": [
+      {
+        "type": "host",
+        "name": "staging.crates.io"
+      }
+    ],
+    "tags": [
+      "env:staging",
+      "service:crates_io",
+      "format:tar.gz"
+    ]
+  },
+  {
+    "metric": "crates_io.db_dump_upload_duration_ns",
+    "type": 3,
+    "points": [
+      {
+        "timestamp": 1000,
+        "value": 1250000000.0
+      }
+    ],
+    "resources": [
+      {
+        "type": "host",
+        "name": "staging.crates.io"
+      }
+    ],
+    "tags": [
+      "env:staging",
+      "service:crates_io",
+      "format:tar.gz"
+    ]
+  }
+]


### PR DESCRIPTION
This reports compressed database dump sizes in bytes and S3 upload durations in nanoseconds to Datadog after each successful upload. A `format` tag distinguishes the tar and zip archives.

I figured it might be valuable to keep track of the size of this database dump, since we've already reached a size of 1.7 GiB.