### PR TITLE
controllers/version: Reject download date underflow

### DIFF
--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -7,7 +7,7 @@ use crate::app::AppState;
 use crate::models::VersionDownload;
 use crate::schema::*;
 use crate::storage::StorageKey;
-use crate::util::errors::AppResult;
+use crate::util::errors::{AppResult, bad_request};
 use crate::util::{RequestUtils, redirect};
 use crate::views::EncodableVersionDownload;
 use axum::Json;
@@ -105,7 +105,9 @@ pub async fn get_version_downloads(
         .before_date
         .unwrap_or_else(|| Utc::now().date_naive());
 
-    let cutoff_start_date = cutoff_end_date - Duration::days(89);
+    let cutoff_start_date = cutoff_end_date
+        .checked_sub_signed(Duration::days(89))
+        .ok_or_else(|| bad_request("before_date is too early"))?;
 
     let version_downloads = VersionDownload::belonging_to(&version)
         .filter(version_downloads::date.between(cutoff_start_date, cutoff_end_date))

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -101,6 +101,29 @@ async fn test_download() {
     assert_dl_count(&anon, "foo_download", Some(&query), 1).await;
 }
 
+/// Rejects dates that cannot represent the full download statistics window.
+#[tokio::test(flavor = "multi_thread")]
+async fn version_downloads_rejects_date_underflow() {
+    let (app, anon, user) = TestApp::init().with_user().await;
+    let mut conn = app.db_conn().await;
+
+    CrateBuilder::new("foo", user.as_model().id)
+        .version("1.0.0")
+        .expect_build(&mut conn)
+        .await;
+
+    let url = "/api/v1/crates/foo/1.0.0/downloads";
+    let response = anon
+        .get_with_query::<()>(url, "before_date=-262143-01-01")
+        .await;
+
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(
+        response.text(),
+        @r#"{"errors":[{"detail":"before_date is too early"}]}"#
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_download_with_counting_via_cdn() {
     let (app, anon, user) = TestApp::init().with_user().await;


### PR DESCRIPTION
The handler returns a bad request error when `before_date` cannot represent the full 90-day download statistics window. This prevents unrepresentable dates from panicking during subtraction.