### PR TITLE
Use `PublicUser` for owner invitations

### DIFF
--- a/crates/crates_io_database/src/models/crate_owner_invitation.rs
+++ b/crates/crates_io_database/src/models/crate_owner_invitation.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use secrecy::SecretString;
 
-use crate::models::{CrateOwner, User};
+use crate::models::{CrateOwner, Email, User};
 use crate::schema::{crate_owner_invitations, crates, users};
 
 #[derive(Debug)]
@@ -108,7 +108,7 @@ impl CrateOwnerInvitation {
             .first(conn)
             .await?;
 
-        let verified_email = user.verified_email(conn).await?;
+        let verified_email = Email::verified_for_user(conn, user.id).await?;
         if verified_email.is_none() {
             let crate_name = get_crate_name(conn).await?;
             return Err(AcceptError::EmailNotVerified { crate_name });

--- a/crates/crates_io_database/src/models/email.rs
+++ b/crates/crates_io_database/src/models/email.rs
@@ -17,6 +17,22 @@ pub struct Email {
     pub token: SecretString,
 }
 
+impl Email {
+    /// Returns the user's verified email address, if one exists.
+    pub async fn verified_for_user(
+        mut conn: &AsyncPgConnection,
+        user_id: i32,
+    ) -> QueryResult<Option<String>> {
+        emails::table
+            .filter(emails::user_id.eq(user_id))
+            .filter(emails::verified.eq(true))
+            .select(emails::email)
+            .first(&mut conn)
+            .await
+            .optional()
+    }
+}
+
 #[derive(Debug, Insertable, AsChangeset, Builder)]
 #[diesel(table_name = emails, check_for_backend(diesel::pg::Pg))]
 pub struct NewEmail<'a> {

--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -1,6 +1,6 @@
 use crate::fns::canon_crate_name;
 use crate::models::version::TopVersions;
-use crate::models::{CrateOwner, Owner, User, Version};
+use crate::models::{CrateOwner, Owner, PublicUser, User, Version};
 use crate::schema::*;
 use chrono::{DateTime, Utc};
 use diesel::associations::Identifiable;
@@ -263,9 +263,9 @@ impl Crate {
 /// Details of a newly created invite.
 #[derive(Debug)]
 pub enum NewOwnerInvite {
-    /// The invitee was a [`User`], and they must accept the invite through the
+    /// The invitee was a [`PublicUser`], and they must accept the invite through the
     /// UI or via the provided invite token.
-    User(User, SecretString),
+    User(PublicUser, SecretString),
 
     /// The invitee was a [`Team`], and they were immediately added as an owner.
     Team(Team),

--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -56,6 +56,14 @@ pub struct PublicUser {
 }
 
 impl PublicUser {
+    /// Finds a public user by ID, returning `NotFound` if the user does not exist.
+    pub async fn find(mut conn: &AsyncPgConnection, id: i32) -> QueryResult<Self> {
+        Self::query()
+            .filter(users::id.eq(id))
+            .first(&mut conn)
+            .await
+    }
+
     pub async fn owning(krate: &Crate, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Self>> {
         CrateOwner::by_owner_kind(OwnerKind::User)
             .inner_join(users::table.left_join(oauth_github::table))

--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -116,20 +116,6 @@ impl User {
             .await
     }
 
-    /// Queries the database for the verified emails
-    /// belonging to a given user.
-    pub async fn verified_email(
-        &self,
-        mut conn: &AsyncPgConnection,
-    ) -> QueryResult<Option<String>> {
-        Email::belonging_to(self)
-            .select(emails::email)
-            .filter(emails::verified.eq(true))
-            .first(&mut conn)
-            .await
-            .optional()
-    }
-
     /// Queries for the email belonging to a particular user.
     pub async fn email(&self, mut conn: &AsyncPgConnection) -> QueryResult<Option<String>> {
         Email::belonging_to(self)

--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -64,6 +64,17 @@ impl PublicUser {
             .await
     }
 
+    /// Finds a GitHub login case-insensitively, preferring the highest GitHub ID.
+    /// Accounts with the legacy ID `-1` are excluded.
+    pub async fn find_by_login(mut conn: &AsyncPgConnection, login: &str) -> QueryResult<Self> {
+        Self::query()
+            .filter(lower(users::gh_login).eq(login.to_lowercase()))
+            .filter(users::gh_id.ne(-1))
+            .order(users::gh_id.desc())
+            .first(&mut conn)
+            .await
+    }
+
     pub async fn owning(krate: &Crate, mut conn: &AsyncPgConnection) -> QueryResult<Vec<Self>> {
         CrateOwner::by_owner_kind(OwnerKind::User)
             .inner_join(users::table.left_join(oauth_github::table))
@@ -102,15 +113,6 @@ impl User {
     pub async fn find(mut conn: &AsyncPgConnection, id: i32) -> QueryResult<User> {
         User::query()
             .filter(users::id.eq(id))
-            .first(&mut conn)
-            .await
-    }
-
-    pub async fn find_by_login(mut conn: &AsyncPgConnection, login: &str) -> QueryResult<User> {
-        User::query()
-            .filter(lower(users::gh_login).eq(login.to_lowercase()))
-            .filter(users::gh_id.ne(-1))
-            .order(users::gh_id.desc())
             .first(&mut conn)
             .await
     }

--- a/crates/crates_io_database/tests/user.rs
+++ b/crates/crates_io_database/tests/user.rs
@@ -1,4 +1,5 @@
-use crates_io_database::models::{NewUser, users_by_username};
+use claims::assert_err_eq;
+use crates_io_database::models::{NewUser, PublicUser, users_by_username};
 use crates_io_database::schema::users;
 use crates_io_test_db::TestDatabase;
 use diesel::prelude::*;
@@ -35,4 +36,25 @@ async fn find_latest_user_by_canonical_username() {
         .unwrap();
 
     assert_eq!(user_id, second_id);
+}
+
+/// Public lookup works without linked accounts and rejects unknown IDs.
+#[tokio::test]
+async fn find_public_user_by_id() {
+    let test_db = TestDatabase::new();
+    let conn = test_db.async_connect().await;
+    let user = NewUser::builder()
+        .gh_id(1)
+        .gh_login("github-user")
+        .username("crates-user")
+        .build();
+    let id = user.insert(&conn).await.unwrap();
+
+    let user = PublicUser::find(&conn, id).await.unwrap();
+    assert_eq!(user.id, id);
+    assert_eq!(user.username, "crates-user");
+    assert!(!user.github_username_matches);
+
+    let missing = PublicUser::find(&conn, 0).await;
+    assert_err_eq!(missing, diesel::result::Error::NotFound);
 }

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -369,7 +369,7 @@ async fn add_owner(
             add_github_team_owner(github, conn, req_user, krate, team, encryption).await
         }
         Login::Unprefixed(login) => {
-            let user = User::find_by_login(conn, login).await.optional()?;
+            let user = PublicUser::find_by_login(conn, login).await.optional()?;
             let user = user.ok_or_else(|| {
                 bad_request(format_args!("could not find user with login `{login}`"))
             })?;
@@ -437,7 +437,7 @@ async fn invite_user_owner(
     conn: &mut AsyncPgConnection,
     req_user: &User,
     krate: &Crate,
-    user: User,
+    user: PublicUser,
 ) -> Result<NewOwnerInvite, OwnerAddError> {
     // Users are invited and must accept before being added
     let expires_at = Utc::now() + app.config.ownership_invitations_expiration;
@@ -597,7 +597,7 @@ enum OwnerAddError {
     /// Note: Teams are always immediately added, so they cannot have a pending
     /// invite to cause this error.
     #[error("user already has pending invite")]
-    AlreadyInvited(Box<User>),
+    AlreadyInvited(Box<PublicUser>),
 }
 
 /// A [`BoxedAppError`] does not impl [`std::error::Error`] so it needs a manual

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -3,7 +3,7 @@
 use crate::controllers::helpers::authorization::Rights;
 use crate::controllers::krate::CratePath;
 use crate::models::krate::OwnerRemoveError;
-use crate::models::{Crate, Owner, PublicUser, Team, User};
+use crate::models::{Crate, Email, Owner, PublicUser, Team, User};
 use crate::models::{
     CrateOwner, NewCrateOwnerInvitation, NewCrateOwnerInvitationOutcome, NewTeam,
     krate::NewOwnerInvite, token::EndpointScope,
@@ -197,7 +197,8 @@ pub async fn add_owners(
                             invitee.username, krate.name,
                         ));
 
-                        if let Some(recipient) = invitee.verified_email(conn).await.ok().flatten() {
+                        let recipient = Email::verified_for_user(conn, invitee.id).await;
+                        if let Some(recipient) = recipient.ok().flatten() {
                             let recipient = recipient.parse().map_err(|_| {
                                 bad_request(format_args!(
                                     "user `{}` has an invalid email address",

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -2,6 +2,7 @@
 
 use crate::app::AppState;
 use crate::auth::{AuthCheck, AuthHeader, Authentication};
+use crate::models::Email;
 use crate::worker::jobs::{
     self, AnalyzeCrateFile, BuildCrateZip, CheckTyposquat, GenerateOgImage,
     SendPublishNotificationsJob, UpdateDefaultVersion,
@@ -238,7 +239,7 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
     }
 
     let verified_email_address = if let Some(user) = auth.user() {
-        let verified_email_address = user.verified_email(&conn).await?;
+        let verified_email_address = Email::verified_for_user(&conn, user.id).await?;
         Some(verified_email_address.ok_or_else(|| verified_email_error(&app.config.domain_name))?)
     } else {
         None

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -2,7 +2,7 @@ use crate::app::AppState;
 use crate::auth::AuthCheck;
 use crate::controllers::helpers::OkResponse;
 use crate::email::EmailMessage;
-use crate::models::NewEmail;
+use crate::models::{Email, NewEmail};
 use crate::schema::users;
 use crate::util::errors::{AppResult, bad_request, server_error};
 use axum::Json;
@@ -76,7 +76,7 @@ pub async fn update_user(
             .await?;
 
         if !publish_notifications {
-            let email_address = user.verified_email(&conn).await?;
+            let email_address = Email::verified_for_user(&conn, user.id).await?;
 
             if let Some(email_address) = email_address {
                 let email = EmailMessage::from_template(


### PR DESCRIPTION
Owner invitations now use `PublicUser`, avoiding loading private user fields and making `github_username_matches` available for upcoming username disambiguation. Verified-email lookup accepts a user ID so it can be shared across user types. Invitation behavior remains unchanged.

### Related

- #13769
- #14213