### PR TITLE
crate.settings: Recognize user prefixes in owner invitations

### DIFF
--- a/e2e/routes/crate/settings.spec.ts
+++ b/e2e/routes/crate/settings.spec.ts
@@ -57,6 +57,36 @@ test.describe('Route | crate.settings', { tag: '@routes' }, () => {
     await expect(page.locator('[data-test-delete-button]')).toBeVisible();
   });
 
+  for (let name of ['alice', 'crates.io:alice', 'github:alice']) {
+    test(`inviting ${name} shows an invitation message`, async ({ msw, page }) => {
+      await prepare(msw);
+      msw.worker.use(http.put('/api/v1/crates/:name/owners', () => HttpResponse.json({ ok: true })));
+
+      await page.goto('/crates/foo/settings');
+      await page.locator('[data-test-add-owner-button]').click();
+      await page.getByLabel('Username', { exact: true }).fill(name);
+      await page.locator('[data-test-save-button]').click();
+
+      await expect(page.locator('[data-test-notification-message="success"]')).toHaveText(
+        `An invite has been sent to ${name}`,
+      );
+    });
+  }
+
+  test('adding a GitHub team shows a team message', async ({ msw, page }) => {
+    await prepare(msw);
+    msw.worker.use(http.put('/api/v1/crates/:name/owners', () => HttpResponse.json({ ok: true })));
+
+    await page.goto('/crates/foo/settings');
+    await page.locator('[data-test-add-owner-button]').click();
+    await page.getByLabel('Username', { exact: true }).fill('github:rust-lang:owners');
+    await page.locator('[data-test-save-button]').click();
+
+    await expect(page.locator('[data-test-notification-message="success"]')).toHaveText(
+      'Team github:rust-lang:owners was added as a crate owner',
+    );
+  });
+
   test('only the authenticated owner has their email shown in the owners list', async ({ msw, page }) => {
     let user1 = await msw.db.user.create({ login: 'authenticated-owner' });
     let user2 = await msw.db.user.create({ login: 'other-owner' });

--- a/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
+++ b/svelte/src/routes/crates/[crate_id]/settings/+page.svelte
@@ -109,7 +109,7 @@
         throw new Error(detail ?? '');
       }
 
-      if (name.includes(':')) {
+      if (name.split(':').length === 3) {
         notifications.success(`Team ${name} was added as a crate owner`);
         await invalidateAll();
       } else {


### PR DESCRIPTION
The owner form now only treats names containing two colons as teams. User identifiers such as `crates.io:alice` and `github:alice` contain only one colon and receive the invitation notification after a successful request. Previously, any colon caused the form to announce that a team was added, which was incompatible with the introduction of these new identifiers.

### Related

- https://github.com/rust-lang/crates.io/issues/13769