### PR TITLE
tests: Skip GitHub accounts for inactive users

### DIFF
--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -1,6 +1,6 @@
 use crate::util::{RequestHelper, TestApp};
 use claims::{assert_none, assert_ok, assert_some, assert_some_eq};
-use crates_io::models::{NewUser, User};
+use crates_io::models::User;
 use crates_io::views::{EncodableLinkedAccount, EncodablePublicUser};
 use crates_io_test_utils::builders::{OauthGithubBuilder, UserBuilder};
 use insta::{assert_json_snapshot, assert_snapshot};
@@ -104,18 +104,14 @@ async fn show_latest_user_case_insensitively() {
 #[tokio::test(flavor = "multi_thread")]
 async fn user_without_github_account() {
     let (app, anon) = TestApp::init().empty().await;
-    let conn = app.db_conn().await;
 
-    let new_user = NewUser::builder()
+    let builder = UserBuilder::new()
         // The gh_id column will eventually be removed; there are currently records in production
         // that have `-1` for their `gh_id` because the associated GitHub accounts have been deleted
-        .gh_id(-1)
-        .gh_login("foobar")
-        .username("foobar")
-        .name("I deleted my github account")
-        .build();
-    new_user.insert(&conn).await.unwrap();
-    // This user doesn't have a linked record in `oauth_github`
+        .with_gh_id(-1)
+        .with_username("foobar")
+        .with_display_name("I deleted my github account");
+    app.db_new_user_from_builder(builder).await;
 
     // The crates.io username still exists
     let url = "/api/v1/users/fOObAr?include=linked_accounts";

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -165,7 +165,9 @@ impl TestApp {
         let id = new_user.insert(&conn).await.unwrap();
         let user = User::find(&conn, id).await.unwrap();
 
-        OauthGithubBuilder::for_user(&user).insert(&conn).await;
+        if user.gh_id != -1 {
+            OauthGithubBuilder::for_user(&user).insert(&conn).await;
+        }
 
         let new_email = NewEmail::builder()
             .user_id(id)


### PR DESCRIPTION
`db_new_user_from_builder()` no longer creates an `oauth_github` row when the legacy `gh_id` is `-1`. This keeps inactive-user fixtures consistent with production records that have no linked GitHub account.

/cc @carols10cents 

### Related 

- https://github.com/rust-lang/crates.io/pull/14628#discussion_r3970092905