### PR TITLE
database_dump: Include all users in database dumps

### DIFF
--- a/crates/crates_io_database_dump/src/dump-db.toml
+++ b/crates/crates_io_database_dump/src/dump-db.toml
@@ -255,13 +255,6 @@ jti = "private"
 used_at = "private"
 expires_at = "private"
 
-[users]
-filter = """
-id in (
-    SELECT owner_id AS user_id FROM crate_owners WHERE NOT deleted AND owner_kind = 0
-    UNION
-    SELECT published_by as user_id FROM versions
-)"""
 [users.columns]
 id = "public"
 gh_login = "public"

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
@@ -13,8 +13,7 @@ BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY;
     \copy "reserved_crate_names" ("name") TO 'data/reserved_crate_names.csv' WITH CSV HEADER
     \copy "reserved_usernames" ("username") TO 'data/reserved_usernames.csv' WITH CSV HEADER
     \copy "teams" ("avatar", "github_id", "id", "login", "name", "org_id") TO 'data/teams.csv' WITH CSV HEADER
-    \copy (SELECT "created_at", "gh_id", "gh_login", "id", "name", "username" FROM "users" WHERE id in (     SELECT owner_id AS user_id FROM crate_owners WHERE NOT deleted AND owner_kind = 0     UNION     SELECT published_by as user_id FROM versions )) TO 'data/users.csv' WITH CSV HEADER
-
+    \copy "users" ("created_at", "gh_id", "gh_login", "id", "name", "username") TO 'data/users.csv' WITH CSV HEADER
     \copy "crates_categories" ("category_id", "crate_id") TO 'data/crates_categories.csv' WITH CSV HEADER
     \copy "crates_keywords" ("crate_id", "keyword_id") TO 'data/crates_keywords.csv' WITH CSV HEADER
     \copy (SELECT "crate_id", "created_at", "created_by", "owner_id", "owner_kind" FROM "crate_owners" WHERE NOT deleted) TO 'data/crate_owners.csv' WITH CSV HEADER


### PR DESCRIPTION
The database dump is currently inconsistent: `crate_owners`, `deleted_crates`, and `oauth_github` contain foreign keys referencing users that are missing from the dump. The user filter only includes current crate owners and publishers of existing versions, so users referenced elsewhere can be left out.

The filter was introduced in https://github.com/rust-lang/crates.io/issues/630 to keep accounts private until they published a crate or became an owner. However, the public API exposes user profiles without requiring either action, and the dump already includes GitHub account records for users excluded by the filter. Filtering only the `users` table no longer provides a consistent privacy boundary. Including all users resolves these missing references and avoids maintaining a separate list of relationships that qualify a user for export. Email addresses, authentication tokens, and other private fields remain excluded.

The alternative would be to adjust the filter, but then we'd also need to introduce a similar but probably even more complex filter to the `oauth_github` table and keep these updated when we add new `user_id` columns in other tables. IMHO that does not seem worth it, given that our API makes all accounts public anyway.