### PR TITLE
controllers/krate: Avoid loading unused version fields in listings

### DIFF
--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -20,7 +20,7 @@ use utoipa::IntoParams;
 
 use crate::app::AppState;
 use crate::controllers::helpers::Paginate;
-use crate::models::{Crate, CrateOwner, OwnerKind, TopVersions, Version};
+use crate::models::{Crate, CrateOwner, OwnerKind, TopVersions};
 use crate::schema::*;
 use crate::util::errors::{AppResult, bad_request};
 use crate::views::EncodableCrate;
@@ -284,16 +284,15 @@ pub async fn list_crates(
     let crates = data.iter().map(|r| &r.krate).collect::<Vec<_>>();
 
     let span = info_span!("db.query", message = "SELECT ... FROM versions");
-    let versions: Vec<Version> = Version::belonging_to(&crates)
+    let versions = PartialVersion::query()
+        .filter(versions::crate_id.eq_any(crates.iter().map(|krate| krate.id)))
         .filter(versions::yanked.eq(false))
-        .select(Version::as_select())
         .load(&mut conn)
         .instrument(span)
         .await?;
-    let versions = versions
-        .grouped_by(&crates)
-        .into_iter()
-        .map(TopVersions::from_versions);
+    let versions = versions.grouped_by(&crates).into_iter().map(|versions| {
+        TopVersions::from_date_version_pairs(versions.into_iter().map(|v| (v.created_at, v.num)))
+    });
 
     let crates = versions
         .zip(data)
@@ -841,6 +840,15 @@ mod seek {
             }
         }
     }
+}
+
+/// Version fields needed to calculate the listing's version summaries.
+#[derive(Debug, Associations, HasQuery)]
+#[diesel(table_name = versions, belongs_to(Crate))]
+pub struct PartialVersion {
+    pub crate_id: i32,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub num: String,
 }
 
 #[derive(Debug, Clone, Queryable)]


### PR DESCRIPTION
Crate listings need version numbers and publication dates to calculate version summaries, but previously loaded complete version records. The handler now uses `PartialVersion` to select only `crate_id`, `created_at`, and `num`, reducing database transfer and decoding work. The existing summary calculation still considers every non-yanked version, preserving the returned highest, highest stable, and newest versions.

Local benchmarks against a production database dump show warm requests for 100 crates sorted by downloads falling from 39.6 to 16.0 ms on page 1 and from 69.5 to 20.1 ms on page 4. With 32 concurrent requests covering the first five pages, throughput increased from 139–142 to 296–305 requests/sec.