### PR TITLE
Import database dumps with staged schema files

### DIFF
--- a/script/import-database-dump.sh
+++ b/script/import-database-dump.sh
@@ -52,15 +52,27 @@ ORIG_WD="$(pwd)"
 readonly ORIG_WD
 
 cd $DUMP_PATH
+
+SCHEMA_FILE=schema.sql
+if [ -f schema-before.sql ] && [ -f schema-after.sql ]; then
+  SCHEMA_FILE=schema-before.sql
+fi
+readonly SCHEMA_FILE
+
 echo "Creating '$DATABASE_NAME' database"
 psql --command="DROP DATABASE IF EXISTS $DATABASE_NAME" "$DROP_CREATE_DATABASE_NAME"
 psql --command="CREATE DATABASE $DATABASE_NAME" "$DROP_CREATE_DATABASE_NAME"
 
 echo "Importing database schema"
-psql -a "$DATABASE_NAME" < schema.sql
+psql -a "$DATABASE_NAME" < "$SCHEMA_FILE"
 
 echo "Importing data"
 psql -a "$DATABASE_NAME" < import.sql
+
+if [ "$SCHEMA_FILE" = schema-before.sql ]; then
+  echo "Creating indexes, constraints, and remaining triggers"
+  psql -a "$DATABASE_NAME" < schema-after.sql
+fi
 
 cd "$ORIG_WD"
 


### PR DESCRIPTION
The importer now uses `schema-before.sql`, `import.sql`, and `schema-after.sql` when both staged schema files are present. This defers index creation and foreign-key validation until after loading the data. The script falls back to `schema.sql` followed by `import.sql` if either staged file is missing.

### Related

- https://github.com/rust-lang/crates.io/pull/14638
- https://github.com/rust-lang/crates.io/pull/14636 (deferring the triggers is causing problems if foreign keys are invalid)