### PR TITLE
db-dump: Document spreadsheet formula risk

### DIFF
--- a/crates/crates_io_database_dump/src/readme_for_tarball.md
+++ b/crates/crates_io_database_dump/src/readme_for_tarball.md
@@ -38,3 +38,9 @@ For performance reasons, the live `version_downloads` table only includes data f
 3.  Run the import script.
 
         psql DATABASE_URL < import.sql
+
+## User-supplied Content
+
+The CSV files contain crate and user metadata exactly as it was submitted to crates.io, without any modification. Fields such as `crates.description`, `crates.homepage`, `crates.repository`, `crates.readme`, and `users.name` can therefore start with characters like `=`, `+`, `-`, or `@` that spreadsheet applications interpret as the beginning of a formula.
+
+The files are intended to be imported with `import.sql` or processed with a CSV library. Do not open them in spreadsheet software with automatic formula evaluation enabled, or make sure that the application treats all cells as plain text when importing.


### PR DESCRIPTION
Database dumps preserve user-supplied metadata, including values beginning with characters that spreadsheet applications can interpret as formulas. The tarball README now recommends using `import.sql` or a CSV library and describes how to prevent formula evaluation when importing the CSV files.

Documenting the risk instead of rewriting exported values keeps `import.sql` restoration lossless for legitimate values with those prefixes.

This addresses a minor https://github.com/alpha-omega-security/scrutineer finding.