### PR TITLE
tarball: Limit metadata file sizes

### DIFF
--- a/crates/crates_io_tarball/examples/check_all_crates.rs
+++ b/crates/crates_io_tarball/examples/check_all_crates.rs
@@ -80,6 +80,7 @@ async fn process_path(path: &Path, pb: &ProgressBar) {
 
     let limits = TarballLimits {
         unpack_size: u64::MAX,
+        metadata_file_size: u64::MAX,
         entries: None,
     };
     let result = process_tarball(&pkg_name, &mut file, limits).await;

--- a/crates/crates_io_tarball/examples/read_file.rs
+++ b/crates/crates_io_tarball/examples/read_file.rs
@@ -33,6 +33,7 @@ async fn main() -> anyhow::Result<()> {
 
     let limits = TarballLimits {
         unpack_size: u64::MAX,
+        metadata_file_size: u64::MAX,
         entries: None,
     };
     let result = process_tarball(&pkg_name, &mut file, limits)

--- a/crates/crates_io_tarball/src/lib.rs
+++ b/crates/crates_io_tarball/src/lib.rs
@@ -37,6 +37,9 @@ pub struct TarballLimits {
     /// Metadata headers consumed by the tar parser are not counted. `None`
     /// disables the limit.
     pub entries: Option<usize>,
+    /// Maximum size in bytes of the `Cargo.toml` and `.cargo_vcs_info.json`
+    /// entries.
+    pub metadata_file_size: u64,
 }
 
 #[derive(Debug)]
@@ -59,6 +62,8 @@ pub enum TarballError {
     UnexpectedEntry { path: String, entry_type: EntryType },
     #[error("uploaded tarball contains more than {max} entries")]
     TooManyEntries { max: usize },
+    #[error("metadata file `{path}` exceeds the maximum size of {max} bytes")]
+    MetadataFileTooLarge { path: String, max: u64 },
     #[error("Cargo.toml manifest is missing")]
     MissingManifest,
     #[error("Cargo.toml manifest is invalid: {0}")]
@@ -154,15 +159,13 @@ pub async fn process_tarball<R: tokio::io::AsyncRead + Unpin>(
         // Let's go hunting for the VCS info and crate manifest. The only valid place for these is
         // in the package root in the tarball.
         if in_pkg_path_str == ".cargo_vcs_info.json" {
-            let mut contents = String::new();
-            entry.read_to_string(&mut contents).await?;
+            let contents = read_metadata_entry(&mut entry, limits.metadata_file_size).await?;
             vcs_info = CargoVcsInfo::from_contents(&contents).ok();
         } else if in_pkg_path_str.eq_ignore_ascii_case("cargo.toml") {
             // Try to extract and read the Cargo.toml from the tarball, silently erroring if it
             // cannot be read.
             let owned_entry_path = entry_path.into_owned();
-            let mut contents = String::new();
-            entry.read_to_string(&mut contents).await?;
+            let contents = read_metadata_entry(&mut entry, limits.metadata_file_size).await?;
 
             let manifest = Manifest::from_str(&contents)?;
             validate_manifest(&manifest)?;
@@ -194,6 +197,21 @@ pub async fn process_tarball<R: tokio::io::AsyncRead + Unpin>(
     manifest.complete_from_abstract_filesystem(&PathsFileSystem(paths))?;
 
     Ok(TarballInfo { manifest, vcs_info })
+}
+
+/// Reads a metadata entry into memory after checking its declared size.
+async fn read_metadata_entry<R: tokio::io::AsyncRead + Unpin>(
+    entry: &mut Entry<R>,
+    max: u64,
+) -> Result<String, TarballError> {
+    if entry.effective_size() > max {
+        let path = entry.path()?.display().to_string();
+        return Err(TarballError::MetadataFileTooLarge { path, max });
+    }
+
+    let mut contents = String::new();
+    entry.read_to_string(&mut contents).await?;
+    Ok(contents)
 }
 
 async fn validate_pax_size<R: tokio::io::AsyncRead + Unpin>(
@@ -276,6 +294,7 @@ mod tests {
     const LIMITS: TarballLimits = TarballLimits {
         unpack_size: 512 * 1024 * 1024,
         entries: None,
+        metadata_file_size: 1024 * 1024,
     };
 
     fn tarball_with_entry_type(entry_type: tar::EntryType) -> Vec<u8> {
@@ -393,7 +412,7 @@ mod tests {
 
         let limits = TarballLimits {
             unpack_size: tarball.len() as u64 - 1,
-            entries: None,
+            ..LIMITS
         };
         let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, limits).await);
         assert_snapshot!(err, @"uploaded tarball is malformed or too large when decompressed");
@@ -421,6 +440,51 @@ mod tests {
         };
         let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, limits).await);
         assert_snapshot!(err, @"uploaded tarball contains more than 3 entries");
+    }
+
+    #[tokio::test]
+    async fn process_tarball_test_metadata_size_limit() {
+        let tarball = TarballBuilder::new()
+            .add_file("foo-0.0.1/Cargo.toml", MANIFEST)
+            .build();
+
+        let limits = TarballLimits {
+            metadata_file_size: MANIFEST.len() as u64,
+            ..LIMITS
+        };
+        assert_ok!(process_tarball("foo-0.0.1", &*tarball, limits).await);
+
+        let limits = TarballLimits {
+            metadata_file_size: MANIFEST.len() as u64 - 1,
+            ..LIMITS
+        };
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, limits).await);
+        assert_snapshot!(err, @"metadata file `foo-0.0.1/Cargo.toml` exceeds the maximum size of 40 bytes");
+
+        let vcs_info = br#"{"path_in_vcs": "a/path/that/is/longer/than/the/manifest"}"#;
+        let tarball = TarballBuilder::new()
+            .add_file("foo-0.0.1/Cargo.toml", MANIFEST)
+            .add_file("foo-0.0.1/.cargo_vcs_info.json", vcs_info)
+            .build();
+
+        let limits = TarballLimits {
+            metadata_file_size: MANIFEST.len() as u64,
+            ..LIMITS
+        };
+        let err = assert_err!(process_tarball("foo-0.0.1", &*tarball, limits).await);
+        assert_snapshot!(err, @"metadata file `foo-0.0.1/.cargo_vcs_info.json` exceeds the maximum size of 41 bytes");
+
+        // Entries other than the two metadata files are not affected by the limit.
+        let tarball = TarballBuilder::new()
+            .add_file("foo-0.0.1/Cargo.toml", MANIFEST)
+            .add_file("foo-0.0.1/src/lib.rs", &[b'a'; 4096])
+            .build();
+
+        let limits = TarballLimits {
+            metadata_file_size: MANIFEST.len() as u64,
+            ..LIMITS
+        };
+        assert_ok!(process_tarball("foo-0.0.1", &*tarball, limits).await);
     }
 
     #[tokio::test]

--- a/src/config/publish_limits.rs
+++ b/src/config/publish_limits.rs
@@ -14,6 +14,10 @@ pub struct PublishLimitsConfig {
     /// value disables the limit.
     pub tarball_entries: Option<usize>,
 
+    /// Maximum size in bytes of the `Cargo.toml` and `.cargo_vcs_info.json`
+    /// files inside an uploaded crate tarball.
+    pub metadata_file_size: u64,
+
     /// Maximum number of dependencies a crate can have.
     pub dependencies: usize,
 
@@ -28,6 +32,7 @@ impl Default for PublishLimitsConfig {
             upload_size: 10 * 1024 * 1024,  // 10 MB
             unpack_size: 512 * 1024 * 1024, // 512 MB
             tarball_entries: None,
+            metadata_file_size: 1024 * 1024, // 1 MB
             dependencies: 500,
             features: 300,
         }
@@ -50,6 +55,7 @@ impl PublishLimitsConfig {
             upload_size: 128 * 1024, // 128 kB should be enough for most testing purposes
             unpack_size: 128 * 1024,
             tarball_entries: None,
+            metadata_file_size: 32 * 1024,
             dependencies: 10,
             features: 10,
         }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -273,6 +273,7 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
     let limits = TarballLimits {
         unpack_size: max_unpack_size,
         entries: app.config.publish_limits.tarball_entries,
+        metadata_file_size: app.config.publish_limits.metadata_file_size,
     };
     let tarball_info = process_tarball(&pkg_name, &*tarball_bytes, limits).await?;
 
@@ -1062,7 +1063,8 @@ impl From<TarballError> for BoxedAppError {
                 bad_request(format!("uploaded tarball contains more than {max} entries"))
             }
             TarballError::InvalidPath(path) => bad_request(format!("invalid path found: {path}")),
-            error @ TarballError::UnexpectedEntry { .. } => bad_request(error.to_string()),
+            error @ (TarballError::UnexpectedEntry { .. }
+            | TarballError::MetadataFileTooLarge { .. }) => bad_request(error.to_string()),
             TarballError::IO(err) => err.into(),
             TarballError::MissingManifest => {
                 bad_request("uploaded tarball is missing a `Cargo.toml` manifest file")

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -40,6 +40,35 @@ async fn tarball_entry_limit_applies_to_new_versions() {
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"uploaded tarball contains more than 2 entries"}]}"#);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn tarball_metadata_file_size_limit() {
+    let (_app, _, _, token) = TestApp::full()
+        .with_config(|config| config.publish_limits.metadata_file_size = 256)
+        .with_token()
+        .await;
+
+    let vcs_info = format!(r#"{{"path_in_vcs": "{}"}}"#, "a".repeat(300));
+    let version =
+        PublishBuilder::new("foo", "1.0.0").add_file("foo-1.0.0/.cargo_vcs_info.json", vcs_info);
+
+    let response = token.publish_crate(version).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"metadata file `foo-1.0.0/.cargo_vcs_info.json` exceeds the maximum size of 256 bytes"}]}"#);
+
+    let version = PublishBuilder::new("foo", "1.0.0").description(&"a".repeat(300));
+
+    let response = token.publish_crate(version).await;
+    assert_snapshot!(response.status(), @"400 Bad Request");
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"metadata file `foo-1.0.0/Cargo.toml` exceeds the maximum size of 256 bytes"}]}"#);
+
+    // Other files are only subject to the overall unpack size limit.
+    let version =
+        PublishBuilder::new("foo", "1.0.0").add_file("foo-1.0.0/README.md", "a".repeat(300));
+
+    let response = token.publish_crate(version).await;
+    assert_snapshot!(response.status(), @"200 OK");
+}
+
 async fn publish_tarball_with_entry(entry_type: tar::EntryType) -> String {
     let (app, _, _, token) = TestApp::full().with_token().await;
 


### PR DESCRIPTION
`process_tarball()` now rejects oversized `Cargo.toml` and `.cargo_vcs_info.json` entries before reading them into memory. This provides a tighter 1 MiB limit for metadata than the overall decompressed tarball limit.

This addresses another minor [alpha-omega-security/scrutineer](https://github.com/alpha-omega-security/scrutineer) finding.